### PR TITLE
docs: fix SKILL.md local repo path

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: options-monitor
 description: |
   期权监控与提醒（sell put / sell call），支持多账户（lx/sy）分开计算约束，但合并输出。
 
-  代码仓库：/home/node/.openclaw/workspace/options-monitor
+  代码仓库：/home/node/.openclaw/workspace/options-monitor-prod
   上游仓库：https://github.com/liuxie85/options-monitor
 
   主要能力：
@@ -23,7 +23,7 @@ description: |
 ### 1) 生产 tick（多账户合并提醒）
 
 ```bash
-cd /home/node/.openclaw/workspace/options-monitor
+cd /home/node/.openclaw/workspace/options-monitor-prod
 ./.venv/bin/python scripts/send_if_needed_multi.py --config config.json --accounts lx sy
 ```
 


### PR DESCRIPTION
This updates SKILL.md to point to the correct local repo path (`/home/node/.openclaw/workspace/options-monitor-prod`) and fixes the example `cd` command accordingly.