### PR TITLE
Detect OpenD auth while trade context construction blocks

### DIFF
--- a/docs/gateflow/trade-intake-async-auth-preflight-final-closeout.md
+++ b/docs/gateflow/trade-intake-async-auth-preflight-final-closeout.md
@@ -1,0 +1,23 @@
+# Final Closeout — trade-intake-async-auth-preflight
+
+- Gate: final closeout
+- Status: final closeout pass
+- Draft PR: https://github.com/liuxie066/options-monitor/pull/90
+
+## Changed
+
+The listener can now detect direct `OpenSecTradeContext` phone-verification warnings while the SDK constructor is still synchronously reconnecting. Terminal auth retains exit 78 and blocked status; sibling construction cancellation is clean; successful construction remains unchanged.
+
+## Verified
+
+163 focused regressions passed; compileall and diff check passed; planreview, slice review, aggregate deepreview, and PR review passed with no unclassified findings.
+
+## Remaining risks / owners
+
+- Exact FTConsoleLog behavior: immediate production canary after v1.2.417 release.
+- Generated unit installation: explicit rollout step before canary.
+- Production trade-intake remains stopped until the hotfix is installed.
+
+## Next entry point
+
+Mark PR #90 ready, merge, release v1.2.417, upgrade production, render/install units, and run the single auth-failure canary already authorized by the CEO.

--- a/docs/gateflow/trade-intake-async-auth-preflight-plan.md
+++ b/docs/gateflow/trade-intake-async-auth-preflight-plan.md
@@ -1,0 +1,70 @@
+# Gateflow Hotfix Plan — trade-intake-async-auth-preflight
+
+- Gate: plan
+- Base: `origin/main` at v1.2.416 (`415c8a45`)
+- Production evidence: v1.2.416 canary failed; trade-intake is intentionally stopped.
+- Status: proposed
+
+## Goal
+
+Detect OpenD phone-verification failure before the Futu SDK's synchronous `OpenSecTradeContext` constructor can trap the application forever, then preserve the v1.2.416 exit-78/systemd contract.
+
+## Revised evidence
+
+- Futu `OpenContextBase.__init__` loops forever around `_init_connect_sync()` while auto-reconnect is enabled.
+- `OpenSecTradeContext` does not expose `is_async_connect`; therefore application code never reaches `listener.check_health()` during phone verification.
+- An async `OpenQuoteContext` experiment emitted the auth warning but its synchronous query/close also blocked, so quote preflight is not a safe owning boundary.
+- The SDK emits the direct trade-context failure through the `FTConsoleLog` warning stream before retrying.
+
+## Behavioral contract
+
+1. Construct the real trade context on a daemon worker thread while the caller remains able to observe cancellation and SDK warning records.
+2. Attach a temporary logging handler to the SDK's `FTConsoleLog` logger during construction and feed warning text into the existing `classify_watchdog_result()`.
+3. `OPEND_NEEDS_PHONE_VERIFY` raises the existing `TradeIntakeAuthRequired` immediately; main returns 78 and the process exits, terminating the daemon constructor thread.
+4. Successful construction transfers the context/handler to the listener and preserves normal push behavior.
+5. A shared multi-source stop event cancels sibling construction waits so source coordinator shutdown is bounded.
+6. Constructor exceptions other than auth remain retryable under the existing capped application backoff. There is no construction timeout/retry while a prior constructor worker is alive.
+7. Do not create a quote context, parse journald/files, monkeypatch Futu internals, or call `os._exit`.
+
+## Slice 1 — cancellable construction monitor
+
+Files:
+- `src/application/trades/push_listener.py`
+- `src/application/trades/auto_intake.py`
+- `tests/test_trades_push_listener.py`
+- `tests/test_trades_auto_intake_restart_policy.py`
+
+Changes:
+- make `OpenDTradePushListener.start()` accept an optional cancellation event;
+- run `_build_default_context()` on a daemon thread and return its result through a queue;
+- temporarily capture only `init connect fail` records for `OpenSecTradeContext`, classify them, and remove the handler in `finally` on every path;
+- check cancellation while waiting and raise a dedicated `TradeIntakeStartCancelled`;
+- pass the shared source-loop stop event into `listener.start()`.
+
+Tests:
+- blocking constructor emits phone-verification warning and start raises terminal auth within a bounded time;
+- successful constructor remains compatible;
+- cancellation exits a blocked construction wait;
+- retryable constructor exception remains retryable;
+- multi-source sibling cancellation remains bounded.
+
+## Slice 2 — release/rollout verification
+
+No application behavior expansion. After review and merge:
+- release v1.2.417;
+- upgrade production;
+- explicitly render/install the generated unit because update reconciliation has not refreshed unit content in prior rollouts;
+- start trade-intake once;
+- prove exit status 78, `RestartPreventExitStatus=78`, no restart, blocked status artifact, and stable journal growth.
+
+## Validation
+
+- focused listener and restart-policy tests;
+- full trade-intake/watchdog/service-deploy regression bundle;
+- full pytest and smoke before release;
+- production canary after explicit unit installation.
+
+## Residual risks
+
+- SDK logger name/level could change in a future futu-api version: dependency-version-owned, with regression test around the current adapter contract.
+- daemon constructor threads are intentionally abandoned only when the whole process is about to exit or coordinated shutdown is underway; they must never accumulate during ordinary retry loops.

--- a/docs/gateflow/trade-intake-async-auth-preflight-slice-1-implementation-20260719.md
+++ b/docs/gateflow/trade-intake-async-auth-preflight-slice-1-implementation-20260719.md
@@ -1,0 +1,7 @@
+# Implementation — trade-intake-async-auth-preflight slice 1
+
+- Gate: implementation
+- Changed: push listener construction monitor, source-loop cancellation, focused tests.
+- Decision: monitor the real blocking trade constructor on a daemon worker; classify only scoped SDK init warnings; no quote context or timeout retry.
+- Validation: focused listener/restart-policy tests pass.
+- Residual risk: current futu-api logger contract is adapter-owned and must be verified in production.

--- a/docs/reviews/code-review-trade-intake-async-auth-preflight-slice-1-20260719.md
+++ b/docs/reviews/code-review-trade-intake-async-auth-preflight-slice-1-20260719.md
@@ -1,0 +1,10 @@
+# Code Review — trade-intake-async-auth-preflight slice 1
+
+- Gate: code review / re-review
+- Decision: pass
+
+No accepted correctness findings. Handler lifetime is protected by `finally`; warning scope requires both `init connect fail` and `OpenSecTradeContext`; cancellation has a dedicated non-retry path; generic constructor errors remain retryable; timeout-driven daemon accumulation is absent.
+
+Validation covers successful construction compatibility, blocking auth detection, cancellation, constructor error cleanup, clean source-loop cancellation, and multi-source coordination.
+
+Residual risk remains production proof against the pinned Futu SDK.

--- a/docs/reviews/deepreview-trade-intake-async-auth-preflight-20260719.md
+++ b/docs/reviews/deepreview-trade-intake-async-auth-preflight-20260719.md
@@ -1,0 +1,33 @@
+# Aggregate Deep Review — trade-intake-async-auth-preflight
+
+- Gate: aggregate deepreview / re-review
+- Base: `origin/main` v1.2.416
+- Decision: pass
+
+## Production failure closure
+
+The patch moves observation ahead of the blocking constructor completion by running the exact trade-context constructor on a daemon worker and observing its scoped SDK warning stream. It does not repeat the failed post-construction health-check assumption or the blocked quote-context experiment.
+
+## Findings
+
+No accepted findings.
+
+## Correctness and recovery
+
+- Only `init connect fail` records naming `OpenSecTradeContext` are eligible for terminal classification.
+- Existing classifier remains the sole phone-verification policy owner.
+- Auth and coordinated cancellation abandon a daemon worker only while the process is exiting; no timeout-driven retry can accumulate workers.
+- Successful construction transfers the real context and handler unchanged.
+- Cancellation is handled before generic retry in the source loop.
+- v1.2.416 exit 78, blocked status, multi-source propagation, and generated systemd policy remain intact.
+
+## Validation
+
+- focused and broader trade-intake/watchdog/service-deploy suite: 163 passed;
+- compileall: passed;
+- diff check: passed.
+
+## Residual risks
+
+- Runtime behavior depends on the pinned Futu SDK continuing to emit the initialization warning to `FTConsoleLog`; assigned to immediate production canary.
+- Production unit content still requires explicit render/install; assigned to rollout.

--- a/docs/reviews/plan-rereview-trade-intake-async-auth-preflight-20260719.md
+++ b/docs/reviews/plan-rereview-trade-intake-async-auth-preflight-20260719.md
@@ -1,0 +1,8 @@
+# Plan Re-review — trade-intake-async-auth-preflight
+
+- Gate: re-review
+- Decision: pass-with-risks
+
+PR-1 fixed with a dedicated cancellation exception and clean source-loop return. PR-2 fixed with mandatory finally cleanup and handler-count assertions. PR-3 fixed by prohibiting timeout-driven retries while a constructor worker lives. PR-4 fixed with trade-context initialization filtering.
+
+Architecture, recovery, testing, and simplicity lenses pass. The remaining SDK logger-contract risk is classified to the pinned dependency adapter and production canary.

--- a/docs/reviews/plan-review-trade-intake-async-auth-preflight-20260719.md
+++ b/docs/reviews/plan-review-trade-intake-async-auth-preflight-20260719.md
@@ -1,0 +1,26 @@
+# Plan Review — trade-intake-async-auth-preflight
+
+- Gate: plan review
+- Decision: changes required
+
+## Findings
+
+### PR-1 — High — cancelled construction must not enter the ordinary retry loop
+
+If sibling auth sets the shared stop event, `start()` cancellation cannot be represented as a generic `RuntimeError`, because `_run_listener_source_loop` would catch it as retryable, write reconnecting status, and potentially wait. Add a dedicated `TradeIntakeStartCancelled` exception and return cleanly when the stop event is already set.
+
+### PR-2 — High — temporary log handler must be removed on every return path
+
+Multiple listeners and retries make handler leakage multiplicative. The handler registration/removal must be inside `try/finally`, and tests must assert no handler remains after success, auth, exception, and cancellation.
+
+### PR-3 — Medium — abandoned constructor threads must not accumulate after generic timeout
+
+The plan should not introduce a construction timeout that retries while the prior SDK thread is still alive. Wait indefinitely for success/auth/cancellation; the SDK owns transport retries during construction. Only auth or coordinated process shutdown may abandon the daemon thread.
+
+### PR-4 — Medium — log classification must be scoped to trade-context initialization
+
+Filter warning records to messages containing both `init connect fail` and `OpenSecTradeContext` before applying the classifier. Otherwise unrelated Futu warnings in the same process could terminate intake.
+
+## Lenses
+
+Architecture: pass after fixes; SDK adaptation remains in push-listener ownership. Recovery: direct auth is terminal, transport remains SDK-retryable, sibling shutdown is cancellable. Simplicity: one worker thread, one handler, two small exceptions; no subprocess or private SDK monkeypatching.

--- a/docs/reviews/pr-90-review-20260719.md
+++ b/docs/reviews/pr-90-review-20260719.md
@@ -1,0 +1,8 @@
+# PR Review — #90 trade-intake async auth preflight
+
+- Gate: PR review / re-review
+- Decision: pass
+
+The patch and PR summary match the production failure. The change observes the exact blocking trade constructor rather than adding quote readiness, log-file scraping, SDK private-state mutation, or a second retry supervisor. Handler cleanup, source scoping, cancellation ordering, and no-timeout worker policy are covered.
+
+No accepted findings. Local validation: 163 passed, compileall and diff check passed. Production canary remains the required residual-risk closure.

--- a/src/application/trades/auto_intake.py
+++ b/src/application/trades/auto_intake.py
@@ -30,7 +30,11 @@ from src.application.trades.state import (
 )
 from src.application.trades.backfill import payload_deal_id, run_history_backfill
 from src.application.trades.state_reconcile import reconcile_trade_intake_state
-from src.application.trades.push_listener import OpenDTradePushListener, TradeIntakeAuthRequired
+from src.application.trades.push_listener import (
+    OpenDTradePushListener,
+    TradeIntakeAuthRequired,
+    TradeIntakeStartCancelled,
+)
 from src.application.trades.receipt import send_trade_intake_receipt
 from src.application.opend_fetch_config import opend_fetch_kwargs
 from src.application.ledger.api import open_position_ledger_from_runtime_config
@@ -625,7 +629,7 @@ def _run_listener_source_loop(
     while not stop.is_set():
         try:
             _write_listener_status(status_path, status_state, status="starting", stage="listener_start", restart_count=restart_count)
-            listener.start()
+            listener.start(cancel_event=stop)
             _log(f"[OK] auto trade intake listener started source={source.get('id')} {host}:{port}")
             _write_listener_status(status_path, status_state, status="listening", stage="listener_started", restart_count=restart_count)
             if bool(backfill_cfg.get("enabled", True)) and not bool(backfill_cfg.get("startup_check", True)) and last_backfill_monotonic is None:
@@ -692,6 +696,16 @@ def _run_listener_source_loop(
             stop.set()
             listener.close()
             _write_listener_status(status_path, status_state, status="stopped", stage="keyboard_interrupt", restart_count=restart_count)
+            return 0
+        except TradeIntakeStartCancelled:
+            listener.close()
+            _write_listener_status(
+                status_path,
+                status_state,
+                status="stopped",
+                stage="start_cancelled",
+                restart_count=restart_count,
+            )
             return 0
         except TradeIntakeAuthRequired as exc:
             listener.close()

--- a/src/application/trades/push_listener.py
+++ b/src/application/trades/push_listener.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import importlib
+import logging
+import queue
 import sys
+import threading
 from typing import Any, Callable
 
 from src.infrastructure.opend_watchdog import classify_watchdog_result
+
+
+class TradeIntakeStartCancelled(RuntimeError):
+    pass
 
 
 class TradeIntakeAuthRequired(RuntimeError):
@@ -75,10 +82,60 @@ class OpenDTradePushListener:
             raise RuntimeError(f"failed to initialize OpenSecTradeContext: {last_error}")
         return ctx, DealHandler(self.on_deal)
 
-    def start(self) -> None:
-        self._ctx, self._handler = self._build_default_context()
-        self._ctx.set_handler(self._handler)
-        self._ctx.start()
+    def start(self, *, cancel_event: threading.Event | None = None) -> None:
+        results: queue.Queue[tuple[str, Any, Any]] = queue.Queue(maxsize=1)
+        auth_required = threading.Event()
+        auth_evidence: dict[str, str] = {}
+
+        class _TradeContextInitLogHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                detail = record.getMessage()
+                if "init connect fail" not in detail or "OpenSecTradeContext" not in detail:
+                    return
+                error_code, message = classify_watchdog_result(None, detail)
+                if error_code == "OPEND_NEEDS_PHONE_VERIFY":
+                    auth_evidence.update(error_code=error_code, message=message, detail=detail)
+                    auth_required.set()
+
+        def _construct() -> None:
+            try:
+                ctx, handler = self._build_default_context()
+            except Exception as exc:
+                results.put(("error", exc, None))
+            else:
+                results.put(("ok", ctx, handler))
+
+        sdk_logger = logging.getLogger("FTConsoleLog")
+        log_handler = _TradeContextInitLogHandler()
+        sdk_logger.addHandler(log_handler)
+        worker = threading.Thread(
+            target=_construct,
+            name=f"trade-context-init-{self.host}-{self.port}",
+            daemon=True,
+        )
+        try:
+            worker.start()
+            while True:
+                if auth_required.is_set():
+                    raise TradeIntakeAuthRequired(
+                        error_code=auth_evidence["error_code"],
+                        message=auth_evidence["message"],
+                        detail=auth_evidence["detail"],
+                    )
+                if cancel_event is not None and cancel_event.is_set():
+                    raise TradeIntakeStartCancelled("trade context initialization cancelled")
+                try:
+                    result, value, handler = results.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                if result == "error":
+                    raise value
+                self._ctx, self._handler = value, handler
+                self._ctx.set_handler(self._handler)
+                self._ctx.start()
+                return
+        finally:
+            sdk_logger.removeHandler(log_handler)
 
     def check_health(self) -> None:
         if self._ctx is None:

--- a/tests/test_trades_auto_intake_restart_policy.py
+++ b/tests/test_trades_auto_intake_restart_policy.py
@@ -46,7 +46,7 @@ def test_auth_required_stops_without_retry_and_writes_blocked_status(tmp_path: P
         def __init__(self, **_kwargs):
             self.close_count = 0
 
-        def start(self):
+        def start(self, **_kwargs):
             return None
 
         def check_health(self):
@@ -92,7 +92,7 @@ def test_retryable_disconnect_recovers_and_resets_to_floor(tmp_path: Path, monke
         def __init__(self, **_kwargs):
             return None
 
-        def start(self):
+        def start(self, **_kwargs):
             type(self).starts += 1
 
         def check_health(self):
@@ -131,7 +131,7 @@ def test_retry_backoff_is_capped_at_sixty_seconds(tmp_path: Path, monkeypatch) -
         def __init__(self, **_kwargs):
             return None
 
-        def start(self):
+        def start(self, **_kwargs):
             return None
 
         def check_health(self):
@@ -163,3 +163,24 @@ def test_multi_source_auth_stops_sibling_and_propagates_exit_code() -> None:
 
     assert rc == auto_intake.TRADE_INTAKE_AUTH_REQUIRED_EXIT_CODE
     assert sibling_stopped.is_set()
+
+
+def test_source_loop_treats_start_cancellation_as_clean_stop(tmp_path: Path, monkeypatch) -> None:
+    from src.application.trades.push_listener import TradeIntakeStartCancelled
+
+    class _Listener:
+        def __init__(self, **_kwargs):
+            return None
+
+        def start(self, **_kwargs):
+            raise TradeIntakeStartCancelled("cancelled")
+
+        def close(self):
+            return None
+
+    rc = _run(tmp_path, monkeypatch, _Listener, stop_event=threading.Event())
+
+    assert rc == 0
+    status = json.loads((tmp_path / "status.json").read_text(encoding="utf-8"))
+    assert status["status"] == "stopped"
+    assert status["stage"] == "start_cancelled"

--- a/tests/test_trades_push_listener.py
+++ b/tests/test_trades_push_listener.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 import sys
+import threading
 from types import SimpleNamespace
 
 from src.application.trades.push_listener import OpenDTradePushListener
@@ -158,3 +160,102 @@ def test_trade_push_listener_health_keeps_disconnect_retryable(monkeypatch) -> N
         assert "OPEND_API_ERROR" in str(exc)
     else:
         raise AssertionError("expected retryable RuntimeError")
+
+
+def test_trade_push_listener_detects_auth_while_constructor_blocks(monkeypatch) -> None:
+    from src.application.trades.push_listener import TradeIntakeAuthRequired
+
+    release_constructor = threading.Event()
+
+    class _FakeHandlerBase:
+        pass
+
+    class _BlockingContext:
+        def __init__(self, **_kwargs):
+            logging.getLogger("FTConsoleLog").warning(
+                "[open_context_base.py:407] _init_connect_sync: init connect fail: "
+                "msg=需要手机验证码 context=<futu.trade.open_trade_context.OpenSecTradeContext object>"
+            )
+            release_constructor.wait(5)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "futu",
+        SimpleNamespace(OpenSecTradeContext=_BlockingContext, TradeDealHandlerBase=_FakeHandlerBase),
+    )
+    sdk_logger = logging.getLogger("FTConsoleLog")
+    handlers_before = list(sdk_logger.handlers)
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=lambda _row: None)
+
+    try:
+        listener.start()
+    except TradeIntakeAuthRequired as exc:
+        assert exc.error_code == "OPEND_NEEDS_PHONE_VERIFY"
+    else:
+        raise AssertionError("expected terminal auth while constructor is blocked")
+    finally:
+        release_constructor.set()
+
+    assert list(sdk_logger.handlers) == handlers_before
+
+
+def test_trade_push_listener_cancels_blocked_constructor_and_removes_handler(monkeypatch) -> None:
+    from src.application.trades.push_listener import TradeIntakeStartCancelled
+
+    release_constructor = threading.Event()
+
+    class _FakeHandlerBase:
+        pass
+
+    class _BlockingContext:
+        def __init__(self, **_kwargs):
+            release_constructor.wait(5)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "futu",
+        SimpleNamespace(OpenSecTradeContext=_BlockingContext, TradeDealHandlerBase=_FakeHandlerBase),
+    )
+    sdk_logger = logging.getLogger("FTConsoleLog")
+    handlers_before = list(sdk_logger.handlers)
+    cancel_event = threading.Event()
+    cancel_event.set()
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=lambda _row: None)
+
+    try:
+        listener.start(cancel_event=cancel_event)
+    except TradeIntakeStartCancelled:
+        pass
+    else:
+        raise AssertionError("expected cancelled construction")
+    finally:
+        release_constructor.set()
+
+    assert list(sdk_logger.handlers) == handlers_before
+
+
+def test_trade_push_listener_constructor_error_removes_handler(monkeypatch) -> None:
+    class _FakeHandlerBase:
+        pass
+
+    class _FailingContext:
+        def __init__(self, **_kwargs):
+            raise ConnectionRefusedError("refused")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "futu",
+        SimpleNamespace(OpenSecTradeContext=_FailingContext, TradeDealHandlerBase=_FakeHandlerBase),
+    )
+    sdk_logger = logging.getLogger("FTConsoleLog")
+    handlers_before = list(sdk_logger.handlers)
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=lambda _row: None)
+
+    try:
+        listener.start()
+    except RuntimeError as exc:
+        assert "failed to initialize" in str(exc)
+    else:
+        raise AssertionError("expected retryable constructor failure")
+
+    assert list(sdk_logger.handlers) == handlers_before


### PR DESCRIPTION
## Summary
- construct the real Futu trade context on a daemon worker so the caller can observe terminal authentication warnings before constructor completion
- classify only scoped `OpenSecTradeContext` initialization failures with the existing OpenD classifier
- cancel sibling construction cleanly without entering the retry loop
- preserve the v1.2.416 exit-78 and systemd restart-prevention contract

## Production evidence
v1.2.416 proved that `OpenSecTradeContext(...)` loops synchronously before `check_health()` can run. Production trade-intake is currently stopped to prevent further log growth.

## Validation
- broader focused bundle: 163 passed
- compileall: passed
- diff check: passed

## Rollout
After review and merge, release v1.2.417, explicitly install the generated unit, then run a single production auth-failure canary.