### PR TITLE
fix: isolate trade-intake shutdown from Futu SDK threads

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 720 (`src`: 400, `domain`: 61, `scripts`: 7, `tests`: 252)
-- Internal import edges: 4018 total, 1892 production/script edges excluding tests
+- Python files scanned: 722 (`src`: 401, `domain`: 61, `scripts`: 7, `tests`: 253)
+- Internal import edges: 4022 total, 1893 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -43,7 +43,7 @@ flowchart LR
   scripts -->|7| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|1468| application
+  tests -->|1471| application
   tests -->|332| domain
   tests -->|2| domain_services
   tests -->|106| infrastructure
@@ -73,7 +73,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 1468 |
+| tests | application | 1471 |
 | tests | domain | 332 |
 | tests | interfaces | 174 |
 | tests | infrastructure | 106 |

--- a/docs/gateflow/trade-intake-process-isolated-auth-preflight-final-closeout.md
+++ b/docs/gateflow/trade-intake-process-isolated-auth-preflight-final-closeout.md
@@ -1,0 +1,73 @@
+# Gateflow Final Closeout — trade-intake-process-isolated-auth-preflight
+
+- Status: final closeout pass
+- Draft PR: https://github.com/liuxie066/options-monitor/pull/92
+- Final implementation/review head before this artifact: `8a2674cd`
+- Production trade-intake: intentionally stopped pending merge/release/canary
+
+## Gate completion
+
+- Goal confirmation: pass
+- Plan: pass
+- Plan review/fix/re-review: pass
+- Accepted plan commit: `833875fa`
+- Implementation slice: pass
+- Code review/fix/re-review: pass
+- Accepted slice commit: `ed3b13fe`
+- Aggregate deepreview: pass
+- Accepted deepreview commit: `4dccd739`
+- Draft PR: opened as PR #92
+- PR review: pass
+- Accepted PR review commit: `8a2674cd`
+- Final CI on PR-review head: all checks passed
+- Draft-PR-pass: achieved
+
+## Delivered behavior
+
+`./om run trade-intake` now supervises the complete existing intake application in a dedicated spawn-context child. After the application returns, the child flushes output and uses a contained hard exit so Futu SDK non-daemon threads cannot block process termination. The parent propagates exit 78 normally to systemd.
+
+The existing semantic owners remain unchanged:
+
+- push listener classifies the SDK warning;
+- auto-intake writes blocked status and selects code 78;
+- process supervisor owns only child lifecycle and exit propagation;
+- systemd owns restart prevention for status 78.
+
+## Validation
+
+```text
+2708 passed, 10 skipped — full repository
+284 passed — trades + service deployment regression
+105 passed — process supervisor + service/CLI delegation
+12 passed — push listener + restart policy
+smoke OK
+ruff passed
+compileall passed
+dependency graph current — 469 production modules, 0 cycles
+git diff --check passed
+GitHub: Agent Plugin, Guardrails, CodeQL actions/python all passed
+```
+
+## Production state and next boundary
+
+The failed v1.2.417 canary was stopped. Current production trade-intake remains inactive, preventing authentication log flooding. No notification, broker, trade, ledger, config, or further service mutation occurred in this work unit.
+
+Merge, release version creation, remote upgrade, and the single production canary remain external actions requiring explicit authorization. The canary acceptance criteria are:
+
+```text
+blocked artifact: status=blocked, stage=auth_required,
+error_code=OPEND_NEEDS_PHONE_VERIFY
+ExecMainStatus=78
+RestartPreventExitStatus=78
+NRestarts=0
+MainPID=0
+no continuing six-second authentication log growth
+```
+
+## Residual risks
+
+- Real Futu/systemd confirmation: assigned to the next authorized production rollout.
+- Child finalizers skipped after application return: accepted and contained to the disposable intake child.
+- Abrupt SIGKILL terminal status persistence: pre-existing systemd-visible limitation.
+
+All residual risks are classified. No code finding or blocking open question remains.

--- a/docs/gateflow/trade-intake-process-isolated-auth-preflight-plan.md
+++ b/docs/gateflow/trade-intake-process-isolated-auth-preflight-plan.md
@@ -131,7 +131,7 @@ Broader before draft PR:
 
 ```bash
 python3.12 -m pytest tests/test_trades_*.py tests/test_service_deploy.py tests/test_service_drift.py -q
-python3.12 scripts/check_dependency_graph.py --check
+python3.12 scripts/generate_dependency_graph.py --check
 python3.12 -m pytest -q
 python3.12 tests/run_smoke.py
 ```

--- a/docs/gateflow/trade-intake-process-isolated-auth-preflight-plan.md
+++ b/docs/gateflow/trade-intake-process-isolated-auth-preflight-plan.md
@@ -1,0 +1,154 @@
+# Gateflow Plan — trade-intake-process-isolated-auth-preflight
+
+- Gate: plan
+- Base: `origin/main` at v1.2.417 (`1203c59d`)
+- Production evidence: v1.2.417 detects `OPEND_NEEDS_PHONE_VERIFY`, but the process remains alive and the SDK continues its six-second reconnect log loop.
+- Status: proposed
+
+## Goal / motivation / success signal
+
+Make the `./om run trade-intake` process boundary deterministic when the Futu SDK leaves non-daemon transport threads behind. The application child must persist the existing blocked status, terminate with exit code 78 without waiting for SDK threads, and let the supervising CLI process return 78 so systemd applies `RestartPreventExitStatus=78`.
+
+Success requires:
+
+1. auth detection still writes `status=blocked`, `stage=auth_required`, and `error_code=OPEND_NEEDS_PHONE_VERIFY`;
+2. the listener execution process exits even when a non-daemon thread remains alive;
+3. the CLI supervisor returns the child's terminal code unchanged, including 78;
+4. normal listener operation remains long-running and systemd stop remains bounded;
+5. production canary reaches `MainPID=0`, `ExecMainStatus=78`, `NRestarts=0`, with no continuing six-second log growth.
+
+## Non-goals / scope boundary
+
+- Do not change trade normalization, ledger writes, receipts, notifications, OpenD configuration, or retry policy.
+- Do not add quote preflight, parse journald, monkeypatch Futu internals, or change the status schema.
+- Do not redesign source coordination or move each account/source into a separate process.
+- Do not use a constructor-only child: a successful Futu context cannot be safely transferred to the parent, and reconstructing it would duplicate the blocking operation.
+
+## First-principles judgment and direct evidence
+
+- `OpenDTradePushListener.start()` now detects the auth warning and `_run_listener_source_loop()` writes blocked status and returns 78.
+- `_coordinate_listener_sources()` receives 78 and joins its source threads, so application-level coordination terminates.
+- Production nevertheless remains `active/running`, while Futu warnings continue. The remaining ownership is interpreter shutdown waiting on SDK-created non-daemon threads.
+- A local reproduction shows a `multiprocessing.Process` target that merely returns/SystemExits still remains alive when it created a non-daemon thread. Therefore process isolation alone is insufficient: the isolated child must finish through `os._exit(code)` after flushing standard streams.
+- The parent supervisor contains the hard exit to the dedicated trade-intake child. The operator CLI and systemd-facing process retain normal Python lifecycle and receive an ordinary child exit status.
+
+## Affected files/modules
+
+- `src/application/trades/process_supervisor.py` — new narrow process boundary owned by trade intake.
+- `src/interfaces/cli/run_ops.py` — delegate the long-running trade-intake command to the supervisor.
+- `tests/test_trades_process_supervisor.py` — process lifecycle and exit-code regressions.
+- `tests/test_service_deploy.py` — preserve CLI argument delegation contract.
+
+No public command, config, status schema, or systemd unit shape changes.
+
+## Contract / state-machine changes
+
+External contract remains:
+
+```text
+./om run trade-intake -> integer exit status
+```
+
+Internal lifecycle becomes:
+
+```text
+CLI parent
+  -> spawn dedicated trade-intake child
+  -> child runs existing auto_intake.main(argv)
+  -> child flushes stdout/stderr
+  -> child os._exit(application_code)
+  -> parent joins and returns child exit code
+```
+
+Terminal auth state remains absorbing:
+
+```text
+SDK warning -> blocked status persisted -> application code 78
+-> isolated child hard-exits 78 -> parent returns 78
+-> systemd does not restart
+```
+
+Signal/cancellation behavior:
+
+- systemd's default control-group kill reaches parent and child;
+- parent `KeyboardInterrupt` terminates and joins the child, preserving the prior operator-facing clean-stop behavior;
+- a child terminated by signal maps to a conventional non-zero shell status rather than being mistaken for success.
+
+## Implementation decision
+
+Use the standard-library `multiprocessing` spawn context for one dedicated child around the entire existing auto-intake application. The child entrypoint imports `auto_intake.main`, captures its integer result, flushes stdout/stderr, and calls `os._exit(code)` in `finally`-safe outer code. It must never invoke the CLI recursively.
+
+Why this is not over-designed:
+
+- one supervisor and one child are the minimum boundary that can own all Futu threads and discard them safely;
+- constructor-only isolation cannot transfer a live SDK context;
+- changing every source to a process would expand state, IPC, and write coordination without current need;
+- calling `os._exit` in the main CLI process would be shorter but would make all parent cleanup and embedding semantics unsafe.
+
+## Slice 1 — deterministic trade-intake process boundary
+
+Objective: introduce the child boundary and preserve CLI behavior.
+
+Allowed files:
+
+- `src/application/trades/process_supervisor.py`
+- `src/interfaces/cli/run_ops.py`
+- `tests/test_trades_process_supervisor.py`
+- focused existing CLI tests in `tests/test_service_deploy.py`
+
+Exact changes:
+
+- add a top-level, spawn-picklable child entrypoint;
+- run existing `auto_intake.main(argv)` only inside that child;
+- flush output and hard-exit the child with the application's code;
+- return the child exit code from the parent;
+- handle operator interruption by terminating/joining the child;
+- reject an impossible/missing exit code as failure;
+- update CLI delegation to call the supervisor instead of importing application `main` directly.
+
+Tests:
+
+- a real spawned child that starts a non-daemon thread still terminates promptly through the hard-exit helper;
+- exit 78 is preserved by the parent;
+- ordinary non-zero exit is preserved;
+- signal termination is non-zero;
+- KeyboardInterrupt cleanup terminates/joins a fake child;
+- existing CLI argument forwarding remains unchanged.
+
+Stop condition: any evidence that spawn cannot initialize safely under the packaged/runtime entrypoint, or that the parent cannot preserve status/exit semantics.
+
+## Validation
+
+Focused:
+
+```bash
+python3.12 -m pytest tests/test_trades_process_supervisor.py tests/test_service_deploy.py -q
+python3.12 -m pytest tests/test_trades_push_listener.py tests/test_trades_auto_intake_restart_policy.py -q
+python3.12 -m compileall -q src/application/trades src/interfaces/cli
+```
+
+Broader before draft PR:
+
+```bash
+python3.12 -m pytest tests/test_trades_*.py tests/test_service_deploy.py tests/test_service_drift.py -q
+python3.12 scripts/check_dependency_graph.py --check
+python3.12 -m pytest -q
+python3.12 tests/run_smoke.py
+```
+
+Expected assertions: no regression in current auth classification/status behavior; process supervisor exits promptly and preserves 78; public CLI arguments and generated service command remain unchanged.
+
+## Docs decision
+
+No user documentation change: command/config/output contracts are unchanged. Durable Gateflow and review artifacts record the lifecycle change.
+
+## Risks / open questions
+
+- `spawn` adds one Python startup and config load only once at service start; acceptable for a long-running listener.
+- `os._exit` skips child interpreter finalizers; this is intentional only after the application has returned and persisted its terminal state. stdout/stderr are explicitly flushed first.
+- abrupt SIGKILL cannot persist a final status; unchanged operational risk, handled by systemd state.
+- production rollout remains blocked until code review, full validation, merge/release approval, explicit upgrade, and a single canary.
+
+## Completion report
+
+Report branch/commits, artifacts, tests, PR/check status, release/remote state if separately approved, process exit status, systemd restart count, blocked artifact, and journal stabilization evidence.

--- a/docs/gateflow/trade-intake-process-isolated-auth-preflight-slice-1-fix-20260719.md
+++ b/docs/gateflow/trade-intake-process-isolated-auth-preflight-slice-1-fix-20260719.md
@@ -1,0 +1,18 @@
+# Fix — trade-intake-process-isolated-auth-preflight / slice 1
+
+- Gate: code review fix / re-review
+- Decision: pass
+
+## CR-1 — generated dependency graph stale
+
+- Status: 已修复
+- Fix: regenerated `docs/DEPENDENCY_GRAPH.md` after adding `process_supervisor.py`.
+- Validation: `python3.12 scripts/generate_dependency_graph.py --check` reports 469 production modules and zero cycles.
+
+## Additional correction
+
+Corrected the plan validation command from the nonexistent `scripts/check_dependency_graph.py` to the repository-owned `scripts/generate_dependency_graph.py --check`.
+
+## Residual risks
+
+No new residual risk. Production Futu proof remains assigned to the approved release canary.

--- a/docs/gateflow/trade-intake-process-isolated-auth-preflight-slice-1-implementation-20260719.md
+++ b/docs/gateflow/trade-intake-process-isolated-auth-preflight-slice-1-implementation-20260719.md
@@ -1,0 +1,30 @@
+# Implementation — trade-intake-process-isolated-auth-preflight / slice 1
+
+- Gate: implementation
+- Status: complete
+
+## Changes
+
+- Added `src/application/trades/process_supervisor.py`.
+- The CLI parent starts one spawn-context child for the complete auto-intake application.
+- The child calls `auto_intake.main(argv)`, flushes stdout/stderr, then uses `os._exit(code)` so SDK-owned non-daemon threads cannot hold interpreter shutdown open.
+- The parent propagates normal exit codes, maps signal exits to conventional shell codes, and terminates/joins the child on operator interruption.
+- `run_ops` now delegates trade-intake to the supervisor while preserving its injectable callable and argument contract.
+- Added a real subprocess regression proving exit 78 is prompt even with a live non-daemon thread.
+
+## Validation
+
+```text
+105 passed — process supervisor + service/CLI delegation
+12 passed — push listener + auto-intake restart policy
+compileall passed — trades + CLI packages
+284 passed — broad trades + service-deploy regression
+dependency graph regenerated/current — 469 production modules, 0 cycles
+git diff --check passed
+```
+
+## Residual risks
+
+- Production Futu behavior still requires a release canary: covered by the separately approved rollout phase after PR/release authorization.
+- Child interpreter finalizers are skipped: fixed/contained by the dedicated process boundary and explicit stream flush after application state writes.
+- No notification, ledger, trade, config, or service mutation occurred in this implementation slice.

--- a/docs/reviews/code-review-trade-intake-process-isolated-auth-preflight-slice-1-20260719.md
+++ b/docs/reviews/code-review-trade-intake-process-isolated-auth-preflight-slice-1-20260719.md
@@ -1,0 +1,49 @@
+# Code Review — trade-intake-process-isolated-auth-preflight / slice 1
+
+- Gate: code review / re-review
+- Decision: pass
+- Scope: process supervisor, CLI delegation, focused tests
+
+## Findings
+
+### CR-1 — Low — generated dependency graph was stale
+
+Adding the supervisor production module changed the graph inventory from 468 to 469 modules. Initial `--check` failed. The generated graph was refreshed and rechecked at 469 modules with zero cycles.
+
+Status: 已修复.
+
+No other accepted correctness, stability, security, or maintainability findings remain.
+
+## Evidence-based review
+
+### Process lifecycle
+
+- The hard exit occurs only in the spawned trade-intake child, after `auto_intake.main()` has returned and after stdout/stderr flush.
+- The CLI parent never imports or constructs Futu contexts; SDK-created threads are confined to the disposable child.
+- Exit 78 and ordinary non-zero codes are propagated unchanged.
+- Negative multiprocessing exit codes are converted to conventional non-zero shell statuses; missing exit status fails closed.
+
+### State machine and recovery
+
+- Existing auth path remains `warning -> blocked status write -> return 78`.
+- New lifecycle appends `child hard exit 78 -> parent return 78`; it does not add a second auth classifier or status writer.
+- Parent KeyboardInterrupt terminates and joins the child; no retry or orphan path was introduced.
+
+### Architecture / coupling
+
+- Process ownership stays in the application/CLI boundary.
+- Domain, ledger, notification, receipt, config, and service-unit contracts are unchanged.
+- Wrapping the complete application avoids unsafe SDK context transfer and avoids per-source IPC.
+
+### Test quality
+
+- The subprocess regression uses a real non-daemon thread and a five-second timeout, reproducing the exact interpreter-shutdown failure class.
+- Unit tests cover code 78, signal mapping, missing status, child application-code forwarding, and interruption cleanup.
+- Existing CLI forwarding tests now assert the supervisor boundary without weakening argument assertions.
+
+## Residual risks / uncovered areas
+
+- Real Futu SDK can only be proven in production: covered by the approved single canary after release.
+- systemd control-group signal behavior is platform/runtime evidence rather than a unit-test concern: covered by existing generated unit defaults and rollout observation.
+
+All residual risks are classified; no blocking open question remains.

--- a/docs/reviews/deepreview-trade-intake-process-isolated-auth-preflight-20260719.md
+++ b/docs/reviews/deepreview-trade-intake-process-isolated-auth-preflight-20260719.md
@@ -1,0 +1,71 @@
+# Aggregate Deep Review — trade-intake-process-isolated-auth-preflight
+
+- Gate: aggregate deepreview / re-review
+- Decision: pass
+- Base: `origin/main` (`1203c59d`)
+- Reviewed head: `ed3b13fe`
+
+## Findings
+
+No accepted blocking or non-blocking findings remain after the slice review fix.
+
+Previously accepted finding:
+
+- CR-1 generated dependency graph stale — 已修复; graph is current at 469 production modules and zero cycles.
+
+## Review lenses
+
+### Correctness and lifecycle
+
+The implementation addresses the observed failure at its owning boundary. The existing application already reaches blocked status and computes code 78; only interpreter shutdown is stuck on SDK-created non-daemon threads. The dedicated child contains those threads, and `hard_exit(78)` terminates that process without asking Python to join them. The parent has no Futu context and can return the observed child status normally.
+
+### State-machine integrity
+
+The existing status writer remains the sole owner of `blocked/auth_required/OPEND_NEEDS_PHONE_VERIFY`. The supervisor neither interprets logs nor writes status. The terminal chain is now deterministic:
+
+```text
+auth warning -> blocked artifact -> application 78 -> child hard exit 78
+-> parent 78 -> systemd RestartPreventExitStatus=78
+```
+
+No terminal state can fall back into application retry through the supervisor.
+
+### Concurrency and cancellation
+
+- SDK threads are isolated to one disposable child.
+- Multi-source coordination remains unchanged inside that child.
+- Parent interruption terminates and joins the child, with kill fallback.
+- A signal-terminated child cannot be reported as success.
+- There is no constructor retry, extra context, or IPC for trade data.
+
+### Architecture and coupling
+
+The change adds one narrow application process adapter and one CLI delegation change. Domain, ledger, receipts, notifications, config, service rendering, and Futu adapter contracts are untouched. The child calls application `main` directly, preventing recursive CLI spawning.
+
+### Security and operational safety
+
+No secrets, permissions, service configuration, notification behavior, broker writes, or ledger semantics changed. Hard exit is restricted to the trade-intake child after application return and explicit stream flush.
+
+### Validation evidence
+
+```text
+2708 passed, 10 skipped — full repository
+284 passed — trades + service deployment regression
+105 passed — process supervisor + service/CLI delegation
+12 passed — push listener + restart policy
+smoke OK
+ruff focused checks passed
+compileall passed
+dependency graph current — 469 modules, 0 cycles
+git diff --check passed
+```
+
+The real subprocess regression creates a non-daemon 60-second thread and proves exit 78 completes within a five-second timeout.
+
+## Residual risks
+
+- Production Futu/systemd behavior: assigned to the approved single production canary after merge/release.
+- Child finalizers are skipped: accepted and contained; application state writes and output flush precede hard exit.
+- Sudden SIGKILL cannot persist a terminal status: pre-existing operational limitation, visible through systemd.
+
+All residual risks are classified. No blocking open question remains.

--- a/docs/reviews/plan-rereview-trade-intake-process-isolated-auth-preflight-20260719.md
+++ b/docs/reviews/plan-rereview-trade-intake-process-isolated-auth-preflight-20260719.md
@@ -1,0 +1,20 @@
+# Plan Re-review — trade-intake-process-isolated-auth-preflight
+
+- Gate: plan re-review
+- Decision: accepted
+
+## Finding disposition
+
+- PR-1: 已修复 — plan explicitly requires child `os._exit(code)` after stream flush and includes a real non-daemon-thread regression.
+- PR-2: 已修复 — the child wraps the complete existing auto-intake application; no context transfer/reconstruction.
+- PR-3: 已修复 — child imports application `main` directly and never re-enters CLI dispatch.
+- PR-4: 已修复 — negative/None exit handling and tests are specified.
+- PR-5: 已修复 — parent KeyboardInterrupt termination/join is specified and tested.
+
+## Residual-risk classification
+
+- Spawn overhead: accepted operational characteristic, no follow-up required.
+- Skipped child finalizers: fixed/contained by explicit ownership boundary; status persistence and stream flush happen before hard exit.
+- Production proof: covered by the approved rollout canary after merge/release authorization.
+
+No blocking open questions remain. The plan is code-generation-ready.

--- a/docs/reviews/plan-review-trade-intake-process-isolated-auth-preflight-20260719.md
+++ b/docs/reviews/plan-review-trade-intake-process-isolated-auth-preflight-20260719.md
@@ -1,0 +1,39 @@
+# Plan Review — trade-intake-process-isolated-auth-preflight
+
+- Gate: plan review
+- Decision: changes required
+
+## Findings
+
+### PR-1 — High — `multiprocessing` return/SystemExit alone does not defeat non-daemon SDK threads
+
+Direct reproduction shows a multiprocessing child remains alive after its target raises `SystemExit(78)` if that target created a non-daemon thread. The plan must require `os._exit(application_code)` inside the isolated child after explicit stdout/stderr flush; otherwise it reproduces the production failure one process deeper.
+
+### PR-2 — High — the child boundary must wrap the entire intake application, not only context construction
+
+A successful live Futu context is not safely transferable across processes. Constructor-only preflight would require a second construction in the parent and reintroduce the same auth race. The entire existing `auto_intake.main(argv)` must execute in the child; the parent owns only lifecycle and exit propagation.
+
+### PR-3 — Medium — avoid recursive CLI spawn
+
+The child entrypoint must import and call `src.application.trades.auto_intake.main` directly. Calling `./om run trade-intake` or `run_ops` from the child would recursively create supervisors.
+
+### PR-4 — Medium — signal exits must not collapse to success
+
+`multiprocessing.Process.exitcode` is negative for signal termination. The supervisor must map it to a conventional non-zero shell status and tests must cover it. `None` after join is an invariant failure, not zero.
+
+### PR-5 — Medium — parent interruption needs bounded child cleanup
+
+The prior foreground behavior handled `KeyboardInterrupt`. The supervisor must terminate and join the child when interrupted, and the test must assert both actions so local/operator stops do not orphan a child.
+
+## Lens results
+
+- Architecture boundary: pass after fixes; process ownership remains in the trade-intake adapter/CLI boundary and does not leak into domain or ledger layers.
+- State machine: pass after fixes; blocked status is persisted before terminal exit, and 78 remains absorbing at systemd.
+- Recovery/cancellation: pass after explicit signal mapping and parent interruption cleanup.
+- Coupling/simplicity: pass; one child around the complete application is narrower than per-source IPC or constructor transfer.
+- Validation: pass after adding a real non-daemon-thread child regression, not only mocked process tests.
+
+## Residual risks
+
+- Spawn startup overhead: accepted, negligible for a long-running service.
+- Child finalizers skipped after application return: accepted by design and contained to the intake child.

--- a/docs/reviews/pr-92-review-20260719.md
+++ b/docs/reviews/pr-92-review-20260719.md
@@ -1,0 +1,47 @@
+# PR Review — PR #92
+
+- Gate: PR review / re-review
+- PR: https://github.com/liuxie066/options-monitor/pull/92
+- Base: `main`
+- Reviewed head: `4dccd739c8753cae7d71d235bf2c0875e05c2394`
+- Decision: pass
+
+## Findings
+
+No accepted correctness, stability, security, concurrency, architecture, or maintainability findings.
+
+## PR-specific verification
+
+- PR is open as draft and targets `main` from `codex/trade-intake-process-isolated-auth-preflight`.
+- GitHub reports the PR mergeable.
+- Head matches the accepted aggregate deepreview commit.
+- The diff is limited to the process supervisor, CLI delegation, focused tests, dependency graph, and Gateflow/review artifacts.
+- The hard exit is contained to the spawned trade-intake child; parent CLI lifecycle and public command contract remain normal.
+- Exit 78 remains the application/systemd protocol and is covered by a real non-daemon-thread regression.
+
+## Validation carried into PR gate
+
+```text
+2708 passed, 10 skipped
+smoke OK
+ruff passed
+compileall passed
+dependency graph current: 469 production modules, 0 cycles
+git diff --check passed
+```
+
+## CI status at initial review
+
+GitHub checks were in progress at the reviewed head:
+
+- Agent Plugin / agent-plugin
+- CodeQL / Analyze (actions)
+- CodeQL / Analyze (python)
+- Guardrails / guardrails
+
+Final `draft-PR-pass` requires all checks to complete successfully on the final pushed head.
+
+## Residual risks
+
+- Production Futu/systemd proof remains assigned to the approved single canary after merge and release.
+- No deferred code finding or unclassified residual risk remains.

--- a/src/application/trades/process_supervisor.py
+++ b/src/application/trades/process_supervisor.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sys
+from collections.abc import Sequence
+
+
+def _coerce_exit_code(value: object) -> int:
+    try:
+        code = int(value)
+    except (TypeError, ValueError):
+        return 1
+    return code if 0 <= code <= 255 else 1
+
+
+def hard_exit(code: int) -> None:
+    """Exit the isolated listener child without waiting for SDK-owned threads."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:
+            pass
+    os._exit(_coerce_exit_code(code))
+
+
+def _trade_intake_child(argv: Sequence[str]) -> None:
+    code = 1
+    try:
+        from src.application.trades.auto_intake import main
+
+        code = _coerce_exit_code(main(list(argv)))
+    except SystemExit as exc:
+        code = _coerce_exit_code(exc.code)
+    except BaseException as exc:
+        print(
+            f"[ERROR] trade-intake child crashed: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+            flush=True,
+        )
+        code = 1
+    hard_exit(code)
+
+
+def _parent_exit_code(child_exit_code: int | None) -> int:
+    if child_exit_code is None:
+        return 1
+    if child_exit_code < 0:
+        return min(128 + abs(child_exit_code), 255)
+    return _coerce_exit_code(child_exit_code)
+
+
+def run_trade_intake_process(argv: Sequence[str]) -> int:
+    """Run trade intake in a disposable child and propagate its exit status."""
+    context = multiprocessing.get_context("spawn")
+    child = context.Process(
+        target=_trade_intake_child,
+        args=(list(argv),),
+        name="options-monitor-trade-intake",
+    )
+    child.start()
+    try:
+        child.join()
+    except KeyboardInterrupt:
+        if child.is_alive():
+            child.terminate()
+        child.join(timeout=5)
+        if child.is_alive():
+            child.kill()
+            child.join()
+        return 0
+    return _parent_exit_code(child.exitcode)

--- a/src/interfaces/cli/run_ops.py
+++ b/src/interfaces/cli/run_ops.py
@@ -167,7 +167,7 @@ def handle_run_command(
 
     if args.run_command == "trade-intake":
         if run_trade_intake_fn is None:
-            from src.application.trades.auto_intake import main as run_trade_intake_fn
+            from src.application.trades.process_supervisor import run_trade_intake_process as run_trade_intake_fn
 
         return int(run_trade_intake_fn(_trade_intake_argv(args)))
 

--- a/tests/test_service_deploy.py
+++ b/tests/test_service_deploy.py
@@ -4100,11 +4100,11 @@ def test_service_cleanup_requires_repo_root_symlink(tmp_path: Path) -> None:
 
 
 def test_cli_run_trade_intake_delegates_to_application(monkeypatch) -> None:
-    import src.application.trades.auto_intake as auto_intake
+    import src.application.trades.process_supervisor as process_supervisor
     from src.interfaces.cli.main import main
 
     calls: list[list[str]] = []
-    monkeypatch.setattr(auto_intake, "main", lambda argv: calls.append(list(argv)) or 0)
+    monkeypatch.setattr(process_supervisor, "run_trade_intake_process", lambda argv: calls.append(list(argv)) or 0)
 
     rc = main([
         "run",
@@ -4121,11 +4121,11 @@ def test_cli_run_trade_intake_delegates_to_application(monkeypatch) -> None:
 
 
 def test_cli_run_trade_intake_delegates_explicit_host_port(monkeypatch) -> None:
-    import src.application.trades.auto_intake as auto_intake
+    import src.application.trades.process_supervisor as process_supervisor
     from src.interfaces.cli.main import main
 
     calls: list[list[str]] = []
-    monkeypatch.setattr(auto_intake, "main", lambda argv: calls.append(list(argv)) or 0)
+    monkeypatch.setattr(process_supervisor, "run_trade_intake_process", lambda argv: calls.append(list(argv)) or 0)
 
     rc = main([
         "run",
@@ -4144,11 +4144,11 @@ def test_cli_run_trade_intake_delegates_explicit_host_port(monkeypatch) -> None:
 
 
 def test_cli_run_trade_intake_delegates_reconcile_state_flags(monkeypatch) -> None:
-    import src.application.trades.auto_intake as auto_intake
+    import src.application.trades.process_supervisor as process_supervisor
     from src.interfaces.cli.main import main
 
     calls: list[list[str]] = []
-    monkeypatch.setattr(auto_intake, "main", lambda argv: calls.append(list(argv)) or 0)
+    monkeypatch.setattr(process_supervisor, "run_trade_intake_process", lambda argv: calls.append(list(argv)) or 0)
 
     rc = main([
         "run",
@@ -4175,12 +4175,12 @@ def test_cli_run_trade_intake_delegates_reconcile_state_flags(monkeypatch) -> No
 
 
 def test_cli_run_trade_intake_delegates_runtime_root(monkeypatch, tmp_path: Path) -> None:
-    import src.application.trades.auto_intake as auto_intake
+    import src.application.trades.process_supervisor as process_supervisor
     from src.interfaces.cli.main import main
 
     runtime_root = tmp_path / "runtime"
     calls: list[list[str]] = []
-    monkeypatch.setattr(auto_intake, "main", lambda argv: calls.append(list(argv)) or 0)
+    monkeypatch.setattr(process_supervisor, "run_trade_intake_process", lambda argv: calls.append(list(argv)) or 0)
 
     rc = main([
         "run",

--- a/tests/test_trades_process_supervisor.py
+++ b/tests/test_trades_process_supervisor.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from src.application.trades import process_supervisor
+
+
+def test_hard_exit_does_not_wait_for_non_daemon_threads() -> None:
+    script = """
+import threading
+import time
+from src.application.trades.process_supervisor import hard_exit
+threading.Thread(target=lambda: time.sleep(60), daemon=False).start()
+hard_exit(78)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        timeout=5,
+    )
+    assert completed.returncode == 78
+
+
+def test_parent_exit_code_preserves_application_status() -> None:
+    assert process_supervisor._parent_exit_code(0) == 0
+    assert process_supervisor._parent_exit_code(1) == 1
+    assert process_supervisor._parent_exit_code(78) == 78
+
+
+def test_parent_exit_code_maps_signal_and_missing_status_to_failure() -> None:
+    assert process_supervisor._parent_exit_code(-15) == 143
+    assert process_supervisor._parent_exit_code(None) == 1
+
+
+def test_child_entry_hard_exits_with_application_status(monkeypatch) -> None:
+    import src.application.trades.auto_intake as auto_intake
+
+    observed: list[int] = []
+    monkeypatch.setattr(auto_intake, "main", lambda argv: 78)
+    monkeypatch.setattr(process_supervisor, "hard_exit", lambda code: observed.append(code))
+
+    process_supervisor._trade_intake_child(["--config", "config.us.json"])
+
+    assert observed == [78]
+
+
+def test_supervisor_terminates_child_on_keyboard_interrupt(monkeypatch) -> None:
+    events: list[object] = []
+
+    class _FakeChild:
+        exitcode = None
+
+        def start(self) -> None:
+            events.append("start")
+
+        def join(self, timeout=None) -> None:
+            events.append(("join", timeout))
+            if timeout is None and events.count(("join", None)) == 1:
+                raise KeyboardInterrupt
+
+        def is_alive(self) -> bool:
+            return "terminate" not in events
+
+        def terminate(self) -> None:
+            events.append("terminate")
+
+        def kill(self) -> None:
+            events.append("kill")
+
+    fake_child = _FakeChild()
+    fake_context = SimpleNamespace(
+        Process=lambda **kwargs: events.append(("process", kwargs)) or fake_child
+    )
+    monkeypatch.setattr(process_supervisor.multiprocessing, "get_context", lambda method: fake_context)
+
+    assert process_supervisor.run_trade_intake_process(["--config", "config.us.json"]) == 0
+    assert events[0][0] == "process"
+    assert events[0][1]["target"] is process_supervisor._trade_intake_child
+    assert events[0][1]["args"] == (["--config", "config.us.json"],)
+    assert "terminate" in events
+    assert "kill" not in events


### PR DESCRIPTION
## Summary

- run the complete trade-intake application in a dedicated spawned child process
- flush child output and use a contained `os._exit(code)` after application return so Futu SDK non-daemon threads cannot block terminal exit
- preserve exit code 78 through the parent supervisor for `RestartPreventExitStatus=78`
- preserve CLI arguments, status ownership, retry policy, and service unit contract

## Production evidence

v1.2.417 correctly detected `OPEND_NEEDS_PHONE_VERIFY` and wrote blocked logs, but the process remained active because SDK-created threads survived application return and continued the six-second authentication log loop. The service was stopped immediately after the failed canary.

## Validation

- `2708 passed, 10 skipped` full repository
- `284 passed` trades + service deployment regression
- `105 passed` process supervisor + service/CLI delegation
- `12 passed` listener + restart policy
- smoke OK
- focused Ruff and compileall passed
- dependency graph current: 469 production modules, 0 cycles
- `git diff --check` passed

A real subprocess regression starts a non-daemon 60-second thread and proves exit 78 completes within five seconds.

## Safety

No notification, broker, ledger, config, or service mutation is included. Production trade-intake remains intentionally stopped pending merge, release, upgrade, and a single controlled canary.
