### PR TITLE
Update Web UI with market-based config navigation

### DIFF
--- a/scripts/webui/frontend/src/App.jsx
+++ b/scripts/webui/frontend/src/App.jsx
@@ -16,6 +16,22 @@ function fmtRange(a,b){
   return `${a ?? ''}~${b ?? ''}`;
 }
 
+const MARKETS = [
+  { key: 'hk', label: 'HK', name: '港股市场', exchange: 'HK' },
+  { key: 'us', label: 'US', name: '美股市场', exchange: 'US' },
+];
+
+const GLOBAL_SECTIONS = [
+  ['schedule', '交易时间'],
+  ['notifications', '通知策略'],
+  ['alert_policy', '提醒阈值'],
+  ['runtime', '运行超时'],
+  ['outputs', '输出'],
+  ['fetch_policy', '数据源策略'],
+  ['portfolio', '持仓来源'],
+  ['templates', '策略模板'],
+];
+
 async function api(path, opts={}){
   const r = await fetch(path, opts);
   const j = await r.json().catch(()=>({detail: r.statusText}));
@@ -52,11 +68,20 @@ function toEditHash({configKey, symbol}){
   return `#/edit${q ? `?${q}` : ''}`;
 }
 
+function selectedMarketMeta(key){
+  return MARKETS.find(m=>m.key === key) || MARKETS[0];
+}
+
+function isEmptyObject(v){
+  return v && typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0;
+}
+
 function createNewForm(configKey){
+  const key = (configKey || 'us').toLowerCase();
   return {
-    configKey: (configKey || 'us').toLowerCase(),
+    configKey: key,
     symbol: '',
-    market: '',
+    market: key.toUpperCase(),
     accounts: '',
     limit_expirations: '8',
     sell_put_enabled: 'true',
@@ -97,6 +122,7 @@ export default function App(){
   const [route, setRoute] = useState(()=>parseRoute());
 
   const [rows, setRows] = useState([]);
+  const [configSummaries, setConfigSummaries] = useState({});
   const [tokenRequired, setTokenRequired] = useState(false);
   const [accountOptions, setAccountOptions] = useState([]);
 
@@ -112,6 +138,8 @@ export default function App(){
 
   const [status, setStatus] = useState('-');
   const [toasts, setToasts] = useState([]);
+  const [selectedMarket, setSelectedMarket] = useState('hk');
+  const [configModule, setConfigModule] = useState('global');
 
   function pushToast(kind, text, ms=3000){
     const id = nowId();
@@ -125,8 +153,6 @@ export default function App(){
   // filters
   const [q, setQ] = useState('');
   const [account, setAccount] = useState('');
-  // NOTE: market here means exchange (US/HK) for the underlying
-  const [market, setMarket] = useState('');
   const [putOn, setPutOn] = useState(false);
   const [callOn, setCallOn] = useState(false);
 
@@ -217,6 +243,12 @@ export default function App(){
     })().catch(e=>pushToast('error', e.message));
   },[]);
 
+  async function loadConfigSummaries(){
+    const data = await api('/api/configs/summary');
+    setConfigSummaries(data.configs || {});
+    return data.configs || {};
+  }
+
   async function loadRows(){
     setStatus('loading...');
     const data = await api('/api/watchlist');
@@ -227,6 +259,7 @@ export default function App(){
   }
 
   useEffect(()=>{ loadRows().catch(e=>pushToast('error', e.message)); },[]);
+  useEffect(()=>{ loadConfigSummaries().catch(e=>pushToast('error', e.message)); },[]);
 
   useEffect(()=>{
     if (route.name !== 'edit') return;
@@ -236,6 +269,7 @@ export default function App(){
 
     const configKey = (route.configKey || 'us').toLowerCase();
     const symbol = (route.symbol || '').toUpperCase();
+    setSelectedMarket(configKey === 'us' ? 'us' : 'hk');
 
     if (!symbol){
       setForm(createNewForm(configKey));
@@ -264,8 +298,8 @@ export default function App(){
   const filtered = useMemo(()=>{
     const qq = q.trim().toUpperCase();
     return rows.filter(r=>{
+      if (r.configKey !== selectedMarket) return false;
       if (qq && !String(r.symbol||'').toUpperCase().includes(qq)) return false;
-      if (market && String(r.market||'').toUpperCase() !== market) return false;
       if (account){
         const a = (r.accounts||[]).map(x=>String(x).toLowerCase());
         if (a.length>0 && !a.includes(account)) return false;
@@ -274,11 +308,12 @@ export default function App(){
       if (callOn && !r.sell_call_enabled) return false;
       return true;
     });
-  }, [rows,q,market,account,putOn,callOn]);
+  }, [rows,q,selectedMarket,account,putOn,callOn]);
 
   useEffect(()=>{ setStatus(`rows=${filtered.length}/${rows.length}`); }, [filtered.length, rows.length]);
 
   function goList(){
+    setConfigModule('symbols');
     window.location.hash = '#/';
   }
 
@@ -287,10 +322,11 @@ export default function App(){
   }
 
   function openNew(){
-    goEdit('us', '');
+    goEdit(selectedMarket, '');
   }
 
   function openEdit(row){
+    setSelectedMarket(row.configKey || selectedMarket);
     goEdit(row.configKey, row.symbol);
   }
 
@@ -336,6 +372,7 @@ export default function App(){
       if (tok) headers['x-om-token'] = String(tok).trim();
       const out = await api('/api/watchlist/upsert', {method:'POST', headers, body: JSON.stringify(payload)});
       setRows(out.rows || []);
+      loadConfigSummaries().catch(e=>pushToast('error', e.message));
       setStatus('saved');
       pushToast('ok', '已保存');
       goList();
@@ -362,6 +399,7 @@ export default function App(){
       if (tok) headers['x-om-token'] = String(tok).trim();
       const out = await api('/api/watchlist/delete', {method:'POST', headers, body: JSON.stringify({configKey: form.configKey, symbol})});
       setRows(out.rows || []);
+      loadConfigSummaries().catch(e=>pushToast('error', e.message));
       pushToast('ok', '已删除');
       goList();
     };
@@ -389,12 +427,16 @@ export default function App(){
   }
 
   const isEdit = route.name === 'edit';
+  const marketMeta = selectedMarketMeta(selectedMarket);
+  const currentSummary = configSummaries[selectedMarket] || {};
+  const marketRows = rows.filter(r=>r.configKey === selectedMarket);
+  const enabledRows = marketRows.filter(r=>r.sell_put_enabled || r.sell_call_enabled);
 
   return (
     <>
       <div className="Header">
         <div className="HeaderInner">
-          <div className="Title"><span className="Mark">OM</span> watchlist（合并视图）</div>
+          <div className="Title"><span className="Mark">OM</span> 配置中心</div>
           <div className="Status">{status}</div>
         </div>
       </div>
@@ -402,58 +444,99 @@ export default function App(){
       <div className="Page">
         {!isEdit && (
           <>
-            <div className="Toolbar">
-              <input className={`Control ControlSearch`} value={q} onChange={e=>setQ(e.target.value)} placeholder="Search symbol（NVDA / 0700.HK）" />
-
-              <select className="Control SelectAccount" value={account} onChange={e=>setAccount(e.target.value)}>
-                <option value="">account: all</option>
-                {accountOptions.map(acct => <option key={acct} value={acct}>{acct}</option>)}
-              </select>
-
-              <select className="Control SelectMarket" value={market} onChange={e=>setMarket(e.target.value)}>
-                <option value="">exchange: all</option>
-                <option value="US">US</option>
-                <option value="HK">HK</option>
-              </select>
-
-              <div className="ToggleGroup">
-                <label className="Toggle TogglePut"><input type="checkbox" checked={putOn} onChange={e=>setPutOn(e.target.checked)} /> put</label>
-                <label className="Toggle ToggleCall"><input type="checkbox" checked={callOn} onChange={e=>setCallOn(e.target.checked)} /> call</label>
+            <section className="HeroPanel">
+              <div>
+                <div className="Eyebrow">Runtime Config</div>
+                <h1 className="HeroTitle">按市场管理配置</h1>
+                <p className="HeroText">先选择 HK 或 US，再维护该市场下的全局配置与标的配置，避免在合并列表里来回确认来源。</p>
               </div>
+              <div className="HeroStats">
+                <div className="StatCard"><span>标的</span><strong>{marketRows.length}</strong></div>
+                <div className="StatCard"><span>启用</span><strong>{enabledRows.length}</strong></div>
+                <div className="StatCard"><span>账户</span><strong>{(currentSummary.accounts || []).length || '-'}</strong></div>
+              </div>
+            </section>
 
-              <span className="Spacer ToolbarSpacer" />
-
-              <button className="Button ButtonPrimary BtnNew" onClick={openNew}>新增</button>
+            <div className="MarketSwitch" role="tablist" aria-label="市场">
+              {MARKETS.map(m=>(
+                <button
+                  key={m.key}
+                  className={`MarketTab ${selectedMarket === m.key ? 'MarketTabActive' : ''}`}
+                  onClick={()=>{
+                    setSelectedMarket(m.key);
+                    setQ('');
+                    setAccount('');
+                  }}
+                >
+                  <span>{m.label}</span>
+                  <small>{m.name}</small>
+                </button>
+              ))}
             </div>
 
-            <div className="Box BoxScroll">
-              <table>
-                <thead>
-                  <tr>
-                    <th>config</th><th>exchange</th><th>symbol</th><th>accounts</th><th>put</th><th>call</th>
-                    <th>limit_exp</th><th>put dte</th><th>put strike</th><th>call dte</th><th>call strike</th><th>ops</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtered.map((r)=> (
-                    <tr key={`${r.configKey}-${r.symbol}`}>
-                      <td><span className="Label">{r.configKey}</span></td>
-                      <td>{r.market ?? ''}</td>
-                      <td><strong>{r.symbol}</strong></td>
-                      <td>{(r.accounts && r.accounts.length)? r.accounts.join(',') : <span style={{color:'var(--muted)'}}>all</span>}</td>
-                      <td>{badgeOnOff(r.sell_put_enabled)}</td>
-                      <td>{badgeOnOff(r.sell_call_enabled)}</td>
-                      <td>{r.limit_expirations ?? ''}</td>
-                      <td>{fmtRange(r.sell_put_min_dte, r.sell_put_max_dte)}</td>
-                      <td>{fmtRange(r.sell_put_min_strike, r.sell_put_max_strike)}</td>
-                      <td>{fmtRange(r.sell_call_min_dte, r.sell_call_max_dte)}</td>
-                      <td>{fmtRange(r.sell_call_min_strike, r.sell_call_max_strike)}</td>
-                      <td><button className="LinkBtn" onClick={()=>openEdit(r)}>Edit</button></td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+            <div className="ModuleTabs" role="tablist" aria-label="配置模块">
+              <button className={`ModuleTab ${configModule === 'global' ? 'ModuleTabActive' : ''}`} onClick={()=>setConfigModule('global')}>全局配置</button>
+              <button className={`ModuleTab ${configModule === 'symbols' ? 'ModuleTabActive' : ''}`} onClick={()=>setConfigModule('symbols')}>标的配置</button>
             </div>
+
+            {configModule === 'global' && (
+              <GlobalConfigPanel summary={currentSummary} marketMeta={marketMeta} />
+            )}
+
+            {configModule === 'symbols' && (
+              <>
+                <div className="Toolbar">
+                  <input className={`Control ControlSearch`} value={q} onChange={e=>setQ(e.target.value)} placeholder={`搜索 ${marketMeta.label} 标的（NVDA / 0700.HK）`} />
+
+                  <select className="Control SelectAccount" value={account} onChange={e=>setAccount(e.target.value)}>
+                    <option value="">account: all</option>
+                    {accountOptions.map(acct => <option key={acct} value={acct}>{acct}</option>)}
+                  </select>
+
+                  <div className="ToggleGroup">
+                    <label className="Toggle TogglePut"><input type="checkbox" checked={putOn} onChange={e=>setPutOn(e.target.checked)} /> put</label>
+                    <label className="Toggle ToggleCall"><input type="checkbox" checked={callOn} onChange={e=>setCallOn(e.target.checked)} /> call</label>
+                  </div>
+
+                  <span className="Spacer ToolbarSpacer" />
+
+                  <button className="Button ButtonPrimary BtnNew" onClick={openNew}>新增 {marketMeta.label} 标的</button>
+                </div>
+
+                <div className="Box BoxScroll">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>exchange</th><th>symbol</th><th>accounts</th><th>put</th><th>call</th>
+                        <th>limit_exp</th><th>put dte</th><th>put strike</th><th>call dte</th><th>call strike</th><th>ops</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filtered.map((r)=> (
+                        <tr key={`${r.configKey}-${r.symbol}`}>
+                          <td>{r.market ?? marketMeta.exchange}</td>
+                          <td><strong>{r.symbol}</strong></td>
+                          <td>{(r.accounts && r.accounts.length)? r.accounts.join(',') : <span style={{color:'var(--muted)'}}>all</span>}</td>
+                          <td>{badgeOnOff(r.sell_put_enabled)}</td>
+                          <td>{badgeOnOff(r.sell_call_enabled)}</td>
+                          <td>{r.limit_expirations ?? ''}</td>
+                          <td>{fmtRange(r.sell_put_min_dte, r.sell_put_max_dte)}</td>
+                          <td>{fmtRange(r.sell_put_min_strike, r.sell_put_max_strike)}</td>
+                          <td>{fmtRange(r.sell_call_min_dte, r.sell_call_max_dte)}</td>
+                          <td>{fmtRange(r.sell_call_min_strike, r.sell_call_max_strike)}</td>
+                          <td><button className="LinkBtn" onClick={()=>openEdit(r)}>Edit</button></td>
+                        </tr>
+                      ))}
+                      {!filtered.length && (
+                        <tr>
+                          <td colSpan="11"><span style={{color:'var(--muted)'}}>当前筛选下没有标的配置</span></td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
           </>
         )}
 
@@ -461,7 +544,7 @@ export default function App(){
           <>
             <div className="Box" style={{padding: 12}}>
               <div style={{display:'flex', alignItems:'center', gap: 12, flexWrap:'wrap'}}>
-                <div style={{fontWeight: 800}}>编辑 {form.symbol || ''}</div>
+                <div style={{fontWeight: 800}}>编辑 {form.configKey?.toUpperCase()} 标的 {form.symbol || ''}</div>
                 <div style={{color:'var(--muted)', fontSize: 12}}>写操作需要 token（弹框输入）</div>
               </div>
 
@@ -469,7 +552,7 @@ export default function App(){
                 <div className="FormSection">
                   <div className="SectionTitle">基础</div>
                   <div className="FormGrid">
-                    <Field label="configKey"><select className="Control" value={form.configKey} onChange={e=>setForm({...form, configKey:e.target.value})}><option value="us">us</option><option value="hk">hk</option></select></Field>
+                    <Field label="市场配置"><select className="Control" value={form.configKey} onChange={e=>setForm({...form, configKey:e.target.value, market:e.target.value.toUpperCase()})}><option value="hk">hk</option><option value="us">us</option></select></Field>
                     <Field label="symbol"><input className="Control" value={form.symbol} onChange={e=>setForm({...form, symbol:e.target.value})} placeholder="NVDA / 0700.HK" /></Field>
                     <Field label="exchange"><select className="Control" value={form.market} onChange={e=>setForm({...form, market:e.target.value})}><option value="">(keep)</option><option value="US">US</option><option value="HK">HK</option></select></Field>
                     <Field label="accounts（逗号分隔，空=all）"><input className="Control" value={form.accounts} onChange={e=>setForm({...form, accounts:e.target.value})} placeholder={accountOptions.length ? accountOptions.join(',') : 'account1,account2'} /></Field>
@@ -584,5 +667,59 @@ function Field({label, children}){
       <div className="FieldLabel">{label}</div>
       {children}
     </div>
+  );
+}
+
+function GlobalConfigPanel({summary, marketMeta}){
+  if (!summary || !summary.exists){
+    return (
+      <div className="Box EmptyState">
+        <div className="EmptyTitle">{marketMeta.label} 全局配置未就绪</div>
+        <div className="EmptyText">{summary?.error || '未找到本地 runtime config 文件'}</div>
+        <code>{summary?.path || ''}</code>
+      </div>
+    );
+  }
+
+  const sections = summary.sections || {};
+
+  return (
+    <div className="GlobalPanel">
+      <div className="GlobalOverview">
+        <div>
+          <div className="Eyebrow">{marketMeta.label} Global</div>
+          <h2 className="PanelTitle">全局配置概览</h2>
+          <p className="PanelText">这里汇总市场级配置：账户、交易时间、通知策略、模板和运行参数。当前为只读摘要，避免误改生产配置。</p>
+        </div>
+        <div className="ConfigPath"><span>文件</span><code>{summary.path}</code></div>
+      </div>
+
+      <div className="SummaryGrid">
+        <div className="SummaryCard"><span>账户</span><strong>{(summary.accounts || []).join(', ') || '-'}</strong></div>
+        <div className="SummaryCard"><span>标的总数</span><strong>{summary.symbolCount ?? 0}</strong></div>
+        <div className="SummaryCard"><span>启用标的</span><strong>{summary.enabledSymbolCount ?? 0}</strong></div>
+        <div className="SummaryCard"><span>模板</span><strong>{(sections.templates || []).join(', ') || '-'}</strong></div>
+      </div>
+
+      <div className="SectionGrid">
+        {GLOBAL_SECTIONS.map(([key, label])=>(
+          <ConfigSection key={key} title={label} value={sections[key]} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ConfigSection({title, value}){
+  const empty = value == null || value === '' || (Array.isArray(value) && value.length === 0) || isEmptyObject(value);
+  return (
+    <section className="ConfigSectionCard">
+      <div className="ConfigSectionTitle">{title}</div>
+      {empty ? (
+        <div className="MutedText">未配置</div>
+      ) : (
+        <pre>{JSON.stringify(value, null, 2)}</pre>
+      )}
+    </section>
   );
 }

--- a/scripts/webui/frontend/src/styles.css
+++ b/scripts/webui/frontend/src/styles.css
@@ -1,66 +1,151 @@
-/* GitHub/Primer-ish tokens */
 :root{
   color-scheme: light dark;
 
   /* Light */
-  --fg:#1f2328;
-  --muted:#636c76;
-  --accent:#0969da;
-  --danger:#d1242f;
+  --fg:rgba(0,0,0,0.95);
+  --muted:#615d59;
+  --subtle:#a39e98;
+  --accent:#0075de;
+  --accentActive:#005bab;
+  --danger:#dd5b00;
+  --success:#1aae39;
 
   --bg:#ffffff;
-  --bgMuted:#f6f8fa;
+  --bgMuted:#f6f5f4;
+  --panel:#ffffff;
 
-  --border:#d0d7de;
-  --borderMuted:#d8dee4;
+  --border:rgba(0,0,0,0.10);
+  --borderMuted:rgba(0,0,0,0.07);
 
-  --shadow:0 8px 24px rgba(140,149,159,0.2);
-  --r:6px;
+  --shadow:0 4px 18px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.04);
+  --shadowDeep:0 12px 52px rgba(0,0,0,0.10), 0 2px 8px rgba(0,0,0,0.06);
+  --r:8px;
   --h:32px;
 
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", sans-serif;
   color: var(--fg);
-  background: var(--bg);
+  background:var(--bg);
 }
 
 @media (prefers-color-scheme: dark){
   :root{
-    --fg:#f0f6fc;
-    --muted:#8b949e;
-    --accent:#2f81f7;
-    --danger:#ff7b72;
+    --fg:rgba(255,255,255,0.92);
+    --muted:#a39e98;
+    --subtle:#7d7771;
+    --accent:#097fe8;
+    --accentActive:#2d8ff0;
+    --danger:#ff9b63;
+    --success:#35c759;
 
-    --bg:#0d1117;
-    --bgMuted:#161b22;
+    --bg:#191919;
+    --bgMuted:#242424;
+    --panel:#202020;
 
-    --border:#30363d;
-    --borderMuted:#21262d;
+    --border:rgba(255,255,255,0.11);
+    --borderMuted:rgba(255,255,255,0.08);
 
-    --shadow:0 8px 24px rgba(1,4,9,0.8);
+    --shadow:0 4px 18px rgba(0,0,0,0.18), 0 1px 2px rgba(0,0,0,0.24);
+    --shadowDeep:0 12px 52px rgba(0,0,0,0.32), 0 2px 8px rgba(0,0,0,0.24);
   }
 }
 
 *{box-sizing:border-box;}
-body{margin:0;}
+body{margin:0;min-height:100vh;background:var(--bg);}
 
-.Page{max-width:1280px;margin:0 auto;padding:16px;}
+.Page{max-width:1180px;margin:0 auto;padding:20px 24px 40px;}
 
 .Header{
   position:sticky;top:0;z-index:10;
-  background:var(--bg);
+  background:color-mix(in srgb,var(--bg) 92%, transparent);
+  backdrop-filter:saturate(1.1) blur(10px);
   border-bottom:1px solid var(--border);
 }
-.HeaderInner{max-width:1280px;margin:0 auto;padding:12px 16px;display:flex;align-items:center;gap:12px;}
-.Title{font-size:14px;font-weight:700;display:flex;align-items:center;gap:8px;}
-.Mark{width:22px;height:22px;border:1px solid var(--border);border-radius:6px;background:var(--bgMuted);display:inline-flex;align-items:center;justify-content:center;font-size:12px;color:var(--muted);} 
-.Status{margin-left:auto;color:var(--muted);font-size:12px;}
+.HeaderInner{max-width:1180px;margin:0 auto;padding:10px 24px;display:flex;align-items:center;gap:12px;}
+.Title{font-size:14px;font-weight:600;display:flex;align-items:center;gap:8px;}
+.Mark{width:24px;height:24px;border:1px solid var(--border);border-radius:6px;background:var(--bgMuted);display:inline-flex;align-items:center;justify-content:center;font-size:10px;color:var(--muted);} 
+.Status{margin-left:auto;color:var(--subtle);font-size:12px;}
+
+.HeroPanel{
+  margin:18px 0 12px;
+  padding:20px 22px;
+  border:1px solid var(--border);
+  border-radius:16px;
+  background:var(--bgMuted);
+  box-shadow:none;
+  display:grid;
+  grid-template-columns:minmax(0,1fr) auto;
+  gap:20px;
+  align-items:end;
+}
+.Eyebrow{font-size:12px;font-weight:600;letter-spacing:.01em;color:var(--muted);}
+.HeroTitle{margin:6px 0 6px;font-family:Georgia, "Times New Roman", "Songti SC", serif;font-size:38px;font-weight:700;line-height:1.08;letter-spacing:-.035em;}
+.HeroText,.PanelText{margin:0;color:var(--muted);font-size:15px;line-height:1.55;max-width:640px;}
+.HeroStats{display:grid;grid-template-columns:repeat(3, minmax(92px,1fr));gap:10px;}
+.StatCard,.SummaryCard{
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:var(--panel);
+  padding:12px;
+}
+.StatCard span,.SummaryCard span{display:block;color:var(--muted);font-size:12px;font-weight:500;}
+.StatCard strong,.SummaryCard strong{display:block;margin-top:5px;font-size:22px;line-height:1.1;font-weight:650;}
+
+.MarketSwitch{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:12px;
+  margin:14px 0;
+}
+.MarketTab{
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:14px 16px;
+  background:var(--panel);
+  color:var(--fg);
+  text-align:left;
+  cursor:pointer;
+  box-shadow:var(--shadow);
+  transition:background .16s ease, border-color .16s ease, transform .16s ease;
+}
+.MarketTab:hover{background:var(--bgMuted);transform:translateY(-1px);}
+.MarketTab span{display:block;font-size:26px;font-weight:700;letter-spacing:-.03em;}
+.MarketTab small{display:block;margin-top:4px;color:var(--muted);font-weight:500;}
+.MarketTabActive{
+  border-color:color-mix(in srgb,var(--accent) 38%, var(--border));
+  background:#f2f9ff;
+  box-shadow:0 0 0 1px color-mix(in srgb,var(--accent) 14%, transparent);
+}
+@media (prefers-color-scheme: dark){.MarketTabActive{background:#1c2833;}}
+
+.ModuleTabs{
+  display:flex;
+  gap:8px;
+  padding:4px;
+  border:1px solid var(--borderMuted);
+  border-radius:8px;
+  background:var(--bgMuted);
+  width:max-content;
+  margin:8px 0 16px;
+}
+.ModuleTab{
+  height:30px;
+  border:0;
+  border-radius:5px;
+  padding:0 16px;
+  background:transparent;
+  color:var(--muted);
+  font-weight:600;
+  cursor:pointer;
+}
+.ModuleTabActive{background:var(--panel);color:var(--fg);box-shadow:0 1px 2px rgba(0,0,0,.06);}
 
 .Toolbar{
   margin:16px 0; padding:12px;
   border:1px solid var(--border);
   border-radius: var(--r);
-  background: var(--bgMuted);
+  background: var(--panel);
   display:flex; gap:8px; flex-wrap:wrap; align-items:center;
+  box-shadow:var(--shadow);
 }
 
 .Control{
@@ -68,14 +153,14 @@ body{margin:0;}
   padding: 0 12px;
   border: 1px solid var(--border);
   border-radius: var(--r);
-  background: var(--bg);
+  background: var(--panel);
   color: var(--fg);
   font-size:13px;
   line-height:30px;
   outline:none;
   min-width: 140px;
 }
-.Control:focus{border-color: rgba(9,105,218,0.6); box-shadow: 0 0 0 3px rgba(9,105,218,0.15);} 
+.Control:focus{border-color: var(--accent); box-shadow: 0 0 0 2px color-mix(in srgb,var(--accent) 24%, transparent);} 
 .ControlSearch{min-width:320px;}
 
 select.Control{appearance:none;-webkit-appearance:none;padding-right:34px;background-image:var(--selectArrow);background-repeat:no-repeat;background-position:right 10px center;background-size:16px 16px;}
@@ -102,14 +187,14 @@ select.Control{appearance:none;-webkit-appearance:none;padding-right:34px;backgr
   line-height:1;
 }
 .Button:hover{background:color-mix(in srgb, var(--bgMuted) 65%, transparent);} 
-.ButtonPrimary{background:#2da44e;color:#fff;border-color:rgba(27,31,36,0.15);} 
-.ButtonPrimary:hover{background:#2c974b;}
+.ButtonPrimary{background:var(--accent);color:#fff;border-color:var(--accent);} 
+.ButtonPrimary:hover{background:var(--accentActive);}
 .ButtonDanger{background:var(--danger);color:#fff;border-color:rgba(27,31,36,0.15);} 
 .ButtonDanger:hover{filter:brightness(0.95);} 
 
 .Spacer{margin-left:auto;}
 
-.Box{border:1px solid var(--border);border-radius: var(--r);overflow:hidden;background:var(--bg);} 
+.Box{border:1px solid var(--border);border-radius: var(--r);overflow:hidden;background:var(--panel);box-shadow:var(--shadow);} 
 .Box thead{background:var(--bgMuted);} 
 
 /* scroll container */
@@ -141,14 +226,56 @@ tbody td{padding:10px 12px;border-bottom:1px solid var(--borderMuted);font-size:
 
 tbody tr:hover{background:color-mix(in srgb, var(--bgMuted) 70%, transparent);} 
 
-.Label{display:inline-flex;align-items:center;padding:0 8px;height:20px;border:1px solid var(--border);border-radius:999px;font-size:11px;font-weight:700;color:var(--muted);background:var(--bgMuted);} 
+.Label{display:inline-flex;align-items:center;padding:0 8px;height:20px;border:1px solid var(--border);border-radius:9999px;font-size:11px;font-weight:600;color:var(--muted);background:var(--bgMuted);} 
 
-.Badge{display:inline-flex;align-items:center;height:20px;padding:0 8px;border-radius:999px;font-size:11px;font-weight:700;border:1px solid transparent;}
-.BadgeOn{background: rgba(46,160,67,0.15); color:#1a7f37; border-color: rgba(46,160,67,0.25);} 
+.Badge{display:inline-flex;align-items:center;height:20px;padding:0 8px;border-radius:9999px;font-size:11px;font-weight:600;border:1px solid transparent;}
+.BadgeOn{background: rgba(26,174,57,0.12); color:var(--success); border-color: rgba(26,174,57,0.22);} 
 .BadgeOff{background: rgba(99,108,118,0.12); color: var(--muted); border-color: rgba(99,108,118,0.2);} 
 
 .LinkBtn{padding:0;border:0;background:transparent;color:var(--accent);font-size:12px;font-weight:700;cursor:pointer;}
 .LinkBtn:hover{text-decoration:underline;}
+
+.GlobalPanel{display:grid;gap:14px;}
+.GlobalOverview{
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:18px;
+  background:var(--panel);
+  display:grid;
+  grid-template-columns:minmax(0,1fr) minmax(280px,420px);
+  gap:16px;
+  align-items:end;
+  box-shadow:var(--shadow);
+}
+.PanelTitle{margin:4px 0 6px;font-family:Georgia, "Times New Roman", "Songti SC", serif;font-size:28px;letter-spacing:-.025em;}
+.ConfigPath{border:1px dashed var(--border);border-radius:8px;padding:12px;background:var(--bgMuted);min-width:0;}
+.ConfigPath span{display:block;color:var(--muted);font-size:12px;font-weight:600;margin-bottom:6px;}
+code{font-family:"SFMono-Regular","Cascadia Code",monospace;font-size:12px;white-space:pre-wrap;word-break:break-word;}
+.SummaryGrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;}
+.SummaryCard strong{font-size:18px;word-break:break-word;}
+.SectionGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px;}
+.ConfigSectionCard{
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:var(--panel);
+  overflow:hidden;
+  box-shadow:var(--shadow);
+}
+.ConfigSectionTitle{padding:12px 14px;border-bottom:1px solid var(--borderMuted);font-weight:650;}
+.ConfigSectionCard pre{
+  margin:0;
+  padding:14px;
+  max-height:260px;
+  overflow:auto;
+  color:var(--fg);
+  background:var(--bgMuted);
+  font-size:12px;
+  line-height:1.5;
+}
+.MutedText{padding:14px;color:var(--muted);font-size:13px;}
+.EmptyState{padding:22px;}
+.EmptyTitle{font-size:20px;font-weight:900;margin-bottom:8px;}
+.EmptyText{color:var(--muted);margin-bottom:10px;}
 
 /* Modal (form) */
 .ModalOverlay{
@@ -253,6 +380,9 @@ select.Control{line-height:30px;}
 
 @media (max-width: 960px){
   .FormGrid{grid-template-columns:repeat(2, minmax(0,1fr));}
+  .HeroPanel,.GlobalOverview{grid-template-columns:1fr;}
+  .SummaryGrid{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .SectionGrid{grid-template-columns:1fr;}
 }
 
 @media (max-width: 720px){
@@ -271,6 +401,12 @@ select.Control{line-height:30px;}
 
   .Page{padding:12px;}
   .HeaderInner{padding:10px 12px;}
+  .HeroPanel{padding:16px;}
+  .HeroTitle{font-size:30px;}
+  .HeroStats{grid-template-columns:repeat(3,minmax(0,1fr));}
+  .MarketSwitch{grid-template-columns:1fr;gap:8px;}
+  .ModuleTabs{width:100%;}
+  .ModuleTab{flex:1;}
 
   /* Mobile toolbar layout: fixed grid areas (stable) */
   .Toolbar{
@@ -278,7 +414,7 @@ select.Control{line-height:30px;}
     grid-template-columns: 1fr 1fr;
     grid-template-areas:
       "search search"
-      "account market"
+      "account account"
       "toggles toggles"
       "new new";
     gap:8px;
@@ -293,7 +429,6 @@ select.Control{line-height:30px;}
   .ControlSearch{grid-area: search; min-width:0;}
 
   .SelectAccount{grid-area: account;}
-  .SelectMarket{grid-area: market;}
   .ToggleGroup{
     grid-area: toggles;
     display:flex;

--- a/scripts/webui/server.py
+++ b/scripts/webui/server.py
@@ -67,6 +67,13 @@ def _load_config(config_key: str) -> dict:
         raise HTTPException(status_code=500, detail=f"failed to parse config: {e}")
 
 
+def _try_load_config(config_key: str) -> tuple[dict | None, str | None]:
+    try:
+        return _load_config(config_key), None
+    except HTTPException as e:
+        return None, str(e.detail)
+
+
 def _write_config_atomic(path: Path, cfg: dict):
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(cfg, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -131,7 +138,9 @@ def _to_row(config_key: str, item: dict) -> SymbolRow:
 def _list_rows() -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for k in ("us", "hk"):
-        cfg = _load_config(k)
+        cfg, _err = _try_load_config(k)
+        if cfg is None:
+            continue
         symbols = cfg.get("symbols") or cfg.get("watchlist") or []
         if not isinstance(symbols, list):
             continue
@@ -147,6 +156,59 @@ def _list_rows() -> list[dict[str, Any]]:
 
     rows.sort(key=_key)
     return rows
+
+
+def _global_summary(config_key: str) -> dict[str, Any]:
+    path = CONFIG_FILES[config_key]
+    cfg, err = _try_load_config(config_key)
+    if cfg is None:
+        return {
+            "configKey": config_key,
+            "path": str(path),
+            "exists": path.exists(),
+            "error": err,
+        }
+
+    symbols = cfg.get("symbols") or cfg.get("watchlist") or []
+    if not isinstance(symbols, list):
+        symbols = []
+
+    notifications = cfg.get("notifications") if isinstance(cfg.get("notifications"), dict) else {}
+    schedule = cfg.get("schedule") if isinstance(cfg.get("schedule"), dict) else {}
+    templates = cfg.get("templates") if isinstance(cfg.get("templates"), dict) else {}
+
+    return {
+        "configKey": config_key,
+        "path": str(path),
+        "exists": True,
+        "accounts": accounts_from_config(cfg),
+        "symbolCount": len(symbols),
+        "enabledSymbolCount": sum(
+            1
+            for it in symbols
+            if isinstance(it, dict)
+            and (
+                bool((it.get("sell_put") or {}).get("enabled"))
+                or bool((it.get("sell_call") or {}).get("enabled"))
+            )
+        ),
+        "sections": {
+            "schedule": schedule,
+            "notifications": {
+                "enabled": notifications.get("enabled"),
+                "channel": notifications.get("channel"),
+                "mode": notifications.get("mode"),
+                "include_cash_footer": notifications.get("include_cash_footer"),
+                "quiet_hours_beijing": notifications.get("quiet_hours_beijing"),
+            },
+            "templates": sorted(templates.keys()),
+            "outputs": cfg.get("outputs") if isinstance(cfg.get("outputs"), dict) else {},
+            "runtime": cfg.get("runtime") if isinstance(cfg.get("runtime"), dict) else {},
+            "alert_policy": cfg.get("alert_policy") if isinstance(cfg.get("alert_policy"), dict) else {},
+            "fetch_policy": cfg.get("fetch_policy") if isinstance(cfg.get("fetch_policy"), dict) else {},
+            "portfolio": cfg.get("portfolio") if isinstance(cfg.get("portfolio"), dict) else {},
+        },
+    }
 
 
 def _find_symbol(cfg: dict, symbol: str) -> tuple[int | None, dict | None]:
@@ -249,6 +311,11 @@ def index():
 @app.get("/api/watchlist")
 def api_list_watchlist():
     return {"rows": _list_rows()}
+
+
+@app.get("/api/configs/summary")
+def api_configs_summary():
+    return {"configs": {k: _global_summary(k) for k in ("hk", "us")}}
 
 
 @app.post("/api/watchlist/upsert")


### PR DESCRIPTION
## Summary
- Split the config UI by market with HK/US tabs.
- Add separate modules for global config and symbol config within each market.
- Add a read-only global config summary view for accounts, symbols, templates, schedules, notifications, and runtime sections.
- Restyle the Web UI with a Notion-inspired visual system using muted surfaces, light borders, serif headings, and compact controls.
- Keep symbol add/edit/delete flows scoped to the selected market.

## Testing
- `PYTHONPYCACHEPREFIX=/tmp/om_pycache python3 -m py_compile scripts/webui/server.py`
- `npm run build`