### PR TITLE
Stop trade-intake auth restart loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ README 只记录公开入口和边界。生产 cron id、长驻服务启停和�
 | 两个账户结果看起来串了 | `scheduler_status`、账户级 source 配置、账户级状态文件 |
 | 通知没发出来 | `preview_notification`、`notifications.channel`、secret 文件、通知 route |
 | 自动交易监听没有回执 | `runtime_status` 的 `trade_intake.summary`、`auto_trade_intake_status.json`、`trade_intake.receipt.enabled`、通知 route |
+| 自动交易监听因认证停止 | 检查 `auto_trade_intake_status.json` 的 `stage=auth_required` / `error_code=OPEND_NEEDS_PHONE_VERIFY`；完成 OpenD 手机验证后再人工启动服务，退出码 `78` 不会被 systemd 自动重启 |
 | 过期自动平仓没有回执 | `runtime_status` 最新 run 里的 `auto_close_receipt` / `expired_position_maintenance`、`option_positions.auto_close.receipt.enabled`、通知 route；每日维护 cron 重跑时还要看 `receipt_key` 是否已确认发送 |
 | 平仓建议异常 | `prepare_close_advice_inputs`、本地 `option_positions`、required data |
 

--- a/docs/gateflow/trade-intake-auth-aware-restart-final-closeout.md
+++ b/docs/gateflow/trade-intake-auth-aware-restart-final-closeout.md
@@ -1,0 +1,48 @@
+# Final Closeout — trade-intake-auth-aware-restart
+
+- Gate: final closeout
+- Work unit: `trade-intake-auth-aware-restart`
+- Status: final closeout pass
+- Draft PR: https://github.com/liuxie066/options-monitor/pull/88
+
+## What changed
+
+- The trade push listener now checks authentication/readiness on its existing OpenD trade context.
+- Explicit phone-verification classification stops the listener with stable process exit code 78 and writes `status=blocked`, `stage=auth_required`, classifier code/message, and detail.
+- Retryable failures retain automatic recovery with exponential backoff capped at 60 seconds; a healthy observation resets the delay.
+- Multi-source listeners propagate terminal auth and stop sibling listeners.
+- Generated trade-intake systemd units retain `Restart=always` but add `RestartPreventExitStatus=78`.
+- README troubleshooting documents the manual recovery path after OpenD phone verification.
+
+## Verification
+
+- Focused trade-intake, watchdog/error-policy, and service-deploy tests: 159 passed.
+- Python compileall for changed application modules: passed.
+- `git diff --check`: passed.
+- GitHub checks after the PR-review commit: Analyze/actions, Analyze/python, CodeQL, agent-plugin, and guardrails passed.
+
+## Finding status
+
+- Plan review findings PR-1 through PR-4: fixed and re-reviewed.
+- Slice review finding CR-1: fixed by reducing steady-state health polling from one second to five seconds.
+- Aggregate deepreview findings DR-1 and DR-2: fixed and re-reviewed.
+- PR review: pass, no accepted findings.
+- No unclassified finding remains.
+
+## Docs decision
+
+Public troubleshooting documentation was updated because terminal exit 78 intentionally requires operator recovery after authentication.
+
+## Remaining risks / owners
+
+- Whether the production Futu SDK exposes `需要手机验证码` through the existing trade context's global-state response: production canary after release.
+- Five-second state-check traffic and resulting log rate: production observation after release.
+- Generated unit installation and service restart: separate CEO-authorized production rollout.
+
+## Issue link status
+
+This work unit was not tied to a GitHub issue; no closing keyword or issue comment is required.
+
+## Next entry point
+
+CEO may review Draft PR #88. Merge, release, production upgrade, generated-unit installation, service restart, and production canary remain separately authorized actions.

--- a/docs/gateflow/trade-intake-auth-aware-restart-plan.md
+++ b/docs/gateflow/trade-intake-auth-aware-restart-plan.md
@@ -61,7 +61,7 @@ Owned files:
 Changes:
 
 - Define/export stable exit code `78` at the trade-intake application boundary.
-- Poll listener health once per second, independently of the 60-second heartbeat/backfill status cadence.
+- Poll listener health immediately after start and then every five seconds, independently of the 60-second heartbeat/backfill status cadence.
 - Catch terminal auth separately, close the context, write blocked status, and return `78` without sleeping/retrying.
 - Apply capped exponential backoff only to retryable exceptions and reset only after the first healthy trade-context observation.
 - Wrap multi-source thread targets with a result queue; the coordinator observes completions while threads are alive, sets the shared stop event immediately on `78`, then joins and returns `78`.

--- a/docs/gateflow/trade-intake-auth-aware-restart-plan.md
+++ b/docs/gateflow/trade-intake-auth-aware-restart-plan.md
@@ -1,0 +1,114 @@
+# Gateflow Plan — trade-intake-auth-aware-restart
+
+- Gate: plan
+- Work unit: `trade-intake-auth-aware-restart`
+- Base: `origin/main` at `0bb5b690`
+- Status: proposed
+
+## Goal
+
+Stop the production trade-intake log/reconnect storm when the OpenD trade context reports a phone-verification requirement, while preserving automatic recovery for ordinary transport failures.
+
+## Evidence
+
+- Production on 2026-07-19 repeatedly logs `需要手机验证码`, `RemoteClose`, and `Context status bad` from one long-running trade-intake PID.
+- `OpenDTradePushListener.start()` creates and starts the Futu trade context but exposes no health observation, so the SDK can reconnect internally forever without raising into the application loop.
+- `_run_listener_source_loop()` only applies reconnect policy to Python exceptions; it cannot distinguish terminal authentication failure from retryable disconnects.
+- generated trade-intake systemd service uses `Restart=always` and has no `RestartPreventExitStatus`.
+- `src.infrastructure.opend_watchdog.classify_watchdog_result()` already owns OpenD error classification, including `OPEND_NEEDS_PHONE_VERIFY`.
+
+## Behavioral contract
+
+1. The listener observes the already-created trade context's own global state. It must not open a quote context or use quote readiness as evidence of trade authentication.
+2. A state/error classified as `OPEND_NEEDS_PHONE_VERIFY` is terminal for this process invocation.
+3. Terminal auth produces stable exit status `78` (`EX_CONFIG` semantics) and a status artifact with `status=blocked`, `stage=auth_required`, and the classifier code/message.
+4. Generated trade-intake systemd service keeps `Restart=always` for retryable exits but adds `RestartPreventExitStatus=78`.
+5. Ordinary listener exceptions remain retryable with bounded exponential backoff: configured `reconnect_sec` is the floor, 60 seconds is the cap, and a successful listener start resets the delay.
+6. In multi-source mode, an auth-required result from any source stops sibling source loops and becomes the process exit status.
+7. Trade writes, idempotency, receipts, account mapping, and backfill semantics do not change.
+
+## Implementation slices
+
+### Slice 1 — listener-owned trade-auth observation
+
+Owned files:
+
+- `src/application/trades/push_listener.py`
+- `tests/test_trades_push_listener.py`
+
+Changes:
+
+- Add a small listener health observation method that calls `get_global_state()` on the existing `OpenSecTradeContext`.
+- Normalize Futu `(ret, data)` responses, pass state/error separately to `classify_watchdog_result()`, and preserve its code/message on the terminal exception.
+- Raise a dedicated `TradeIntakeAuthRequired` exception only for `OPEND_NEEDS_PHONE_VERIFY`.
+- Treat other non-OK responses/exceptions as retryable listener errors.
+- Do not classify `OPEND_TRD_NOT_LOGINED` alone as terminal because it can be transient and lacks explicit human-action evidence.
+
+Validation:
+
+- healthy READY/trade-logged-in state;
+- phone-verification response raises terminal exception;
+- generic disconnect/error remains retryable;
+- no new quote context is created.
+
+### Slice 2 — process exit and multi-source propagation
+
+Owned files:
+
+- `src/application/trades/auto_intake.py`
+- focused `tests/test_trades_auto_intake_*.py` or a new narrowly named test module
+
+Changes:
+
+- Define/export stable exit code `78` at the trade-intake application boundary.
+- Poll listener health once per second, independently of the 60-second heartbeat/backfill status cadence.
+- Catch terminal auth separately, close the context, write blocked status, and return `78` without sleeping/retrying.
+- Apply capped exponential backoff only to retryable exceptions and reset only after the first healthy trade-context observation.
+- Wrap multi-source thread targets with a result queue; the coordinator observes completions while threads are alive, sets the shared stop event immediately on `78`, then joins and returns `78`.
+
+Validation:
+
+- single-source auth returns 78 and performs no retry sleep;
+- retryable failure backs off and can recover;
+- delay cap is 60 seconds;
+- multi-source auth stops siblings and propagates 78;
+- status artifact contains stable classifier details.
+
+### Slice 3 — generated systemd lifecycle policy
+
+Owned files:
+
+- `src/application/service_deploy.py`
+- `tests/test_service_deploy.py`
+- public operations documentation only if the generated unit contract is documented there
+
+Changes:
+
+- Extend the systemd renderer with an optional list of restart-prevent exit statuses.
+- Set `[78]` only for `options-monitor-trade-intake.service`.
+- Preserve existing unit output for every other service.
+
+Validation:
+
+- trade-intake unit contains `Restart=always` and `RestartPreventExitStatus=78`;
+- unrelated long-running and one-shot units do not gain the directive;
+- existing service renderer tests continue to pass.
+
+## Validation ladder
+
+1. Focused listener and auto-intake tests.
+2. Focused service-deploy tests.
+3. Import/lint/static checks used by the repository for changed modules.
+4. Broader trade-intake and service-deploy suites.
+5. `git diff --check`.
+6. Aggregate deepreview against `origin/main`.
+
+## Rollout boundary
+
+This work unit ends at a Draft PR. Merge, release, production unit installation, service stop/start, and production authentication actions require separate CEO authorization.
+
+## Residual risks
+
+- The Futu SDK may expose a phone-verification message only through asynchronous logging and not through `get_global_state()`. Tests can prove our boundary but production canary must confirm the actual SDK response. Owner: production rollout.
+- A terminal exit intentionally leaves trade intake stopped until the operator completes authentication and starts/restarts it. Owner: operations runbook/rollout communication.
+- Other persistent authentication modes not classified as `OPEND_NEEDS_PHONE_VERIFY` remain retryable. Owner: later evidence-driven work unit; do not broaden terminal classification speculatively.

--- a/docs/gateflow/trade-intake-auth-aware-restart-slice-1-implementation-20260719.md
+++ b/docs/gateflow/trade-intake-auth-aware-restart-slice-1-implementation-20260719.md
@@ -1,0 +1,10 @@
+# Implementation — trade-intake-auth-aware-restart slice 1
+
+- Gate: implementation
+- Scope: listener-owned trade-auth observation
+- Changed: `src/application/trades/push_listener.py`, `tests/test_trades_push_listener.py`
+- Decision: added health observation on the existing trade context and a terminal exception carrying classifier evidence.
+- Validation: `python3 -m pytest -q tests/test_trades_push_listener.py` -> 4 passed.
+- Docs: no public command changed.
+- Residual risks: actual SDK response remains production-canary-owned; non-phone auth modes remain retryable by design.
+- Status: complete pending review.

--- a/docs/gateflow/trade-intake-auth-aware-restart-slice-2-implementation-20260719.md
+++ b/docs/gateflow/trade-intake-auth-aware-restart-slice-2-implementation-20260719.md
@@ -1,0 +1,10 @@
+# Implementation — trade-intake-auth-aware-restart slice 2
+
+- Gate: implementation
+- Scope: process exit, bounded retry, multi-source propagation
+- Changed: `src/application/trades/auto_intake.py`, `tests/test_trades_auto_intake_restart_policy.py`
+- Decisions: exit 78 on terminal auth; blocked status evidence; five-second health polling; capped exponential retry; queue-based sibling cancellation.
+- Validation: focused listener/auto-intake suites -> 19 passed.
+- Docs: public CLI unchanged.
+- Residual risks: actual SDK state exposure requires production canary; unexpected worker crashes return nonzero but remain systemd-retryable.
+- Status: complete pending review.

--- a/docs/gateflow/trade-intake-auth-aware-restart-slice-3-implementation-20260719.md
+++ b/docs/gateflow/trade-intake-auth-aware-restart-slice-3-implementation-20260719.md
@@ -1,0 +1,10 @@
+# Implementation — trade-intake-auth-aware-restart slice 3
+
+- Gate: implementation
+- Scope: generated systemd lifecycle policy
+- Changed: `src/application/service_deploy.py`, `tests/test_service_deploy.py`
+- Decision: optional renderer field; exit 78 is restart-preventing only for trade intake.
+- Validation: `tests/test_service_deploy.py` -> 100 passed.
+- Docs: generated unit behavior is captured in Gateflow artifacts; no CLI syntax changed.
+- Residual risks: deployed units are not updated by this Draft PR; rollout must render/install units under a separate production gate.
+- Status: complete pending review.

--- a/docs/reviews/code-review-trade-intake-auth-aware-restart-slice-1-20260719.md
+++ b/docs/reviews/code-review-trade-intake-auth-aware-restart-slice-1-20260719.md
@@ -1,0 +1,19 @@
+# Code Review — trade-intake-auth-aware-restart slice 1
+
+- Gate: code review / re-review
+- Base: `fda43837`
+- Reviewed: listener and focused tests
+- Decision: pass
+
+## Findings
+
+No accepted findings. The implementation uses the existing trade context, does not create a quote probe, preserves classifier code/message, and only makes explicit phone verification terminal. Generic transport errors remain retryable.
+
+## Validation
+
+`python3 -m pytest -q tests/test_trades_push_listener.py` -> 4 passed.
+
+## Residual risks
+
+- Asynchronous-only SDK messages: production canary owner.
+- Additional auth classes: later evidence-driven work unit.

--- a/docs/reviews/code-review-trade-intake-auth-aware-restart-slice-2-20260719.md
+++ b/docs/reviews/code-review-trade-intake-auth-aware-restart-slice-2-20260719.md
@@ -1,0 +1,25 @@
+# Code Review — trade-intake-auth-aware-restart slice 2
+
+- Gate: code review / fix / re-review
+- Base: `df692615`
+- Decision: pass after fix
+
+## Finding
+
+### CR-1 — Medium — one-second global-state polling risks becoming a new OpenD request/log source
+
+The accepted plan proposed one-second polling to bound detection, but `get_global_state()` is an SDK request rather than a local flag. A permanent one-Hz probe is unnecessarily aggressive after startup and could interact with OpenD rate limiting. Fixed by checking immediately after start and then using a fixed five-second interval, still far below the previous 60-second application observation gap and without adding config.
+
+## Re-review
+
+Pass. Terminal auth exits immediately on the first observation; steady-state health checks occur at five-second intervals. Retry delay remains independent and capped at 60 seconds. Multi-source result coordination cannot block indefinitely on sibling join after terminal auth because it observes the queue and sets the shared stop event.
+
+## Validation
+
+- focused listener/auto-intake suites: 19 passed.
+- Python compile: passed.
+
+## Residual risks
+
+- SDK may not expose asynchronous auth text in global state: production canary owner.
+- five-second polling cost must be observed in production, but is bounded and materially lower than the reviewed one-second plan.

--- a/docs/reviews/code-review-trade-intake-auth-aware-restart-slice-3-20260719.md
+++ b/docs/reviews/code-review-trade-intake-auth-aware-restart-slice-3-20260719.md
@@ -1,0 +1,17 @@
+# Code Review — trade-intake-auth-aware-restart slice 3
+
+- Gate: code review / re-review
+- Base: `1ab818aa`
+- Decision: pass
+
+## Findings
+
+No accepted findings. The renderer extension is optional, validates numeric exit statuses, and is applied only to trade intake. Existing restart and one-shot policies remain unchanged.
+
+## Validation
+
+`python3 -m pytest -q tests/test_service_deploy.py` -> 100 passed.
+
+## Residual risks
+
+Production installation/restart remains a separately authorized rollout action.

--- a/docs/reviews/deepreview-rereview-trade-intake-auth-aware-restart-20260719.md
+++ b/docs/reviews/deepreview-rereview-trade-intake-auth-aware-restart-20260719.md
@@ -1,0 +1,18 @@
+# Aggregate Deep Re-review — trade-intake-auth-aware-restart
+
+- Gate: re-review
+- Prior review: `docs/reviews/deepreview-trade-intake-auth-aware-restart-20260719.md`
+- Decision: pass
+
+## Finding closure
+
+- DR-1 fixed: plan evidence now matches the reviewed five-second implementation cadence.
+- DR-2 fixed: README documents blocked status evidence and manual recovery after OpenD phone verification.
+
+## Validation
+
+159 focused tests passed; compileall and diff check passed.
+
+## Residual risks
+
+All residual risks are classified to production canary/observation or the separately authorized rollout. No unclassified risk remains.

--- a/docs/reviews/deepreview-trade-intake-auth-aware-restart-20260719.md
+++ b/docs/reviews/deepreview-trade-intake-auth-aware-restart-20260719.md
@@ -1,0 +1,42 @@
+# Aggregate Deep Review — trade-intake-auth-aware-restart
+
+- Gate: aggregate deepreview / fix / re-review
+- Base: `origin/main` (`0bb5b690`)
+- Reviewed target: all branch changes through slice 3
+- Decision: pass after fixes
+
+## Findings
+
+### DR-1 — Medium — accepted plan artifacts still claimed one-second polling
+
+Implementation review correctly reduced steady-state `get_global_state()` polling to five seconds to avoid creating a new request/rate-limit source, but the accepted plan and plan re-review still stated one second. This would make the final evidence internally contradictory and could cause a later maintainer to “restore” the rejected cadence. Fixed both artifacts to state immediate startup observation followed by five-second polling.
+
+### DR-2 — Medium — operator recovery behavior was not in public troubleshooting documentation
+
+Exit 78 plus `RestartPreventExitStatus=78` intentionally leaves trade intake stopped until authentication is completed and an operator starts it. Without a public recovery hint, the safe fail-stop behavior can look like an outage. Fixed the README troubleshooting table with the status/error evidence and manual recovery boundary.
+
+## Correctness review
+
+- Existing trade context is observed; no quote context or readiness proxy is introduced.
+- Only classifier code `OPEND_NEEDS_PHONE_VERIFY` maps to terminal exit 78.
+- Generic context failures remain retryable with a floor and 60-second cap.
+- Multi-source terminal auth sets the shared event before result propagation and is returned by the coordinator.
+- systemd prevents restart only for exit 78 on trade intake; unrelated services are unchanged.
+
+## Stability / maintainability review
+
+- One dedicated exception and one stable exit code are sufficient; no generic supervisor framework was added.
+- Status artifacts preserve classifier code, message, detail, stage, and restart count.
+- Existing trade write, receipt, backfill, and mapping paths are unchanged.
+
+## Validation
+
+- focused trade intake, watchdog/error-policy, and service deployment suite: 159 passed.
+- compileall for changed application modules: passed.
+- `git diff --check`: passed.
+
+## Residual risks
+
+- Futu may emit phone-verification only asynchronously and not return it from the trade context global-state call: assigned to production canary after release.
+- Five-second steady-state state checks add bounded OpenD traffic: assigned to production observation.
+- Production unit rendering/installation and service start/stop require a separate CEO-authorized rollout.

--- a/docs/reviews/plan-rereview-trade-intake-auth-aware-restart-20260719.md
+++ b/docs/reviews/plan-rereview-trade-intake-auth-aware-restart-20260719.md
@@ -1,0 +1,29 @@
+# Plan Re-review — trade-intake-auth-aware-restart
+
+- Gate: re-review
+- Target: `docs/gateflow/trade-intake-auth-aware-restart-plan.md`
+- Prior review: `docs/reviews/plan-review-trade-intake-auth-aware-restart-20260719.md`
+- Decision: pass-with-risks
+
+## Finding closure
+
+- PR-1 fixed: health observation is explicitly once per second and independent from the 60-second heartbeat/backfill cadence.
+- PR-2 fixed: multi-source coordination uses a result queue and observes completion before blocking joins.
+- PR-3 fixed: retry delay resets only after a healthy trade-context observation.
+- PR-4 fixed: state/error classifier inputs and preserved code/message are explicit.
+
+## Required lenses
+
+- Architecture: pass; ownership and dependency direction remain valid.
+- State/recovery: pass; terminal auth, retryable transport failure, sibling cancellation, and process exit are specified.
+- Tests: pass; single/multi-source terminal paths, recovery, cap, and unit isolation are covered.
+- Simplicity: pass; no generic supervisor or speculative auth state model.
+
+## Residual risks
+
+- Actual SDK may log phone verification asynchronously without exposing it through `get_global_state()`: production canary owner.
+- Other authentication modes remain retryable until supported by direct evidence: later work unit owner.
+
+## Final decision
+
+Code-generation-ready.

--- a/docs/reviews/plan-rereview-trade-intake-auth-aware-restart-20260719.md
+++ b/docs/reviews/plan-rereview-trade-intake-auth-aware-restart-20260719.md
@@ -7,7 +7,7 @@
 
 ## Finding closure
 
-- PR-1 fixed: health observation is explicitly once per second and independent from the 60-second heartbeat/backfill cadence.
+- PR-1 fixed: health observation is immediate after start and then every five seconds and independent from the 60-second heartbeat/backfill cadence.
 - PR-2 fixed: multi-source coordination uses a result queue and observes completion before blocking joins.
 - PR-3 fixed: retry delay resets only after a healthy trade-context observation.
 - PR-4 fixed: state/error classifier inputs and preserved code/message are explicit.

--- a/docs/reviews/plan-review-trade-intake-auth-aware-restart-20260719.md
+++ b/docs/reviews/plan-review-trade-intake-auth-aware-restart-20260719.md
@@ -1,0 +1,40 @@
+# Plan Review — trade-intake-auth-aware-restart
+
+- Gate: plan review
+- Target: `docs/gateflow/trade-intake-auth-aware-restart-plan.md`
+- Review mode: adversarial implementation-plan review
+- Decision: changes required
+
+## Findings
+
+### PR-1 — High — Health polling cadence is underspecified and the existing loop can wait 60 seconds
+
+The plan says to poll during the heartbeat/backfill loop, but the current loop ends with `stop.wait(60)`. Production emits many SDK reconnect attempts in 60 seconds. The implementation needs an explicit short health interval independent of the 60-second status heartbeat/backfill cadence. Use a small fixed poll interval (for example one second) without changing backfill scheduling.
+
+### PR-2 — High — Multi-source result collection can deadlock
+
+If one source returns 78 and the main thread is blocked joining another source, the terminal result may not be observed in time. The plan must require a result queue/coordinator loop that observes completed source results while threads are alive, sets the shared stop event immediately on 78, then joins all threads.
+
+### PR-3 — Medium — Successful `start()` is not evidence that retry delay should reset
+
+The SDK can return from `start()` while authentication is still failing asynchronously. Resetting backoff immediately after `start()` can keep repeated transport failures at the minimum delay. Reset only after at least one healthy observation from the existing trade context.
+
+### PR-4 — Medium — Error classifier inputs need an explicit contract
+
+Futu may return either a state dict or `(ret != 0, error text)`. The listener method must pass state and error separately to the existing classifier, preserve the classifier code/message on the terminal exception, and avoid depending on an imported Futu `RET_OK` constant in tests if `ret == 0` is the existing SDK contract.
+
+## Architecture boundary review
+
+Pass with the above corrections. Application listener code may depend on infrastructure classification, while systemd policy remains in service deployment. No domain dependency reversal is introduced.
+
+## Best-practice / optimal-solution review
+
+Using the existing trade context is superior to a quote probe or a second connection. Native systemd `RestartPreventExitStatus` is the minimal lifecycle mechanism. A stable sysexits-style code avoids a new config key.
+
+## Overengineering / coupling review
+
+No need for a generic retry framework, new daemon supervisor, notification path, or authentication state machine. Keep one exception, one exit code, one optional renderer field, and a small coordinator.
+
+## Residual risks
+
+The asynchronous-only SDK failure risk remains assigned to production canary. It does not justify log scraping inside the process.

--- a/docs/reviews/pr-88-review-20260719.md
+++ b/docs/reviews/pr-88-review-20260719.md
@@ -1,0 +1,28 @@
+# PR Review — #88 Stop trade-intake auth restart loops
+
+- Gate: PR review / re-review
+- PR: #88
+- Base/head: `main` <- `codex/trade-intake-auth-aware-restart`
+- Draft: yes
+- Decision: pass
+
+## Patch / summary consistency
+
+The PR body accurately describes the existing-trade-context auth observation, exit 78, bounded retry, multi-source propagation, systemd restart prevention, documentation, validation, and rollout boundary. Changed files match the accepted plan and reviewed slices.
+
+## Findings
+
+No accepted findings. Terminal behavior is limited to the existing classifier's phone-verification result; retryable failures preserve automatic recovery; trade write semantics are untouched; generated lifecycle policy is isolated to trade intake.
+
+## Validation
+
+- Local focused suite: 159 passed.
+- compileall: passed.
+- diff check: passed.
+- GitHub checks at review time: Analyze/actions, Analyze/python, agent-plugin, and guardrails pending.
+
+## Residual risks
+
+- SDK global-state exposure of the production phone-verification condition: production canary owner.
+- bounded five-second health probe cost: production observation owner.
+- merge/release/unit installation/service restart: separate CEO authorization.

--- a/src/application/service_deploy.py
+++ b/src/application/service_deploy.py
@@ -397,6 +397,7 @@ def _systemd_unit(
     wants: list[str] | None = None,
     before: list[str] | None = None,
     runtime_max_sec: int | None = None,
+    restart_prevent_exit_statuses: list[int] | None = None,
 ) -> str:
     after_units = _dedupe_unit_dependencies(["network-online.target", *(after or [])])
     wants_units = _dedupe_unit_dependencies(["network-online.target", *(wants or [])])
@@ -435,6 +436,11 @@ def _systemd_unit(
     if restart:
         lines.append(f"Restart={restart}")
         lines.append("RestartSec=10")
+        if restart_prevent_exit_statuses:
+            statuses = [int(status) for status in restart_prevent_exit_statuses]
+            if any(status < 0 or status > 255 for status in statuses):
+                raise ValueError("restart_prevent_exit_statuses must be between 0 and 255")
+            lines.append("RestartPreventExitStatus=" + " ".join(str(status) for status in statuses))
     lines.extend(["StandardOutput=journal", "StandardError=journal", ""])
     if restart:
         lines.extend(["[Install]", "WantedBy=multi-user.target", ""])
@@ -930,6 +936,7 @@ def render_service_bundle(
                 exec_args=trade_args,
                 service_type="simple",
                 restart="always",
+                restart_prevent_exit_statuses=[78],
                 after=opend_dependency_units or None,
                 wants=opend_dependency_units or None,
             ),

--- a/src/application/trades/auto_intake.py
+++ b/src/application/trades/auto_intake.py
@@ -5,6 +5,7 @@ import argparse
 import contextlib
 import json
 import os
+import queue
 import sys
 import threading
 import time
@@ -29,7 +30,7 @@ from src.application.trades.state import (
 )
 from src.application.trades.backfill import payload_deal_id, run_history_backfill
 from src.application.trades.state_reconcile import reconcile_trade_intake_state
-from src.application.trades.push_listener import OpenDTradePushListener
+from src.application.trades.push_listener import OpenDTradePushListener, TradeIntakeAuthRequired
 from src.application.trades.receipt import send_trade_intake_receipt
 from src.application.opend_fetch_config import opend_fetch_kwargs
 from src.application.ledger.api import open_position_ledger_from_runtime_config
@@ -37,6 +38,9 @@ from src.application.runtime_paths import resolve_runtime_root
 from src.application.trades.intake import process_trade_payload
 from src.application.write_contract import attach_write_contract, write_control
 from src.infrastructure.io_utils import atomic_write_json, utc_now
+
+
+TRADE_INTAKE_AUTH_REQUIRED_EXIT_CODE = 78
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -138,6 +142,52 @@ class _ReplayRepo:
     def create_record(self, fields: dict[str, Any]) -> dict[str, Any]:
         return {"record": {"record_id": "dry_run_replay"}}
 
+
+
+def _coordinate_listener_sources(
+    sources: list[dict[str, Any]],
+    *,
+    run_source: Callable[[dict[str, Any], threading.Event], int],
+) -> int:
+    stop_event = threading.Event()
+    results: queue.Queue[int] = queue.Queue()
+
+    def _worker(source: dict[str, Any]) -> None:
+        try:
+            result = run_source(source, stop_event)
+        except Exception as exc:
+            _log(f"[ERROR] listener source={source.get('id')} crashed: {type(exc).__name__}: {exc}")
+            result = 1
+        results.put(result)
+
+    threads = [
+        threading.Thread(target=_worker, args=(source,), name=f"trade-intake-{source.get('id')}", daemon=False)
+        for source in sources
+    ]
+    exit_code = 0
+    completed = 0
+    try:
+        for thread in threads:
+            thread.start()
+        while completed < len(threads):
+            try:
+                source_code = results.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            completed += 1
+            if source_code == TRADE_INTAKE_AUTH_REQUIRED_EXIT_CODE:
+                exit_code = source_code
+                stop_event.set()
+            elif source_code != 0 and exit_code == 0:
+                exit_code = source_code
+        for thread in threads:
+            thread.join()
+    except KeyboardInterrupt:
+        stop_event.set()
+        for thread in threads:
+            thread.join(timeout=5)
+        return 0
+    return exit_code
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
@@ -344,39 +394,22 @@ def main(argv: list[str] | None = None) -> int:
             process_lock=process_lock,
         )
 
-    stop_event = threading.Event()
-    threads = [
-        threading.Thread(
-            target=_run_listener_source_loop,
-            kwargs={
-                "source": source,
-                "repo": repo,
-                "cfg": cfg,
-                "cfg_path": cfg_path,
-                "runtime_root": runtime_root,
-                "runtime_root_source": runtime_resolution.source,
-                "intake_cfg": intake_cfg,
-                "apply_changes": apply_changes,
-                "receipt_callback": receipt_callback,
-                "process_lock": process_lock,
-                "stop_event": stop_event,
-            },
-            name=f"trade-intake-{source.get('id')}",
-            daemon=False,
-        )
-        for source in sources
-    ]
-    try:
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-    except KeyboardInterrupt:
-        stop_event.set()
-        for thread in threads:
-            thread.join(timeout=5)
-        return 0
-    return 0
+    return _coordinate_listener_sources(
+        sources,
+        run_source=lambda source, stop_event: _run_listener_source_loop(
+            source=source,
+            repo=repo,
+            cfg=cfg,
+            cfg_path=cfg_path,
+            runtime_root=runtime_root,
+            runtime_root_source=runtime_resolution.source,
+            intake_cfg=intake_cfg,
+            apply_changes=apply_changes,
+            receipt_callback=receipt_callback,
+            process_lock=process_lock,
+            stop_event=stop_event,
+        ),
+    )
 
 
 def _build_receipt_callback(
@@ -585,8 +618,10 @@ def _run_listener_source_loop(
     listener = OpenDTradePushListener(host=host, port=port, on_deal=_on_deal)
     restart_count = 0
     last_backfill_monotonic: float | None = None
+    last_heartbeat_monotonic: float | None = None
     backfill_cfg = dict(source.get("backfill") or intake_cfg.get("backfill") or {})
-    reconnect_sec = int(source.get("reconnect_sec") or intake_cfg.get("reconnect_sec") or 5)
+    reconnect_floor_sec = max(1, int(source.get("reconnect_sec") or intake_cfg.get("reconnect_sec") or 5))
+    reconnect_delay_sec = reconnect_floor_sec
     while not stop.is_set():
         try:
             _write_listener_status(status_path, status_state, status="starting", stage="listener_start", restart_count=restart_count)
@@ -596,6 +631,8 @@ def _run_listener_source_loop(
             if bool(backfill_cfg.get("enabled", True)) and not bool(backfill_cfg.get("startup_check", True)) and last_backfill_monotonic is None:
                 last_backfill_monotonic = time.monotonic()
             while not stop.is_set():
+                listener.check_health()
+                reconnect_delay_sec = reconnect_floor_sec
                 should_backfill = bool(backfill_cfg.get("enabled", True))
                 now_mono = time.monotonic()
                 if should_backfill:
@@ -646,14 +683,32 @@ def _run_listener_source_loop(
                         last_backfill_monotonic = time.monotonic()
                         status_state.update(_update_status_from_backfill(status_state, result))
                         _write_listener_status(status_path, status_state, status="listening", stage="backfill_check", restart_count=restart_count)
-                _write_listener_status(status_path, status_state, status="listening", stage="heartbeat", restart_count=restart_count)
-                if stop.wait(60):
+                if last_heartbeat_monotonic is None or now_mono - last_heartbeat_monotonic >= 60:
+                    _write_listener_status(status_path, status_state, status="listening", stage="heartbeat", restart_count=restart_count)
+                    last_heartbeat_monotonic = now_mono
+                if stop.wait(5):
                     break
         except KeyboardInterrupt:
             stop.set()
             listener.close()
             _write_listener_status(status_path, status_state, status="stopped", stage="keyboard_interrupt", restart_count=restart_count)
             return 0
+        except TradeIntakeAuthRequired as exc:
+            listener.close()
+            stop.set()
+            status_state["last_error"] = str(exc)
+            _write_listener_status(
+                status_path,
+                status_state,
+                status="blocked",
+                stage="auth_required",
+                restart_count=restart_count,
+                last_error=str(exc),
+                error_code=exc.error_code,
+                error_message=exc.message,
+            )
+            _log(f"[ERROR] listener source={source.get('id')} blocked: {exc}")
+            return TRADE_INTAKE_AUTH_REQUIRED_EXIT_CODE
         except Exception as exc:
             listener.close()
             restart_count += 1
@@ -665,10 +720,12 @@ def _run_listener_source_loop(
                 stage="listener_exception",
                 restart_count=restart_count,
                 last_error=f"{type(exc).__name__}: {exc}",
+                reconnect_delay_sec=reconnect_delay_sec,
             )
-            _log(f"[WARN] listener source={source.get('id')} exited: {exc}; retry in {reconnect_sec} sec")
-            if stop.wait(reconnect_sec):
+            _log(f"[WARN] listener source={source.get('id')} exited: {exc}; retry in {reconnect_delay_sec} sec")
+            if stop.wait(reconnect_delay_sec):
                 break
+            reconnect_delay_sec = min(reconnect_delay_sec * 2, 60)
     listener.close()
     _write_listener_status(status_path, status_state, status="stopped", stage="stop_event", restart_count=restart_count)
     return 0

--- a/src/application/trades/push_listener.py
+++ b/src/application/trades/push_listener.py
@@ -4,6 +4,17 @@ import importlib
 import sys
 from typing import Any, Callable
 
+from src.infrastructure.opend_watchdog import classify_watchdog_result
+
+
+class TradeIntakeAuthRequired(RuntimeError):
+    def __init__(self, *, error_code: str, message: str, detail: str = "") -> None:
+        self.error_code = str(error_code)
+        self.message = str(message)
+        self.detail = str(detail)
+        suffix = f": {self.detail}" if self.detail else ""
+        super().__init__(f"{self.error_code} {self.message}{suffix}")
+
 
 class OpenDTradePushListener:
     def __init__(
@@ -68,6 +79,29 @@ class OpenDTradePushListener:
         self._ctx, self._handler = self._build_default_context()
         self._ctx.set_handler(self._handler)
         self._ctx.start()
+
+    def check_health(self) -> None:
+        if self._ctx is None:
+            raise RuntimeError("trade context is not started")
+        try:
+            ret, data = self._ctx.get_global_state()
+        except Exception as exc:
+            detail = f"get_global_state failed: {type(exc).__name__}: {exc}"
+            error_code, message = classify_watchdog_result(None, detail)
+        else:
+            if ret == 0 and isinstance(data, dict):
+                ready = data.get("program_status_type") in (None, "", "READY")
+                trade_logined = bool(data.get("trd_logined", True))
+                if ready and trade_logined:
+                    return
+                detail = f"OpenD trade context not ready: {data}"
+                error_code, message = classify_watchdog_result(data, detail)
+            else:
+                detail = f"get_global_state ret={ret} data={data}"
+                error_code, message = classify_watchdog_result(None, detail)
+        if error_code == "OPEND_NEEDS_PHONE_VERIFY":
+            raise TradeIntakeAuthRequired(error_code=error_code, message=message, detail=detail)
+        raise RuntimeError(f"{error_code} {message}: {detail}")
 
     def close(self) -> None:
         if self._ctx is not None:

--- a/tests/test_service_deploy.py
+++ b/tests/test_service_deploy.py
@@ -96,6 +96,10 @@ def test_render_systemd_bundle_uses_runtime_root_and_canonical_entrypoints(tmp_p
     assert "--journal-summary" in runtime_status
     assert str(repo / "om-agent") not in runtime_status
     assert "Restart=always" in intake
+    assert "RestartPreventExitStatus=78" in intake
+    assert "RestartPreventExitStatus=" not in tick
+    assert "RestartPreventExitStatus=" not in runtime_status
+    assert "RestartPreventExitStatus=" not in verify
     assert "RuntimeMaxSec=" not in tick
     assert "RuntimeMaxSec=" not in runtime_status
     assert "RuntimeMaxSec=" not in verify

--- a/tests/test_trades_auto_intake_restart_policy.py
+++ b/tests/test_trades_auto_intake_restart_policy.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+from src.application.trades import auto_intake
+from src.application.trades.push_listener import TradeIntakeAuthRequired
+
+
+def _source(tmp_path: Path, *, reconnect_sec: int = 5) -> dict:
+    return {
+        "id": "lx",
+        "account": "lx",
+        "host": "127.0.0.1",
+        "port": 11111,
+        "state_path": tmp_path / "state.json",
+        "audit_path": tmp_path / "audit.jsonl",
+        "status_path": tmp_path / "status.json",
+        "reconnect_sec": reconnect_sec,
+        "account_mapping": {},
+        "futu_account_ids": [],
+        "backfill": {"enabled": False},
+    }
+
+
+def _run(tmp_path: Path, monkeypatch, listener_type, *, reconnect_sec: int = 5, stop_event=None) -> int:
+    monkeypatch.setattr(auto_intake, "OpenDTradePushListener", listener_type)
+    return auto_intake._run_listener_source_loop(
+        source=_source(tmp_path, reconnect_sec=reconnect_sec),
+        repo=object(),
+        cfg={},
+        cfg_path=tmp_path / "config.json",
+        runtime_root=tmp_path,
+        runtime_root_source="test",
+        intake_cfg={"mode": "dry-run", "enabled": True, "account_mapping": {}, "backfill": {"enabled": False}},
+        apply_changes=False,
+        receipt_callback=lambda _context: {},
+        process_lock=threading.RLock(),
+        stop_event=stop_event,
+    )
+
+
+def test_auth_required_stops_without_retry_and_writes_blocked_status(tmp_path: Path, monkeypatch) -> None:
+    class _Listener:
+        def __init__(self, **_kwargs):
+            self.close_count = 0
+
+        def start(self):
+            return None
+
+        def check_health(self):
+            raise TradeIntakeAuthRequired(
+                error_code="OPEND_NEEDS_PHONE_VERIFY",
+                message="OpenD 需要手机验证码登录",
+                detail="需要手机验证码",
+            )
+
+        def close(self):
+            self.close_count += 1
+
+    rc = _run(tmp_path, monkeypatch, _Listener)
+
+    assert rc == auto_intake.TRADE_INTAKE_AUTH_REQUIRED_EXIT_CODE == 78
+    status = json.loads((tmp_path / "status.json").read_text(encoding="utf-8"))
+    assert status["status"] == "blocked"
+    assert status["stage"] == "auth_required"
+    assert status["error_code"] == "OPEND_NEEDS_PHONE_VERIFY"
+
+
+def test_retryable_disconnect_recovers_and_resets_to_floor(tmp_path: Path, monkeypatch) -> None:
+    waits: list[float] = []
+
+    class _Stop:
+        stopped = False
+
+        def is_set(self):
+            return self.stopped
+
+        def set(self):
+            self.stopped = True
+
+        def wait(self, seconds):
+            waits.append(seconds)
+            if len(waits) >= 2:
+                self.stopped = True
+            return self.stopped
+
+    class _Listener:
+        starts = 0
+
+        def __init__(self, **_kwargs):
+            return None
+
+        def start(self):
+            type(self).starts += 1
+
+        def check_health(self):
+            if type(self).starts == 1:
+                raise ConnectionResetError("connection reset")
+
+        def close(self):
+            return None
+
+    rc = _run(tmp_path, monkeypatch, _Listener, reconnect_sec=5, stop_event=_Stop())
+
+    assert rc == 0
+    assert _Listener.starts == 2
+    assert waits == [5, 5]
+
+
+def test_retry_backoff_is_capped_at_sixty_seconds(tmp_path: Path, monkeypatch) -> None:
+    waits: list[float] = []
+
+    class _Stop:
+        stopped = False
+
+        def is_set(self):
+            return self.stopped
+
+        def set(self):
+            self.stopped = True
+
+        def wait(self, seconds):
+            waits.append(seconds)
+            if len(waits) >= 2:
+                self.stopped = True
+            return self.stopped
+
+    class _Listener:
+        def __init__(self, **_kwargs):
+            return None
+
+        def start(self):
+            return None
+
+        def check_health(self):
+            raise ConnectionResetError("connection reset")
+
+        def close(self):
+            return None
+
+    rc = _run(tmp_path, monkeypatch, _Listener, reconnect_sec=40, stop_event=_Stop())
+
+    assert rc == 0
+    assert waits == [40, 60]
+
+
+def test_multi_source_auth_stops_sibling_and_propagates_exit_code() -> None:
+    sibling_stopped = threading.Event()
+
+    def _runner(source: dict, stop_event: threading.Event) -> int:
+        if source["id"] == "auth":
+            return auto_intake.TRADE_INTAKE_AUTH_REQUIRED_EXIT_CODE
+        assert stop_event.wait(2), "auth result did not stop sibling source"
+        sibling_stopped.set()
+        return 0
+
+    rc = auto_intake._coordinate_listener_sources(
+        [{"id": "auth"}, {"id": "sibling"}],
+        run_source=_runner,
+    )
+
+    assert rc == auto_intake.TRADE_INTAKE_AUTH_REQUIRED_EXIT_CODE
+    assert sibling_stopped.is_set()

--- a/tests/test_trades_push_listener.py
+++ b/tests/test_trades_push_listener.py
@@ -48,3 +48,113 @@ def test_trade_push_listener_isolates_callback_exception(monkeypatch) -> None:
 
     assert ret == 0
     assert seen == ["bad", "good"]
+
+
+def test_trade_push_listener_health_uses_existing_trade_context(monkeypatch) -> None:
+    class _FakeHandlerBase:
+        pass
+
+    class _FakeContext:
+        instances = 0
+
+        def __init__(self, **_kwargs):
+            type(self).instances += 1
+
+        def set_handler(self, _handler):
+            return None
+
+        def start(self):
+            return None
+
+        def get_global_state(self):
+            return 0, {"program_status_type": "READY", "trd_logined": True, "qot_logined": False}
+
+        def close(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "futu",
+        SimpleNamespace(OpenSecTradeContext=_FakeContext, TradeDealHandlerBase=_FakeHandlerBase),
+    )
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=lambda _row: None)
+
+    listener.start()
+    listener.check_health()
+
+    assert _FakeContext.instances == 1
+
+
+def test_trade_push_listener_health_raises_terminal_phone_verification(monkeypatch) -> None:
+    from src.application.trades.push_listener import TradeIntakeAuthRequired
+
+    class _FakeHandlerBase:
+        pass
+
+    class _FakeContext:
+        def __init__(self, **_kwargs):
+            return None
+
+        def set_handler(self, _handler):
+            return None
+
+        def start(self):
+            return None
+
+        def get_global_state(self):
+            return -1, "需要手机验证码"
+
+        def close(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "futu",
+        SimpleNamespace(OpenSecTradeContext=_FakeContext, TradeDealHandlerBase=_FakeHandlerBase),
+    )
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=lambda _row: None)
+    listener.start()
+
+    try:
+        listener.check_health()
+    except TradeIntakeAuthRequired as exc:
+        assert exc.error_code == "OPEND_NEEDS_PHONE_VERIFY"
+        assert "需要手机验证码" in exc.detail
+    else:
+        raise AssertionError("expected TradeIntakeAuthRequired")
+
+
+def test_trade_push_listener_health_keeps_disconnect_retryable(monkeypatch) -> None:
+    class _FakeHandlerBase:
+        pass
+
+    class _FakeContext:
+        def __init__(self, **_kwargs):
+            return None
+
+        def set_handler(self, _handler):
+            return None
+
+        def start(self):
+            return None
+
+        def get_global_state(self):
+            raise ConnectionResetError("connection reset")
+
+        def close(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "futu",
+        SimpleNamespace(OpenSecTradeContext=_FakeContext, TradeDealHandlerBase=_FakeHandlerBase),
+    )
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=lambda _row: None)
+    listener.start()
+
+    try:
+        listener.check_health()
+    except RuntimeError as exc:
+        assert "OPEND_API_ERROR" in str(exc)
+    else:
+        raise AssertionError("expected retryable RuntimeError")


### PR DESCRIPTION
## Summary
- observe authentication state on the existing OpenD trade context and exit with stable status 78 when phone verification is required
- preserve retryable disconnect recovery with bounded backoff and propagate terminal auth across multi-source listeners
- render `RestartPreventExitStatus=78` only for the trade-intake systemd service
- document the blocked status and manual recovery path

## Validation
- `python3 -m pytest -q tests/test_trades_push_listener.py tests/test_trades_auto_intake_*.py tests/test_opend_watchdog_alerts.py tests/test_runtime_script_dependency_cleanup.py tests/test_error_policy.py tests/test_service_deploy.py` (159 passed)
- `python3 -m compileall -q src/application/trades src/application/service_deploy.py`
- `git diff --check`

## Rollout boundary
This PR does not merge, release, install generated units, or restart production services. Production rollout requires separate authorization and a canary confirming that the Futu SDK exposes the phone-verification condition through the trade context global-state call.