### PR TITLE
refactor: decouple Combo Yield runtime from Sell Put

### DIFF
--- a/docs/STRATEGY_ARCHITECTURE.md
+++ b/docs/STRATEGY_ARCHITECTURE.md
@@ -150,6 +150,8 @@ Covered Call 的 `premium_edge_score` 使用与 Sell Put 相同的去重补偿�
 
 Combo Yield 是与 Sell Put、Covered Call 平行的开仓策略，不是 Sell Put 或 Covered Call 的 overlay。当前 runtime key 是 `combo_yield`；历史 `yield_enhancement` 只作为旧配置、旧 artifact 和既有持仓的兼容读取口径。
 
+运行所有权同样独立：per-symbol pipeline 分别调用 Sell Put step 与 Combo Yield step。`sell_put.enabled=false`、Sell Put 扫描失败或 Sell Put 无候选都不会隐式禁用 Combo Yield；Combo Yield 只由自身 `enabled` 和共享 required-data 是否可用决定。它可以复用 Sell Put 配置作为 funding-put 的期限、价格边界和 underwriting 输入，但不复用 Sell Put step 的候选结果或成功状态。共享 required-data 获取仍是 symbol 级前置边界。
+
 当前结构由 `structure_mode` 决定：
 
 | 结构 | 期限关系 | 当前定位 |
@@ -277,7 +279,8 @@ funding_ratio = put_net_credit / call_total_cost
 - 承保定价核心：`domain/domain/insurance_underwriting.py`
 - Sell Put 开仓入口：`src/application/sell_put_strategy_risk.py::enrich_and_filter_sell_put_underwriting`
 - Covered Call 开仓入口：`src/application/covered_call_strategy_risk.py::enrich_and_filter_covered_call_underwriting`
-- Combo Yield 开仓编排：`src/application/combo_yield_steps.py::run_combo_yield_scan_and_summarize`
+- Combo Yield symbol-level 入口：`src/application/combo_yield_steps.py::run_combo_yield_for_symbol_and_summarize`
+- Combo Yield 低层开仓编排：`src/application/combo_yield_steps.py::run_combo_yield_scan_and_summarize`
 - 策略语义解析：`src/application/strategy_policy.py`
 - 扫描上下文装配：`src/application/pipeline_context.py`
 

--- a/docs/gateflow/combo-yield-sell-put-runtime-decoupling-S1-S3-implementation-20260718-164531.md
+++ b/docs/gateflow/combo-yield-sell-put-runtime-decoupling-S1-S3-implementation-20260718-164531.md
@@ -1,0 +1,47 @@
+# Gateflow Implementation Artifact — Combo Yield / Sell Put Runtime Decoupling
+
+- **Gate**: implementation
+- **Work unit**: Combo Yield 与 Sell Put 的运行耦合审计与解耦
+- **Slices**: S1 independent orchestration; S2 caller/prefetch gating; S3 compatibility/docs
+- **Status**: implementation complete, awaiting code review
+
+## Changed files
+
+- `src/application/symbol_monitoring.py`
+- `src/application/pipeline_symbol.py`
+- `src/application/sell_put_steps.py`
+- `src/application/combo_yield_steps.py`
+- `src/application/required_data_prefetch_planning.py`
+- `src/application/multi_tick/required_data_prefetch.py`
+- `tests/test_symbol_monitoring_fetch_spec_merge.py`
+- `tests/test_required_data_prefetch_inprocess.py`
+- `docs/STRATEGY_ARCHITECTURE.md`
+
+## Decisions implemented
+
+1. `run_symbol_monitoring()` computes Combo Yield enablement independently from Sell Put enablement.
+2. Sell Put and Combo Yield are invoked as separate injected application dependencies in stable summary order.
+3. A symbol-level Combo Yield facade owns policy/window/liquidity/event-risk resolution and low-level Combo runner invocation.
+4. Sell Put runner no longer calls Combo Yield.
+5. Strategy exceptions are isolated at symbol orchestration; failing/disabled strategies materialize empty current artifacts to prevent stale recommendations.
+6. Combo Yield separate execution uses its own funding-put scan; Sell Put candidates are used only for legacy inline attachment and only when Sell Put is enabled.
+7. Strategy prefetch includes Combo Yield put and call requirements even when Sell Put recommendation is disabled.
+8. Canonical `required_data_planning.py` remains unchanged.
+
+## Validation
+
+```text
+python3 -m pytest tests/test_symbol_monitoring_fetch_spec_merge.py tests/test_combo_yield_steps.py tests/test_required_data_prefetch_inprocess.py tests/test_sell_put_yield_enhancement_required_data_planning.py -q
+47 passed in 0.62s
+```
+
+## Docs decision
+
+Updated `docs/STRATEGY_ARCHITECTURE.md` to distinguish shared funding-put capabilities/config from independent runtime step ownership.
+
+## Residual risks
+
+- Shared required-data acquisition failure remains symbol-level: assigned to later work unit if independent fetch failure domains are required.
+- Duplicate funding-put scans remain accepted current cost.
+- Legacy inline mode cannot attach Combo output when Sell Put is disabled/failed; separate output remains canonical and independent.
+- Existing dirty changes overlap some touched files; accepted-slice commit requires precise ownership handling before commit.

--- a/docs/gateflow/combo-yield-sell-put-runtime-decoupling-aggregate-fix-20260718-165238.md
+++ b/docs/gateflow/combo-yield-sell-put-runtime-decoupling-aggregate-fix-20260718-165238.md
@@ -1,0 +1,21 @@
+# Aggregate Deepreview Fix — Combo Yield / Sell Put Runtime Decoupling
+
+- **Finding**: ADR-1
+- **Decision**: accepted
+- **Status**: fixed
+
+## Fix
+
+- Made `run_combo_yield_scan_fn`, `empty_combo_yield_summary_fn`, `materialize_empty_sell_put_artifacts_fn`, and `materialize_empty_combo_yield_artifacts_fn` required `SymbolMonitoringDependencies` fields.
+- Removed optional guards from runtime orchestration.
+- Updated every test composition root to wire explicit Combo and artifact dependencies.
+
+## Validation
+
+- affected strategy/data tests: 83 passed
+- multi-tick/notification/architecture tests: 106 passed
+- diff check and compileall: passed
+
+## Residual risks
+
+All classified: duplicate scan accepted; shared fetch failure assigned to later work unit.

--- a/docs/gateflow/combo-yield-sell-put-runtime-decoupling-final-closeout-20260718-170107.md
+++ b/docs/gateflow/combo-yield-sell-put-runtime-decoupling-final-closeout-20260718-170107.md
@@ -1,0 +1,56 @@
+# Gateflow Final Closeout — Combo Yield / Sell Put Runtime Decoupling
+
+- **Work unit**: Combo Yield 与 Sell Put 的运行耦合审计与解耦
+- **Status**: final closeout pass
+- **Draft PR**: https://github.com/liuxie066/options-monitor/pull/74
+- **PR base**: `codex/diagonal-combo-yield-lifecycle` (stacked on #73)
+- **PR head**: `codex/runtime-decoupling-isolation-backup`
+
+## What changed
+
+- Combo Yield is now an explicit per-symbol strategy step rather than a tail call inside Sell Put.
+- `combo_yield.enabled` controls Combo execution independently from `sell_put.enabled`.
+- Sell Put disabled, exception, account prefilter rejection, or empty candidates no longer implicitly stop Combo Yield.
+- Combo Yield owns a symbol-level facade that resolves its policy, funding-put window, liquidity/event-risk context, artifacts and low-level pairing call.
+- Required-data planning callers and scheduled prefetch request Combo put/call data independently from Sell Put recommendation enablement.
+- Disabled/failed strategy paths replace fixed-path artifacts with explicit empty outputs to prevent stale recommendations.
+- Combo/Sell Put composition dependencies are required, so missing runtime wiring fails at construction instead of silently skipping Combo.
+
+## What was verified
+
+- Sell Put disabled + Combo enabled: Combo fetches and runs.
+- Sell Put exception: Sell Put artifacts clear; Combo continues.
+- Sell Put empty: Combo independently scans its funding-put universe.
+- Combo exception: Combo artifacts clear; Sell Put result survives.
+- Account prefilter disables Sell Put: Combo retains original market funding configuration.
+- Diagonal Combo call DTE prefetch remains intact.
+- Aggregate local suite: 189 tests passed under Python 3.12.
+- `git diff --check`: passed.
+- application compileall: passed.
+- GitHub reports no CI checks configured/reported for PR #74.
+
+## Docs updates
+
+`docs/STRATEGY_ARCHITECTURE.md` now states that Combo Yield has independent product and runtime ownership while reusing Sell Put funding configuration/capabilities.
+
+## Finding status
+
+- Plan review PR-1/2/3: fixed and re-reviewed.
+- Code review CR-1/2/3: fixed and re-reviewed.
+- Aggregate deepreview ADR-1: fixed and re-reviewed.
+- PR review PR74-1 scope contamination: fixed through clean-history rebuild and exact-SHA guarded force-with-lease; re-reviewed.
+- No unresolved accepted findings.
+
+## Remaining risks / owners
+
+- Shared required-data acquisition failure remains a symbol-level boundary. **Owner**: later work unit if per-strategy fetch isolation becomes a product requirement.
+- Sell Put and Combo Yield independently scan funding-put candidates when both run. **Owner**: accepted runtime cost; optimize only with evidence that cost is material and without recoupling execution.
+- PR #74 is stacked on #73. **Owner**: retarget #74 to `main` after #73 merges if GitHub does not update the base automatically.
+
+## Issue link status
+
+No GitHub issue was supplied for this work unit; no issue closing keyword or closeout comment is required.
+
+## Next entry point
+
+Review draft PR #74 after #73 is merged/ready. Retarget to `main` if necessary, rerun CI/local affected tests against the final base, then mark ready/merge only with CEO authorization.

--- a/docs/gateflow/combo-yield-sell-put-runtime-decoupling-fix-20260718-164830.md
+++ b/docs/gateflow/combo-yield-sell-put-runtime-decoupling-fix-20260718-164830.md
@@ -1,0 +1,26 @@
+# Gateflow Fix Artifact — Combo Yield / Sell Put Runtime Decoupling
+
+- **Gate**: fix
+- **Review**: `docs/reviews/code-review-20260718-164805.md`
+- **Status**: fixes implemented
+
+## Finding resolutions
+
+| Finding | Decision | Fix |
+|---|---|---|
+| CR-1 | accepted | Removed obsolete `yield_window/yield_sp` reference and unused market gate; Sell Put runner now owns only Sell Put config. |
+| CR-2 | accepted | Disabled and exception branches materialize empty Sell Put/Combo artifacts; Combo facade does not read Sell Put artifact when Sell Put is disabled. |
+| CR-3 | accepted | Replaced nested-ownership tests with explicit Sell Put-only regression; retained Combo-owned cash/underwriting coverage. |
+
+## Validation
+
+- affected strategy/data tests: `83 passed`
+- multi-tick/notification/architecture tests: `106 passed`
+- `git diff --check`: pass
+- `python3 -m compileall -q src/application`: pass
+
+## Residual risks
+
+- Shared required-data failure: assigned to later work unit.
+- Duplicate funding-put scans: accepted current cost.
+- Commit isolation: requires explicit user decision because pre-existing staged hunks overlap touched files.

--- a/docs/gateflow/combo-yield-sell-put-runtime-decoupling-goal-confirmation-20260718.md
+++ b/docs/gateflow/combo-yield-sell-put-runtime-decoupling-goal-confirmation-20260718.md
@@ -1,0 +1,97 @@
+# Gateflow Goal Confirmation — Combo Yield 与 Sell Put 运行解耦
+
+- **Gate**: goal confirmation
+- **Work unit**: Combo Yield 与 Sell Put 的运行耦合审计与解耦
+- **Date**: 2026-07-18
+- **Branch**: `codex/diagonal-combo-yield-lifecycle`
+- **Status**: awaiting user confirmation
+
+## 目标
+
+让已经拥有独立产品身份的 Combo Yield，在每个 symbol 的运行编排中也成为独立策略 step：是否运行只由 Combo Yield 自身配置和其必要输入决定，不再要求 Sell Put step 被启用或成功完成。
+
+## 动机
+
+当前产品架构已声明 Combo Yield 与 Sell Put、Covered Call 平行，但实际执行仍通过 `run_sell_put_scan_and_summarize()` 尾部触发。这导致 Combo Yield 的可用性和故障域被 Sell Put 的开关、前置过滤及异常路径隐式控制，产品所有权与运行所有权不一致。
+
+## 直接代码证据
+
+1. `src/application/symbol_monitoring.py`
+   - `want_yield_enhancement = bool(market_want_put and yield_enhancement_policy.enabled)`：Combo Yield 明确依赖原始 Sell Put `enabled=true`。
+   - symbol pipeline 只有一个 `run_sell_put_scan_fn` dependency；当 `want_put or want_yield_enhancement` 时调用 Sell Put runner。
+   - Combo Yield 没有独立 dependency、独立调用或独立异常边界。
+
+2. `src/application/sell_put_steps.py`
+   - `run_sell_put_scan_and_summarize()` 先执行 Sell Put，再无条件在函数尾部调用 `run_combo_yield_scan_and_summarize()`。
+   - 两个策略共享同一调用栈；Sell Put scan、label、cash filter、underwriting 或其外围代码抛出异常时，控制流到不了 Combo Yield。
+
+3. `src/application/combo_yield_steps.py`
+   - Combo Yield 实际已具备独立 runner。
+   - 它会独立扫描自己的 funding-put universe，并不需要 Sell Put 的候选结果才能配对；`df_sell_put_labeled` 只用于 legacy inline attachment。
+   - 因此“Sell Put 无候选”理论上不应阻断 separate Combo Yield；但当前调用位置仍使其受 Sell Put runner 的前序执行影响。
+
+4. required-data / prefetch 路径仍存在相同 gating：
+   - `src/application/required_data_prefetch_planning.py`
+   - `src/application/multi_tick/required_data_prefetch.py`
+   - 两处均以 `want_put and yield_policy.enabled` 判断 Combo Yield 数据需求，Sell Put 禁用时不会为 Combo Yield 请求 put/call 数据。
+
+5. 现有测试只覆盖了“Sell Put 被账户 prefilter 禁用但市场配置仍启用”时继续调用复合 runner；没有覆盖产品级 Sell Put disabled、Sell Put runner exception、Sell Put empty candidates 三个核心状态的独立行为矩阵。
+
+## 已确认的当前行为矩阵
+
+| 场景 | 当前行为 | 期望方向 |
+|---|---|---|
+| Sell Put 配置 `enabled=false`，Combo Yield `enabled=true` | Combo Yield 不取数、不执行 | Combo Yield 独立取数并执行 |
+| Sell Put 原始启用，但账户 prefilter 将 `want_put=false` | Combo Yield仍可通过 Sell Put runner 执行 | 保持可执行，但改由独立 step 表达 |
+| Sell Put scan/label/filter 抛异常 | 同调用栈中断，Combo Yield不执行 | Sell Put 失败不应自动阻断 Combo Yield；各自 fail-closed、独立记录 |
+| Sell Put 无候选但没有异常 | Combo Yield会再次扫描独立 funding-put universe，仍可能产出组合 | 保持此语义，并用显式测试锁定 |
+| Combo Yield 自身无 funding put / 无 pair | 产出空结果及 trace reason | 保持 fail-closed 和可诊断性 |
+
+## 成功信号
+
+1. symbol orchestration 中存在显式、独立的 Combo Yield step/dependency，而不是由 Sell Put runner 尾部触发。
+2. `sell_put.enabled=false + combo_yield.enabled=true` 时，required-data planning、prefetch 和 symbol execution 都仍请求所需 put/call 数据并运行 Combo Yield。
+3. Sell Put runner 失败时，Combo Yield 的运行由独立故障边界决定；Combo Yield 自身可继续运行并返回/记录自己的结果。
+4. Sell Put 无候选时，Combo Yield 仍基于自身 funding-put universe 扫描，不复用空 Sell Put 候选作为阻断条件。
+5. Sell Put 与 Combo Yield 的 summary 顺序、通知汇总、既有 separate 输出契约保持兼容。
+6. focused tests 覆盖至少上述三种关键场景，并通过相关 pipeline、required-data、Combo Yield 和 notification tests。
+7. 架构文档明确产品所有权与运行所有权均已独立。
+
+## Scope boundary
+
+### 本 work unit 包含
+
+- per-symbol orchestration 的 Sell Put / Combo Yield step 分离；
+- Combo Yield 独立 enablement 计算；
+- required-data planning 与 scheduled prefetch 的独立 Combo Yield gating；
+- 必要的 dependency injection、summary aggregation、故障隔离与诊断；
+- 回归测试和对应架构文档更新。
+
+### 本 work unit 不包含
+
+- 改变 Combo Yield 配对、评分、underwriting、现金过滤或生命周期业务规则；
+- 改变生产配置值、账户配置或通知开关；
+- 改变 trade intake、position pairing、close advice 或 broker-facing state；
+- 为未来策略建立通用 plugin framework / strategy registry；当前只做最小的第二个明确 step；
+- 清理所有 legacy `yield_enhancement` 命名；只在触及的运行边界使用当前 canonical `combo_yield` 语义。
+
+## 关键设计约束
+
+- Combo Yield 可以复用 Sell Put 的 funding-put 配置参数和底层扫描/过滤函数，但复用能力不等于依赖 Sell Put step 的执行结果或成功状态。
+- separate 输出是当前 canonical 行为；legacy inline/both 模式如继续支持，必须明确其对 Sell Put artifact 的依赖，不能让该兼容路径重新绑死 separate Combo Yield。
+- 所有策略失败都应 fail-closed；“独立故障域”不代表吞掉异常或伪造成功结果。
+- 不修改真实通知、生产配置、持仓或 broker-facing 数据。
+
+## Blocking open question
+
+无。默认产品决策为：当 Combo Yield 自身启用且输入可获得时，它应独立运行；Sell Put disabled、失败或无候选都不是 Combo Yield 的隐式禁用条件。
+
+## Residual risks at this gate
+
+- legacy `output_mode=inline|both` 需要 Sell Put labeled artifact；计划阶段需决定最小兼容边界。
+- symbol-level exception handling 当前可能由更上层统一承担；计划阶段需确认独立故障隔离放在 orchestration 还是 runner adapter，避免吞掉基础设施级致命错误。
+- dirty worktree 含其他已确认保留的在途改动；后续 commit 必须精确 stage 当前 work unit 文件。
+
+## Next gate
+
+用户确认本目标与边界后进入 `plan`。

--- a/docs/gateflow/combo-yield-sell-put-runtime-decoupling-plan-20260718.md
+++ b/docs/gateflow/combo-yield-sell-put-runtime-decoupling-plan-20260718.md
@@ -1,0 +1,183 @@
+# Gateflow Plan — Combo Yield 与 Sell Put 运行解耦
+
+- **Gate**: plan
+- **Work unit**: Combo Yield 与 Sell Put 的运行耦合审计与解耦
+- **Date**: 2026-07-18
+- **Goal artifact**: `docs/gateflow/combo-yield-sell-put-runtime-decoupling-goal-confirmation-20260718.md`
+- **Status**: proposed
+
+## Design decision
+
+在 `run_symbol_monitoring()` 建立两个显式策略 step：Sell Put step 和 Combo Yield step。二者共享 required-data fetch 和 funding-put 配置，但调用、summary、异常结果与 enablement 独立。`run_sell_put_scan_and_summarize()` 恢复为只负责 Sell Put；`run_combo_yield_scan_and_summarize()` 由 symbol orchestrator 直接调用。
+
+不引入 registry、base class 或通用 pipeline framework。仅增加一个明确 dependency 和一个窄 adapter/context preparation boundary。
+
+## Behavioral contract
+
+1. `sell_put.enabled` 只控制 Sell Put recommendation step。
+2. `combo_yield.enabled` 只控制 Combo Yield recommendation step。
+3. Combo Yield 使用 Sell Put 配置作为 funding-put underwriting 参数；Sell Put 配置对象存在但 `enabled=false` 时，其他参数仍可作为 Combo Yield 输入。
+4. required-data `want_put/want_call` 是所有启用策略需求的并集。
+5. Sell Put empty result 不传递为 Combo Yield input gate；Combo Yield独立扫描 funding-put universe。
+6. Sell Put exception 不阻止 Combo Yield。策略 step exception 在 symbol orchestration 层转换为该策略的 fail-closed empty summary，并保留日志；基础 required-data 获取失败仍属于共享前置失败，不在本 work unit 隔离。
+7. canonical `output_mode=separate` 完全独立。legacy `inline|both` 仅在 Sell Put labeled artifact存在时执行 attachment；Sell Put disabled/failed 时 separate Combo Yield 仍正常，inline attachment best-effort/fail-closed，不反向阻断 Combo Yield summary。
+
+## Implementation slices
+
+### S1 — Independent orchestration and runner ownership
+
+**Files expected**
+
+- `src/application/symbol_monitoring.py`
+- `src/application/pipeline_symbol.py`
+- `src/application/sell_put_steps.py`
+- optionally a narrow adapter/helper in `src/application/` only if signature size demands it
+- `tests/test_symbol_monitoring_fetch_spec_merge.py`
+- focused Sell Put/Combo Yield tests
+
+**Changes**
+
+1. Extend `SymbolMonitoringDependencies` with `run_combo_yield_scan_fn` and an empty/failure summary surface if required.
+2. Compute `want_combo_yield = yield_policy.enabled` independently of `market_want_put`.
+3. Invoke Sell Put only when post-prefilter `want_put`; invoke Combo Yield independently when `want_combo_yield`.
+4. Move Combo Yield invocation out of `run_sell_put_scan_and_summarize()`.
+5. Preserve summary ordering as Sell Put, Combo Yield, Sell Call.
+6. Add narrow per-strategy fail-closed exception isolation around Sell Put and Combo Yield invocations, with `log.exception` and explicit empty summary rows where existing report contract expects a row.
+7. Pass original market Sell Put config to Combo Yield as `yield_sp`, while passing artifact paths/context explicitly.
+
+**Tests**
+
+- Sell Put disabled + Combo Yield enabled invokes only Combo Yield.
+- Sell Put raises + Combo Yield enabled still invokes Combo Yield.
+- Sell Put returns empty + Combo Yield enabled still invokes Combo Yield.
+- Combo Yield raises does not erase Sell Put result and fails closed.
+- existing account-prefilter behavior remains valid.
+- summary order remains stable.
+
+### S2 — Required-data and scheduled prefetch decoupling
+
+**Files expected**
+
+- `src/application/symbol_monitoring.py`
+- `src/application/required_data_prefetch_planning.py`
+- `src/application/multi_tick/required_data_prefetch.py`
+- `src/application/required_data_planning.py` only if current canonical planner still couples enablement
+- related required-data/prefetch tests
+
+**Changes**
+
+1. Replace `want_put and combo_enabled` gates with independent Combo Yield enablement.
+2. Required data union:
+   - put data when Sell Put or Combo Yield enabled;
+   - call data when Sell Call or Combo Yield enabled;
+   - RV only according to the independent strategy policies.
+3. Preserve funding-put strike/DTE config for Combo Yield even when Sell Put recommendation is disabled.
+4. Ensure both direct symbol fetch and scheduled multi-tick prefetch follow the same contract.
+
+**Tests**
+
+- disabled Sell Put + enabled Combo Yield requests put and call.
+- disabled Sell Put + disabled Combo Yield does not request Combo Yield data.
+- diagonal call DTE window remains intact.
+- existing merged multi-account prefetch behavior remains unchanged.
+
+### S3 — Compatibility, diagnostics, and documentation
+
+**Files expected**
+
+- `src/application/combo_yield_steps.py`
+- tests for `output_mode` compatibility if needed
+- `docs/STRATEGY_ARCHITECTURE.md`
+- possibly `docs/DEPENDENCY_GRAPH.md` / `docs/dependency_graph.mmd` only if their runtime edge is authoritative and currently wrong
+
+**Changes**
+
+1. Remove unnecessary hard dependency on live Sell Put dataframe for separate mode; allow an empty/missing Sell Put artifact input.
+2. Keep inline attachment best-effort and explicit; do not let compatibility behavior gate separate Combo Yield execution.
+3. Add/retain trace reasons for Combo Yield’s own empty/failure states.
+4. Update architecture docs to state independent runtime ownership and shared capability/config reuse.
+
+**Tests**
+
+- no Sell Put candidates still allows Combo Yield independent universe and recommendation.
+- no Sell Put artifact with separate mode works.
+- inline/both behavior is deterministic and fail-closed.
+
+## Validation plan
+
+Focused per slice, then aggregate:
+
+```bash
+python3 -m pytest \
+  tests/test_symbol_monitoring_fetch_spec_merge.py \
+  tests/test_combo_yield_steps.py \
+  tests/test_sell_put_yield_enhancement_required_data_planning.py \
+  tests/test_required_data_prefetch_inprocess.py
+
+python3 -m pytest \
+  tests/test_multi_tick_*.py \
+  tests/test_unified_tick_entrypoint.py \
+  tests/test_notify_symbols_markdown.py \
+  tests/test_multi_tick_notify_format.py
+
+python3 -m pytest tests/test_architecture_guards.py
+```
+
+Run broader affected-area tests if focused failures reveal shared contracts. Do not run production tick or notification commands.
+
+## Docs decision
+
+Update strategy architecture because the public conceptual contract changes from “product independent, runtime nested” to “product and runtime independent.” Update dependency graph only where it explicitly models the old `Sell Put -> Combo Yield` execution edge.
+
+## Rollback strategy
+
+Changes are facade-preserving and local to orchestration. Each slice receives its own accepted commit. Rollback can revert the independent orchestration commit(s) without modifying config or persisted state. No migration is required.
+
+## Residual risks
+
+- **Legacy inline/both output**: covered by S3; compatibility attachment may not exist when Sell Put is disabled, but separate result must remain valid.
+- **Shared required-data failure**: explicitly outside strategy-step isolation and remains a symbol-level failure; assigned to a later work unit if product requires per-strategy fetch isolation.
+- **Duplicate funding-put scans when both strategies run**: accepted current cost; eliminating it would couple results or require caching and is out of scope.
+- **Dirty worktree overlap**: controlled by precise staging and diff review before every commit.
+
+## Completion criteria
+
+All slices accepted; plan/code/deepreview artifacts complete; focused and aggregate validation passes; docs match runtime; only work-unit files are committed; draft PR opened and reviewed through Gateflow final closeout.
+
+## Plan review fixes
+
+### Resolution of PR-1 — facade ownership
+
+**Accepted.** Add a symbol-level facade in `src/application/combo_yield_steps.py`, tentatively `run_combo_yield_for_symbol_and_summarize(...)`. Its public application inputs are limited to raw symbol/config/runtime context already available to `run_symbol_monitoring`: `base`, symbol identifiers, `symbol_cfg`, original Sell Put funding config, top-N, required/report directories, schedule flag, converter, portfolio context, and global Sell Put liquidity/event-risk defaults. The facade owns:
+
+- resolving Combo Yield config and policy;
+- resolving funding-put candidate window, liquidity and event-risk defaults;
+- constructing optional Sell Put labeled artifact path for legacy inline attachment;
+- wiring the low-level scan/filter/pairing helpers;
+- materializing Combo Yield empty artifacts on disabled/failure paths.
+
+`run_symbol_monitoring` does not import or construct `CandidateWindowDefaults` or other low-level scan details. `run_sell_put_scan_and_summarize` no longer calls or prepares Combo Yield.
+
+### Resolution of PR-2 — fail-closed artifacts
+
+**Accepted.** Each independently invoked strategy step must clear/materialize its current report artifacts before work that may throw, or its symbol-level facade must do so in the exception path. For Combo Yield this includes candidates and alerts plus any current-run diagnostic outputs that could otherwise remain stale. For Sell Put, preserve existing empty artifact behavior and add an orchestration failure helper only where injected exceptions bypass it.
+
+The symbol orchestrator logs the exception with strategy and symbol, appends the strategy’s explicit empty summary, and continues to the next independent strategy. Tests seed stale artifacts, inject a failure, and assert the failing strategy’s current artifacts are empty/replaced while the other strategy still executes.
+
+Programmer/config errors are still visible through `log.exception` and diagnostics; they are not reported as successful scans. Shared required-data acquisition remains outside this isolation.
+
+### Resolution of PR-3 — planner scope
+
+**Accepted.** `src/application/required_data_planning.py` is a protected non-change target unless a failing test proves a defect. It already models Combo Yield independently. S2 changes only caller-level gates in:
+
+- `src/application/symbol_monitoring.py`;
+- `src/application/required_data_prefetch_planning.py`;
+- `src/application/multi_tick/required_data_prefetch.py`.
+
+Existing canonical planner tests will be used as regression evidence, especially diagonal DTE behavior.
+
+## Revised slice boundaries
+
+- **S1**: introduce the Combo Yield symbol facade, remove nested invocation, add independent orchestration and strategy failure artifacts/tests.
+- **S2**: repair only caller/prefetch enablement gates; leave canonical planner unchanged.
+- **S3**: finalize inline/both compatibility, diagnostics and docs after independent separate-mode behavior is proven.

--- a/docs/gateflow/combo-yield-sell-put-runtime-decoupling-pr74-fix-20260718-165953.md
+++ b/docs/gateflow/combo-yield-sell-put-runtime-decoupling-pr74-fix-20260718-165953.md
@@ -1,0 +1,24 @@
+# PR #74 Fix Artifact — Runtime Decoupling
+
+- **Finding**: PR74-1
+- **Decision**: accepted
+- **Status**: fixed
+
+## Fix performed
+
+1. Created isolated worktree from latest `origin/codex/diagonal-combo-yield-lifecycle` (`634ef0e1`).
+2. Cherry-picked only the reviewed work-unit commits into clean hashes:
+   - `9e3bd4ff` accepted plan
+   - `02ae80b4` accepted implementation
+   - `3cede68a` required-dependency fix
+   - `8337740f` accepted deepreview artifacts
+3. Ran the 189-test aggregate suite under Python 3.12: all passed.
+4. Updated only `codex/runtime-decoupling-isolation-backup` with exact-SHA guarded `--force-with-lease`.
+
+## Scope verification
+
+PR metadata now lists exactly the four work-unit commits and only runtime-decoupling code/tests/docs/artifacts. The unrelated diagonal final-closeout file is absent.
+
+## Residual risk
+
+Stacked base retarget after #73 merge remains an explicit PR follow-up.

--- a/docs/reviews/code-review-20260718-164805.md
+++ b/docs/reviews/code-review-20260718-164805.md
@@ -1,0 +1,65 @@
+# Code Review — Combo Yield / Sell Put Runtime Decoupling
+
+## Scope
+
+- Mode: current slice changes
+- Branch: `codex/diagonal-combo-yield-lifecycle`
+- Base: accepted plan commit `ae9c748a`
+- Included: symbol orchestration, Combo facade, Sell Put ownership removal, prefetch gating, focused tests, architecture doc
+- Excluded: unrelated dirty worktree changes and option-performance/lifecycle work
+- Parallel review coverage: none
+
+## Findings
+
+### CR-1-未修复-高-Sell Put runner 保留已删除局部变量引用
+- **入口/函数**: `run_sell_put_scan_and_summarize`
+- **文件(行号)**: `src/application/sell_put_steps.py`, candidate configuration setup
+- **输入场景**: any enabled Sell Put symbol
+- **实际分支**: runner resolves `yield_window` from `yield_sp` after Combo policy setup was removed
+- **预期行为**: Sell Put runner should resolve only its own window and execute independently
+- **实际行为**: raises `NameError` before scanning, preventing both Sell Put and downstream independent orchestration behavior
+- **直接证据**: `tests/test_global_liquidity_filters.py` initially produced 12 failures at the undefined `yield_sp` reference
+- **影响**: Sell Put unavailable for every enabled symbol
+- **建议改法和验证点**: remove the obsolete `yield_window` line; run full Sell Put liquidity/filter tests
+- **修复风险（低/中/高）**: low
+- **严重程度（低/中/高/严重）**: high
+
+### CR-2-未修复-高-禁用策略未清空固定路径 artifact
+- **入口/函数**: `run_symbol_monitoring`
+- **文件(行号)**: disabled Sell Put / disabled Combo Yield branches
+- **输入场景**: a strategy produced candidates in a previous run and is disabled in the current run
+- **实际分支**: orchestrator appended an empty summary but did not replace prior candidates/alerts files
+- **预期行为**: disabled and failed strategies are fail-closed in both summary and current artifacts
+- **实际行为**: stale files can remain readable; legacy inline Combo logic could read stale Sell Put candidates
+- **直接证据**: fixed report paths and facade `safe_read_csv(sell_put_labeled_path)`; failure tests already seed stale files
+- **影响**: stale recommendations can be mistaken for current evidence
+- **建议改法和验证点**: materialize empty artifacts in disabled branches; never read Sell Put artifact for inline attachment when Sell Put config is disabled; add stale-file assertions
+- **修复风险（低/中/高）**: medium
+- **严重程度（低/中/高/严重）**: high
+
+### CR-3-未修复-中-旧 Sell Put tests enforce 已删除的 nested ownership
+- **入口/函数**: affected-area regression suite
+- **文件(行号)**: `tests/test_global_liquidity_filters.py`, former Combo-through-Sell-Put cases
+- **输入场景**: running affected-area tests after moving Combo to its own step
+- **实际分支**: tests expect two scans and patch Combo helpers on `sell_put_steps`
+- **预期行为**: Sell Put tests prove Sell Put-only ownership; Combo business behavior remains covered by `tests/test_combo_yield_steps.py`
+- **实际行为**: five failures enforce the old runtime coupling and block safe refactoring
+- **直接证据**: failing assertions expected `['sell_put', 'combo_yield']` and missing helper attributes on `sell_put_steps`
+- **影响**: false regression signal; future ownership can drift back to nested execution
+- **建议改法和验证点**: replace redundant nested tests with an explicit “Sell Put does not trigger Combo Yield” regression; retain cash/underwriting coverage in Combo-owned tests
+- **修复风险（低/中/高）**: low
+- **严重程度（低/中/高/严重）**: medium
+
+## Open Questions
+
+None blocking.
+
+## Residual Risk
+
+- Shared required-data failures remain symbol-level.
+- Duplicate funding-put scans remain accepted.
+- Commit isolation remains unresolved because touched files contain pre-existing staged changes.
+
+## Conclusion
+
+`fail` pending fixes and re-review.

--- a/docs/reviews/code-review-20260718-164830.md
+++ b/docs/reviews/code-review-20260718-164830.md
@@ -1,0 +1,37 @@
+# Code Re-review — Combo Yield / Sell Put Runtime Decoupling
+
+## Scope
+
+- Re-review of `docs/reviews/code-review-20260718-164805.md`
+- Included: all accepted findings and focused/broader validation evidence
+
+## Finding status
+
+| Finding | Final status | Evidence |
+|---|---|---|
+| CR-1 | 已修复 | Sell Put affected-area suite passes; undefined variable removed. |
+| CR-2 | 已修复 | Disabled/failure artifact materializers are wired; stale-file failure tests pass. |
+| CR-3 | 已修复 | Sell Put ownership regression now expects only Sell Put; Combo behavior remains in Combo tests. |
+
+## Validation
+
+```text
+83 affected strategy/data tests passed
+106 multi-tick/notification/architecture tests passed
+git diff --check passed
+compileall passed
+```
+
+## Findings
+
+未发现剩余实质性问题。
+
+## Residual Risk
+
+- Shared required-data failure remains symbol-level: later work unit.
+- Duplicate funding-put scans: accepted current cost.
+- Accepted slice commit is blocked by overlapping pre-existing staged changes in touched files; this is a repository state/ownership issue, not a code finding.
+
+## Conclusion
+
+`pass-with-risks`. All accepted code findings are fixed and re-reviewed.

--- a/docs/reviews/code-review-20260718-165238.md
+++ b/docs/reviews/code-review-20260718-165238.md
@@ -1,0 +1,41 @@
+# Aggregate Deepreview — Combo Yield / Sell Put Runtime Decoupling
+
+## Scope
+
+- Mode: aggregate current work unit review
+- Branch: `codex/diagonal-combo-yield-lifecycle`
+- Included: real symbol entry point, dependency composition, enablement chain, failure/artifact paths, prefetch callers, tests, docs
+- Excluded: unrelated `cross-expiry-yield-capital-attribution` artifact
+- Parallel review coverage: none
+
+## Findings
+
+### ADR-1-未修复-高-Optional Combo dependency 会静默恢复运行缺失
+- **入口/函数**: `SymbolMonitoringDependencies` and `run_symbol_monitoring`
+- **文件(行号)**: `src/application/symbol_monitoring.py`
+- **输入场景**: a composition root enables `combo_yield` but omits the newly optional `run_combo_yield_scan_fn`
+- **实际分支**: optional dependency gate evaluates false
+- **预期行为**: Combo Yield is an explicit required pipeline step; incomplete composition fails at construction/test time
+- **实际行为**: Combo Yield silently does not run
+- **直接证据**: dependency fields had `None` defaults and runtime `None` guards
+- **影响**: silent strategy outage and weak composition contract
+- **建议改法和验证点**: make Combo runner, empty summary, and artifact materializers required; update all constructors; rerun tests
+- **修复风险（低/中/高）**: low
+- **严重程度（低/中/高/严重）**: high
+
+## Adversarial failure pass
+
+Sell Put disabled, failed and empty paths are covered; Combo failure and disabled stale-artifact paths are covered. Shared required-data failure intentionally remains symbol-level.
+
+## Open Questions
+
+None blocking.
+
+## Residual Risk
+
+- Duplicate funding-put scans: accepted current cost.
+- Shared fetch failure boundary: later work unit if required.
+
+## Conclusion
+
+`fail` until ADR-1 is fixed and re-reviewed.

--- a/docs/reviews/code-review-20260718-165302.md
+++ b/docs/reviews/code-review-20260718-165302.md
@@ -1,0 +1,27 @@
+# Aggregate Deepreview Re-review — Combo Yield / Sell Put Runtime Decoupling
+
+## Finding status
+
+| Finding | Decision | Final status | Evidence |
+|---|---|---|---|
+| ADR-1 optional dependency silently skips Combo | accepted | 已修复 | Required dataclass fields, no runtime `None` gate, all constructors explicit, 189 aggregate tests pass. |
+
+## Findings
+
+未发现剩余实质性问题。
+
+## Validation
+
+- 83 affected strategy/data tests passed
+- 106 multi-tick/notification/architecture tests passed
+- `git diff --check` passed
+- application compileall passed
+
+## Residual Risk
+
+- Duplicate funding-put scans: accepted current cost.
+- Shared required-data failure: assigned to a later work unit.
+
+## Conclusion
+
+`pass-with-risks`. Aggregate deepreview accepted finding is fixed and re-reviewed.

--- a/docs/reviews/plan-review-20260718-163513.md
+++ b/docs/reviews/plan-review-20260718-163513.md
@@ -1,0 +1,61 @@
+# Plan Review — Combo Yield 与 Sell Put 运行解耦
+
+- **Reviewed target**: `docs/gateflow/combo-yield-sell-put-runtime-decoupling-plan-20260718.md`
+- **Scope**: independent symbol orchestration, failure semantics, required-data/prefetch gating, compatibility, tests, docs
+- **Conclusion**: fail
+
+## Assumptions tested
+
+- `run_combo_yield_scan_and_summarize()` can be lifted directly into symbol orchestration.
+- Catching strategy exceptions and returning empty summaries is sufficient fail-closed behavior.
+- required-data changes are uniformly required across planners.
+- legacy inline output can remain a best-effort detail without specifying artifact ownership.
+
+### PR-1-未修复-高-独立 step 的 application facade 与派生配置所有权未定义
+- **位置**: S1 “Extend dependencies / invoke Combo Yield independently”
+- **问题类型**: 架构边界 / 不可直接实施 / 过度耦合
+- **当前写法**: 计划让 `SymbolMonitoringDependencies` 直接增加 `run_combo_yield_scan_fn`，但没有规定该函数的稳定输入契约。
+- **反例/失败场景**: 当前低层 runner 需要 `CandidateWindowDefaults`、liquidity、event risk、Sell Put artifact path、policy、converter、portfolio context 及多个 injected helpers。若 symbol orchestrator 直接组装这些细节，它会穿透 Combo Yield/Sell Put application ownership；若继续从 Sell Put runner 借用，又没有真正解耦。
+- **为什么有问题**: 实施者必须临场决定复制解析逻辑、扩大 orchestrator 签名或保留嵌套调用，三者会产生不同架构和测试契约。
+- **直接证据**: `src/application/combo_yield_steps.py::run_combo_yield_scan_and_summarize` 的当前参数；`src/application/sell_put_steps.py` 当前拥有 window/liquidity/event-risk 解析和 helper wiring。
+- **影响**: 实施跑偏、跨层穿透、重复配置解析、解耦不完整。
+- **建议改法和验证点**: 在计划中明确新增一个 symbol-level Combo Yield application facade，由 `combo_yield_steps.py` 自己解析 policy/window/liquidity/event-risk 并调用低层 scan；orchestrator 只传 raw symbol/config/runtime context。Sell Put runner 不再组装 Combo Yield 参数。测试 facade 输入契约及独立调用。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-2-未修复-高-异常 fail-closed 未定义 artifact 清理与可观察契约
+- **位置**: Behavioral contract 6；S1 exception isolation
+- **问题类型**: 契约缺失 / 最佳实践偏离 / 测试缺口
+- **当前写法**: 捕获 Sell Put 或 Combo Yield exception，写日志并返回 empty summary。
+- **反例/失败场景**: 上一次成功运行留下 candidates/alerts CSV；本次 runner 在覆盖 artifact 前失败。仅返回 empty summary 会让后续通知或人工读取看到旧文件，形成“summary 失败但 artifact 看似成功”的 stale evidence。
+- **为什么有问题**: 本仓库是 operations-sensitive monitor，fail-closed 不只是控制流继续，还必须避免旧 artifact 冒充当前结果，并留下明确诊断。
+- **直接证据**: 两个 runner 使用固定 symbol report paths；现有 Sell Put disabled 分支会主动写空 CSV；Combo Yield `_empty_result` 只构造路径，不保证异常路径清理。
+- **影响**: 陈旧推荐被通知或误读，诊断与真实运行状态不一致。
+- **建议改法和验证点**: 明确 facade/step 在开始或 exception 时 materialize empty current-run artifacts，并记录 strategy-specific failure trace/log；测试先放置 stale file、注入异常后确认文件为空/被替换且另一策略继续。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-3-未修复-中-S2 未区分已独立的 canonical planner 与仍耦合的 caller
+- **位置**: S2 required-data changes
+- **问题类型**: 范围漂移 / 非最优方案
+- **当前写法**: 把 `required_data_planning.py` 列为可能修改对象。
+- **反例/失败场景**: canonical `build_required_data_fetch_plan()` 已经直接用 `combo_yield_enabled` 添加 put 与 Combo call side plan；修改它可能重复修复或破坏已有 diagonal logic。实际耦合位于 caller/prefetch enablement。
+- **为什么有问题**: 未明确“保持 canonical planner、修 caller”，增加无必要触碰高风险取数逻辑的概率。
+- **直接证据**: `src/application/required_data_planning.py` 已使用 `if want_put or combo_yield_enabled` 和独立 Combo call plan。
+- **影响**: scope 扩大、diagonal DTE 回归风险。
+- **建议改法和验证点**: 明确 canonical planner 不改，除非测试证明缺陷；只修 `symbol_monitoring`、`required_data_prefetch_planning`、`multi_tick/required_data_prefetch` 的 gating，并用现有 planner tests 证明。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open questions
+
+- 固定 report path 是否已经由 run-scoped output directory 隔离？即使通常隔离，异常前清空当前 run path 仍应作为 facade 契约。
+
+## Residual risks and tracking
+
+- Shared required-data acquisition failure remains symbol-level: later work unit if per-strategy fetch isolation is desired.
+- Duplicate put scanning remains accepted current cost.
+
+## Final conclusion
+
+`fail`。计划方向正确，但在 application facade ownership 与 fail-closed artifact semantics 上尚不能直接交付实现。

--- a/docs/reviews/plan-review-20260718-163635.md
+++ b/docs/reviews/plan-review-20260718-163635.md
@@ -1,0 +1,47 @@
+# Plan Re-review — Combo Yield 与 Sell Put 运行解耦
+
+- **Reviewed target**: `docs/gateflow/combo-yield-sell-put-runtime-decoupling-plan-20260718.md`, including `Plan review fixes`
+- **Prior review**: `docs/reviews/plan-review-20260718-163513.md`
+- **Conclusion**: pass-with-risks
+
+## Finding re-review
+
+| Finding | Decision | Final status | Evidence |
+|---|---|---|---|
+| PR-1 facade ownership undefined | accepted | 已修复 | Revised plan defines a symbol-level Combo Yield application facade owned by `combo_yield_steps.py`; orchestrator receives only raw application context. |
+| PR-2 fail-closed artifacts undefined | accepted | 已修复 | Revised plan requires current-run empty artifact materialization, exception logging and stale-artifact tests. |
+| PR-3 canonical planner scope too broad | accepted | 已修复 | Revised plan protects `required_data_planning.py` and limits changes to coupled callers unless tests prove otherwise. |
+
+## Architecture boundary review
+
+Pass. The revised facade keeps candidate-window, liquidity, event-risk and helper wiring in the owning Combo Yield application module. Domain boundaries remain unchanged; no `domain -> src` dependency is introduced.
+
+## Best-practice review
+
+Pass. Independent strategy failure handling now includes observable exceptions and stale-artifact prevention, rather than only continuing control flow.
+
+## Optimal-solution review
+
+Pass. A narrow second application facade is simpler and safer than a generic strategy registry, and avoids teaching the orchestrator low-level scan details.
+
+## Overengineering review
+
+Pass. No new framework, state model, schema or configuration key is proposed.
+
+## Overcoupling review
+
+Pass. Shared market-data acquisition and reusable funding-put capabilities remain shared, while strategy execution and result ownership become independent.
+
+## Open questions
+
+None blocking.
+
+## Residual risks
+
+- Shared required-data acquisition failure remains symbol-level; assigned to a later work unit if independent fetch failure domains become a product requirement.
+- Duplicate funding-put scans remain accepted current cost.
+- Legacy inline mode cannot attach to a nonexistent Sell Put recommendation artifact; S3 must make this explicit and must not block separate output.
+
+## Final conclusion
+
+`pass-with-risks`. The plan is code-generation-ready. All prior findings are fixed; residual risks are classified and covered by approved slice boundaries or later work units.

--- a/docs/reviews/pr-74-review-20260718-165953.md
+++ b/docs/reviews/pr-74-review-20260718-165953.md
@@ -1,0 +1,36 @@
+# PR Review — #74 Combo Yield Runtime Decoupling
+
+## Scope
+
+- PR: #74 `refactor: decouple Combo Yield runtime from Sell Put`
+- URL: https://github.com/liuxie066/options-monitor/pull/74
+- Base: `codex/diagonal-combo-yield-lifecycle`
+- Head: `codex/runtime-decoupling-isolation-backup`
+- Mode: PR review
+
+## Findings
+
+### PR74-1-未修复-高-PR ancestry 暂时包含无关 diagonal closeout history
+- **入口/函数**: PR commit/file scope
+- **文件(行号)**: GitHub PR metadata before repair
+- **输入场景**: base branch was rewritten to a clean diagonal history while head retained the old ancestry
+- **实际分支**: GitHub listed old diagonal final-closeout and merge-history files in #74
+- **预期行为**: stacked PR contains only runtime-decoupling plan, implementation, fixes, tests and reviews
+- **实际行为**: initial PR scope included unrelated diagonal lifecycle history
+- **直接证据**: initial `gh pr view 74` listed commit `644915fe` and `docs/gateflow/diagonal-combo-yield-final-closeout-20260718-163741.md`
+- **影响**: unreviewable stacked diff and risk of duplicating/reverting base work
+- **建议改法和验证点**: rebuild head from latest remote base in isolated worktree; cherry-pick only four reviewed work-unit commits; update head using exact-SHA `--force-with-lease`; re-read PR metadata
+- **修复风险（低/中/高）**: medium
+- **严重程度（低/中/高/严重）**: high
+
+## Checks
+
+No GitHub checks reported for the head branch. Local validated suite is required evidence.
+
+## Residual Risk
+
+Stacked PR must be retargeted to `main` after #73 merges if GitHub does not update it automatically.
+
+## Conclusion
+
+`fail` pending scope repair and re-review.

--- a/docs/reviews/pr-74-review-20260718-165954.md
+++ b/docs/reviews/pr-74-review-20260718-165954.md
@@ -1,0 +1,36 @@
+# PR #74 Re-review — Combo Yield Runtime Decoupling
+
+## Finding status
+
+| Finding | Decision | Final status | Evidence |
+|---|---|---|---|
+| PR74-1 contaminated ancestry/scope | accepted | 已修复 | PR now contains commits `9e3bd4ff`, `02ae80b4`, `3cede68a`, `8337740f`; unrelated diagonal final-closeout file is absent. |
+
+## Diff review
+
+- Runtime ownership is independent and explicit.
+- Sell Put disabled/failure/empty matrix is covered.
+- Required-data callers request Combo put/call independently.
+- Disabled/failure artifacts fail closed.
+- Dependency composition cannot silently omit Combo.
+- Architecture documentation matches the implementation.
+
+## Validation
+
+- 189 focused/aggregate tests passed on the repaired head.
+- `git diff --check` passed.
+- GitHub reports no CI checks for this branch.
+
+## Findings
+
+未发现剩余实质性问题。
+
+## Residual Risk
+
+- Retarget stacked PR #74 to `main` after #73 merges if not automatic.
+- Shared required-data acquisition remains symbol-level.
+- Duplicate funding-put scan cost remains accepted.
+
+## Conclusion
+
+`pass-with-risks`. PR review accepted finding is fixed and re-reviewed.

--- a/src/application/combo_yield_steps.py
+++ b/src/application/combo_yield_steps.py
@@ -9,9 +9,17 @@ from typing import Any, Callable
 
 import pandas as pd
 
-from domain.domain.candidate_defaults import CandidateLiquidityDefaults, CandidateWindowDefaults
+from domain.domain.candidate_defaults import (
+    DEFAULT_SELL_PUT_WINDOW,
+    CandidateLiquidityDefaults,
+    CandidateWindowDefaults,
+    resolve_candidate_liquidity,
+    resolve_candidate_window,
+    resolve_event_risk_config,
+)
 from domain.domain.insurance_underwriting import evaluate_event_risk_candidate
 from domain.domain.sell_put_config import resolve_min_annualized_net_return
+from domain.domain.symbol_identity import symbol_market
 from src.application.candidate_filter_trace import (
     append_candidate_filter_trace_rows,
     build_candidate_filter_trace_row,
@@ -32,6 +40,8 @@ from src.application.sell_put_call_helper import (
 from src.application.sell_put_strategy_risk import enrich_and_filter_sell_put_underwriting
 from src.application.yield_enhancement_config import (
     YieldEnhancementPolicy,
+    derive_yield_enhancement_policy,
+    resolve_yield_enhancement_cfg,
     wants_yield_enhancement_inline,
     wants_yield_enhancement_separate,
 )
@@ -366,3 +376,88 @@ def run_combo_yield_scan_and_summarize(
     if final_result.separate_enabled:
         summary = summarize_yield_enhancement(final_result.recommended_pairs, symbol, symbol_cfg=symbol_cfg)
     return final_result, summary
+
+
+def materialize_empty_combo_yield_artifacts(*, report_dir: Path, symbol_lower: str) -> ComboYieldResult:
+    """Replace current Combo Yield outputs with explicit empty artifacts."""
+
+    result = _empty_result(report_dir=report_dir, symbol_lower=symbol_lower)
+    report_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame().to_csv(result.candidates_path, index=False)
+    result.alerts_path.write_text("", encoding="utf-8")
+    for suffix in (
+        "combo_yield_pair_diagnostics.csv",
+        "combo_yield_rank_shadow.csv",
+        "combo_yield_put_universe.csv",
+        "combo_yield_put_universe_labeled.csv",
+        "combo_yield_put_universe_cash_filtered.csv",
+        "combo_yield_put_universe_underwritten.csv",
+    ):
+        pd.DataFrame().to_csv((report_dir / f"{symbol_lower}_{suffix}").resolve(), index=False)
+    return result
+
+
+def empty_combo_yield_summary(symbol: str, *, symbol_cfg: dict[str, Any]) -> dict[str, Any]:
+    return summarize_yield_enhancement(pd.DataFrame(), symbol, symbol_cfg=symbol_cfg)
+
+
+def run_combo_yield_for_symbol_and_summarize(
+    *,
+    base: Path,
+    sym: str,
+    symbol: str,
+    symbol_lower: str,
+    symbol_cfg: dict[str, Any],
+    sell_put_cfg: dict[str, Any],
+    top_n: int,
+    required_data_dir: Path,
+    report_dir: Path,
+    is_scheduled: bool,
+    exchange_rate_converter: CurrencyConverter,
+    portfolio_ctx: dict[str, Any] | None,
+    global_sell_put_liquidity: dict[str, Any] | None = None,
+    global_sell_put_event_risk: dict[str, Any] | None = None,
+    cash_filter_put_candidates_fn: Callable[..., pd.DataFrame] | None = None,
+) -> dict[str, Any] | None:
+    """Symbol-level Combo Yield facade with independent config and artifact ownership."""
+
+    yield_cfg = resolve_yield_enhancement_cfg(symbol_cfg)
+    policy = derive_yield_enhancement_policy(yield_cfg, sell_put_cfg, market=symbol_market(symbol))
+    if not policy.enabled:
+        materialize_empty_combo_yield_artifacts(report_dir=report_dir, symbol_lower=symbol_lower)
+        return None
+
+    materialize_empty_combo_yield_artifacts(report_dir=report_dir, symbol_lower=symbol_lower)
+    liquidity = resolve_candidate_liquidity(global_sell_put_liquidity)
+    event_risk = resolve_event_risk_config(global_sell_put_event_risk)
+    yield_window = resolve_candidate_window(sell_put_cfg, defaults=DEFAULT_SELL_PUT_WINDOW)
+    sell_put_labeled_path = (report_dir / f"{symbol_lower}_sell_put_candidates_labeled.csv").resolve()
+    df_sell_put_labeled = (
+        safe_read_csv(sell_put_labeled_path)
+        if bool(sell_put_cfg.get("enabled", False))
+        else pd.DataFrame()
+    )
+
+    _result, summary = run_combo_yield_scan_and_summarize(
+        base=base,
+        sym=sym,
+        symbol=symbol,
+        symbol_lower=symbol_lower,
+        symbol_cfg=symbol_cfg,
+        yield_enhancement_cfg=yield_cfg,
+        yield_sp=dict(sell_put_cfg),
+        yield_enhancement_policy=policy,
+        df_sell_put_labeled=df_sell_put_labeled,
+        sell_put_labeled_path=sell_put_labeled_path,
+        required_data_dir=required_data_dir,
+        report_dir=report_dir,
+        yield_window=yield_window,
+        liquidity=liquidity,
+        event_risk=event_risk,
+        exchange_rate_converter=exchange_rate_converter,
+        portfolio_ctx=portfolio_ctx,
+        top_n=top_n,
+        is_scheduled=is_scheduled,
+        cash_filter_put_candidates_fn=cash_filter_put_candidates_fn,
+    )
+    return summary

--- a/src/application/multi_tick/required_data_prefetch.py
+++ b/src/application/multi_tick/required_data_prefetch.py
@@ -173,7 +173,7 @@ def _build_single_prefetch_fetch_plan(
     yield_policy = derive_yield_enhancement_policy(yield_enhancement_cfg, sell_put_cfg)
     want_put = bool(sell_put_cfg.get("enabled", False))
     want_call = bool(sell_call_cfg.get("enabled", False))
-    want_yield_enhancement = bool(want_put and yield_policy.enabled)
+    want_yield_enhancement = bool(yield_policy.enabled)
     snapshot_cfg = _as_dict(opend_fetch_cfg.get("market_snapshot"))
     expiration_cfg = _as_dict(opend_fetch_cfg.get("option_expiration"))
     return build_required_data_fetch_plan(

--- a/src/application/pipeline_symbol.py
+++ b/src/application/pipeline_symbol.py
@@ -9,13 +9,24 @@ from run_pipeline.py with minimal/no behavioral changes.
 from __future__ import annotations
 
 from pathlib import Path
+from functools import partial
 
 from src.application.exchange_rate_loader import build_converter
 from src.application.prefilters import apply_prefilters
 from src.application.multiplier_steps import apply_multiplier_cache_to_required_data_csv
 from src.application.required_data_steps import ensure_required_data
 from src.application.sell_call_steps import empty_sell_call_summary, run_sell_call_scan_and_summarize
-from src.application.sell_put_steps import empty_sell_put_summary, run_sell_put_scan_and_summarize
+from src.application.sell_put_steps import (
+    _enrich_and_filter_sell_put_cash,
+    empty_sell_put_summary,
+    materialize_empty_sell_put_artifacts,
+    run_sell_put_scan_and_summarize,
+)
+from src.application.combo_yield_steps import (
+    empty_combo_yield_summary,
+    materialize_empty_combo_yield_artifacts,
+    run_combo_yield_for_symbol_and_summarize,
+)
 from src.application.symbol_monitoring import (
     SymbolMonitoringDependencies,
     SymbolMonitoringInputs,
@@ -71,5 +82,12 @@ def process_symbol(
             empty_sell_put_summary_fn=empty_sell_put_summary,
             run_sell_call_scan_fn=run_sell_call_scan_and_summarize,
             empty_sell_call_summary_fn=empty_sell_call_summary,
+            run_combo_yield_scan_fn=partial(
+                run_combo_yield_for_symbol_and_summarize,
+                cash_filter_put_candidates_fn=_enrich_and_filter_sell_put_cash,
+            ),
+            empty_combo_yield_summary_fn=empty_combo_yield_summary,
+            materialize_empty_sell_put_artifacts_fn=materialize_empty_sell_put_artifacts,
+            materialize_empty_combo_yield_artifacts_fn=materialize_empty_combo_yield_artifacts,
         ),
     )

--- a/src/application/required_data_prefetch_planning.py
+++ b/src/application/required_data_prefetch_planning.py
@@ -238,7 +238,7 @@ def strategy_prefetch_kwargs(symbol_cfg: dict[str, Any], *, enabled: bool) -> di
     want_put = bool(sp.get("enabled", False))
     want_direct_call = bool(cc.get("enabled", False))
     yield_policy = derive_yield_enhancement_policy(ye, sp)
-    want_yield_call = bool(want_put and yield_policy.enabled)
+    want_yield_call = bool(yield_policy.enabled)
     sell_put_semantics = strategy_semantics_for_side_config(family=SELL_PUT_FAMILY, side_cfg=sp)
     sell_call_semantics = strategy_semantics_for_side_config(family=SELL_CALL_FAMILY, side_cfg=cc)
     include_realized_volatility = bool(
@@ -252,7 +252,7 @@ def strategy_prefetch_kwargs(symbol_cfg: dict[str, Any], *, enabled: bool) -> di
     max_dtes: list[int] = []
     side_strike_windows: dict[str, dict[str, float | None]] = {}
 
-    if want_put:
+    if want_put or want_yield_call:
         min_dte, max_dte = _window_values(sp, defaults=DEFAULT_SELL_PUT_WINDOW)
         min_dtes.append(min_dte)
         max_dtes.append(max_dte)

--- a/src/application/sell_put_steps.py
+++ b/src/application/sell_put_steps.py
@@ -26,15 +26,9 @@ from src.application.render_sell_put_alerts import render_sell_put_alerts
 from src.application.report_labels import add_sell_put_labels
 from src.application.report_summaries import summarize_sell_put
 from src.application.scan_sell_put import run_sell_put_scan
-from src.application.sell_put_call_helper import (
-    attach_best_linked_calls,
-    find_sell_put_yield_enhancement_pairs,
-    select_best_yield_enhancement_pairs,
-)
 from src.application.sell_put_cash import enrich_sell_put_candidates_with_cash
 from src.application.sell_put_strategy_risk import enrich_and_filter_sell_put_underwriting
 from src.application.strategy_policy import SELL_PUT_FAMILY, strategy_semantics_for_side_config
-from src.application.combo_yield_steps import run_combo_yield_scan_and_summarize
 from src.application.candidate_filter_trace import (
     append_candidate_filter_trace_rows,
     build_candidate_filter_trace_row,
@@ -43,10 +37,6 @@ from src.application.candidate_filter_trace import (
 )
 from domain.domain.sell_put_config import validate_min_annualized_net_return
 from domain.domain.risk_capacity import compute_sell_put_cash_capacity
-from src.application.yield_enhancement_config import (
-    derive_yield_enhancement_policy,
-    resolve_yield_enhancement_cfg,
-)
 
 log = logging.getLogger(__name__)
 
@@ -254,14 +244,6 @@ def run_sell_put_scan_and_summarize(
 ) -> list[dict[str, Any]]:
     symbol_sp = (report_dir / f'{symbol_lower}_sell_put_candidates.csv').resolve()
     symbol_sp_labeled = (report_dir / f'{symbol_lower}_sell_put_candidates_labeled.csv').resolve()
-    yield_enhancement_cfg = resolve_yield_enhancement_cfg(symbol_cfg)
-    yield_sp = dict(yield_enhancement_sell_put_cfg or sp)
-    yield_enhancement_policy = derive_yield_enhancement_policy(
-        yield_enhancement_cfg,
-        yield_sp,
-        market=symbol_market(symbol),
-    )
-
     sell_put_semantics = strategy_semantics_for_side_config(family=SELL_PUT_FAMILY, side_cfg=sp)
     resolved_min_annualized_net_return = 0.0 if sell_put_semantics.scan_uses_underwriting_gate else validate_min_annualized_net_return(
         sp.get('min_annualized_net_return'),
@@ -271,7 +253,6 @@ def run_sell_put_scan_and_summarize(
     liquidity = resolve_candidate_liquidity(global_sell_put_liquidity)
     event_risk = resolve_event_risk_config(global_sell_put_event_risk)
     window = resolve_candidate_window(sp, defaults=DEFAULT_SELL_PUT_WINDOW)
-    yield_window = resolve_candidate_window(yield_sp, defaults=DEFAULT_SELL_PUT_WINDOW)
     global_min_net_income = float((global_sell_put_liquidity or {}).get('min_net_income', 0.0) or 0.0)
     min_net_income_cny = float(sp.get('min_net_income', global_min_net_income) or 0.0)
 
@@ -344,34 +325,6 @@ def run_sell_put_scan_and_summarize(
         except Exception as exc:
             log.warning("sell_put_steps: failed to write fail-closed sell-put CSV for %s: %s", symbol, exc)
 
-    _yield_result, yield_summary = run_combo_yield_scan_and_summarize(
-        base=base,
-        sym=sym,
-        symbol=symbol,
-        symbol_lower=symbol_lower,
-        symbol_cfg=symbol_cfg,
-        yield_enhancement_cfg=yield_enhancement_cfg,
-        yield_sp=yield_sp,
-        yield_enhancement_policy=yield_enhancement_policy,
-        df_sell_put_labeled=df_sp_lab,
-        sell_put_labeled_path=symbol_sp_labeled,
-        required_data_dir=required_data_dir,
-        report_dir=report_dir,
-        yield_window=yield_window,
-        liquidity=liquidity,
-        event_risk=event_risk,
-        exchange_rate_converter=exchange_rate_converter,
-        portfolio_ctx=portfolio_ctx,
-        top_n=top_n,
-        is_scheduled=bool(is_scheduled),
-        run_put_scan_fn=run_sell_put_scan,
-        label_put_candidates_fn=add_sell_put_labels,
-        find_pairs_fn=find_sell_put_yield_enhancement_pairs,
-        select_pairs_fn=select_best_yield_enhancement_pairs,
-        attach_calls_fn=attach_best_linked_calls,
-        cash_filter_put_candidates_fn=_enrich_and_filter_sell_put_cash,
-        underwriting_filter_put_candidates_fn=enrich_and_filter_sell_put_underwriting,
-    )
 
     if not is_scheduled:
         render_sell_put_alerts(
@@ -383,10 +336,16 @@ def run_sell_put_scan_and_summarize(
             base_dir=base,
         )
 
-    rows = [summarize_sell_put(safe_read_csv(symbol_sp_labeled), symbol, symbol_cfg=symbol_cfg)]
-    if yield_summary is not None:
-        rows.append(yield_summary)
-    return rows
+    return [summarize_sell_put(safe_read_csv(symbol_sp_labeled), symbol, symbol_cfg=symbol_cfg)]
+
+
+def materialize_empty_sell_put_artifacts(*, report_dir: Path, symbol_lower: str) -> None:
+    """Replace current Sell Put outputs with explicit empty artifacts."""
+
+    report_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame().to_csv((report_dir / f"{symbol_lower}_sell_put_candidates.csv").resolve(), index=False)
+    pd.DataFrame().to_csv((report_dir / f"{symbol_lower}_sell_put_candidates_labeled.csv").resolve(), index=False)
+    (report_dir / f"{symbol_lower}_sell_put_alerts.txt").resolve().write_text("", encoding="utf-8")
 
 
 def empty_sell_put_summary(symbol: str, *, symbol_cfg: dict[str, Any]) -> dict[str, Any]:

--- a/src/application/symbol_monitoring.py
+++ b/src/application/symbol_monitoring.py
@@ -54,10 +54,10 @@ class SymbolMonitoringDependencies:
     empty_sell_put_summary_fn: Callable[..., object]
     run_sell_call_scan_fn: Callable[..., object]
     empty_sell_call_summary_fn: Callable[..., object]
-    run_combo_yield_scan_fn: Callable[..., object] | None = None
-    empty_combo_yield_summary_fn: Callable[..., object] | None = None
-    materialize_empty_sell_put_artifacts_fn: Callable[..., None] | None = None
-    materialize_empty_combo_yield_artifacts_fn: Callable[..., object] | None = None
+    run_combo_yield_scan_fn: Callable[..., object]
+    empty_combo_yield_summary_fn: Callable[..., object]
+    materialize_empty_sell_put_artifacts_fn: Callable[..., None]
+    materialize_empty_combo_yield_artifacts_fn: Callable[..., object]
 
 
 def _append_summary_result(summary_rows: list[dict[str, Any]], result: object) -> None:
@@ -227,21 +227,19 @@ def run_symbol_monitoring(
             )
         except Exception:
             log.exception("symbol_monitoring: sell_put step failed for %s", symbol)
-            if deps.materialize_empty_sell_put_artifacts_fn is not None:
-                deps.materialize_empty_sell_put_artifacts_fn(
-                    report_dir=inputs.report_dir, symbol_lower=symbol_lower
-                )
+            deps.materialize_empty_sell_put_artifacts_fn(
+                report_dir=inputs.report_dir, symbol_lower=symbol_lower
+            )
             _append_summary_result(
                 summary_rows, deps.empty_sell_put_summary_fn(symbol, symbol_cfg=symbol_cfg)
             )
     else:
-        if deps.materialize_empty_sell_put_artifacts_fn is not None:
-            deps.materialize_empty_sell_put_artifacts_fn(
-                report_dir=inputs.report_dir, symbol_lower=symbol_lower
-            )
+        deps.materialize_empty_sell_put_artifacts_fn(
+            report_dir=inputs.report_dir, symbol_lower=symbol_lower
+        )
         _append_summary_result(summary_rows, deps.empty_sell_put_summary_fn(symbol, symbol_cfg=symbol_cfg))
 
-    if want_yield_enhancement and deps.run_combo_yield_scan_fn is not None:
+    if want_yield_enhancement:
         try:
             _append_summary_result(
                 summary_rows,
@@ -264,16 +262,14 @@ def run_symbol_monitoring(
             )
         except Exception:
             log.exception("symbol_monitoring: combo_yield step failed for %s", symbol)
-            if deps.materialize_empty_combo_yield_artifacts_fn is not None:
-                deps.materialize_empty_combo_yield_artifacts_fn(
-                    report_dir=inputs.report_dir, symbol_lower=symbol_lower
-                )
-            if deps.empty_combo_yield_summary_fn is not None:
-                _append_summary_result(
-                    summary_rows,
-                    deps.empty_combo_yield_summary_fn(symbol, symbol_cfg=symbol_cfg),
-                )
-    elif not want_yield_enhancement and deps.materialize_empty_combo_yield_artifacts_fn is not None:
+            deps.materialize_empty_combo_yield_artifacts_fn(
+                report_dir=inputs.report_dir, symbol_lower=symbol_lower
+            )
+            _append_summary_result(
+                summary_rows,
+                deps.empty_combo_yield_summary_fn(symbol, symbol_cfg=symbol_cfg),
+            )
+    elif not want_yield_enhancement:
         deps.materialize_empty_combo_yield_artifacts_fn(
             report_dir=inputs.report_dir, symbol_lower=symbol_lower
         )

--- a/src/application/symbol_monitoring.py
+++ b/src/application/symbol_monitoring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from pathlib import Path
 from typing import Any, Callable, Protocol
 
@@ -12,6 +13,9 @@ from src.application.yield_enhancement_config import (
     derive_yield_enhancement_policy,
     resolve_yield_enhancement_cfg,
 )
+
+
+log = logging.getLogger(__name__)
 
 
 class _PrefilterResultLike(Protocol):
@@ -50,6 +54,10 @@ class SymbolMonitoringDependencies:
     empty_sell_put_summary_fn: Callable[..., object]
     run_sell_call_scan_fn: Callable[..., object]
     empty_sell_call_summary_fn: Callable[..., object]
+    run_combo_yield_scan_fn: Callable[..., object] | None = None
+    empty_combo_yield_summary_fn: Callable[..., object] | None = None
+    materialize_empty_sell_put_artifacts_fn: Callable[..., None] | None = None
+    materialize_empty_combo_yield_artifacts_fn: Callable[..., object] | None = None
 
 
 def _append_summary_result(summary_rows: list[dict[str, Any]], result: object) -> None:
@@ -80,7 +88,6 @@ def run_symbol_monitoring(
     want_put = bool(sp.get("enabled", False))
     want_call = bool(cc.get("enabled", False))
     market_sp = dict(sp)
-    market_want_put = bool(want_put)
 
     exchange_rate_converter = deps.build_converter_fn(
         usd_per_cny_exchange_rate=inputs.usd_per_cny_exchange_rate,
@@ -118,7 +125,7 @@ def run_symbol_monitoring(
         if effective_min_strike is not None:
             cc["min_strike"] = effective_min_strike
             symbol_cfg["sell_call"] = cc
-    want_yield_enhancement = bool(market_want_put and yield_enhancement_policy.enabled)
+    want_yield_enhancement = bool(yield_enhancement_policy.enabled)
     fetch_want_put = bool(want_put or want_yield_enhancement)
     fetch_want_call = bool(want_call or want_yield_enhancement)
     fetch_sell_put_cfg = market_sp if want_yield_enhancement else sp
@@ -194,32 +201,82 @@ def run_symbol_monitoring(
 
     summary_rows: list[dict[str, Any]] = []
 
-    if want_put or want_yield_enhancement:
-        _append_summary_result(
-            summary_rows,
-            deps.run_sell_put_scan_fn(
-                py=inputs.py,
-                base=inputs.base,
-                sym=symbol,
-                symbol=symbol,
-                symbol_lower=symbol_lower,
-                symbol_cfg=symbol_cfg,
-                sp=sp,
-                top_n=inputs.top_n,
-                required_data_dir=inputs.required_data_dir,
-                report_dir=inputs.report_dir,
-                timeout_sec=inputs.timeout_sec,
-                is_scheduled=bool(inputs.is_scheduled),
-                exchange_rate_converter=exchange_rate_converter,
-                portfolio_ctx=inputs.portfolio_ctx,
-                global_sell_put_liquidity=(symbol_cfg.get("_global_sell_put_liquidity") or {}),
-                global_sell_put_event_risk=(symbol_cfg.get("_global_sell_put_event_risk") or {}),
-                run_sell_put=want_put,
-                yield_enhancement_sell_put_cfg=market_sp,
+    if want_put:
+        try:
+            _append_summary_result(
+                summary_rows,
+                deps.run_sell_put_scan_fn(
+                    py=inputs.py,
+                    base=inputs.base,
+                    sym=symbol,
+                    symbol=symbol,
+                    symbol_lower=symbol_lower,
+                    symbol_cfg=symbol_cfg,
+                    sp=sp,
+                    top_n=inputs.top_n,
+                    required_data_dir=inputs.required_data_dir,
+                    report_dir=inputs.report_dir,
+                    timeout_sec=inputs.timeout_sec,
+                    is_scheduled=bool(inputs.is_scheduled),
+                    exchange_rate_converter=exchange_rate_converter,
+                    portfolio_ctx=inputs.portfolio_ctx,
+                    global_sell_put_liquidity=(symbol_cfg.get("_global_sell_put_liquidity") or {}),
+                    global_sell_put_event_risk=(symbol_cfg.get("_global_sell_put_event_risk") or {}),
+                    run_sell_put=True,
+                )
             )
-        )
+        except Exception:
+            log.exception("symbol_monitoring: sell_put step failed for %s", symbol)
+            if deps.materialize_empty_sell_put_artifacts_fn is not None:
+                deps.materialize_empty_sell_put_artifacts_fn(
+                    report_dir=inputs.report_dir, symbol_lower=symbol_lower
+                )
+            _append_summary_result(
+                summary_rows, deps.empty_sell_put_summary_fn(symbol, symbol_cfg=symbol_cfg)
+            )
     else:
+        if deps.materialize_empty_sell_put_artifacts_fn is not None:
+            deps.materialize_empty_sell_put_artifacts_fn(
+                report_dir=inputs.report_dir, symbol_lower=symbol_lower
+            )
         _append_summary_result(summary_rows, deps.empty_sell_put_summary_fn(symbol, symbol_cfg=symbol_cfg))
+
+    if want_yield_enhancement and deps.run_combo_yield_scan_fn is not None:
+        try:
+            _append_summary_result(
+                summary_rows,
+                deps.run_combo_yield_scan_fn(
+                    base=inputs.base,
+                    sym=symbol,
+                    symbol=symbol,
+                    symbol_lower=symbol_lower,
+                    symbol_cfg=symbol_cfg,
+                    sell_put_cfg=market_sp,
+                    top_n=inputs.top_n,
+                    required_data_dir=inputs.required_data_dir,
+                    report_dir=inputs.report_dir,
+                    is_scheduled=bool(inputs.is_scheduled),
+                    exchange_rate_converter=exchange_rate_converter,
+                    portfolio_ctx=inputs.portfolio_ctx,
+                    global_sell_put_liquidity=(symbol_cfg.get("_global_sell_put_liquidity") or {}),
+                    global_sell_put_event_risk=(symbol_cfg.get("_global_sell_put_event_risk") or {}),
+                )
+            )
+        except Exception:
+            log.exception("symbol_monitoring: combo_yield step failed for %s", symbol)
+            if deps.materialize_empty_combo_yield_artifacts_fn is not None:
+                deps.materialize_empty_combo_yield_artifacts_fn(
+                    report_dir=inputs.report_dir, symbol_lower=symbol_lower
+                )
+            if deps.empty_combo_yield_summary_fn is not None:
+                _append_summary_result(
+                    summary_rows,
+                    deps.empty_combo_yield_summary_fn(symbol, symbol_cfg=symbol_cfg),
+                )
+    elif not want_yield_enhancement and deps.materialize_empty_combo_yield_artifacts_fn is not None:
+        deps.materialize_empty_combo_yield_artifacts_fn(
+            report_dir=inputs.report_dir, symbol_lower=symbol_lower
+        )
 
     if want_call:
         option_ctx = (inputs.portfolio_ctx or {}).get("option_ctx") or {}

--- a/tests/test_global_liquidity_filters.py
+++ b/tests/test_global_liquidity_filters.py
@@ -935,71 +935,12 @@ def test_sell_put_steps_use_global_liquidity_filters_only() -> None:
     assert 'require_bid_ask' not in kwargs
 
 
-def test_sell_put_steps_combo_yield_put_universe_reuses_sell_put_return_floor() -> None:
+def test_sell_put_steps_does_not_trigger_combo_yield() -> None:
     base = _add_repo_to_syspath()
     import src.application.sell_put_steps as steps
     import pandas as pd
     from src.infrastructure.exchange_rates import CurrencyConverter, ExchangeRates
 
-    calls: list[dict] = []
-    orig_run_sell_put_scan = steps.run_sell_put_scan
-    orig_add_labels = steps.add_sell_put_labels
-
-    def _fake_run_sell_put_scan(**kwargs):
-        calls.append(kwargs)
-        Path(kwargs["output"]).parent.mkdir(parents=True, exist_ok=True)
-        pd.DataFrame().to_csv(kwargs["output"], index=False)
-
-    steps.run_sell_put_scan = _fake_run_sell_put_scan
-    steps.add_sell_put_labels = lambda *args, **kwargs: None
-    try:
-        out = steps.run_sell_put_scan_and_summarize(
-            py='python',
-            base=base,
-            sym='AAPL',
-            symbol='AAPL',
-            symbol_lower='aapl',
-            symbol_cfg={'symbol': 'AAPL', 'combo_yield': {'enabled': True}},
-            sp={
-                'enabled': True,
-                'strategy': 'return_first',
-                'min_dte': 7,
-                'max_dte': 45,
-                'min_strike': 1,
-                'max_strike': 200,
-                'min_annualized_net_return': 0.25,
-                'min_net_income': 500,
-            },
-            top_n=3,
-            required_data_dir=base / 'output',
-            report_dir=base / 'output' / 'reports',
-            timeout_sec=10,
-            is_scheduled=True,
-            exchange_rate_converter=CurrencyConverter(ExchangeRates(usd_per_cny=0.14)),
-            portfolio_ctx=None,
-        )
-    finally:
-        steps.run_sell_put_scan = orig_run_sell_put_scan
-        steps.add_sell_put_labels = orig_add_labels
-
-    assert [row['strategy'] for row in out] == ['sell_put', 'combo_yield']
-    assert len(calls) == 2
-    assert calls[0]['min_annualized_net_return'] == 0.25
-    assert calls[0]['min_net_income'] == 70.0
-    assert calls[1]['min_annualized_net_return'] == 0.25
-    assert calls[1]['min_net_income'] == 0.0
-    assert calls[1]['min_dte'] == 7
-    assert calls[1]['max_dte'] == 45
-
-
-def test_sell_put_steps_yield_enhancement_return_first_runs_put_universe(tmp_path: Path) -> None:
-    base = _add_repo_to_syspath()
-    import src.application.sell_put_steps as steps
-    import pandas as pd
-    from src.infrastructure.exchange_rates import CurrencyConverter, ExchangeRates
-
-    report_dir = tmp_path / "reports"
-    report_dir.mkdir(parents=True, exist_ok=True)
     calls: list[dict] = []
     orig_run_sell_put_scan = steps.run_sell_put_scan
     orig_add_labels = steps.add_sell_put_labels
@@ -1021,6 +962,7 @@ def test_sell_put_steps_yield_enhancement_return_first_runs_put_universe(tmp_pat
             symbol_cfg={"symbol": "AAPL", "combo_yield": {"enabled": True}},
             sp={
                 "enabled": True,
+                "strategy": "return_first",
                 "min_dte": 7,
                 "max_dte": 45,
                 "min_strike": 1,
@@ -1029,326 +971,21 @@ def test_sell_put_steps_yield_enhancement_return_first_runs_put_universe(tmp_pat
                 "min_net_income": 500,
             },
             top_n=3,
-            required_data_dir=tmp_path / "required_data",
-            report_dir=report_dir,
+            required_data_dir=base / "output",
+            report_dir=base / "output" / "reports",
             timeout_sec=10,
             is_scheduled=True,
-            exchange_rate_converter=CurrencyConverter(ExchangeRates(usd_per_cny=1.0)),
+            exchange_rate_converter=CurrencyConverter(ExchangeRates(usd_per_cny=0.14)),
             portfolio_ctx=None,
         )
     finally:
         steps.run_sell_put_scan = orig_run_sell_put_scan
         steps.add_sell_put_labels = orig_add_labels
 
-    assert [row["strategy"] for row in out] == ["sell_put", "combo_yield"]
-    assert len(calls) == 2
+    assert [row["strategy"] for row in out] == ["sell_put"]
+    assert len(calls) == 1
     assert calls[0]["min_annualized_net_return"] == 0.25
-    assert calls[0]["min_net_income"] == 500.0
-    assert calls[1]["min_annualized_net_return"] == 0.25
-    assert calls[1]["min_net_income"] == 0.0
-
-
-def test_sell_put_steps_combo_yield_put_universe_is_retained_but_pairs_are_cash_filtered(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    base = _add_repo_to_syspath()
-    import src.application.sell_put_steps as steps
-    from src.infrastructure.exchange_rates import CurrencyConverter, ExchangeRates
-
-    report_dir = tmp_path / "reports"
-    report_dir.mkdir(parents=True, exist_ok=True)
-    captured_pairs_input: dict[str, pd.DataFrame] = {}
-    enrich_calls: list[Path] = []
-
-    candidate = {
-        "symbol": "AAPL",
-        "expiration": "2026-06-19",
-        "dte": 35,
-        "contract_symbol": "AAPL260619P00180000",
-        "multiplier": 100,
-        "currency": "USD",
-        "strike": 180.0,
-        "spot": 200.0,
-        "bid": 2.4,
-        "ask": 2.6,
-        "mid": 2.5,
-        "net_income": 250.0,
-        "annualized_net_return_on_cash_basis": 0.14,
-        "otm_pct": 0.1,
-        "risk_label": "中性",
-        "open_interest": 100,
-        "volume": 20,
-        "implied_volatility": 0.25,
-        "delta": -0.2,
-        "event_source_status": "ok",
-    }
-
-    def _fake_run_sell_put_scan(**kwargs):
-        Path(kwargs["output"]).parent.mkdir(parents=True, exist_ok=True)
-        pd.DataFrame([candidate]).to_csv(kwargs["output"], index=False)
-
-    def _fake_add_sell_put_labels(_base, _input, output):
-        Path(output).parent.mkdir(parents=True, exist_ok=True)
-        pd.DataFrame([candidate]).to_csv(output, index=False)
-
-    def _fake_enrich(*, df_labeled, symbol, portfolio_ctx, exchange_rate_converter, out_path):
-        enrich_calls.append(Path(out_path))
-        df = df_labeled.copy()
-        df["cash_required_cny"] = 20000.0
-        df["cash_free_cny"] = 1000.0
-        df.to_csv(out_path, index=False)
-        return df
-
-    def _fake_find_pairs(**kwargs):
-        captured_pairs_input["df"] = kwargs["df_candidates"].copy()
-        return pd.DataFrame()
-
-    def _fake_underwriting_gate(**kwargs):
-        df = kwargs["df_labeled"].copy()
-        df.to_csv(kwargs["out_path"], index=False)
-        return df
-
-    monkeypatch.setattr(steps, "run_sell_put_scan", _fake_run_sell_put_scan)
-    monkeypatch.setattr(steps, "add_sell_put_labels", _fake_add_sell_put_labels)
-    monkeypatch.setattr(steps, "enrich_sell_put_candidates_with_cash", _fake_enrich)
-    monkeypatch.setattr(steps, "enrich_and_filter_sell_put_underwriting", _fake_underwriting_gate)
-    monkeypatch.setattr(steps, "find_sell_put_yield_enhancement_pairs", _fake_find_pairs)
-
-    out = steps.run_sell_put_scan_and_summarize(
-        py="python",
-        base=base,
-        sym="AAPL",
-        symbol="AAPL",
-        symbol_lower="aapl",
-        symbol_cfg={"symbol": "AAPL", "combo_yield": {"enabled": True}},
-        sp={
-            "enabled": True,
-            "strategy": "insurance_underwriting",
-            "min_dte": 7,
-            "max_dte": 45,
-            "min_strike": 1,
-            "max_strike": 200,
-            "min_annualized_net_return": 0.1,
-        },
-        top_n=3,
-        required_data_dir=tmp_path / "required_data",
-        report_dir=report_dir,
-        timeout_sec=10,
-        is_scheduled=True,
-        exchange_rate_converter=CurrencyConverter(ExchangeRates(usd_per_cny=0.14)),
-        portfolio_ctx={"cash_by_currency": {"CNY": 1000}},
-    )
-
-    filtered_sell_put = pd.read_csv(report_dir / "aapl_sell_put_candidates_labeled.csv")
-    retained_universe = pd.read_csv(report_dir / "aapl_combo_yield_put_universe_labeled.csv")
-    assert [row["strategy"] for row in out] == ["sell_put", "combo_yield"]
-    assert filtered_sell_put.empty
-    assert len(retained_universe) == 1
-    assert "cash_required_cny" not in retained_universe.columns
-    assert len(enrich_calls) == 2
-    assert enrich_calls[0].name == "aapl_sell_put_candidates_labeled.csv"
-    assert enrich_calls[1].name == "aapl_combo_yield_put_universe_cash_filtered.csv"
-    assert captured_pairs_input["df"].empty
-    assert "cash_required_cny" in captured_pairs_input["df"].columns
-
-    trace_rows = [
-        json.loads(line)
-        for line in (report_dir / "candidate_filter_trace.jsonl").read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-    combo_cash_rows = [
-        row
-        for row in trace_rows
-        if row["function"] == "cash_reserve" and row.get("strategy_family") == "combo_yield"
-    ]
-    assert combo_cash_rows
-    assert combo_cash_rows[0]["rule"] == "base_cny_cash_insufficient"
-    assert combo_cash_rows[0]["evidence_path"] == "aapl_combo_yield_put_universe_cash_filtered.csv"
-
-
-def test_sell_put_steps_combo_yield_put_universe_reuses_underwriting_gate_for_insurance(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    base = _add_repo_to_syspath()
-    import src.application.sell_put_steps as steps
-    from src.infrastructure.exchange_rates import CurrencyConverter, ExchangeRates
-
-    report_dir = tmp_path / "reports"
-    report_dir.mkdir(parents=True, exist_ok=True)
-    captured_pairs_input: dict[str, pd.DataFrame] = {}
-    underwriting_gate_paths: list[str] = []
-
-    candidate = {
-        "symbol": "AAPL",
-        "expiration": "2026-06-19",
-        "dte": 35,
-        "contract_symbol": "AAPL260619P00180000",
-        "multiplier": 100,
-        "currency": "USD",
-        "strike": 180.0,
-        "spot": 200.0,
-        "bid": 2.4,
-        "ask": 2.6,
-        "mid": 2.5,
-        "net_income": 250.0,
-        "annualized_net_return_on_cash_basis": 0.14,
-        "otm_pct": 0.1,
-        "risk_label": "中性",
-        "open_interest": 100,
-        "volume": 20,
-        "implied_volatility": 0.18,
-        "realized_volatility_estimate": 0.20,
-        "delta": -0.2,
-        "event_source_status": "ok",
-    }
-
-    def _fake_run_sell_put_scan(**kwargs):
-        Path(kwargs["output"]).parent.mkdir(parents=True, exist_ok=True)
-        pd.DataFrame([candidate]).to_csv(kwargs["output"], index=False)
-
-    def _fake_add_sell_put_labels(_base, _input, output):
-        Path(output).parent.mkdir(parents=True, exist_ok=True)
-        pd.DataFrame([candidate]).to_csv(output, index=False)
-
-    def _fake_underwriting_gate(**kwargs):
-        out_path = Path(kwargs["out_path"])
-        underwriting_gate_paths.append(out_path.name)
-        if "combo_yield_put_universe" in out_path.name:
-            empty = kwargs["df_labeled"].iloc[0:0].copy()
-            empty.to_csv(out_path, index=False)
-            return empty
-        df = kwargs["df_labeled"].copy()
-        df.to_csv(out_path, index=False)
-        return df
-
-    def _fake_find_pairs(**kwargs):
-        captured_pairs_input["df"] = kwargs["df_candidates"].copy()
-        return pd.DataFrame()
-
-    monkeypatch.setattr(steps, "run_sell_put_scan", _fake_run_sell_put_scan)
-    monkeypatch.setattr(steps, "add_sell_put_labels", _fake_add_sell_put_labels)
-    monkeypatch.setattr(steps, "enrich_and_filter_sell_put_underwriting", _fake_underwriting_gate)
-    monkeypatch.setattr(steps, "find_sell_put_yield_enhancement_pairs", _fake_find_pairs)
-
-    steps.run_sell_put_scan_and_summarize(
-        py="python",
-        base=base,
-        sym="AAPL",
-        symbol="AAPL",
-        symbol_lower="aapl",
-        symbol_cfg={"symbol": "AAPL", "combo_yield": {"enabled": True}},
-        sp={
-            "enabled": True,
-            "strategy": "insurance_underwriting",
-            "min_dte": 7,
-            "max_dte": 45,
-            "min_strike": 1,
-            "max_strike": 200,
-            "min_annualized_net_return": 0.10,
-        },
-        top_n=3,
-        required_data_dir=tmp_path / "required_data",
-        report_dir=report_dir,
-        timeout_sec=10,
-        is_scheduled=True,
-        exchange_rate_converter=CurrencyConverter(ExchangeRates(usd_per_cny=0.14)),
-        portfolio_ctx={"cash_by_currency": {"USD": 100000}},
-    )
-
-    assert "aapl_combo_yield_put_universe_underwritten.csv" in underwriting_gate_paths
-    assert captured_pairs_input["df"].empty
-
-
-def test_sell_put_steps_combo_yield_put_universe_skips_underwriting_gate_for_return_first(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    base = _add_repo_to_syspath()
-    import src.application.sell_put_steps as steps
-    from src.infrastructure.exchange_rates import CurrencyConverter, ExchangeRates
-
-    report_dir = tmp_path / "reports"
-    report_dir.mkdir(parents=True, exist_ok=True)
-    captured_pairs_input: dict[str, pd.DataFrame] = {}
-    underwriting_gate_paths: list[str] = []
-
-    candidate = {
-        "symbol": "AAPL",
-        "expiration": "2026-06-19",
-        "dte": 35,
-        "contract_symbol": "AAPL260619P00180000",
-        "multiplier": 100,
-        "currency": "USD",
-        "strike": 180.0,
-        "spot": 200.0,
-        "bid": 2.4,
-        "ask": 2.6,
-        "mid": 2.5,
-        "net_income": 250.0,
-        "annualized_net_return_on_cash_basis": 0.14,
-        "otm_pct": 0.1,
-        "risk_label": "中性",
-        "open_interest": 100,
-        "volume": 20,
-        "implied_volatility": 0.18,
-        "realized_volatility_estimate": 0.20,
-        "delta": -0.2,
-        "event_source_status": "ok",
-    }
-
-    def _fake_run_sell_put_scan(**kwargs):
-        Path(kwargs["output"]).parent.mkdir(parents=True, exist_ok=True)
-        pd.DataFrame([candidate]).to_csv(kwargs["output"], index=False)
-
-    def _fake_add_sell_put_labels(_base, _input, output):
-        Path(output).parent.mkdir(parents=True, exist_ok=True)
-        pd.DataFrame([candidate]).to_csv(output, index=False)
-
-    def _fake_underwriting_gate(**kwargs):
-        out_path = Path(kwargs["out_path"])
-        underwriting_gate_paths.append(out_path.name)
-        df = kwargs["df_labeled"].copy()
-        df.to_csv(out_path, index=False)
-        return df
-
-    def _fake_find_pairs(**kwargs):
-        captured_pairs_input["df"] = kwargs["df_candidates"].copy()
-        return pd.DataFrame()
-
-    monkeypatch.setattr(steps, "run_sell_put_scan", _fake_run_sell_put_scan)
-    monkeypatch.setattr(steps, "add_sell_put_labels", _fake_add_sell_put_labels)
-    monkeypatch.setattr(steps, "enrich_and_filter_sell_put_underwriting", _fake_underwriting_gate)
-    monkeypatch.setattr(steps, "find_sell_put_yield_enhancement_pairs", _fake_find_pairs)
-
-    steps.run_sell_put_scan_and_summarize(
-        py="python",
-        base=base,
-        sym="AAPL",
-        symbol="AAPL",
-        symbol_lower="aapl",
-        symbol_cfg={"symbol": "AAPL", "combo_yield": {"enabled": True}},
-        sp={
-            "enabled": True,
-            "strategy": "return_first",
-            "min_dte": 7,
-            "max_dte": 45,
-            "min_strike": 1,
-            "max_strike": 200,
-            "min_annualized_net_return": 0.10,
-        },
-        top_n=3,
-        required_data_dir=tmp_path / "required_data",
-        report_dir=report_dir,
-        timeout_sec=10,
-        is_scheduled=True,
-        exchange_rate_converter=CurrencyConverter(ExchangeRates(usd_per_cny=0.14)),
-        portfolio_ctx={"cash_by_currency": {"USD": 100000}},
-    )
-
-    assert "aapl_combo_yield_put_universe_labeled.csv" not in underwriting_gate_paths
-    assert len(captured_pairs_input["df"]) == 1
+    assert calls[0]["min_net_income"] == 70.0
 
 
 def test_sell_put_steps_filter_uses_total_cny_when_base_cny_missing(tmp_path: Path) -> None:

--- a/tests/test_required_data_prefetch_inprocess.py
+++ b/tests/test_required_data_prefetch_inprocess.py
@@ -997,3 +997,31 @@ def test_inprocess_prefetch_summary_includes_symbol_duration(tmp_path: Path, mon
     assert result["symbols"][0]["duration_sec"] >= 0.0
     assert result["audit"][0]["duration_sec"] >= 0.0
     assert built and built[0].close_calls >= 1
+
+
+def test_strategy_prefetch_kwargs_requests_combo_put_and_call_when_sell_put_disabled() -> None:
+    out = strategy_prefetch_kwargs(
+        {
+            "symbol": "NVDA",
+            "sell_put": {
+                "enabled": False,
+                "min_dte": 20,
+                "max_dte": 60,
+                "min_strike": 90,
+                "max_strike": 96,
+            },
+            "sell_call": {"enabled": False},
+            "combo_yield": {
+                "enabled": True,
+                "structure_mode": "staggered_expiry_pair",
+                "call": {"min_dte": 61, "max_dte": 90},
+            },
+        },
+        enabled=True,
+    )
+
+    assert out["option_types"] == "put,call"
+    assert out["min_dte"] == 20
+    assert out["max_dte"] == 90
+    assert out["side_strike_windows"]["put"]["min_strike"] == 90.0
+    assert out["side_strike_windows"]["put"]["max_strike"] == 96.0

--- a/tests/test_symbol_monitoring_fetch_spec_merge.py
+++ b/tests/test_symbol_monitoring_fetch_spec_merge.py
@@ -499,10 +499,12 @@ def test_run_symbol_monitoring_keeps_yield_enhancement_market_put_scope_after_ac
         apply_prefilters_fn=_apply_prefilters_fn,
         apply_multiplier_cache_fn=lambda **kwargs: None,
         ensure_required_data_fn=lambda **kwargs: captured_required_data.update(kwargs),
-        run_sell_put_scan_fn=lambda **kwargs: captured_scan.update(kwargs) or {"strategy": "combo_yield"},
-        empty_sell_put_summary_fn=lambda symbol, symbol_cfg: (_ for _ in ()).throw(AssertionError("sell_put scan should still run for yield enhancement")),
+        run_sell_put_scan_fn=lambda **kwargs: (_ for _ in ()).throw(AssertionError("sell_put recommendation should be prefiltered")),
+        empty_sell_put_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_put"},
         run_sell_call_scan_fn=lambda **kwargs: {"strategy": "sell_call"},
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call"},
+        run_combo_yield_scan_fn=lambda **kwargs: captured_scan.update(kwargs) or {"strategy": "combo_yield"},
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield"},
     )
 
     out = mod.run_symbol_monitoring(
@@ -535,12 +537,146 @@ def test_run_symbol_monitoring_keeps_yield_enhancement_market_put_scope_after_ac
         deps=deps,
     )
 
-    assert [row["strategy"] for row in out] == ["combo_yield", "sell_call"]
+    assert [row["strategy"] for row in out] == ["sell_put", "combo_yield", "sell_call"]
     assert captured_required_data["want_put"] is True
     assert captured_required_data["want_call"] is True
     assert captured_required_data["max_strike"] == 50.0
     assert captured_plan["want_put"] is True
     assert captured_plan["sell_put_cfg"]["max_strike"] == 50
-    assert captured_scan["run_sell_put"] is False
-    assert captured_scan["sp"]["max_strike"] == 0
-    assert captured_scan["yield_enhancement_sell_put_cfg"]["max_strike"] == 50
+    assert captured_scan["sell_put_cfg"]["max_strike"] == 50
+
+
+
+def _run_strategy_decoupling_case(monkeypatch, tmp_path: Path, *, sell_put_enabled: bool, sell_put_runner, combo_runner):
+    import src.application.symbol_monitoring as mod
+
+    captured_required_data: dict[str, object] = {}
+    monkeypatch.setattr(
+        mod,
+        "build_required_data_fetch_plan",
+        lambda **kwargs: {
+            "symbol": kwargs["symbol"],
+            "merged_specs": [],
+            "side_plans": [],
+            "to_debug_dict": lambda: {"ok": True},
+        },
+    )
+    deps = mod.SymbolMonitoringDependencies(
+        build_converter_fn=lambda **kwargs: object(),
+        apply_prefilters_fn=lambda **kwargs: type(
+            "Prefilters",
+            (),
+            {
+                "want_put": kwargs["want_put"],
+                "want_call": kwargs["want_call"],
+                "sp": kwargs["sp"],
+                "cc": kwargs["cc"],
+                "stock": None,
+            },
+        )(),
+        apply_multiplier_cache_fn=lambda **kwargs: None,
+        ensure_required_data_fn=lambda **kwargs: captured_required_data.update(kwargs),
+        run_sell_put_scan_fn=sell_put_runner,
+        empty_sell_put_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_put", "count": 0},
+        run_sell_call_scan_fn=lambda **kwargs: {"strategy": "sell_call"},
+        empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call", "count": 0},
+        run_combo_yield_scan_fn=combo_runner,
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield", "count": 0},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: __import__(
+            "src.application.sell_put_steps", fromlist=["materialize_empty_sell_put_artifacts"]
+        ).materialize_empty_sell_put_artifacts(**kwargs),
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: __import__(
+            "src.application.combo_yield_steps", fromlist=["materialize_empty_combo_yield_artifacts"]
+        ).materialize_empty_combo_yield_artifacts(**kwargs),
+    )
+    out = mod.run_symbol_monitoring(
+        inputs=mod.SymbolMonitoringInputs(
+            py="python3",
+            base=tmp_path,
+            symbol_cfg={
+                "symbol": "NVDA",
+                "fetch": {"host": "127.0.0.1", "port": 11111, "limit_expirations": 8},
+                "sell_put": {"enabled": sell_put_enabled, "min_dte": 20, "max_dte": 60},
+                "combo_yield": {"enabled": True},
+                "sell_call": {"enabled": False},
+            },
+            top_n=3,
+            portfolio_ctx=None,
+            usd_per_cny_exchange_rate=None,
+            cny_per_hkd_exchange_rate=None,
+            timeout_sec=10,
+            required_data_dir=tmp_path / "required_data",
+            report_dir=tmp_path / "reports",
+            state_dir=tmp_path / "state",
+            is_scheduled=False,
+        ),
+        deps=deps,
+    )
+    return out, captured_required_data
+
+
+def test_combo_yield_runs_when_sell_put_is_disabled(monkeypatch, tmp_path: Path) -> None:
+    calls: list[str] = []
+    out, required = _run_strategy_decoupling_case(
+        monkeypatch,
+        tmp_path,
+        sell_put_enabled=False,
+        sell_put_runner=lambda **kwargs: (_ for _ in ()).throw(AssertionError("sell_put must stay disabled")),
+        combo_runner=lambda **kwargs: calls.append("combo") or {"strategy": "combo_yield", "count": 1},
+    )
+
+    assert calls == ["combo"]
+    assert required["want_put"] is True
+    assert required["want_call"] is True
+    assert [row["strategy"] for row in out] == ["sell_put", "combo_yield", "sell_call"]
+
+
+def test_combo_yield_runs_after_sell_put_failure_and_stale_put_artifacts_are_cleared(monkeypatch, tmp_path: Path) -> None:
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    (report_dir / "nvda_sell_put_candidates.csv").write_text("stale\n1\n", encoding="utf-8")
+    calls: list[str] = []
+
+    out, _required = _run_strategy_decoupling_case(
+        monkeypatch,
+        tmp_path,
+        sell_put_enabled=True,
+        sell_put_runner=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("sell put failed")),
+        combo_runner=lambda **kwargs: calls.append("combo") or {"strategy": "combo_yield", "count": 1},
+    )
+
+    assert calls == ["combo"]
+    assert (report_dir / "nvda_sell_put_candidates.csv").read_text(encoding="utf-8") == "\n"
+    assert [row["strategy"] for row in out] == ["sell_put", "combo_yield", "sell_call"]
+
+
+def test_combo_yield_runs_when_sell_put_returns_no_candidates(monkeypatch, tmp_path: Path) -> None:
+    calls: list[str] = []
+    out, _required = _run_strategy_decoupling_case(
+        monkeypatch,
+        tmp_path,
+        sell_put_enabled=True,
+        sell_put_runner=lambda **kwargs: {"strategy": "sell_put", "count": 0},
+        combo_runner=lambda **kwargs: calls.append("combo") or {"strategy": "combo_yield", "count": 1},
+    )
+
+    assert calls == ["combo"]
+    assert [row["count"] for row in out[:2]] == [0, 1]
+
+
+def test_sell_put_result_survives_combo_yield_failure_and_stale_combo_artifacts_are_cleared(monkeypatch, tmp_path: Path) -> None:
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    (report_dir / "nvda_combo_yield_candidates.csv").write_text("stale\n1\n", encoding="utf-8")
+
+    out, _required = _run_strategy_decoupling_case(
+        monkeypatch,
+        tmp_path,
+        sell_put_enabled=True,
+        sell_put_runner=lambda **kwargs: {"strategy": "sell_put", "count": 1},
+        combo_runner=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("combo failed")),
+    )
+
+    assert (report_dir / "nvda_combo_yield_candidates.csv").read_text(encoding="utf-8") == "\n"
+    assert [row["strategy"] for row in out] == ["sell_put", "combo_yield", "sell_call"]
+    assert [row["count"] for row in out[:2]] == [1, 0]

--- a/tests/test_symbol_monitoring_fetch_spec_merge.py
+++ b/tests/test_symbol_monitoring_fetch_spec_merge.py
@@ -46,6 +46,10 @@ def test_run_symbol_monitoring_passes_fetch_plan_to_required_data_step(monkeypat
         empty_sell_put_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_put"},
         run_sell_call_scan_fn=lambda **kwargs: {"strategy": "sell_call"},
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call"},
+        run_combo_yield_scan_fn=lambda **kwargs: None,
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield", "count": 0},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: None,
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: None,
     )
 
     out = mod.run_symbol_monitoring(
@@ -114,6 +118,10 @@ def test_run_symbol_monitoring_fetch_only_skips_scans_after_required_data(monkey
         empty_sell_put_summary_fn=lambda symbol, symbol_cfg: _scan_should_not_run(),
         run_sell_call_scan_fn=_scan_should_not_run,
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: _scan_should_not_run(),
+        run_combo_yield_scan_fn=lambda **kwargs: None,
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield", "count": 0},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: None,
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: None,
     )
 
     out = mod.run_symbol_monitoring(
@@ -181,6 +189,10 @@ def test_run_symbol_monitoring_uses_runtime_opend_fetch_config(monkeypatch, tmp_
         empty_sell_put_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_put"},
         run_sell_call_scan_fn=lambda **kwargs: {"strategy": "sell_call"},
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call"},
+        run_combo_yield_scan_fn=lambda **kwargs: None,
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield", "count": 0},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: None,
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: None,
     )
 
     mod.run_symbol_monitoring(
@@ -270,6 +282,10 @@ def test_run_symbol_monitoring_lifts_sell_call_min_strike_to_avg_cost(monkeypatc
         empty_sell_put_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_put"},
         run_sell_call_scan_fn=lambda **kwargs: captured_scan.update(kwargs) or {"strategy": "sell_call"},
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call"},
+        run_combo_yield_scan_fn=lambda **kwargs: None,
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield", "count": 0},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: None,
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: None,
     )
 
     mod.run_symbol_monitoring(
@@ -354,6 +370,10 @@ def test_run_symbol_monitoring_still_builds_plan_with_local_required_data(monkey
         empty_sell_put_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_put"},
         run_sell_call_scan_fn=lambda **kwargs: {"strategy": "sell_call"},
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call"},
+        run_combo_yield_scan_fn=lambda **kwargs: None,
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield", "count": 0},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: None,
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: None,
     )
 
     mod.run_symbol_monitoring(
@@ -419,6 +439,10 @@ def test_run_symbol_monitoring_fetches_calls_for_sell_put_yield_enhancement(monk
         empty_sell_put_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_put"},
         run_sell_call_scan_fn=lambda **kwargs: {"strategy": "sell_call"},
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call"},
+        run_combo_yield_scan_fn=lambda **kwargs: None,
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield", "count": 0},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: None,
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: None,
     )
 
     out = mod.run_symbol_monitoring(
@@ -505,6 +529,8 @@ def test_run_symbol_monitoring_keeps_yield_enhancement_market_put_scope_after_ac
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {"strategy": "sell_call"},
         run_combo_yield_scan_fn=lambda **kwargs: captured_scan.update(kwargs) or {"strategy": "combo_yield"},
         empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {"strategy": "combo_yield"},
+        materialize_empty_sell_put_artifacts_fn=lambda **kwargs: None,
+        materialize_empty_combo_yield_artifacts_fn=lambda **kwargs: None,
     )
 
     out = mod.run_symbol_monitoring(


### PR DESCRIPTION
## Summary
- run Combo Yield as an explicit per-symbol strategy step instead of from the Sell Put runner
- keep Combo Yield enabled when Sell Put is disabled, fails, or returns no candidates
- independently plan/prefetch Combo Yield put and call data
- fail closed by replacing stale strategy artifacts on disabled and exception paths
- make Combo Yield composition dependencies required and document runtime ownership

## Validation
- 83 affected strategy/data tests passed
- 106 multi-tick/notification/architecture tests passed
- 189 combined focused/aggregate tests passed
- `git diff --check` passed
- `python3 -m compileall -q src/application` passed

## Stack
This is a stacked draft PR targeting #73 (`codex/diagonal-combo-yield-lifecycle`) because it builds on the diagonal Combo Yield lifecycle work. It should be retargeted to `main` after #73 merges if GitHub does not update the base automatically.

## Residual risks
- shared required-data acquisition remains a symbol-level failure boundary
- when both strategies run, their funding-put scans remain duplicated by design for execution independence
