### PR TITLE
Improve notifications: BJ time, cash snapshots, per-account correctness

### DIFF
--- a/scripts/alert_engine.py
+++ b/scripts/alert_engine.py
@@ -60,7 +60,23 @@ def top_pick_line(row: pd.Series) -> str:
             shares_total = int(row.get('shares_total') or 0)
             shares_locked = int(row.get('shares_locked') or 0)
             cover_avail = int(row.get('cover_avail') or 0)
-            extra = f" | cover {cover_avail} | shares {shares_total}(-{shares_locked})"
+            # include suggested sell price (mid) + currency
+            parts = []
+            try:
+                ccy = row.get('option_ccy')
+                if ccy and isinstance(ccy, str):
+                    parts.append(f"ccy {ccy.strip().upper()}")
+            except Exception:
+                pass
+            try:
+                mid = row.get('mid')
+                if mid is not None and not pd.isna(mid):
+                    parts.append(f"mid {float(mid):.3f}")
+            except Exception:
+                pass
+            parts.append(f"cover {cover_avail}")
+            parts.append(f"shares {shares_total}(-{shares_locked})")
+            extra = " | " + " | ".join(parts)
         if row.get('strategy') == 'sell_put':
             used_total = float(row.get('cash_secured_used_usd') or 0.0)
             used_symbol = float(row.get('cash_secured_used_usd_symbol') or 0.0) if 'cash_secured_used_usd_symbol' in row else 0.0
@@ -106,6 +122,20 @@ def top_pick_line(row: pd.Series) -> str:
                     parts.append(f"cash_req_cny ¥{req_cny_v:,.0f}")
                 elif req is not None and req > 0:
                     parts.append(f"cash_req ${float(req):,.0f}")
+            except Exception:
+                pass
+
+            # include suggested sell price (mid) and option currency for clarity
+            try:
+                mid = row.get('mid')
+                if mid is not None and not pd.isna(mid):
+                    parts.insert(0, f"mid {float(mid):.3f}")
+            except Exception:
+                pass
+            try:
+                ccy = row.get('option_ccy')
+                if ccy and isinstance(ccy, str):
+                    parts.insert(0, f"ccy {ccy.strip().upper()}")
             except Exception:
                 pass
 

--- a/scripts/append_cash_summary.py
+++ b/scripts/append_cash_summary.py
@@ -45,7 +45,7 @@ def money_cny(v) -> str:
     try:
         if v is None:
             return '-'
-        return f"¥{float(v):,.0f}"
+        return f"¥{float(v):,.0f} (CNY)"
     except Exception:
         return '-'
 
@@ -62,6 +62,26 @@ def main():
     notif_path = base / args.notification
     text = notif_path.read_text(encoding='utf-8').strip() if notif_path.exists() else ''
 
+    # Remove any previous cash footer blocks to keep the file clean and idempotent.
+    # We support older formats as well.
+    def _strip_old_cash_blocks(t: str) -> str:
+        if not t:
+            return t
+        lines = t.splitlines()
+        cut = len(lines)
+        headers = {
+            '现金结余:',
+            '现金（holding表，CNY）:',
+            '现金（CNY）:',
+        }
+        for i, ln in enumerate(lines):
+            if ln.strip() in headers:
+                cut = i
+                break
+        return '\n'.join(lines[:cut]).rstrip()
+
+    text = _strip_old_cash_blocks(text)
+
     py = str(base / '.venv' / 'bin' / 'python')
 
     rows = []
@@ -74,12 +94,19 @@ def main():
             '--format', 'json',
         ], cwd=base, timeout_sec=180)
         payload = parse_last_json(out)
-        rows.append((acct.upper(), payload.get('cash_free_cny')))
+        # Show BOTH:
+        # - holding-table cash (cash_available_cny)
+        # - free cash after subtracting put cash-secured (cash_free_cny)
+        rows.append((
+            acct.upper(),
+            payload.get('cash_available_cny'),
+            payload.get('cash_free_cny'),
+        ))
 
     footer = []
-    footer.append('现金结余:')
-    for acct, free_cny in rows:
-        footer.append(f"{acct}账户 base free(CNY): {money_cny(free_cny)}")
+    footer.append('现金（CNY）:')
+    for acct, avail_cny, free_cny in rows:
+        footer.append(f"{acct}: holding {money_cny(avail_cny)} | free {money_cny(free_cny)}")
 
     new_text = (text + '\n\n' + '\n'.join(footer).strip() + '\n').strip() + '\n'
     notif_path.write_text(new_text, encoding='utf-8')

--- a/scripts/notify_symbols.py
+++ b/scripts/notify_symbols.py
@@ -52,6 +52,20 @@ def _format_alert_line(line: str) -> str:
     annual = next((p for p in parts if p.startswith('年化')), '')
     income = next((p for p in parts if p.startswith('净收入')), '')
     dte = next((p for p in parts if p.startswith('DTE')), '')
+
+    def income_int_tag(s: str) -> str:
+        # input like "净收入 137.99" -> "净收 138"
+        try:
+            if not s:
+                return ''
+            x = s.replace('净收入', '').strip()
+            v = float(x)
+            return f"净收 {int(round(v))}"
+        except Exception:
+            return s
+    # mid price used for return calculation (if present)
+    mid = next((p for p in parts if p.startswith('mid ')), '')
+    ccy = next((p for p in parts if p.startswith('ccy ')), '')
     risk = parts[7] if len(parts) >= 8 else ''
 
     extras: dict[str, str] = {}
@@ -71,13 +85,19 @@ def _format_alert_line(line: str) -> str:
         cash_req_only = extras.get('cash_req_cny', '') or extras.get('cash_req', '')
 
         # Line 1 (compact)
-        line1 = f"{symbol} 卖Put {contract} | {annual} | {income} | {dte}"
+        # Include suggested sell price (mid)
+        price_val = mid.split(' ', 1)[1] if mid and ' ' in mid else 'mid'
+        ccy_val = ccy.split(' ', 1)[1] if ccy and ' ' in ccy else ''
+        price_tag = f"卖价 {price_val} ({ccy_val})" if ccy_val else f"卖价 {price_val}"
+        line1 = f"{symbol} 卖Put {contract} | {price_tag} | {annual} | {income_int_tag(income)} | {dte}"
 
         # Line 2 (cash)
         req = cash_req_cny or cash_req or cash_req_only or ''
         line2 = ''
         if req:
-            line2 = f"占用担保 {req}"
+            # Append explicit currency tag (CNY/USD)
+            cur = 'CNY' if (cash_req_cny or '¥' in str(req)) else 'USD'
+            line2 = f"占用担保 {req} ({cur})"
 
         out = [line1]
         if line2:
@@ -90,7 +110,11 @@ def _format_alert_line(line: str) -> str:
         cover = extras.get('cover', '')
         shares = extras.get('shares', '')
 
-        line1 = f"{symbol} 卖Call {contract} | {annual} | {income} | {dte}"
+        # Include suggested sell price (mid)
+        price_val = mid.split(' ', 1)[1] if mid and ' ' in mid else 'mid'
+        ccy_val = ccy.split(' ', 1)[1] if ccy and ' ' in ccy else ''
+        price_tag = f"卖价 {price_val} ({ccy_val})" if ccy_val else f"卖价 {price_val}"
+        line1 = f"{symbol} 卖Call {contract} | {price_tag} | {annual} | {income_int_tag(income)} | {dte}"
         line2 = ''
         if cover or shares:
             line2 = f"覆盖 cover {cover or '-'} | shares {shares or '-'}"

--- a/scripts/query_sell_put_cash.py
+++ b/scripts/query_sell_put_cash.py
@@ -53,6 +53,11 @@ def main():
     ap.add_argument("--format", choices=["text", "json"], default="text")
     ap.add_argument("--top", type=int, default=10, help="top N symbols in cash-secured breakdown")
     ap.add_argument("--no-fx", action="store_true", help="do not fetch FX rates / CNY equivalent")
+    ap.add_argument(
+        "--out-dir",
+        default="output/state",
+        help="Directory to write intermediate JSON state (portfolio_context/option_positions_context/rate_cache). Default: output/state",
+    )
     args = ap.parse_args()
 
     base = Path(__file__).resolve().parents[1]
@@ -61,7 +66,9 @@ def main():
     if not pm_config_path.is_absolute():
         pm_config_path = (base / pm_config_path).resolve()
 
-    out_dir = (base / "output" / "state").resolve()
+    out_dir = Path(args.out_dir)
+    if not out_dir.is_absolute():
+        out_dir = (base / out_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
     portfolio_out = out_dir / "portfolio_context.json"

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -93,6 +93,8 @@ def summarize_sell_put(df: pd.DataFrame, symbol: str) -> dict:
         'cash_available_cny': None,
         'cash_free_cny': None,
         'cash_required_cny': None,
+        'mid': None,
+        'option_ccy': None,
         'note': '无候选',
     }
     if df.empty:
@@ -157,6 +159,8 @@ def summarize_sell_put(df: pd.DataFrame, symbol: str) -> dict:
         'cash_available_cny': cash_avail_cny,
         'cash_free_cny': cash_free_cny,
         'cash_required_cny': cash_required_cny,
+        'mid': (float(top['mid']) if 'mid' in top else None),
+        'option_ccy': ('HKD' if str(symbol).upper().endswith('.HK') else 'USD'),
         'note': '有候选',
     })
     return row
@@ -174,6 +178,8 @@ def summarize_sell_call(df: pd.DataFrame, symbol: str) -> dict:
         'net_income': None,
         'annualized_return': None,
         'risk_label': '',
+        'mid': None,
+        'option_ccy': None,
         'note': '无候选',
     }
     if df.empty:
@@ -197,7 +203,9 @@ def summarize_sell_call(df: pd.DataFrame, symbol: str) -> dict:
         'net_income': float(top['net_income']),
         'annualized_return': float(top['annualized_net_premium_return']),
         'risk_label': top.get('risk_label', ''),
-        'note': f"有候选 | cover_avail {cover_avail} | shares_total {int(top.get('shares_total', 0) or 0)} | shares_locked {int(top.get('shares_locked', 0) or 0)}", 
+        'mid': (float(top['mid']) if 'mid' in top else None),
+        'option_ccy': ('HKD' if str(symbol).upper().endswith('.HK') else 'USD'),
+        'note': f"有候选 | cover_avail {cover_avail} | shares_total {int(top.get('shares_total', 0) or 0)} | shares_locked {int(top.get('shares_locked', 0) or 0)}",
     })
     return row
 
@@ -262,18 +270,30 @@ def process_symbol(
         df_sp_lab = safe_read_csv(symbol_sp_labeled)
         if not df_sp_lab.empty and portfolio_ctx:
             option_ctx = portfolio_ctx.get('option_ctx') if isinstance(portfolio_ctx, dict) else None
-            used_symbol = 0.0
-            used_total = 0.0
+
+            # New schema (preferred): cash_secured_by_symbol_by_ccy / cash_secured_total_by_ccy / cash_secured_total_cny
+            # Old schema (legacy): cash_secured_by_symbol (USD-only)
+            used_symbol_usd = 0.0
+            used_total_usd = 0.0
+            used_total_cny = None
+
             if option_ctx:
-                used_map = (option_ctx.get('cash_secured_by_symbol') or {})
                 try:
-                    used_symbol = float(used_map.get(symbol) or 0.0)
+                    by_sym_ccy = option_ctx.get('cash_secured_by_symbol_by_ccy') or {}
+                    tot_by_ccy = option_ctx.get('cash_secured_total_by_ccy') or {}
+                    if isinstance(by_sym_ccy, dict) and (by_sym_ccy or tot_by_ccy):
+                        used_symbol_usd = float(((by_sym_ccy.get(symbol) or {}).get('USD')) or 0.0)
+                        used_total_usd = float((tot_by_ccy.get('USD')) or 0.0)
+                        v = option_ctx.get('cash_secured_total_cny')
+                        used_total_cny = float(v) if v is not None else None
+                    else:
+                        used_map = (option_ctx.get('cash_secured_by_symbol') or {})
+                        used_symbol_usd = float(used_map.get(symbol) or 0.0)
+                        used_total_usd = float(sum(float(v or 0.0) for v in used_map.values()))
                 except Exception:
-                    used_symbol = 0.0
-                try:
-                    used_total = float(sum(float(v or 0.0) for v in used_map.values()))
-                except Exception:
-                    used_total = 0.0
+                    used_symbol_usd = 0.0
+                    used_total_usd = 0.0
+                    used_total_cny = None
 
             cash_avail = None
             cash_avail_est = None  # USD equivalent (from base CNY)
@@ -286,14 +306,19 @@ def process_symbol(
 
                 cny = cash_by_ccy.get('CNY')
                 cash_avail_cny = float(cny) if cny is not None else None
+
                 if cash_avail_cny is not None:
                     # Base-currency (CNY) free cash after reserving existing cash-secured puts.
-                    # NOTE: used_total is recorded in USD; we convert it into CNY using USDCNY.
-                    if fx_usd_per_cny:
-                        usdcny = 1.0 / float(fx_usd_per_cny)
-                        cash_free_cny = cash_avail_cny - (used_total * usdcny)
+                    # Prefer option_ctx.cash_secured_total_cny (already FX-normalized).
+                    if used_total_cny is not None:
+                        cash_free_cny = cash_avail_cny - used_total_cny
                     else:
-                        cash_free_cny = None
+                        # Fallback: treat used_total_usd as USD and convert into CNY
+                        if fx_usd_per_cny:
+                            usdcny = 1.0 / float(fx_usd_per_cny)
+                            cash_free_cny = cash_avail_cny - (used_total_usd * usdcny)
+                        else:
+                            cash_free_cny = None
 
                 # If no USD cash record in holdings, derive USD equivalent from base CNY using fx.
                 if cash_avail is None and cash_avail_cny is not None and fx_usd_per_cny:
@@ -302,24 +327,24 @@ def process_symbol(
                 cash_avail = None
                 cash_avail_est = None
 
-            # Account-level cash usage: all open short puts (cash has to cover all of them)
-            df_sp_lab['cash_secured_used_usd_total'] = used_total
-            df_sp_lab['cash_secured_used_usd_symbol'] = used_symbol
+            # Account-level cash usage: all open short puts (USD bucket for USD-based reporting)
+            df_sp_lab['cash_secured_used_usd_total'] = used_total_usd
+            df_sp_lab['cash_secured_used_usd_symbol'] = used_symbol_usd
             # Backward-compatible: treat cash_secured_used_usd as account-level used
-            df_sp_lab['cash_secured_used_usd'] = used_total
+            df_sp_lab['cash_secured_used_usd'] = used_total_usd
 
             # If we have true USD cash from holdings, use it; else use USD equivalent derived from base CNY.
             if cash_avail is not None:
                 df_sp_lab['cash_available_usd'] = cash_avail
                 df_sp_lab['cash_available_usd_est'] = pd.NA
-                df_sp_lab['cash_free_usd'] = cash_avail - used_total
+                df_sp_lab['cash_free_usd'] = cash_avail - used_total_usd
                 df_sp_lab['cash_free_usd_est'] = pd.NA
             else:
                 df_sp_lab['cash_available_usd'] = pd.NA
                 df_sp_lab['cash_free_usd'] = pd.NA
                 df_sp_lab['cash_available_usd_est'] = (cash_avail_est if cash_avail_est is not None else pd.NA)
                 if cash_avail_est is not None:
-                    df_sp_lab['cash_free_usd_est'] = cash_avail_est - used_total
+                    df_sp_lab['cash_free_usd_est'] = cash_avail_est - used_total_usd
                 else:
                     df_sp_lab['cash_free_usd_est'] = pd.NA
 
@@ -715,14 +740,22 @@ def main():
             '--output', 'output/reports/symbols_notification.txt',
         ], cwd=base)
 
-        # Append cash summaries at the bottom (LX + SY). Do NOT compute "after-buy" remaining cash.
-        run([
-            py, 'scripts/append_cash_summary.py',
-            '--pm-config', str(pm_config),
-            '--market', str(market),
-            '--accounts', 'lx', 'sy',
-            '--notification', 'output/reports/symbols_notification.txt',
-        ], cwd=base)
+        # Append cash summaries at the bottom (optional).
+        # In multi-account merged notifications, we prefer adding cash footer only once in send_if_needed_multi.py.
+        include_cash_footer = True
+        try:
+            include_cash_footer = bool((cfg.get('notifications') or {}).get('include_cash_footer', True))
+        except Exception:
+            include_cash_footer = True
+
+        if include_cash_footer:
+            run([
+                py, 'scripts/append_cash_summary.py',
+                '--pm-config', str(pm_config),
+                '--market', str(market),
+                '--accounts', 'lx', 'sy',
+                '--notification', 'output/reports/symbols_notification.txt',
+            ], cwd=base)
 
         notifications_cfg = cfg.get('notifications', {}) or {}
         if notifications_cfg.get('enabled', False):

--- a/scripts/run_pipeline_for_account.py
+++ b/scripts/run_pipeline_for_account.py
@@ -68,19 +68,22 @@ def main():
     # keep both legacy + aliasing behavior in run_pipeline.py
     cfg['symbols'] = filtered
 
-    # optionally write filtered config for inspection
+    # write filtered config (always), so the delegated pipeline actually uses per-account overrides.
     if args.out_config:
         outp = Path(args.out_config)
         if not outp.is_absolute():
             outp = (base / outp).resolve()
-        outp.parent.mkdir(parents=True, exist_ok=True)
-        outp.write_text(json.dumps(cfg, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
-        print(f"[DONE] filtered config -> {outp} (symbols={len(filtered)})")
+    else:
+        outp = (base / 'output' / 'state' / f'config.filtered_{acct}.json').resolve()
+
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    outp.write_text(json.dumps(cfg, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"[DONE] filtered config -> {outp} (symbols={len(filtered)})")
 
     # delegate to run_pipeline.py
     import subprocess
     vpy = base / '.venv' / 'bin' / 'python'
-    res = subprocess.run([str(vpy), 'scripts/run_pipeline.py', '--config', str(cfg_path if not args.out_config else outp)], cwd=str(base))
+    res = subprocess.run([str(vpy), 'scripts/run_pipeline.py', '--config', str(outp)], cwd=str(base))
     raise SystemExit(res.returncode)
 
 

--- a/scripts/scan_scheduler.py
+++ b/scripts/scan_scheduler.py
@@ -10,8 +10,6 @@ from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-
-
 @dataclass
 class SchedulerDecision:
     now_utc: str
@@ -79,6 +77,9 @@ def decide(schedule_cfg: dict, state: dict, now_utc: datetime) -> SchedulerDecis
     market_close = parse_hhmm(schedule_cfg.get('market_close', '16:00'))
     in_hours = is_market_hours(now_market, market_open, market_close)
 
+    # Base notification cooldown (minutes).
+    # Content-aware overrides (e.g., HIGH-priority before 02:00 Beijing) are implemented in send_if_needed_multi
+    # after the pipeline generates the notification text.
     notify_cooldown_min = int(schedule_cfg.get('notify_cooldown_min', 60))
 
     # Decide scan interval
@@ -104,6 +105,9 @@ def decide(schedule_cfg: dict, state: dict, now_utc: datetime) -> SchedulerDecis
         # Sparse window: [sparse_after, close_bj_time] (handles DST because close_bj_time changes)
         use_sparse = _time_in_range(now_bj.time(), sparse_after, close_bj_time)
         interval_min = sparse if use_sparse else dense
+
+        # Notification cooldown is handled separately (content-aware) in send_if_needed_multi.
+        # Scheduler keeps a single base cooldown (notify_cooldown_min) here.
 
     last_scan = maybe_parse_dt(state.get('last_scan_utc'))
     last_notify = maybe_parse_dt(state.get('last_notify_utc'))

--- a/scripts/send_if_needed_multi.py
+++ b/scripts/send_if_needed_multi.py
@@ -32,13 +32,203 @@ import json
 import os
 import re
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta, time
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def bj_now() -> str:
+    return datetime.now(timezone.utc).astimezone(ZoneInfo('Asia/Shanghai')).strftime('%Y-%m-%d %H:%M:%S')
+
+
+def read_json(path: Path, default):
+    try:
+        if path.exists() and path.stat().st_size > 0:
+            return json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        pass
+    return default
+
+
+def write_json(path: Path, obj):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+
+
+def parse_hhmm(value: str) -> time:
+    hour, minute = value.split(':', 1)
+    return time(hour=int(hour), minute=int(minute))
+
+
+def maybe_parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def is_high_priority_notification(text: str) -> bool:
+    # notify_symbols.py emits "重点:" when there are high-priority candidates.
+    return bool(re.search(r"(?m)^重点:\s*$", text or ""))
+
+
+def parse_last_json(stdout: str) -> dict:
+    """Parse the last JSON object printed to stdout (tolerant of logs above it)."""
+    lines = (stdout or '').splitlines()
+    buf = []
+    for ln in reversed(lines):
+        if not ln.strip():
+            continue
+        buf.append(ln)
+        if ln.strip().startswith('{'):
+            break
+    txt = '\n'.join(reversed(buf)).strip()
+    return json.loads(txt) if txt else {}
+
+
+def money_cny(v) -> str:
+    try:
+        if v is None:
+            return '-'
+        return f"¥{float(v):,.0f} (CNY)"
+    except Exception:
+        return '-'
+
+
+def _snapshot_fresh(payload: dict, max_age_sec: int) -> bool:
+    if not payload or max_age_sec <= 0:
+        return False
+    try:
+        as_of = payload.get('as_of_utc')
+        if not as_of:
+            return False
+        dt = datetime.fromisoformat(str(as_of))
+        # tolerate naive timestamps by treating them as UTC
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - dt.astimezone(timezone.utc)
+        return age.total_seconds() <= float(max_age_sec)
+    except Exception:
+        return False
+
+
+def query_cash_footer(
+    base: Path,
+    *,
+    market: str,
+    accounts: list[str],
+    timeout_sec: int = 180,
+    snapshot_max_age_sec: int = 900,
+) -> list[str]:
+    """Compute the cash footer once.
+
+    Engineering goals:
+    - Prefer reading per-account cash_snapshot.json (fast + reproducible)
+    - Refresh snapshot when missing/stale
+    - Best-effort: if some account fails, still print others
+    - Make failures visible in the footer
+    """
+    vpy = str(base / '.venv' / 'bin' / 'python')
+
+    lines: list[str] = []
+    payloads: dict[str, dict] = {}
+    errors: dict[str, str] = {}
+
+    def _run_one(acct_l: str) -> tuple[str, dict | None, str | None]:
+        """Return (acct, payload, error)."""
+        state_dir = (base / 'output_accounts' / acct_l / 'state').resolve()
+        state_dir.mkdir(parents=True, exist_ok=True)
+        snap_path = state_dir / 'cash_snapshot.json'
+
+        # 1) Try snapshot first
+        try:
+            if snap_path.exists() and snap_path.stat().st_size > 0:
+                snap = json.loads(snap_path.read_text(encoding='utf-8'))
+                if isinstance(snap, dict) and _snapshot_fresh(snap, snapshot_max_age_sec):
+                    return acct_l, snap, None
+        except Exception:
+            pass
+
+        # 2) Refresh snapshot
+        try:
+            p = subprocess.run(
+                [
+                    vpy,
+                    'scripts/query_sell_put_cash.py',
+                    '--market', str(market),
+                    '--account', acct_l,
+                    '--format', 'json',
+                    '--out-dir', str(state_dir),
+                ],
+                cwd=str(base),
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+            )
+        except Exception as e:
+            return acct_l, None, f"exec_error: {e}"
+
+        if p.returncode != 0:
+            err = (p.stderr or p.stdout or '').strip().splitlines()[-1:]  # last line only
+            return acct_l, None, (err[0] if err else f"returncode={p.returncode}")
+
+        payload = parse_last_json(p.stdout)
+        try:
+            if isinstance(payload, dict) and payload:
+                snap_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+        except Exception:
+            pass
+
+        return acct_l, payload, None
+
+    acct_list = [str(a).strip().lower() for a in accounts if str(a).strip()]
+
+    # Parallelize per-account snapshot read/refresh
+    with ThreadPoolExecutor(max_workers=min(8, max(1, len(acct_list)))) as ex:
+        futs = {ex.submit(_run_one, acct_l): acct_l for acct_l in acct_list}
+        for fut in as_completed(futs):
+            acct_l, payload, err = fut.result()
+            if err:
+                errors[acct_l] = err
+            elif payload is not None:
+                payloads[acct_l] = payload
+
+    if not payloads and not errors:
+        return []
+
+    def asof_bj(payload: dict) -> str:
+        try:
+            s = payload.get('as_of_utc')
+            if not s:
+                return ''
+            dt = datetime.fromisoformat(str(s))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            bj = dt.astimezone(ZoneInfo('Asia/Shanghai'))
+            return bj.strftime('%Y-%m-%d %H:%M')
+        except Exception:
+            return ''
+
+    lines.append('现金（CNY）:')
+    for acct in accounts:
+        acct_l = str(acct).strip().lower()
+        acct_u = acct_l.upper()
+        if acct_l in payloads:
+            payload = payloads[acct_l] or {}
+            t = asof_bj(payload)
+            tag = f" (as_of {t})" if t else ''
+            lines.append(
+                f"{acct_u}: holding {money_cny(payload.get('cash_available_cny'))} | free {money_cny(payload.get('cash_free_cny'))}{tag}"
+            )
+        elif acct_l in errors:
+            lines.append(f"{acct_u}: (cash query failed) {errors[acct_l]}")
+
+    return lines
 
 
 def atomic_symlink(path: Path, target: Path):
@@ -216,39 +406,29 @@ def flatten_auto_close_summary(text: str, *, always_show: bool = False) -> str:
     return ('---\n' + '\n'.join(lines).strip()).strip()
 
 
-def build_merged_message(results: list[AccountResult]) -> str:
-    now = utc_now()
+def build_merged_message(
+    results: list[AccountResult],
+    *,
+    base_cfg: dict | None = None,
+    cash_accounts: list[str] | None = None,
+) -> str:
+    now_bj = bj_now()
     lines: list[str] = []
-    lines.append(f"options-monitor 合并提醒")
-    lines.append(f"UTC: {now}")
+    lines.append("options-monitor 合并提醒")
+    lines.append(f"北京时间: {now_bj}")
     lines.append('')
 
     any_content = False
-    cash_footer: dict[str, str] = {}
+    # Cash footer is computed once at the end (do not rely on parsing per-account notifications).
 
     for r in results:
         if not (r.should_notify and r.meaningful and r.notification_text.strip()):
             continue
         any_content = True
 
-        # Extract and remove any per-notification cash footer (we append both accounts at the very end)
-        txt_lines = r.notification_text.strip().splitlines()
-        kept: list[str] = []
-        in_cash = False
-        for ln in txt_lines:
-            if ln.strip() == '现金结余:':
-                in_cash = True
-                continue
-            if in_cash:
-                # expected: "LX账户 base free(CNY): ¥..."
-                if '账户 base free(CNY):' in ln:
-                    try:
-                        acct2, rest = ln.split('账户', 1)
-                        cash_footer[acct2.strip().upper()] = '账户' + rest
-                    except Exception:
-                        pass
-                continue
-            kept.append(ln)
+        # Per-account notification should not include cash footer anymore.
+        # Keep logic simple: just take the text as-is.
+        kept = r.notification_text.strip().splitlines()
 
         # Count Put/Call blocks for this account (for quick sanity check; sections may be omitted when empty)
         put_n = sum(1 for ln in kept if ' 卖Put ' in ln)
@@ -261,14 +441,30 @@ def build_merged_message(results: list[AccountResult]) -> str:
     if not any_content:
         return ''
 
-    # Append cash footer at the end
-    if cash_footer:
-        lines.append('现金结余:')
-        # Keep deterministic order
-        for acct in ['LX', 'SY']:
-            if acct in cash_footer:
-                lines.append(f"{acct}{cash_footer[acct]}")
-        lines.append('')
+    # Append cash footer at the end (compute once)
+    try:
+        base = Path(__file__).resolve().parents[1]
+        cfg = base_cfg or {}
+        cfg_market = str((cfg.get('portfolio') or {}).get('market') or '富途')
+
+        notif_cfg = (cfg.get('notifications') or {}) if isinstance(cfg, dict) else {}
+        accts = cash_accounts or (notif_cfg.get('cash_footer_accounts') or ['lx', 'sy'])
+        timeout_sec = int(notif_cfg.get('cash_footer_timeout_sec') or 180)
+        max_age_sec = int(notif_cfg.get('cash_snapshot_max_age_sec') or 900)
+
+        footer_lines = query_cash_footer(
+            base,
+            market=cfg_market,
+            accounts=accts,
+            timeout_sec=timeout_sec,
+            snapshot_max_age_sec=max_age_sec,
+        )
+        if footer_lines:
+            lines.extend(footer_lines)
+            lines.append('')
+    except Exception:
+        # best-effort: skip cash footer if anything fails
+        pass
 
     return '\n'.join(lines).strip() + '\n'
 
@@ -287,6 +483,11 @@ def main():
     if not cfg_path.is_absolute():
         cfg_path = (base / cfg_path).resolve()
     base_cfg = json.loads(cfg_path.read_text(encoding='utf-8'))
+
+    schedule_cfg = base_cfg.get('schedule', {}) or {}
+    dense_notify_cooldown_min = int(schedule_cfg.get('notify_cooldown_dense_min', 30))
+    sparse_after_beijing = parse_hhmm(schedule_cfg.get('sparse_after_beijing', '02:00'))
+    bj_tz = ZoneInfo(schedule_cfg.get('beijing_timezone', 'Asia/Shanghai'))
 
     # Ensure output/accounts layout
     accounts_root = (base / 'output_accounts').resolve()
@@ -350,6 +551,17 @@ def main():
             results.append(AccountResult(acct, True, should_notify, False, 'pipeline failed', ''))
             continue
 
+        # Update scan timestamp so the scheduler interval works next tick.
+        # (scan_scheduler.py only updates last_scan_utc in --run-if-due mode, which we don't use here.)
+        try:
+            st = read_json(state_path, {'last_scan_utc': None, 'last_notify_utc': None})
+            if not isinstance(st, dict):
+                st = {'last_scan_utc': None, 'last_notify_utc': None}
+            st['last_scan_utc'] = utc_now()
+            write_json(state_path, st)
+        except Exception:
+            pass
+
         text = notif_path.read_text(encoding='utf-8', errors='replace').strip() if notif_path.exists() else ''
 
         # Append compact auto-close summary (only when applied>0 or errors>0)
@@ -360,10 +572,45 @@ def main():
             text = (text.strip() + '\n\n' + auto_close_flat.strip()).strip()
 
         meaningful = bool(text) and (text != '今日无需要主动提醒的内容。')
-        results.append(AccountResult(acct, True, should_notify, meaningful, reason, text))
 
-    merged = build_merged_message(results)
+        # Content-aware notify override (your preference):
+        # Before Beijing 02:00, allow HIGH-priority notifications as frequently as every 30 minutes.
+        # Medium/changes still follow scan_scheduler's base cooldown (typically 60 minutes).
+        should_notify_effective = should_notify
+        try:
+            now_bj = datetime.now(timezone.utc).astimezone(bj_tz)
+            before_sparse = now_bj.time() < sparse_after_beijing
+            high_pri = meaningful and is_high_priority_notification(text)
+
+            if (not should_notify_effective) and before_sparse and high_pri:
+                st = read_json(state_path, {'last_notify_utc': None})
+                last_notify = maybe_parse_dt((st or {}).get('last_notify_utc')) if isinstance(st, dict) else None
+                if last_notify is None:
+                    should_notify_effective = True
+                    reason = (reason + f" | override(high,dense): last_notify missing")
+                else:
+                    elapsed = datetime.now(timezone.utc) - last_notify.astimezone(timezone.utc)
+                    if elapsed >= timedelta(minutes=dense_notify_cooldown_min):
+                        should_notify_effective = True
+                        reason = (reason + f" | override(high,dense): elapsed>={dense_notify_cooldown_min}m")
+        except Exception:
+            pass
+
+        results.append(AccountResult(acct, True, should_notify_effective, meaningful, reason, text))
+
+    merged = build_merged_message(results, base_cfg=base_cfg, cash_accounts=['lx', 'sy'])
     if not merged:
+        # Even if we didn't send, record that we ran.
+        try:
+            write_json(base / 'output' / 'state' / 'last_run.json', {
+                'last_run_utc': utc_now(),
+                'sent': False,
+                'reason': 'no_merged_notification',
+                'accounts': [r.account for r in results],
+                'results': [r.__dict__ for r in results],
+            })
+        except Exception:
+            pass
         return 0
 
     # Send ONCE
@@ -391,6 +638,32 @@ def main():
                 [str(vpy), 'scripts/scan_scheduler.py', '--config', str(cfg_override), '--state', str(state_path), '--mark-notified'],
                 cwd=str(base),
             )
+
+    # Write shared last_run.json (for cron observability)
+    try:
+        last_run_path = base / 'output' / 'state' / 'last_run.json'
+        prev = read_json(last_run_path, {})
+        run_meta = {
+            'last_run_utc': utc_now(),
+            'sent': True,
+            'channel': str(channel),
+            'target': str(target),
+            'accounts': [r.account for r in results],
+            'results': [r.__dict__ for r in results],
+        }
+        # Keep a small history for debugging (no unbounded growth)
+        hist = prev.get('history') if isinstance(prev, dict) else None
+        if not isinstance(hist, list):
+            hist = []
+        hist.append(run_meta)
+        hist = hist[-20:]
+        write_json(last_run_path, {
+            **(prev if isinstance(prev, dict) else {}),
+            **run_meta,
+            'history': hist,
+        })
+    except Exception:
+        pass
 
     return 0
 


### PR DESCRIPTION
背景 / 问题
通知时间与策略逻辑（北京时间 02:00 前/后）不一致，阅读成本高。
Put 候选的“现金是否覆盖”判断存在口径错误：cash_secured 只按 USD 统计会漏掉 HKD 占用，导致 cash_free_cny 虚高，从而把“实际上现金覆盖不住”的 Put 也推到重点。
multi-account pipeline 中 per-account config（portfolio.account、symbols 过滤）在 run_pipeline_for_account.py 里实际未生效。
合并通知里现金 footer 之前依赖解析文本/重复拼接，逻辑绕且不稳定；并发查询时还存在 output/state 覆盖互串的风险。

主要改动
通知时间统一为北京时间
合并提醒头部仅显示北京时间（去掉 UTC 行）。
修复 Put 现金覆盖口径（关键修复）
run_pipeline.py 计算 cash_free_cny 时优先使用新 schema：cash_secured_total_cny（包含 USD/HKD 等折算后的总占用），避免漏算。
per-account pipeline 真正生效
run_pipeline_for_account.py 现在总是输出 filtered config（默认 output/state/config.filtered_<acct>.json）并用其运行 pipeline，确保 portfolio.account / symbols 过滤生效。
现金 footer 工程化：一次生成、可复盘、避免互串
单账户通知文件不再 append 现金 footer（由合并通知统一输出一次）。
合并通知使用 query_sell_put_cash.py 生成/读取每账户 cash_snapshot.json（默认 15min 以内视为 fresh），缺失/过期再刷新。
支持并行查询；并修复并发下共享 output/state 互相覆盖的问题：新增 --out-dir 并按账户隔离写入 output_accounts/<acct>/state/。
现金行附带 as_of（北京时间）便于核对快照时间。
通知内容小优化
Put/Call 行增加“净收”（净收入取整）字段，阅读更直观。

配置变更
notifications.include_cash_footer=false（现金仅在合并消息统一输出）
notifications.cash_footer_accounts=["lx","sy"]
notifications.cash_footer_timeout_sec=180
notifications.cash_snapshot_max_age_sec=900

验证
LX：cash_free_cny 正确扣除全部担保占用（含 HKD），避免 NVDA 160P 等候选被误判为可做/重点。
合并通知现金行与 query_sell_put_cash.py 输出一致，并显示 as_of（北京时间）。