### PR TITLE
Fix HK margin fallback and update Web UI

### DIFF
--- a/scripts/alert_engine.py
+++ b/scripts/alert_engine.py
@@ -205,6 +205,10 @@ def top_pick_line(row: pd.Series) -> str:
             # Unified CNY view
             if req_cny is not None and req_cny > 0:
                 parts.append(f"cash_req_cny ¥{req_cny:,.0f}")
+            elif req is not None and req > 0:
+                # Keep margin display available even when other CNY fields exist
+                # but HKDCNY was unavailable for cash_required_cny.
+                parts.append(f"cash_req ${req:,.0f}")
             if used_total is not None and used_total > 0:
                 parts.append(f"cash_used_total_cny ¥{used_total:,.0f}")
                 if used_symbol is not None and used_symbol > 0:
@@ -216,8 +220,6 @@ def top_pick_line(row: pd.Series) -> str:
 
             # If we don't have CNY view, fallback to legacy USD view
             if not parts:
-                if req is not None and req > 0:
-                    parts.append(f"cash_req ${req:,.0f}")
                 if used_total is not None and used_total > 0:
                     parts.append(f"cash_used_total ${used_total:,.0f}")
                     if used_symbol is not None and used_symbol > 0:

--- a/scripts/pipeline_context.py
+++ b/scripts/pipeline_context.py
@@ -269,13 +269,31 @@ def maybe_auto_close_expired_positions(
         log(f"[WARN] auto-close expired positions failed: {e2}")
 
 
-def load_fx_rates(*, base: Path, state_dir: Path, log) -> tuple[float | None, float | None]:
+def _extract_hkdcny_from_rates(rates: dict | None) -> float | None:
+    if not isinstance(rates, dict):
+        return None
+    value = rates.get('HKDCNY')
+    if value is None:
+        nested = rates.get('rates')
+        if isinstance(nested, dict):
+            value = nested.get('HKDCNY')
+    if value is None:
+        return None
+    try:
+        value = float(value)
+    except Exception:
+        return None
+    return value if value > 0 else None
+
+
+def load_fx_rates(*, base: Path, state_dir: Path, log, shared_state_dir: Path | None = None) -> tuple[float | None, float | None]:
     """Best-effort FX loader.
 
     Keep the original behavior from run_pipeline:
     - load scripts/fx_rates.py via importlib by file path
     - fx_usd_per_cny from get_usd_per_cny(base)
-    - hkdcny from state_dir/rate_cache.json via get_rates
+    - hkdcny from rate_cache.json, preferring the account state dir and then
+      falling back to shared/global caches
     """
     fx_usd_per_cny = None
     hkdcny = None
@@ -292,23 +310,36 @@ def load_fx_rates(*, base: Path, state_dir: Path, log) -> tuple[float | None, fl
         spec.loader.exec_module(mod)  # type: ignore
 
         fx_usd_per_cny = mod.get_usd_per_cny(base)  # type: ignore
+        rate_candidates = [
+            (state_dir / 'rate_cache.json').resolve(),
+        ]
+        if shared_state_dir is not None:
+            rate_candidates.append((shared_state_dir / 'rate_cache.json').resolve())
+        rate_candidates.extend(
+            [
+                (base / 'output_shared' / 'state' / 'rate_cache.json').resolve(),
+                (base / 'output' / 'state' / 'rate_cache.json').resolve(),
+            ]
+        )
         try:
-            rates = mod.get_rates(cache_path=(state_dir / 'rate_cache.json').resolve(), shared_cache_path=None)
-            # Support both legacy {HKDCNY: <value>} and nested {rates: {HKDCNY: <value>}} schemas
-            hkdcny = None
-            if isinstance(rates, dict):
-                hkdcny = rates.get('HKDCNY')
-                if hkdcny is None:
-                    nested = rates.get('rates')
-                    if isinstance(nested, dict):
-                        hkdcny = nested.get('HKDCNY')
-            if hkdcny is not None:
-                try:
-                    hkdcny = float(hkdcny)
-                except Exception:
-                    hkdcny = None
+            rate_candidates.append((base.parents[0] / 'portfolio-management' / '.data' / 'rate_cache.json').resolve())
         except Exception:
-            hkdcny = None
+            pass
+
+        seen: set[str] = set()
+        for cache_path in rate_candidates:
+            key = str(cache_path)
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                hkdcny = _extract_hkdcny_from_rates(
+                    mod.get_rates(cache_path=cache_path, shared_cache_path=None)
+                )
+            except Exception:
+                hkdcny = None
+            if hkdcny is not None:
+                break
     except Exception as e:
         log(f"[WARN] fx rates not available: {e}")
     return fx_usd_per_cny, hkdcny
@@ -383,6 +414,11 @@ def build_pipeline_context(
         log=log,
     )
 
-    fx_usd_per_cny, hkdcny = load_fx_rates(base=base, state_dir=state_dir, log=log)
+    fx_usd_per_cny, hkdcny = load_fx_rates(
+        base=base,
+        state_dir=state_dir,
+        shared_state_dir=shared_state_dir,
+        log=log,
+    )
 
     return portfolio_ctx, option_ctx, fx_usd_per_cny, hkdcny

--- a/tests/test_notify_symbols_markdown.py
+++ b/tests/test_notify_symbols_markdown.py
@@ -136,6 +136,30 @@ def test_notify_symbols_markdown_put_chain_uses_upstream_fields_when_available()
     assert "告警未提供iv" not in out
 
 
+def test_notify_symbols_markdown_put_falls_back_to_usd_margin_when_cny_margin_missing() -> None:
+    out = _render_via_alert_engine(
+        {
+            "symbol": "0700.HK",
+            "strategy": "sell_put",
+            "candidate_count": 1,
+            "top_contract": "2026-04-29 460P",
+            "annualized_return": 0.1721,
+            "net_income": 557.00,
+            "dte": 26,
+            "strike": 460.0,
+            "risk_label": "中性",
+            "delta": -0.23,
+            "cash_required_usd": 58880.0,
+            "cash_free_cny": 200000.0,
+            "mid": 5.72,
+            "option_ccy": "HKD",
+        }
+    )
+
+    assert "保证金占用=$58,880 (USD)" in out
+    assert "告警未提供cash_req_cny/cash_req" not in out
+
+
 def test_notify_symbols_markdown_put_chain_missing_fields_keep_reasons() -> None:
     out = _render_via_alert_engine(
         {

--- a/tests/test_pipeline_context_fx_rates.py
+++ b/tests/test_pipeline_context_fx_rates.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_load_fx_rates_falls_back_to_shared_state_dir_for_hkdcny(tmp_path: Path) -> None:
+    from scripts.pipeline_context import load_fx_rates
+
+    base = Path(__file__).resolve().parents[1]
+    account_state = tmp_path / "output_runs" / "run1" / "accounts" / "lx" / "state"
+    shared_state = tmp_path / "output_runs" / "run1" / "state"
+    account_state.mkdir(parents=True)
+    shared_state.mkdir(parents=True)
+    (shared_state / "rate_cache.json").write_text(
+        json.dumps({"rates": {"HKDCNY": 0.92}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    logs: list[str] = []
+    _usd_per_cny, hkdcny = load_fx_rates(
+        base=base,
+        state_dir=account_state,
+        shared_state_dir=shared_state,
+        log=logs.append,
+    )
+
+    assert hkdcny == 0.92
+
+
+def test_load_fx_rates_falls_back_to_legacy_shared_cache_for_hkdcny(tmp_path: Path) -> None:
+    from scripts import pipeline_context as ctx
+
+    base = Path(__file__).resolve().parents[1]
+    account_state = tmp_path / "account_state"
+    account_state.mkdir()
+    shared_cache = base / "output_shared" / "state" / "rate_cache.json"
+    original = shared_cache.read_text(encoding="utf-8") if shared_cache.exists() else None
+    shared_cache.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        shared_cache.write_text(
+            json.dumps({"rates": {"HKDCNY": 0.91}}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        _usd_per_cny, hkdcny = ctx.load_fx_rates(
+            base=base,
+            state_dir=account_state,
+            log=lambda _msg: None,
+        )
+    finally:
+        if original is None:
+            shared_cache.unlink(missing_ok=True)
+        else:
+            shared_cache.write_text(original, encoding="utf-8")
+
+    assert hkdcny == 0.91


### PR DESCRIPTION
## Summary
- Add HKDCNY FX fallback lookup from account, shared, global, and legacy rate caches.
- Preserve USD margin display when CNY margin is unavailable but USD cash requirement exists.
- Update Web UI frontend and server files.
- Add regression coverage for FX fallback and notification margin rendering.

## Testing
- `PYTHONPYCACHEPREFIX=/tmp/om_pycache python3 -m py_compile scripts/pipeline_context.py scripts/alert_engine.py`
- `PYTHONPYCACHEPREFIX=/tmp/om_pycache python3 -m pytest tests/test_pipeline_context_fx_rates.py tests/test_notify_symbols_markdown.py`
- `PYTHONPYCACHEPREFIX=/tmp/om_pycache python3 -m pytest tests/test_fetch_option_positions_context_rates.py`