### PR TITLE
fix: restore canonical Daily Brief canary authority

### DIFF
--- a/docs/gateflow/daily-decision-brief-canary-fix-goal-confirmation-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-goal-confirmation-20260720.md
@@ -1,0 +1,62 @@
+# Goal Confirmation — HK Daily Decision Brief Canary Correction
+
+- **Gate**: goal confirmation
+- **Work unit**: `daily-decision-brief-canary-correction`
+- **Date**: 2026-07-20
+- **Status**: confirmed by user
+- **Base**: `main` / `2e850529` / `v1.3.1`
+- **Branch**: `fix/daily-brief-canary-correction`
+- **Artifact path**: `docs/gateflow/daily-decision-brief-canary-fix-goal-confirmation-20260720.md`
+
+## Goal
+
+Correct the post-v1.3.0 HK no-send Canary defects while preserving the existing Daily Brief lifecycle:
+
+1. Sell Put Daily Brief consumes only canonical labeled artifacts and never falls back to raw rows.
+2. CLI and Agent Tool read the canonical stateful runtime root.
+3. Payload and Markdown keep active actions, candidate evidence, data quality, and gaps unambiguous.
+4. Production no-send evidence proves the persisted brief, prepared notification, CLI, and Agent Tool refer to the same immutable revision.
+5. Release and remote upgrade follow the normal VERSION-driven path; real sending remains separately authorized.
+
+## Motivation and direct evidence
+
+- Current assembler loads both `*_sell_put_candidates_labeled.csv` and `*_sell_put_candidates.csv`, then dedupes/reranks them.
+- HK production Canary showed accepted labeled P430/P440 rows but the Daily Brief selected raw-only P450 rows without capacity.
+- CLI and Agent Tool pass repo root directly instead of using the existing runtime-root resolver, so release-local shadow state can be read instead of production state.
+- Existing notification, repository, revision, diff, delivery-pointer, and no-send behavior otherwise remained safe and must not be redesigned.
+
+## Success signals
+
+- Artifact empty/missing/malformed/partial semantics match the accepted plan and fixtures.
+- Raw-only rows cannot enter candidates, actions, events, summary, or rendered Markdown.
+- `OM_RUNTIME_ROOT` wins in real CLI/Agent read integration tests.
+- Only `actions[state=active]` are executable; renderer exposes both actionability and data quality.
+- Focused, subsystem, Agent contract, release, and production no-send validation pass.
+- Delivery pointer remains unchanged and provider send count remains zero during Canary.
+
+## Non-goals
+
+- No strategy threshold or ranking-policy change.
+- No schema v2, DB migration, queue, scheduler, or second delivery stack.
+- No global `repo_base()` change.
+- No repository/diff/delivery-key state-machine change.
+- No event rendering fix in this work unit.
+- No real notification send without a separate explicit user authorization.
+
+## Scope boundary
+
+Implementation follows:
+
+- `docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md`
+- final accepted plan review: `docs/reviews/plan-review-20260720-114038.md`
+
+The user confirmed creation of the work branch and execution on 2026-07-20.
+
+## Blocking open questions
+
+None. The accepted plan resolves canonical empty encoding, render-context replay, exact-revision Canary reads, and event deferral.
+
+## Gate transition
+
+- **Current gate**: goal confirmation pass
+- **Next gate**: accepted plan commit, then implementation S1

--- a/docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md
@@ -1,0 +1,589 @@
+# Gateflow Plan — HK Daily Decision Brief Canary Correction
+
+- **Work unit**: `daily-decision-brief-canary-correction`
+- **Date**: 2026-07-20
+- **Status**: revised; ready for plan re-review
+- **Trigger**: HK no-send production Canary exposed a canonical candidate-source error and a runtime-root read split
+- **Review source**: `docs/reviews/plan-review-20260720-105521.md`
+- **Related completed work**: `docs/gateflow/daily-decision-brief-final-closeout-20260719.md`
+- **Safety posture**: default-off, no-send first, fail-closed, no production-config mutation in implementation
+
+## 1. Goal
+
+Restore one authoritative Daily Decision Brief chain without changing its delivery state machine:
+
+1. Sell Put Daily Brief candidates come only from the existing canonical `*_sell_put_candidates_labeled.csv` artifacts.
+2. Raw `*_sell_put_candidates.csv` artifacts never contribute rows to normal Daily Brief candidates, actions, ranking, events, or summary counts.
+3. Production notification preparation, CLI read, and Agent Tool read resolve the same runtime root and therefore the same persisted brief revision.
+4. The payload and renderer distinguish executable actions, canonical candidate evidence, data quality, and data gaps without introducing a second eligibility policy.
+5. A production-scoped HK no-send Canary proves content correctness and four-surface consistency before any real-send authorization is requested.
+
+## 2. Completion signals
+
+The work unit is complete only when all of the following hold:
+
+- a labeled/raw conflict fixture proves that an attractive raw-only contract cannot enter `candidates`, `actions`, `events`, strategy summary counts, or rendered Markdown;
+- labeled empty, missing, malformed, and partial states have deterministic tests matching the state table below;
+- CLI and Agent Tool prefer `OM_RUNTIME_ROOT` over repo-local shadow state and fall back to repo root only when no runtime root is configured;
+- renderer exposes both actionability and payload data-quality status;
+- only `actions[state=active]` are described as executable;
+- no Daily Brief schema version, revision allocation, semantic diff, delivery pointer, idempotency key, or confirmation behavior is changed;
+- all focused and broad regression gates pass;
+- the HK production Canary is no-send, reads one revision through all four surfaces, and leaves delivery pointers unchanged;
+- real sending remains blocked pending a separate explicit user authorization.
+
+## 3. Non-goals and protected boundaries
+
+This work unit does **not**:
+
+- change Sell Put scanning, labeling, cash filtering, underwriting thresholds, or ranking policy;
+- change Covered Call or Combo Yield artifact precedence;
+- modify `repo_base()` semantics or introduce another runtime-root abstraction;
+- introduce `daily_decision_brief.v2`, a new candidate state machine, database migration, outbox, queue, or scheduler;
+- change `daily_decision_brief_repository.py`, revision numbering, full/delta selection, semantic digest, last-delivered pointers, delivery keys, or confirmation rules;
+- delete release-local shadow artifacts;
+- enable `notifications.daily_brief.enabled` in committed production config;
+- send a real notification;
+- fix event rendering in this release-blocking batch; that decision is recorded in section 9.
+
+## 4. Canonical Sell Put artifact contract
+
+### 4.1 Authority
+
+For Daily Brief assembly, `*_sell_put_candidates_labeled.csv` is the only canonical Sell Put candidate source. It represents the rows that have completed the existing labeling, account cash-capacity, and underwriting path.
+
+`*_sell_put_candidates.csv` is raw provenance/diagnostic evidence only. Its contents must never be passed to `rank_candidate_rows()`, `_candidate_view()`, `_candidate_action()`, `_candidate_events()`, or `_strategy_summary()`.
+
+This rule applies only to Sell Put. Covered Call continues to consume `*_sell_call_candidates.csv`; Combo Yield continues to consume `*_combo_yield_candidates.csv`.
+
+### 4.2 Artifact state table
+
+| State | Detection | Candidate rows | Availability | Required gap/status behavior | Raw fallback |
+|---|---|---:|---:|---|---|
+| **valid non-empty** | labeled CSV exists and parses with one or more rows | consume only market-matching labeled rows | `True` | normal; row-level market/identity gaps may still degrade | forbidden |
+| **valid empty** | labeled CSV parses with headers and zero rows, or its bytes are exactly the controlled empty encoding `b"\n"` / `b"\r\n"` emitted by the current `pd.DataFrame().to_csv(index=False)` fail-closed path | zero | `True` | authoritative zero-candidate result; no missing-source gap | forbidden |
+| **missing** | no labeled artifact exists for the family, or a raw per-symbol artifact has no labeled counterpart | zero for missing scope | `False` when no parseable labeled artifact exists | add explicit canonical-labeled-missing gap; block only if existing global blocker rules conclude all decision sources are unavailable | forbidden |
+| **malformed/unreadable** | labeled read raises `ParserError`, `UnicodeError`, or `OSError`; or raises `EmptyDataError` but bytes are zero-length or any whitespace/content other than the controlled `b"\n"` / `b"\r\n"` empty encoding | zero for that file | file unavailable; family `False` only if no other parseable labeled artifact exists | add `csv_unavailable` with masked/relative path and `error_type`; fail closed for affected scope | forbidden |
+| **partial** | at least one labeled file is parseable, while another expected per-symbol labeled file is missing or unreadable | consume only rows from parseable labeled files | `True` | preserve reliable rows; add per-symbol/source gaps; payload `status=degraded`; do not globally block if another reliable candidate/close source supports the existing actionability rules | forbidden |
+
+### 4.3 Partial detection and symbol scope
+
+Use the existing run-account directory and filename pairing; do not add a config-driven source registry.
+
+- Discover labeled paths and raw paths separately.
+- Derive the per-symbol artifact key by removing exactly `_sell_put_candidates_labeled.csv` or `_sell_put_candidates.csv` from the filename.
+- The expected key set for partial diagnostics is the union of labeled and raw keys present in that run-account directory.
+- A raw-only key proves that the corresponding canonical labeled artifact is missing. Record a gap, but do not read raw rows into the brief.
+- A labeled-only key is valid and requires no raw counterpart; raw is not a prerequisite.
+- If neither raw nor labeled exists, emit the existing family-level missing-source gap.
+- If one labeled file is valid empty under the exact encoding contract below, it is available for that key and is not partial failure.
+
+#### Empty-file encoding contract
+
+The implementation must not interpret every `EmptyDataError` as a business-empty result.
+
+1. A header-bearing CSV that parses to zero rows is valid empty only when its columns include `symbol` and at least one contract identifier from `contract_symbol|code`; an arbitrary or schema-incompatible header-only file is malformed.
+2. For compatibility with the current upstream fail-closed writer, a file whose complete bytes are exactly `b"\n"` or `b"\r\n"` is valid empty.
+3. A zero-byte file is malformed/truncated, not valid empty.
+4. Any other whitespace-only representation is malformed/unrecognized, not valid empty.
+5. `EmptyDataError` must therefore trigger a bounded check: inspect file size first, read at most two bytes only when size is at most two, and accept only the exact controlled encodings above.
+6. A parsed zero-row frame must pass the minimal-column check before it can mark the family/source available.
+
+This is a narrow compatibility contract for the existing `sell_put_steps.py` writer, not a general whitespace parser. This batch does not modify upstream artifact generation. A later cleanup may standardize header-only empty CSVs, but normal Daily Brief assembly must remain able to read the current controlled single-line empty artifact.
+
+The raw filename may be inspected to establish provenance coverage. Raw CSV contents are not read by the Daily Brief candidate loader.
+
+### 4.4 Availability and global status consequences
+
+Preserve the existing global actionability rules:
+
+- pipeline failure still blocks;
+- all structured decision sources unavailable still blocks;
+- all required account-capacity sources unavailable still blocks under the current conditions;
+- a Sell Put partial failure alone does not suppress reliable Covered Call, Combo Yield, or Close Advice;
+- when at least one reliable source remains and a source gap exists, the brief may be `actionability=live_actionable` and `status=degraded` simultaneously;
+- a valid empty labeled artifact is an available source with zero candidates, not a failure and not a reason to reopen raw candidates.
+
+## 5. Strict no-fallback implementation boundary
+
+### 5.1 Owning file
+
+`src/application/daily_decision_brief_service.py` owns artifact discovery and application-layer assembly.
+
+Required change:
+
+- replace the Sell Put `paths_to_try` list with a labeled-only canonical selection path;
+- if needed, add one narrow private helper in the same file to pair labeled/raw filenames and emit missing/partial diagnostics;
+- continue to reuse `_load_candidate_family()` for parsing canonical files, or specialize it narrowly if the current boolean availability contract cannot express partial availability;
+- do not move filename precedence into domain ranking, renderer, repository, or notification delivery code.
+
+Explicitly forbidden implementations:
+
+```text
+labeled rows if non-empty else raw rows
+labeled parse error -> raw rows
+missing labeled symbol -> raw rows for that symbol
+merge labeled and raw -> dedupe -> rerank
+```
+
+### 5.2 Required conflict proof
+
+The production-shaped conflict fixture contains:
+
+- labeled accepted rows: `0700` P430 and P440 with usable cash capacity;
+- raw rows: the same rows plus a higher-ranked P450 contract that was not accepted;
+- expected result: only P430/P440 may appear in Sell Put candidates/actions and P450 must be absent from the whole brief and rendered message.
+
+## 6. Runtime-root ownership and exact file scope
+
+The existing resolver is authoritative:
+
+```python
+src.application.runtime_paths.resolve_runtime_root()
+```
+
+Do not change `src/application/runtime_paths.py` unless a test reveals an existing resolver defect. Do not change global `repo_base()`.
+
+### 6.1 CLI ownership
+
+Modify only:
+
+- `src/interfaces/cli/daily_brief_ops.py`
+- `tests/test_daily_decision_brief_cli.py`
+
+At the CLI handler boundary:
+
+```python
+repo_root = repo_base_fn()
+runtime_root = resolve_runtime_root(repo_root=repo_root).runtime_root
+read_daily_brief_view(base=runtime_root, ...)
+```
+
+The CLI remains pure read. It does not create directories, refresh data, or mutate state.
+
+### 6.2 Agent Tool ownership
+
+Modify only:
+
+- `src/application/agent_tools/daily_brief.py`
+- `tests/test_daily_decision_brief_agent_tool.py`
+
+At the Agent Tool handler boundary:
+
+```python
+repo_root = repo_base()
+runtime_root = resolve_runtime_root(repo_root=repo_root).runtime_root
+read_daily_brief_view(base=runtime_root, ...)
+```
+
+No new input field is added. Runtime-root source metadata is not added to the public output in this batch; the existing masked state path remains the public provenance surface.
+
+### 6.3 Root precedence contract
+
+Both read surfaces must prove this precedence:
+
+1. explicit runtime-root argument, if a future caller directly invokes the resolver with one;
+2. effective `OM_RUNTIME_ROOT`;
+3. repo root fallback.
+
+This work unit exercises items 2 and 3 at the CLI and Agent Tool integration boundary.
+
+## 7. Payload and renderer invariants
+
+### 7.1 Payload authority
+
+The existing `daily_decision_brief.v1` fields remain sufficient:
+
+- `actions`: action authority;
+- `candidates`: canonical accepted evidence;
+- `capacity`: known account capacity evidence;
+- `status`: payload data quality (`ready|degraded|blocked`);
+- `actionability`: temporal/execution posture (`live_actionable|planning_only|blocked`);
+- `data_gaps`: explicit unavailable or incomplete evidence.
+
+No schema version bump and no new `candidate.state` or `candidate.eligibility` field is introduced.
+
+### 7.2 Action invariant
+
+- Only an item in `actions` with `state=active` is an executable recommendation.
+- `actions[state=observe|blocked|invalidated]` remain non-executable state evidence.
+- A candidate with missing required capacity may remain canonical candidate evidence but must not produce an active action.
+- Renderer and consumers must never infer executability from candidate rank or candidate priority.
+
+### 7.3 Candidate invariant
+
+- `candidates[family]` contains only canonical, strategy-accepted evidence selected from that family's authoritative artifact.
+- Candidate `priority` is evidence tier/importance, not proof of an executable action.
+- Raw candidates and rejected rows belong only to provenance/rejection diagnostics and never to `candidates`.
+- Renderer must describe candidate sections as evidence and direct the operator to the action sections for execution.
+
+### 7.4 Summary invariant
+
+`strategy_summary` must separately report:
+
+1. count of `actions[state=active]`;
+2. candidate evidence count by strategy family;
+3. count of data gaps when non-zero.
+
+It must not call all candidates “actions” and must not include raw/rejected rows in candidate counts.
+
+Expected shape, preserving concise Chinese tone:
+
+```text
+有效行动 2 条；候选证据：Sell Put 2，Covered Call 0，Combo Yield 0；数据缺口 1 条。
+```
+
+For `actionability=blocked`, retain the existing blocker-focused summary.
+
+### 7.5 Renderer invariant
+
+The header shows both independent dimensions:
+
+```text
+状态：可执行（LIVE） | 数据质量：降级（DEGRADED）
+```
+
+Add a bounded label map for `ready|degraded|blocked`; unknown values render explicitly rather than silently becoming `ready`.
+
+Candidate headings become evidence-oriented, for example:
+
+```text
+## Sell Put 候选证据（非行动）
+```
+
+Candidate lines may display whether capacity evidence is known, but renderer must not recreate strategy eligibility rules. The authoritative rule remains: execution comes only from an `active` action in `actions`.
+
+Blocked rendering remains blocked and does not expose candidates as executable alternatives.
+
+### 7.6 Diff and persistence invariant
+
+Candidate-content correction may legitimately change the semantic brief content and therefore the computed semantic digest. However this work unit must not alter:
+
+- normalization schema;
+- stable action identity;
+- material-diff classification;
+- revision allocation;
+- full/delta selection;
+- delivery key construction;
+- pointer confirmation.
+
+Regression tests must prove no-send does not advance delivery state and an account with no prior delivery pointer still prepares a full lifecycle.
+
+## 8. Test and fixture matrix
+
+### 8.1 Service fixtures
+
+Add production-shaped tests to `tests/test_daily_decision_brief_service.py`:
+
+| Fixture | Input | Required assertions |
+|---|---|---|
+| `conflict` | labeled P430/P440; raw also contains higher-ranked P450 | only P430/P440 in candidates/actions; P450 absent from entire normalized brief, events, summary, and renderer input |
+| `empty_header_only` | header-bearing labeled CSV with zero rows and minimal canonical columns; non-empty raw | Sell Put candidates/actions empty; source available; no raw fallback; no missing-source gap |
+| `empty_wrong_header` | zero-row labeled CSV with unrelated/incompatible columns; valid raw | malformed/unavailable gap; no fallback |
+| `empty_controlled_newline` | labeled bytes exactly `b"\n"` and separately `b"\r\n"`; non-empty raw | authoritative empty and available; no fallback |
+| `empty_zero_byte_truncated` | zero-byte labeled; valid raw | malformed/unavailable gap; no fallback; raw contract absent |
+| `empty_unrecognized_whitespace` | labeled contains spaces/tabs plus newline; valid raw | malformed/unavailable gap; no fallback |
+| `missing` | raw exists; labeled missing | no Sell Put candidates/actions; canonical-missing gap; raw contract absent; family unavailable |
+| `malformed` | syntactically malformed labeled; valid raw | no fallback; `csv_unavailable` with error type; family unavailable if no other labeled file |
+| `partial` | one valid labeled symbol; one raw-only symbol; optionally one malformed labeled symbol | valid symbol retained; failed symbols absent; per-source gaps present; `status=degraded`; reliable other actions preserved |
+
+Add a partial cross-family assertion: a usable Covered Call active action remains available when one Sell Put symbol is missing/malformed. Expected result is `actionability=live_actionable` plus `status=degraded`.
+
+### 8.2 Renderer fixtures
+
+Update `tests/test_daily_decision_brief_renderer.py` to prove:
+
+- header renders both actionability and `ready|degraded|blocked` data quality;
+- candidate sections are explicitly evidence/non-action sections;
+- an evidence candidate with no capacity is not rendered as an action;
+- action sections distinguish `active` from `observe|blocked` through existing state labels;
+- summary separates active action count, family candidate counts, and data-gap count;
+- bounded message and blocked-message behavior remain intact.
+
+### 8.3 CLI `OM_RUNTIME_ROOT` integration fixture
+
+In `tests/test_daily_decision_brief_cli.py`:
+
+1. create different canonical brief revisions under `repo_root` and `runtime_root`;
+2. set `OM_RUNTIME_ROOT=runtime_root`;
+3. invoke the actual CLI handler with the actual read service, not a mocked `read_daily_brief_view`;
+4. assert the runtime-root run/revision is returned and repo-local shadow content is absent;
+5. clear `OM_RUNTIME_ROOT` and assert repo-root fallback still works;
+6. assert no files or pointers were modified.
+
+### 8.4 Agent Tool `OM_RUNTIME_ROOT` integration fixture
+
+In `tests/test_daily_decision_brief_agent_tool.py`:
+
+1. create distinct repo-root and runtime-root briefs;
+2. monkeypatch only `repo_base()` to the repo fixture and set the real `OM_RUNTIME_ROOT` environment variable;
+3. invoke `DAILY_DECISION_BRIEF_READ_TOOL.call()` through its public contract;
+4. assert the runtime-root run/revision wins;
+5. clear `OM_RUNTIME_ROOT` and assert repo fallback;
+6. retain path masking and pure-read manifest assertions.
+
+### 8.5 Notification/delivery regression fixtures
+
+Update focused tests in `tests/test_daily_decision_brief_notification_flow.py` and reuse repository tests to prove:
+
+- no-send prepares content but does not confirm or advance a delivery pointer;
+- no existing pointer produces `delivery_kind=full`;
+- corrected candidate content is rendered from the same lifecycle brief that was persisted;
+- revision/diff/delivery-key contracts remain unchanged.
+
+## 9. Event rendering decision
+
+**Decision: defer event rendering to a separate follow-up work unit.**
+
+Reasoning:
+
+- current assembler emits plural fields `event_types` and `event_dates`, while renderer reads singular/generic `event_type|kind|type` and `reason|status`;
+- this is a real presentation defect, but it does not cause the canonical candidate-source error or runtime-root split;
+- fixing it in the release-blocking batch would expand renderer/schema/digest review scope and make Canary failure attribution less clear;
+- events generated from raw-only rows disappear automatically once the canonical source is fixed, which removes the safety-critical part of the symptom.
+
+Follow-up scope, after the Canary correction is accepted:
+
+- decide whether plural values remain strings or normalize to arrays;
+- align assembler and renderer field names;
+- add event dedupe and rendering fixtures;
+- assess semantic-digest impact explicitly.
+
+The deferred event issue does not authorize suppressing or fabricating event data in this batch. Existing event fields remain unchanged.
+
+## 10. Implementation slices
+
+### S1 — Canonical Sell Put source and failure semantics
+
+**Objective**: enforce labeled-only Sell Put assembly and the artifact state table.
+
+**Allowed files**:
+
+- `src/application/daily_decision_brief_service.py`
+- `tests/test_daily_decision_brief_service.py`
+- S1 Gateflow artifacts
+
+**Required tests**: conflict, empty, missing, malformed, partial, cross-family degraded/live scenario.
+
+**Stop condition**: focused service tests pass; no raw row can reach the brief; code review confirms Covered Call behavior is unchanged.
+
+### S2 — Runtime-root read authority
+
+**Objective**: make CLI and Agent Tool read the canonical stateful runtime root.
+
+**Allowed files**:
+
+- `src/interfaces/cli/daily_brief_ops.py`
+- `src/application/agent_tools/daily_brief.py`
+- `tests/test_daily_decision_brief_cli.py`
+- `tests/test_daily_decision_brief_agent_tool.py`
+- S2 Gateflow artifacts
+
+**Stop condition**: both integration fixtures prove `OM_RUNTIME_ROOT` precedence and repo fallback; no global root helper changes.
+
+### S3 — Payload presentation and Canary observability
+
+**Objective**: expose action/candidate/data-quality distinctions and make the actual no-send prepared message verifiable without persisting message content.
+
+**Allowed files**:
+
+- `src/application/daily_decision_brief_service.py` — summary wording/counts only
+- `src/application/daily_decision_brief_renderer.py` — header/candidate-evidence presentation plus the shared public render-limit normalizer
+- `src/application/tick_notification_flow.py` — prepared-message digest and resolved render-context metadata only
+- `tests/test_daily_decision_brief_service.py`
+- `tests/test_daily_decision_brief_renderer.py`
+- `tests/test_daily_decision_brief_notification_flow.py`
+- S3 Gateflow artifacts
+
+Because the production no-send flow does not persist prepared message content, add bounded, non-sensitive observability to each `tick_metrics.daily_brief.prepared[]` item after the actual message is rendered:
+
+```text
+brief_id
+message_sha256
+message_chars
+render_limits:
+  max_actions_per_priority
+  max_candidates_per_strategy
+  max_rejection_reasons
+```
+
+The hash must be SHA-256 of the exact UTF-8 prepared message passed into `messages_by_account`. `render_limits` must contain the three bounded effective integer limits actually passed to `render_daily_brief_lifecycle()`, after renderer/default normalization—not merely the raw config mapping. Add one narrow public renderer helper, `resolve_daily_brief_render_limits(limits)`, in `daily_decision_brief_renderer.py`; all full/delta renderer entry points and `tick_notification_flow.py` must reuse that helper so normalization is not duplicated or imported through a private function. Do not persist the message body. For `delivery_kind=none`, omit the message digest/length or store them as null consistently while still recording the resolved limits if rendering was evaluated. This metadata is operational evidence only and must not enter brief semantic digest, material diff, or delivery-key calculation.
+
+Do not make CLI or Agent Tool load production notification config merely to reproduce notification bytes. Their read contract remains independent and pure-read.
+
+**Stop condition**: renderer and notification-flow focused tests pass; the prepared digest is demonstrably derived from the exact outgoing no-send message; repository/diff contracts remain unchanged.
+
+### S4 — Regression and production Canary
+
+**Objective**: close regressions, publish through the normal release flow, then run a production-scoped HK no-send Canary.
+
+S4 contains no feature expansion. Event rendering remains deferred.
+
+## 11. Validation ladder
+
+Run after each slice, then cumulatively:
+
+```bash
+# S1
+python3 -m pytest tests/test_daily_decision_brief_service.py
+
+# S2
+python3 -m pytest \
+  tests/test_daily_decision_brief_cli.py \
+  tests/test_daily_decision_brief_agent_tool.py
+
+# S3
+python3 -m pytest \
+  tests/test_daily_decision_brief_renderer.py \
+  tests/test_daily_decision_brief_notification_flow.py
+
+# Daily Brief subsystem regression
+python3 -m pytest tests/test_daily_decision_brief_*.py
+
+# Agent public contract regression
+python3 -m pytest \
+  tests/test_agent_plugin_contract.py \
+  tests/test_agent_plugin_smoke.py
+
+# Formatting/static diff hygiene
+git diff --check
+```
+
+Before release, run the repository's current release validation ladder, including supported Python and `scripts/release_check.py`, without weakening any check.
+
+## 12. Four-surface HK no-send production Canary
+
+### 12.1 Preconditions
+
+Before any remote mutation:
+
+- release artifact and server version are verified through the normal VERSION-driven flow;
+- production config remains default-off outside the controlled Canary invocation;
+- Canary command is explicitly `no-send`;
+- record pre-Canary delivery pointer state for `lx` and `sy`;
+- record the active `OM_RUNTIME_ROOT` and verify it is the production state root;
+- do not delete release-local shadow artifacts; they are useful negative controls.
+
+### 12.2 Required four surfaces
+
+For each account (`lx`, `sy`):
+
+1. Capture the Canary `run_id`, `market_trading_date`, `revision`, and `brief_id` from the run-scoped JSON/prepared audit first.
+2. Freeze those immutable identifiers for the rest of verification; do not use a mutable `latest` read as primary evidence.
+3. Collect these four surfaces:
+
+   1. **Production JSON**: immutable/run-scoped Daily Brief JSON plus the canonical revision JSON under production runtime root.
+   2. **Prepared notification**: `tick_metrics.daily_brief.prepared[]` entry from the actual no-send notification path, including `delivery_kind`, revision, `brief_id`, `message_sha256`, and effective `render_limits`.
+   3. **CLI exact read**:
+
+      ```bash
+      ./om daily-brief day \
+        --account <account> \
+        --market HK \
+        --date <market_trading_date> \
+        --revision <revision> \
+        --json
+      ```
+
+   4. **Agent Tool exact read**:
+
+      ```bash
+      ./om-agent run --tool daily_decision_brief_read --input-json \
+        '{"account":"<account>","market":"HK","date":"<market_trading_date>","revision":<revision>}'
+      ```
+
+An additional `latest` read may verify where the current pointer points at collection time, but it is not part of the primary four-surface equality proof.
+
+### 12.3 Structured source-identity criteria
+
+The four surfaces prove source identity independently of presentation bytes:
+
+- prepared audit, production JSON, CLI, and Agent Tool agree on account, market, market trading date, `run_id`, `brief_id`, and revision;
+- CLI `brief` and Agent Tool `brief` are exact structural matches for the persisted canonical revision JSON;
+- actionability and status stored in the brief are identical;
+- active-action count, candidate count by family, and data-gap count are identical;
+- the run-scoped brief JSON and canonical immutable revision JSON represent the same normalized brief;
+- any concurrently newer `current` revision is recorded as an observation but does not invalidate the exact-revision proof.
+
+### 12.4 Renderer-integrity criteria
+
+Presentation verification is separate because notification, CLI, and Agent reads may have different valid render contexts.
+
+For a first/full no-send preparation:
+
+1. `delivery_kind` must be `full`.
+2. Re-render the persisted lifecycle/brief offline with:
+   - the persisted original `actionability`;
+   - the exact effective `render_limits` recorded in prepared audit;
+   - the same `render_daily_brief_lifecycle()` production renderer.
+3. SHA-256 of that re-rendered UTF-8 message must equal prepared `message_sha256`, and its character count must equal `message_chars`.
+4. Inspect the reproduced prepared message for the content criteria in the next section.
+
+CLI and Agent Tool Markdown are checked separately:
+
+- their structured `brief` must already satisfy section 12.3;
+- record each `effective_actionability` and query timestamp;
+- if both reads have the same effective actionability, their Markdown SHA-256 should match because both use the same default read renderer context;
+- if the reads straddle `valid_until_utc`, Markdown hash equality is not required; repeat both after the boundary or compare only the structured brief and explicitly record the expected LIVE-to-PLANNING transition;
+- neither CLI nor Agent Markdown is required to equal prepared notification Markdown when production render limits differ.
+
+If `delivery_kind=none` because the exact semantic brief was already delivered, the Canary is inconclusive for prepared-message integrity; generate a fresh production-scoped no-send run or use an account/date with no delivery pointer. Do not force or mutate the delivery pointer merely to obtain a full message.
+
+### 12.5 Content criteria
+
+For the production-shaped HK evidence:
+
+- accepted labeled 0700 P430/P440 rows may appear according to canonical ranking and display limits;
+- rejected/raw-only P450 must not appear anywhere in production brief JSON, CLI Markdown, Agent Tool Markdown, or the reproduced prepared notification message whose hash matches `message_sha256`;
+- no candidate lacking required capacity may appear as an active action;
+- candidate evidence is visibly identified as non-action evidence;
+- if partial/missing evidence remains, `status=degraded` and the relevant `data_gaps` are visible while reliable active actions remain usable;
+- summary active-action count equals the number of `actions[state=active]`.
+
+### 12.6 Safety criteria
+
+The Canary passes only if:
+
+```text
+no_send = true
+send_attempted_count = 0
+send_confirmed_count = 0
+send_failed_count = 0
+```
+
+Additionally:
+
+- delivery pointer before and after is byte-for-byte unchanged or absent in both snapshots;
+- no provider message ID exists;
+- production default-off configuration is restored/unchanged;
+- no config, ledger, broker-facing state, or Feishu state was written by the verification steps.
+
+Any mismatch is a stop condition. Do not authorize real sending on a partial pass.
+
+## 13. Rollback and stop conditions
+
+Stop implementation or rollout if:
+
+- any raw-only contract appears in candidates/actions/events/rendered message;
+- a valid empty labeled artifact causes raw fallback;
+- CLI or Agent Tool still reads release-local shadow state when `OM_RUNTIME_ROOT` is set;
+- one read surface points to a different revision;
+- no-send advances a delivery pointer or attempts provider delivery;
+- the fix requires changing global `repo_base()`, repository lifecycle, semantic diff, delivery key, or production configuration contract.
+
+Rollback is the normal release rollback to the previous verified version. Because this work unit has no schema or state migration, rollback must not require state rewriting.
+
+## 14. Residual risks and follow-ups
+
+- Existing release-local shadow artifacts remain on disk but become non-authoritative; cleanup is a separate guarded operations task.
+- Event rendering remains a tracked follow-up per section 9.
+- Historical briefs created from mixed raw/labeled inputs remain historical evidence and are not rewritten.
+- Real provider behavior is not exercised by no-send; real-send authorization remains a distinct user decision after Canary evidence review.
+
+## 15. Gate transition
+
+- **Current gate**: revised implementation plan
+- **Next gate**: adversarial plan re-review
+- **Implementation entry condition**: plan re-review returns `pass` or `pass-with-risks` with no unresolved correctness/safety blocker
+- **Production entry condition**: implementation review, focused tests, broad regressions, release verification, and explicit no-send Canary authorization
+- **Real-send entry condition**: successful four-surface Canary plus separate explicit user authorization

--- a/docs/gateflow/daily-decision-brief-canary-fix-s1-implementation-20260720-122659.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-s1-implementation-20260720-122659.md
@@ -1,0 +1,49 @@
+# Gateflow Implementation — S1 Canonical Sell Put Source
+
+- **Gate**: implementation
+- **Work unit**: `daily-decision-brief-canary-correction`
+- **Slice**: S1 — Canonical Sell Put source and failure semantics
+- **Date**: 2026-07-20 12:26:59 CST
+- **Status**: implementation complete; pending code-review decision
+- **Artifact path**: `docs/gateflow/daily-decision-brief-canary-fix-s1-implementation-20260720-122659.md`
+
+## Scope
+
+Changed files:
+
+- `src/application/daily_decision_brief_service.py`
+- `tests/test_daily_decision_brief_service.py`
+
+No changes were made to ranking policy, Covered Call or Combo Yield source precedence, repository persistence, delivery state, renderer behavior, or upstream artifact writers.
+
+## Decisions implemented
+
+1. Sell Put discovery now separates labeled and raw artifact names.
+2. Only `*_sell_put_candidates_labeled.csv` paths are passed to CSV parsing and ranking input.
+3. A raw-only per-symbol key emits `canonical_labeled_artifact_missing`; raw CSV contents are never read.
+4. A family with no labeled or raw artifacts retains the existing `source_artifact_missing` behavior.
+5. Sell Put-only empty validation accepts parsed zero-row CSVs only with `symbol` and `contract_symbol|code` columns.
+6. `EmptyDataError` is available-empty only for exact `b"\n"` or `b"\r\n"`; zero-byte and other whitespace fail closed as `csv_unavailable`.
+7. Partial labeled failures preserve rows from other valid labeled files and reliable cross-family actions, while degrading payload status.
+
+## Validation
+
+- `python3 -m py_compile src/application/daily_decision_brief_service.py` — pass
+- `python3 -m pytest tests/test_daily_decision_brief_service.py` — pass, 20 tests
+- `git diff --check` — pass
+
+Covered fixtures: labeled/raw conflict, valid header-only empty, exact newline, exact CRLF, wrong header, zero-byte, unrecognized whitespace, no-source missing, raw-only canonical missing, parser-malformed partial, and cross-family live-actionable/degraded behavior.
+
+## Docs decision
+
+No public command or schema changed. The accepted Gateflow plan remains the contract; no additional user documentation is required in S1.
+
+## Residual risks
+
+- Renderer wording and prepared-message observability are **covered by later approved slice S3**.
+- CLI and Agent Tool runtime-root convergence is **covered by later approved slice S2**.
+- Event rendering field alignment is **assigned to later work unit `daily-brief-event-rendering`**.
+
+## Completion status
+
+Implementation complete. Entry point: S1 code review using Deepreview.

--- a/docs/gateflow/daily-decision-brief-canary-fix-s2-implementation-20260720-123036.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-s2-implementation-20260720-123036.md
@@ -1,0 +1,46 @@
+# Gateflow Implementation — S2 Runtime-root Read Authority
+
+- **Gate**: implementation
+- **Work unit**: `daily-decision-brief-canary-correction`
+- **Slice**: S2 — Runtime-root read authority
+- **Date**: 2026-07-20 12:30:36 CST
+- **Status**: implementation complete; pending code-review decision
+- **Artifact path**: `docs/gateflow/daily-decision-brief-canary-fix-s2-implementation-20260720-123036.md`
+
+## Scope
+
+Changed files:
+
+- `src/interfaces/cli/daily_brief_ops.py`
+- `src/application/agent_tools/daily_brief.py`
+- `tests/test_daily_decision_brief_cli.py`
+- `tests/test_daily_decision_brief_agent_tool.py`
+
+No changes were made to `repo_base()`, `resolve_runtime_root()`, repository persistence, public tool inputs, or read output schemas.
+
+## Decisions implemented
+
+1. CLI resolves `repo_base_fn()` once, then passes `resolve_runtime_root(repo_root=repo_root).runtime_root` to `read_daily_brief_view()`.
+2. Agent Tool resolves `repo_base()` once through the same existing resolver before reading.
+3. Both surfaces remain pure read and retain exact-date/exact-revision behavior.
+4. Integration fixtures persist divergent repo and runtime histories: runtime revision 1 is readable only through `OM_RUNTIME_ROOT`; after removing it, repo revision 0 is read.
+
+## Validation
+
+- `python3 -m py_compile src/interfaces/cli/daily_brief_ops.py src/application/agent_tools/daily_brief.py` — pass
+- `python3 -m pytest tests/test_daily_decision_brief_cli.py tests/test_daily_decision_brief_agent_tool.py` — pass, 12 tests
+- `git diff --check` — pass
+
+## Docs decision
+
+No public CLI syntax or Agent Tool payload changed. Existing command documentation remains accurate.
+
+## Residual risks
+
+- Renderer and prepared-message four-surface observability are **covered by later approved slice S3**.
+- Production process environment correctness is **covered by the approved HK no-send Canary after release**.
+- Event rendering remains **assigned to later work unit `daily-brief-event-rendering`**.
+
+## Completion status
+
+Implementation complete. Entry point: S2 code review using Deepreview.

--- a/docs/gateflow/daily-decision-brief-canary-fix-s3-implementation-20260720-123653.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-s3-implementation-20260720-123653.md
@@ -1,0 +1,52 @@
+# Gateflow Implementation — S3 Payload Presentation and Canary Observability
+
+- **Gate**: implementation
+- **Work unit**: `daily-decision-brief-canary-correction`
+- **Slice**: S3 — Payload presentation and Canary observability
+- **Date**: 2026-07-20 12:36:53 CST
+- **Status**: implementation complete; pending code-review decision
+- **Artifact path**: `docs/gateflow/daily-decision-brief-canary-fix-s3-implementation-20260720-123653.md`
+
+## Scope
+
+Changed files:
+
+- `src/application/daily_decision_brief_service.py` — summary counts/wording only
+- `src/application/daily_decision_brief_renderer.py` — action/candidate/data-quality presentation and public limit resolver
+- `src/application/tick_notification_flow.py` — prepared-message audit metadata only
+- `tests/test_daily_decision_brief_service.py`
+- `tests/test_daily_decision_brief_renderer.py`
+- `tests/test_daily_decision_brief_notification_flow.py`
+
+No repository, revision, semantic-digest, delivery-pointer, delivery-key, confirmation, config-default, or event-field behavior changed.
+
+## Decisions implemented
+
+1. Strategy summary now counts deduplicated `actions[state=active]`, canonical candidate evidence by family, and deduplicated data gaps when non-zero.
+2. Full renderer action sections contain only active actions; observe/blocked/invalidated items are rendered in an explicitly non-executable state section.
+3. Candidate headings now say `候选证据（非行动）`; rank/priority is not interpreted as execution authority.
+4. Header independently renders actionability and data quality; unknown quality values are explicit.
+5. Added public `resolve_daily_brief_render_limits(limits)`; all renderer entry points and notification preparation reuse it.
+6. Every prepared audit item records `brief_id`, resolved limits, and either exact-message SHA-256/character length or consistent nulls when no message exists.
+7. The digest is computed from the exact UTF-8 string inserted into `messages_by_account`; the message body is not persisted in metrics or audit.
+8. Raw-only conflict fixture now verifies absence from both the normalized brief and rendered Markdown.
+
+## Validation
+
+- `python3 -m py_compile src/application/daily_decision_brief_service.py src/application/daily_decision_brief_renderer.py src/application/tick_notification_flow.py` — pass
+- `python3 -m pytest tests/test_daily_decision_brief_service.py tests/test_daily_decision_brief_renderer.py tests/test_daily_decision_brief_notification_flow.py` — pass, 35 tests
+- `python3 -m pytest tests/test_daily_decision_brief_*.py` — pass, 93 tests
+- `git diff --check` — pass
+
+## Docs decision
+
+The accepted Gateflow plan defines the operational audit contract. No public command syntax or persisted brief schema changed; no separate operator documentation is required in this slice.
+
+## Residual risks
+
+- Production four-surface replay and zero-send proof are **covered by the approved post-release HK no-send Canary**.
+- Exact event rendering remains **assigned to later work unit `daily-brief-event-rendering`**; this slice intentionally leaves event fields unchanged.
+
+## Completion status
+
+Implementation complete. Entry point: S3 code review using Deepreview.

--- a/docs/reviews/code-review-20260720-122659.md
+++ b/docs/reviews/code-review-20260720-122659.md
@@ -1,0 +1,54 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes, Gateflow S1 slice
+- Branch: `fix/daily-brief-canary-correction`
+- Base: `0e8d6a43` (accepted plan commit)
+- Output file: `docs/reviews/code-review-20260720-122659.md`
+- Included scope: `src/application/daily_decision_brief_service.py`, `tests/test_daily_decision_brief_service.py`, Sell Put discovery -> CSV parse -> availability -> ranking -> candidates/actions/events/summary data flow
+- Excluded scope: accepted plan artifacts; S2 runtime-root files; S3 renderer/notification files; release and production operations
+- Parallel review coverage: 无；本 slice 范围窄，直接逐路径审查
+
+## Intent and authority checks
+
+- The only Sell Put paths passed to `_load_candidate_family()` are labeled paths.
+- Raw paths are used only to derive missing labeled artifact keys and diagnostic paths; `pd.read_csv()` is never invoked for raw paths.
+- Existing Covered Call and Combo Yield calls retain default loader semantics because `validate_empty_schema=False` by default.
+- The controlled-empty check is bounded by file size and reads at most two bytes only when size is at most two.
+- Family availability remains true when at least one labeled source is valid, so a malformed sibling produces degraded partial output rather than suppressing reliable rows.
+- Global blockers remain unchanged and still depend on pipeline state, all-source availability, and required-capacity availability.
+
+## Adversarial failure pass
+
+Checked conflict, empty, missing, malformed, partial, cross-family degradation, raw-only high-rank leakage, zero-byte truncation, unsupported whitespace, and header-schema mismatch. The tests exercise both positive and fail-closed branches and inspect the normalized whole brief for raw-only contract leakage.
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Validation
+
+- `python3 -m pytest tests/test_daily_decision_brief_service.py` — 20 passed
+- `python3 -m py_compile src/application/daily_decision_brief_service.py` — pass
+- `git diff --check` — pass
+
+## Docs decision
+
+No public interface changed in S1; no additional docs update required.
+
+## Residual Risk
+
+- Notification renderer integrity is not covered in S1; **covered by later approved slice S3**.
+- Runtime-root read consistency is not covered in S1; **covered by later approved slice S2**.
+- Existing event field/render alignment remains **assigned to later work unit `daily-brief-event-rendering`**.
+
+## Decision
+
+- Review result: pass
+- Findings requiring fix/re-review: none
+- Completion status: S1 code-review pass; ready for accepted slice commit

--- a/docs/reviews/code-review-20260720-123036.md
+++ b/docs/reviews/code-review-20260720-123036.md
@@ -1,0 +1,53 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes, Gateflow S2 slice
+- Branch: `fix/daily-brief-canary-correction`
+- Base: `c18f52ed` (accepted S1 commit)
+- Output file: `docs/reviews/code-review-20260720-123036.md`
+- Included scope: CLI handler and Agent Tool handler runtime-root resolution through exact repository reads; associated integration fixtures
+- Excluded scope: S1 committed implementation; S3 renderer/notification changes; release and production operations
+- Parallel review coverage: 无；本 slice 为两个窄入口，直接审查
+
+## Intent and authority checks
+
+- Both entry points reuse the existing `src.application.runtime_paths.resolve_runtime_root`; no competing root policy was introduced.
+- Precedence remains resolver-owned: explicit resolver argument, effective `OM_RUNTIME_ROOT`, repo fallback. These entry points exercise environment and fallback paths.
+- The lower-level `read_daily_brief_view(base=...)` stays explicit and testable; only owning handlers select the runtime base.
+- No directory creation, refresh, persistence, delivery mutation, or notification send was introduced.
+- Exact revision fixtures use divergent roots and therefore fail if either entry point accidentally reads repo-local shadow state while `OM_RUNTIME_ROOT` is configured.
+
+## Adversarial failure pass
+
+Checked stale repo shadow vs newer runtime revision, environment removal fallback, exact date/revision lookup, output path masking, pure-read metadata, and existing invalid revision handling.
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Validation
+
+- `python3 -m pytest tests/test_daily_decision_brief_cli.py tests/test_daily_decision_brief_agent_tool.py` — 12 passed
+- `python3 -m py_compile src/interfaces/cli/daily_brief_ops.py src/application/agent_tools/daily_brief.py` — pass
+- `git diff --check` — pass
+
+## Docs decision
+
+No public interface changed; no additional docs update required.
+
+## Residual Risk
+
+- Actual production service environment and exact revision identity remain **covered by the approved post-release HK no-send Canary**.
+- Prepared-message digest and renderer-integrity proof remain **covered by later approved slice S3**.
+- Event rendering remains **assigned to later work unit `daily-brief-event-rendering`**.
+
+## Decision
+
+- Review result: pass
+- Findings requiring fix/re-review: none
+- Completion status: S2 code-review pass; ready for accepted slice commit

--- a/docs/reviews/code-review-20260720-123653.md
+++ b/docs/reviews/code-review-20260720-123653.md
@@ -1,0 +1,56 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes, Gateflow S3 slice
+- Branch: `fix/daily-brief-canary-correction`
+- Base: `7354b1db` (accepted S2 commit)
+- Output file: `docs/reviews/code-review-20260720-123653.md`
+- Included scope: service summary derivation, full/blocked/delta renderer call paths, render-limit normalization, notification preparation -> message map -> prepared metrics/audit chain, focused tests
+- Excluded scope: committed S1/S2 implementations; repository/diff internals; event rendering redesign; release and production operations
+- Parallel review coverage: 无；直接沿三条 owning call chain 审查
+
+## Intent and authority checks
+
+- Summary is derived from the same deduplicated action and gap collections returned in the normalized payload.
+- Only `state=active` reaches effective-action sections; observe/blocked/invalidated state remains visible under a non-executable heading.
+- Candidate rendering remains a pure projection of canonical payload evidence and performs no strategy eligibility or ranking decisions.
+- Data-quality status and actionability are rendered independently, including `live_actionable + degraded`.
+- The public limit resolver owns all defaulting/clamping; notification flow stores exactly the resolved values passed to the renderer.
+- SHA-256 and character length are computed from the same local `message` value inserted into `messages_by_account`.
+- `delivery_kind=none` uses consistent null digest/length; no message body is persisted.
+- No prepared metadata enters brief normalization, semantic digest, material diff, delivery-key calculation, or confirmation state.
+
+## Adversarial failure pass
+
+Checked active vs observe ambiguity, unknown status, invalid/oversized limits, full vs none lifecycle, no-send pointer safety, raw-only candidate leakage into Markdown, and audit/message digest equality.
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Validation
+
+- `python3 -m pytest tests/test_daily_decision_brief_service.py tests/test_daily_decision_brief_renderer.py tests/test_daily_decision_brief_notification_flow.py` — 35 passed
+- `python3 -m pytest tests/test_daily_decision_brief_*.py` — 93 passed
+- `python3 -m py_compile src/application/daily_decision_brief_service.py src/application/daily_decision_brief_renderer.py src/application/tick_notification_flow.py` — pass
+- `git diff --check` — pass
+
+## Docs decision
+
+No public command or persisted schema changed; no additional docs update required before aggregate review.
+
+## Residual Risk
+
+- Production runtime identity, delivery-pointer immutability, and zero-send counters remain **covered by the approved HK no-send Canary**.
+- Event renderer field alignment remains **assigned to later work unit `daily-brief-event-rendering`**.
+
+## Decision
+
+- Review result: pass
+- Findings requiring fix/re-review: none
+- Completion status: S3 code-review pass; ready for accepted slice commit

--- a/docs/reviews/code-review-20260720-123831.md
+++ b/docs/reviews/code-review-20260720-123831.md
@@ -1,0 +1,77 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes, aggregate Gateflow deepreview
+- Branch: `fix/daily-brief-canary-correction`
+- Base: `main` at `2e850529`
+- Output file: `docs/reviews/code-review-20260720-123831.md`
+- Included scope: all 21 files in `git diff main...HEAD`; Daily Brief artifact discovery, state semantics, runtime-root entry points, normalized payload, renderer, notification preparation/audit, tests, and Gateflow artifacts
+- Excluded scope: unrelated candidate tools and portfolio-capacity fallback behavior; event-rendering redesign assigned to `daily-brief-event-rendering`; release/remote runtime state not yet executed
+- Parallel review coverage: 无；按 artifact authority、read entry points、payload/renderer contract、notification lifecycle 四条链逐项审查
+
+## Change intent and source-of-truth alignment
+
+- Sell Put Daily Brief discovery is owned only by `daily_decision_brief_service.py` and only labeled paths enter parsing/ranking.
+- Raw filenames provide missing-labeled diagnostics only; raw file contents cannot reach candidate/action/event/summary or renderer paths.
+- Empty/missing/malformed/partial semantics are explicit and fail closed without changing Covered Call or Combo Yield loading defaults.
+- CLI and Agent Tool select one runtime base through the existing `resolve_runtime_root()` authority and retain pure-read repository calls.
+- Payload authority remains `daily_decision_brief.v1`: active actions are execution authority; candidates are canonical evidence; status and actionability remain independent.
+- Renderer performs projection only. It neither ranks nor promotes candidates, and non-active actions are visibly non-executable.
+- Prepared audit metadata is downstream observability only; it does not enter persistence identity, semantic diff, delivery key, or delivery confirmation.
+
+## Adversarial failure pass
+
+Reviewed these failure scenarios against implementation and tests:
+
+- labeled/raw contract conflict with a higher-ranked raw-only P450;
+- labeled valid empty via minimal header, exact LF, and exact CRLF;
+- zero-byte, unsupported whitespace, incompatible header, parser failure, raw-only missing labeled artifact, and mixed valid/malformed partial families;
+- reliable Covered Call action under Sell Put failure with `live_actionable + degraded`;
+- stale repo shadow state vs `OM_RUNTIME_ROOT` for CLI and Agent exact-revision reads;
+- candidate priority mistaken for execution authority;
+- observe action rendered under an effective-action heading;
+- unknown data-quality state silently defaulting to ready;
+- invalid render limits diverging between actual rendering and audit;
+- full/none prepared-message states, exact hash/length evidence, no-send pointer immutability, and absence of persisted message content.
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Validation
+
+- `python3 -m pytest tests/test_daily_decision_brief_*.py` — 93 passed
+- `python3 -m pytest tests/test_agent_plugin_contract.py tests/test_agent_plugin_smoke.py` — 102 passed
+- Slice-focused test totals: S1 20 passed; S2 12 passed; S3 35 passed
+- Python compile checks for all changed production modules — pass
+- `git diff --check main...HEAD` — pass
+- Worktree before aggregate artifact: clean
+
+## Architecture and coupling checks
+
+- No domain-to-application import inversion introduced.
+- No new root resolver, schema version, state machine, storage entity, config key, queue, or delivery abstraction introduced.
+- Runtime-root changes remain at the CLI/Agent owning boundaries.
+- Render-limit normalization has one public owner and no duplicated clamping logic in notification flow.
+- Existing repository/delivery implementation files are untouched.
+
+## Docs decision
+
+Gateflow goal, plan, three plan reviews, three implementation artifacts, and three slice code-review artifacts are present. Public command syntax and schema version did not change; no additional external documentation is required before the draft PR.
+
+## Residual Risk
+
+- Production environment identity, GitHub release, remote server upgrade, delivery-pointer immutability, and four-surface exact-revision consistency are **covered by the approved release and HK no-send Canary phase**.
+- Event field/render alignment is **assigned to later work unit `daily-brief-event-rendering`**.
+- Real notification sending remains **out of scope and requires separate explicit user authorization**.
+
+## Decision
+
+- Aggregate deepreview result: pass
+- Findings requiring fix/re-review: none
+- Completion status: accepted deepreview; ready for protected deepreview commit and draft PR gate

--- a/docs/reviews/plan-review-20260720-105521.md
+++ b/docs/reviews/plan-review-20260720-105521.md
@@ -1,0 +1,217 @@
+# Plan Review — HK Daily Brief Canary Findings 修复计划
+
+- **Reviewed target**: 对 2026-07-20 HK no-send 生产 Canary 暴露问题的修复计划
+- **Target summary**:
+  1. Sell Put 日报只消费 canonical labeled/accepted rows，raw candidates 不进入正常候选池；
+  2. CLI 与 Agent Tool 使用统一 runtime-root resolver；
+  3. 摘要区分 active actions 与 informational candidates；
+  4. 缺少容量的候选明确显示为不可执行；
+  5. renderer 展示 `ready/degraded`；
+  6. 修复事件字段渲染；
+  7. 增加 labeled/raw 冲突和 `OM_RUNTIME_ROOT` 回归测试；
+  8. 修复发布后重跑 HK no-send 生产 Canary，再决定真实发送。
+- **Review scope**: plan assumptions、canonical artifact ownership、runtime-root boundary、payload/renderer contract、failure semantics、tests、rollout sequencing
+- **Review posture**: adversarial；判断该计划是否已经足够具体，可以安全交给 implementation agent
+- **Conclusion**: **fail**
+
+## Goal and success signal understood
+
+目标不是修正文案，而是恢复 `daily_decision_brief.v1` 的单一权威链：
+
+1. 日报只消费现有策略链已经接受的 Sell Put 候选；
+2. production notification、CLI、Agent Tool 读取同一 runtime payload；
+3. action、candidate、capacity gap 和 degraded 状态对用户有一致、不可误解的语义；
+4. 不破坏 revision、last-delivered pointer、full/delta、no-send 和 default-off 状态机；
+5. 修复后用 production-scoped no-send Canary 证明内容和运维入口一致。
+
+## Assumptions tested
+
+1. **`*_sell_put_candidates_labeled.csv` 是正常 Sell Put 下游的 canonical accepted artifact。**
+   - 证据支持：`src/application/sell_put_steps.py:299-319` 先 label，再做现金与 underwriting enrich/filter；`src/application/sell_put_steps.py:329-339` 的告警和 summary 也消费 labeled 文件。
+   - 证据支持：禁用/失败路径显式写空 raw 和 labeled artifact，见 `src/application/sell_put_steps.py:320-326,342-348`。
+2. **当前日报确实把 raw 与 labeled 合并后重新排名。**
+   - 证据支持：`src/application/daily_decision_brief_service.py:64-74,99-106` 同时加载两类文件、合并、dedupe、rerank。
+3. **局部 Sell Put 容量缺失不应阻断可靠 Covered Call。**
+   - 设计支持：`docs/gateflow/daily-decision-brief-plan-20260719.md:90-92`；因此 Canary 的全局 `live_actionable` 不必改成 `blocked`。
+4. **已有 runtime-root resolver 可复用。**
+   - 证据支持：`src/application/runtime_paths.py:15-35` 明确区分 code/config repo root 与 stateful runtime root。
+5. **当前 CLI/Agent read path 没有使用该 resolver。**
+   - 证据支持：`src/interfaces/cli/daily_brief_ops.py:51-58` 直接传 `repo_base_fn()`；Agent Tool 也直接调用 `repo_base()`。
+6. **当前测试没有覆盖真实冲突。**
+   - `tests/test_daily_decision_brief_service.py` 主要构造单一 labeled artifact；没有覆盖 labeled 非空且 raw 的高分未接受行同时存在。
+   - `tests/test_daily_decision_brief_cli.py:37-58` mock 了 read service，只证明格式转发，不证明 `OM_RUNTIME_ROOT` 优先级。
+
+## Findings
+
+### PR-01-未修复-严重-canonical Sell Put artifact 的缺失、空、损坏和 fallback 语义未被锁定
+- **位置**: 修复项 1“只消费 canonical labeled/accepted rows；raw 不进入正常候选池”
+- **问题类型**: 契约缺失 / 状态机漏洞 / 不可直接实施
+- **当前写法**: 方向上要求优先或仅消费 labeled rows，但没有定义 labeled artifact 在 `存在且非空`、`存在且为空`、`缺失`、`无法解析`、`部分 symbol 缺失` 时的精确行为，也没有明确 raw 是否仍可作为 fallback。
+- **反例/失败场景**:
+  1. implementation agent 把逻辑改成“labeled 有行则使用，否则 fallback raw”；当 labeled 因现金过滤结果为合法空集时，raw 又被重新引入，原问题复发。
+  2. 一个 symbol 的 labeled 文件因 pipeline crash 缺失，另一个 symbol 正常；若回退 raw，会把未完成账户约束的行包装成 P1；若全账户直接 blocked，又会错误阻断其他可靠策略。
+  3. labeled CSV parser error 时 fallback raw，fail-closed 语义被悄悄降级成 fail-open。
+- **为什么有问题**: `sell_put_steps` 已经把 labeled artifact 定义成通知与 summary 的下游结果，并在禁用/失败时写显式空 artifact。对正常日报而言，“空”是权威业务结果，不是“找不到数据”的同义词；缺失或损坏才是数据缺口。计划如果不逐态定义，implementation agent 必须重新设计最关键的安全策略。
+- **直接证据**:
+  - `src/application/sell_put_steps.py:299-319`：labeled 后继续执行 cash/underwriting filter。
+  - `src/application/sell_put_steps.py:320-326,342-348`：disabled/fail-closed 路径物化空 labeled artifact。
+  - `docs/gateflow/daily-decision-brief-plan-20260719.md:92`：局部失败只写 gap 并抑制受影响 action。
+  - 生产 Canary：labeled 只有 0700 P430/P440，而日报从 raw 选出 P450 三行并全部出现 `cash_capacity_unavailable`。
+- **影响**: 生成错误代码 / 重新引入未通过账户约束的交易候选 / fail-open / 用户可能把 raw 候选当成可执行建议。
+- **建议改法和验证点**:
+  1. 在计划中明确 Sell Put artifact state machine：
+     - labeled 存在且可解析：它是唯一正常候选源；即使为空也禁止 fallback raw；
+     - labeled 缺失或损坏：记录 symbol/strategy gap，Sell Put 不产生 candidate/action；是否全局 blocked 继续由现有“是否仍有其他可信 source”规则决定；
+     - raw 仅作为 provenance/diagnostic artifact，不进入正常 `candidates.sell_put` 或 `actions`；
+     - 禁止因“labeled 无行”读取 raw。
+  2. 明确只修 Sell Put，不把“labeled-only”错误推广到当前没有 labeled contract 的 Covered Call。
+  3. 测试必须覆盖：labeled 非空 + raw 高分行、labeled 合法空 + raw 非空、labeled 缺失 + raw 非空、labeled malformed + raw 非空、多个 symbol 部分缺失。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 严重
+
+### PR-02-未修复-高-runtime-root 修复边界不清，存在全局改变 `repo_base()` 语义的回归风险
+- **位置**: 修复项 2“CLI 和 Agent Tool 使用统一 runtime-root resolver”
+- **问题类型**: 架构边界 / 过度耦合 / 非最优方案 / 不可直接实施
+- **当前写法**: 没有指定修改哪个函数、由谁解析 root、是否修改 `repo_base()` 本身，也没有明确 CLI 和 Agent Tool 如何共享但不扩大公共契约。
+- **反例/失败场景**: implementation agent 为了让日报读 `/var/lib/options-monitor`，直接修改 `src.application.agent_tool_config.repo_base()` 让其返回 runtime root；大量依赖 repo root 定位代码、默认配置或工具资源的 Agent Tool 会一起改变行为。另一种实现是在 CLI 和 Agent Tool 各复制一套环境判断，未来再次漂移。
+- **为什么有问题**: 项目已经明确区分 repo root 和 runtime root；`repo_base()` 是代码根，不应该被重定义。已有 `resolve_runtime_root(repo_root=...)` 就是 owning boundary。计划必须约束为日报 read surface 的窄改动，而不是改变全局基础函数。
+- **直接证据**:
+  - `src/application/runtime_paths.py:21-35`：repo root 是 code/config execution root，runtime root 拥有 `output_runs/output_shared/output_accounts/locks/logs`。
+  - `src/interfaces/cli/scheduler_ops.py:45`、`src/application/agent_tools/close_advice_read_impl.py:234` 已展示复用该 resolver 的项目惯例。
+  - `src/interfaces/cli/daily_brief_ops.py:51-58` 和 `src/application/agent_tools/daily_brief.py` 当前直接使用 repo base。
+- **影响**: 无关 Agent Tool 行为漂移 / 配置与状态根混淆 / 大范围 regression / 后续难以定位的 release-local 与 production state 交叉读取。
+- **建议改法和验证点**:
+  1. 计划明确：保持 `repo_base()` 不变；在 daily brief CLI handler 和 Agent Tool handler 入口调用现有 `resolve_runtime_root(repo_root=repo_base())`，把 `.runtime_root` 传给 `read_daily_brief_view()`。
+  2. 不新增第二个 resolver，不修改 repository API；`read_daily_brief_view(base=...)` 继续接收显式 canonical state root。
+  3. 分别测试 CLI 与 Agent Tool：repo root 和 `OM_RUNTIME_ROOT` 同时存在相同 identity、不同 run_id 的 brief，断言两者都返回 runtime run；未设置 env 时仍回退 repo root，保持开发体验。
+  4. 增加路径 source assertion，不只比较 rendered Markdown。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-03-未修复-高-“候选不可执行”的 payload 与 renderer 契约没有确定，可能只修文案而继续保留错误语义
+- **位置**: 修复项 3、4、5“摘要分离、缺容量候选标为不可执行、显示 degraded”
+- **问题类型**: 公共契约缺失 / 架构边界 / 测试缺口 / 过度耦合
+- **当前写法**: 要求 UI 更明确，但没有规定 `candidates[]` 是否只代表 canonical accepted candidates、候选 `priority` 是否具有 action priority 语义、renderer 如何判断“不可执行”，以及是否需要修改 schema/digest/diff。
+- **反例/失败场景**:
+  1. 只把摘要改成“候选 3”，但 raw P450 仍存在于 payload，Agent Tool 或其他消费者仍可能把 P1 当成行动建议。
+  2. renderer 通过“capacity 为空”推断不可执行，但 Combo Yield 或未来候选可能合法没有同样的 capacity shape，形成跨策略脆弱启发式。
+  3. 为了解决显示问题新增 candidate `state/eligibility` 字段，却没有同步 schema normalization、semantic digest、full/delta 行为和 Agent Tool output contract，导致同版本 payload 语义漂移。
+- **为什么有问题**: 原始设计把 `actions[]` 定义为行动权威，而 `candidates` 是候选证据；当前 renderer 同时展示两者，却未在视觉上维持这个边界。计划需要先锁定 payload 不变量，再决定最小 renderer 改动，不能让 renderer 重新实现资格判断。
+- **直接证据**:
+  - `docs/gateflow/daily-decision-brief-plan-20260719.md:77-92`：action 有明确 priority/state；局部 gap 应抑制 action。
+  - `src/application/daily_decision_brief_service.py:121-155`：capacity 缺失时不创建 action，但仍创建 candidate view。
+  - `src/application/daily_decision_brief_service.py:990-1003`：摘要把 active action 数与所有 candidate 数并列。
+  - `src/application/daily_decision_brief_renderer.py:223-256`：candidate renderer 无条件显示 candidate priority，不展示 capacity/eligibility。
+- **影响**: 修复只覆盖 Feishu 文案但不覆盖 Agent/API 消费者 / schema 偷渡 / diff 噪声 / 同一 payload 被不同消费者解释为不同风险等级。
+- **建议改法和验证点**:
+  1. 计划先声明不变量：只有 `actions[state=active]` 是可执行建议；`candidates` 是 canonical filtered evidence，不单独授予执行性。
+  2. 在修复 raw 合并后，正常 Sell Put labeled row应携带 capacity；防御性缺 capacity 行不生成 action。renderer 只陈述事实：“候选，未形成行动：容量未确认”，不得自行提升/降低策略资格。
+  3. 优先避免 schema v2：利用 candidate 已有 `capacity` 与是否存在对应 active action来生成展示标签；如果决定新增 `eligibility`，必须把 schema、normalizer、digest、diff 和 Agent Tool contract 纳入显式 scope。
+  4. 摘要按 active actions 的 `strategy_family` 统计，再单独列 candidate evidence 数和 gap 数；不要混用口径。
+  5. renderer header 同时显示 `actionability` 与 `status`，测试 `live_actionable + degraded`、`planning_only + degraded`、`blocked`。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-04-未修复-中-计划切片和验收没有保护 delivery/diff 状态机，也没有定义生产 Canary 的内容一致性验收
+- **位置**: 修复项 6、7、8 与整体实施顺序
+- **问题类型**: 切片过粗 / 测试缺口 / rollout 风险 / review 不可验收
+- **当前写法**: 把 candidate source、runtime path、summary、degraded、event renderer、测试、发布和 Canary 合在一个列表里；没有规定实现顺序、focused gates、是否触碰 digest/diff，以及 Canary 如何证明 CLI/Agent/notification message 三者一致。
+- **反例/失败场景**:
+  1. renderer 先改、source 后改，测试用人工构造 payload 全绿，但生产 payload 仍混入 raw。
+  2. candidate payload变化使 semantic digest/material diff 改变，却只跑 renderer/service tests，last-delivered pointer 行为未验证。
+  3. Canary 只检查 JSON 文件生成，不比较 notification prepared message hash 与 CLI/Agent rendering，runtime-root split 再次漏过。
+  4. event 字段修复扩大 scope，掩盖两个发送阻塞问题并增加无关回归面。
+- **为什么有问题**: 该功能的核心价值不只是生成 JSON，而是“assemble -> persist -> diff against last delivered -> render -> deliver/confirm -> read back”的完整闭环。计划必须按 ownership 切片，并让每个 slice 有独立成功条件。
+- **直接证据**:
+  - `docs/gateflow/daily-decision-brief-plan-20260719.md:128-136` 定义了 prepare/full-delta/no-send/pointer 状态机。
+  - 本次 Canary 已证明 no-send/pointer 正常，但没有现成计划确保内容修复不改变或破坏该状态机。
+  - `tests/test_daily_decision_brief_cli.py` 和 service tests 当前分别 mock/单层验证，无法证明端到端同源。
+- **影响**: implementation agent 跨层同时修改、review 难定位、状态机回归、Canary 假阳性、真实发送仍可能与人工读取不一致。
+- **建议改法和验证点**:
+  1. 分为四个顺序 slice：
+     - S1 canonical Sell Put input selection与 failure semantics；
+     - S2 runtime-root read authority；
+     - S3 summary/renderer status与候选语义；
+     - S4 event rendering（若不影响发送安全可单独 defer）。
+  2. 每个 slice 先跑 focused tests；最后跑 repository/diff/notification/CLI/Agent/tick regressions和完整 pytest。
+  3. 明确不修改 revision、delivery pointer、idempotency key、full/delta 状态机；若 candidate payload变化影响 digest，这是预期内容变化，但必须有测试证明 no-send 不推进 pointer、首次真实发送仍为 full。
+  4. Canary 验收增加三方一致性：production JSON run_id、notification prepared message digest、CLI read、Agent Tool read必须指向同一 production revision；同时检查 raw rejected candidate 不出现、active action 按 family 计数一致、`degraded` 可见、delivery pointer 不存在。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 中
+
+## Architecture boundary review
+
+- Candidate source选择属于 application assembly/I/O boundary，应留在 `daily_decision_brief_service.py`；不要把文件名、labeled/raw precedence 放入 domain ranking engine或 renderer。
+- Candidate ranking继续复用 `domain.domain.engine.rank_candidate_rows()`，但只对 canonical accepted rows排序；不要新增日报专属评分。
+- Runtime root解析属于 `src/application/runtime_paths.py`；保持 repo root与runtime root分离。
+- Renderer只呈现 payload事实，不应重新实现 capacity或candidate filtering政策。
+- Repository/diff/delivery pointer不应因本修复改变职责。
+
+## Best-practice review
+
+计划方向符合 fail-closed 与 single source of truth，但必须把“空是权威结果、缺失是故障”写入契约。生产状态读取必须通过统一 resolver，并使用冲突 fixture证明优先级，而不是只测单一路径。用户可见的风险状态应同时表达 actionability 与 data quality。
+
+## Optimal-solution review
+
+最实际的方案不是创建 candidate source registry、adapter hierarchy或新 schema，而是：
+
+1. Sell Put 仅加载已有 labeled artifact；
+2. raw 只保留在 provenance/rejection诊断；
+3. daily brief read surface复用现有 `resolve_runtime_root()`；
+4. summary/renderer消费现有 `actions/candidates/capacity/status/data_gaps`，尽量不扩 schema。
+
+这条路径修改面最小，也最符合现有 ownership。
+
+## Overengineering review
+
+当前问题不需要：
+
+- `daily_decision_brief.v2`；
+- 新数据库或迁移；
+- 通用 candidate artifact registry；
+- 新 runtime-root abstraction；
+- 新 eligibility state machine；
+- 重写 notification pipeline。
+
+若 implementation plan引入这些内容，应视为 scope drift，除非先证明现有字段无法无歧义表达。
+
+## Overcoupling review
+
+风险最高的过度耦合方式是：
+
+- 修改全局 `repo_base()` 来修日报；
+- 让 renderer根据文件名或 raw/labeled来源决定资格；
+- 为 event小问题同步改变 schema/digest/diff；
+- 把 source修复、状态机迁移和真实发送放进同一不可回滚步骤。
+
+计划应保持四个 slice 的 write scope和验收边界清楚。
+
+## Open questions
+
+1. `candidates[]` 的正式产品语义是“canonical accepted evidence”还是“进入 ranking前的观察池”？现有设计文本更支持前者，修订计划应明确写死。
+2. 对 labeled artifact 单 symbol 缺失而其他策略可用的情况，是否保留 `live_actionable + degraded`？根据现有设计应当是，但需要明确场景测试。
+3. 是否必须在本次阻塞修复中处理 `event_types/event_dates`，还是创建独立低风险 follow-up？它不应阻塞 canonical source和runtime-root修复。
+4. Agent Tool 是否需要显式返回 runtime root source（如 `env:OM_RUNTIME_ROOT`）以增强可观测性？这可能有价值，但不是本次修复必要条件。
+
+## Residual risks and tracking
+
+- **Historical release-local shadow artifacts**: 修复 runtime root后仍会留在磁盘，但不应删除；建议记录为运维清理项，不放入本修复。
+- **Already delivered revisions**: 当前 HK delivery pointer不存在且生产开关关闭，迁移风险低；发布前仍应重新检查 US/HK所有账户 pointer，若已有 delivery则验证 corrected payload相对last-delivered的material行为。
+- **Candidate source drift**: 未来 Sell Put pipeline若更换canonical artifact，必须通过显式公共契约更新，而不是重新添加raw fallback。建议在日报计划/AGENT_WIKI记录source authority。
+- **Renderer consumer drift**: CLI、Agent、notification应共享同一renderer测试fixture，避免未来再次分叉。
+
+## Required plan changes before implementation
+
+计划至少补齐以下内容后才可交付实现：
+
+1. 写明 labeled artifact四态语义和严格禁止raw fallback的正常路径；
+2. 锁定 runtime-root变更为daily brief入口的窄改动，明确复用 `resolve_runtime_root()`且不改`repo_base()`；
+3. 定义candidate与action的payload不变量、summary统计口径和degraded显示契约；
+4. 按S1-S4拆分实现顺序与focused tests；
+5. 增加冲突fixture、空/缺失/malformed/partial覆盖、CLI+Agent runtime-root集成测试；
+6. 把Canary验收升级为JSON、prepared notification、CLI、Agent四方同源验证；
+7. 明确event修复是当前slice还是deferred follow-up。
+
+## Final conclusion
+
+**fail** — 修复方向正确，但当前计划还不是 code-generation-ready。最大风险不是实现难度，而是两个关键边界仍留给 implementation agent临场决定：Sell Put labeled/raw的failure semantics，以及repo root/runtime root的修改范围。如果不先收敛，最可能出现的是“文案看起来修好，但raw候选仍可进入payload”或“为了修日报读取而改变所有Agent Tool的root语义”。

--- a/docs/reviews/plan-review-20260720-111103.md
+++ b/docs/reviews/plan-review-20260720-111103.md
@@ -1,0 +1,220 @@
+# Plan Review — HK Daily Decision Brief Canary Correction（修订计划复审）
+
+- **Reviewed target**: `docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md`
+- **Review date**: 2026-07-20
+- **Review scope**: Sell Put canonical artifact state machine、no-fallback boundary、runtime-root ownership、candidate/action/renderer contract、fixtures、prepared-message observability、four-surface production Canary、event deferral
+- **Review posture**: adversarial；判断修订计划是否已足够具体，可安全交给 implementation agent
+- **Conclusion**: **fail**
+
+## Goal and success signal understood
+
+计划目标已经明显收敛：
+
+1. Sell Put 日报仅消费完成 labeling、现金和 underwriting 约束后的 canonical labeled artifact；
+2. raw artifact 只用于诊断，不能进入 candidate/action/event/summary；
+3. CLI、Agent Tool 与 production notification 使用同一 runtime root 和同一持久化 brief；
+4. `actions[state=active]` 是唯一执行权威，`candidates` 只是 canonical evidence；
+5. 不改变 revision、diff、delivery pointer、idempotency 和 confirmation 状态机；
+6. 先完成 no-send Canary，再单独授权真实发送。
+
+与上一版相比，计划已经补齐 artifact 五态、文件 ownership、fixtures、slice 顺序和 event defer 决策。剩余问题集中在两个仍会迫使 implementation/rollout 临场设计的边界：如何区分合法空 artifact 与截断损坏，以及如何在不同 renderer 参数、不同查询时刻和并发 revision 下证明“四方同源”。
+
+## Assumptions tested
+
+### 1. Labeled-only 是正确的 Sell Put 正常路径 authority
+
+**成立。**
+
+- `src/application/sell_put_steps.py:299-319` 在生成 labeled 后继续完成现金与 underwriting enrich/filter。
+- `src/application/sell_put_steps.py:329-339` 的 Sell Put alert/summary 也消费 labeled artifact。
+- 当前错误来自 `src/application/daily_decision_brief_service.py:64-74` 把 labeled 与 raw 一起交给通用 loader，再在 `:99-106` 合并、去重和重排。
+
+计划把修复限定在 application assembly boundary，并禁止把 artifact precedence 移入 domain ranking 或 renderer，方向正确。
+
+### 2. Raw 文件名可以作为 partial provenance，而 raw 行不必进入 brief
+
+**成立。**
+
+同一 run-account 目录中的 per-symbol raw/labeled 文件名可用于发现 raw-only key；只比较 suffix/stem 不需要读取 raw CSV 内容。该路径能满足 partial 诊断且不重新引入 raw candidate authority。
+
+### 3. `EmptyDataError` 可以直接表示“pipeline 的显式合法空 artifact”
+
+**不成立。**
+
+当前 upstream 的 `pd.DataFrame().to_csv(index=False)` 确实产生单个换行符；但 pandas 对零字节文件、单换行文件和纯空白文件都会抛出同一个 `EmptyDataError`。仅凭异常类型无法知道文件是受控空结果还是写入中断/截断。
+
+### 4. CLI 与 Agent Tool 可在 consumer boundary 复用现有 runtime-root resolver
+
+**成立。**
+
+- `src/application/runtime_paths.py:15-35` 已定义 `argument > OM_RUNTIME_ROOT > repo_default`。
+- `src/interfaces/cli/daily_brief_ops.py:51-58` 当前错误地直接传 `repo_base_fn()`。
+- `src/application/agent_tools/daily_brief.py:189-199` 当前直接传 `repo_base()`。
+
+计划明确不改变全局 `repo_base()`，且仅修改两个 read consumer，ownership 合理。
+
+### 5. Prepared notification、CLI 和 Agent Tool 的 Markdown 应具有相同 SHA-256
+
+**不总成立。**
+
+- notification path 使用 `render_daily_brief_lifecycle(lifecycle, limits=daily_limits)`，其中 `daily_limits` 来自有效配置，见 `src/application/tick_notification_flow.py:608-652`；这些 limits 是公开可配置的。
+- CLI/Agent read path 使用 `render_full_brief(rendered_brief)`，没有传 production limits，见 `src/application/agent_tools/daily_brief.py:114-128`。
+- CLI/Agent read 还会在读取时通过 `effective_daily_brief_actionability()` 按当前时刻把过期 LIVE brief 转为 PLANNING，见 `domain/domain/daily_decision_brief.py:143-164`；prepared notification 使用组装/持久化时的 actionability。
+
+因此即使三者读取同一 brief，消息 hash 也可能因为展示 limits 或跨越 `valid_until_utc` 而不同。
+
+### 6. 使用 `latest` 可以稳定证明四方读取同一 revision
+
+**不成立。**
+
+计划先要求“identify one run_id/date/revision”，但随后规定 CLI 使用 `daily-brief latest`、Agent Tool 省略 date/revision。若 Canary 取证期间另一个 scheduled run 更新 current pointer，后两个 read surface 会合法读取更新后的 revision。现有 CLI/Agent 都已经支持按 date + revision 精确读取，无需接受这个竞态。
+
+### 7. Event rendering 可以延期
+
+**成立。**
+
+当前 assembler 写 `event_types/event_dates`，renderer 读 `event_type|kind|type` 与 `reason|status`，展示确有缺陷；但它不控制 canonical source、action creation 或 runtime-root authority。将其延期可缩小本次发布阻塞修复面。canonical source 修复也会阻止 raw-only candidate 继续生成 event。
+
+## Findings
+
+### PR-01-未修复-高-合法空 artifact 与零字节或空白截断文件仍不可区分
+- **位置**: 4.2 Artifact state table、4.3 Partial detection、8.1 `empty`/`malformed` fixtures
+- **问题类型**: 契约缺失 / 状态机漏洞 / 不可直接实施 / 测试缺口
+- **当前写法**: 计划把“parses with headers and zero rows，或 raises `EmptyDataError` for the pipeline's explicit empty artifact”归为 valid empty，但没有给出如何证明这个 `EmptyDataError` 来自受控显式空输出。
+- **反例/失败场景**:
+  1. 进程在创建 labeled 文件后、写入内容前崩溃，留下 0-byte 文件；`pd.read_csv()` 抛 `EmptyDataError`，implementation 按计划把它当作 authoritative zero-candidate result，既不写 gap，也把 source 标为 available。
+  2. 文件只写入空白后异常终止；异常与当前 upstream 单换行空 artifact 相同，损坏被静默降级成业务空集。
+  3. `empty` fixture 只使用 `pd.DataFrame().to_csv()`，测试通过，但没有证明 0-byte truncation 会 fail closed。
+- **为什么有问题**: 本修复的核心原则是“空是权威业务结果，损坏是数据缺口”。当前状态表声明了这个区别，却没有可实现的判定规则，implementation agent仍需自行设计最关键的 failure semantics。
+- **直接证据**:
+  - 计划 `:64` 把显式空 `EmptyDataError` 视为 available。
+  - `src/application/sell_put_steps.py:320-326,342-348` 使用 `pd.DataFrame().to_csv(index=False)` 物化显式空 artifact；当前 pandas 结果是单个换行符。
+  - `src/application/daily_decision_brief_service.py:319-342` 当前对任何 `EmptyDataError` 都标为 available，而 parser/OSError 才写 gap。
+  - 实测 pandas 对 `""`、`"\n"`、`"   \n"` 都抛 `EmptyDataError`。
+- **影响**: 上游截断可被误报为“零候选且数据正常”；日报 status 可能错误保持 `ready`，缺失证据不可审计，fail-closed 目标未实现。
+- **建议改法和验证点**:
+  1. 在计划中锁定一个可检测的 v1 空文件契约。最小方案：header-only CSV 正常解析为空；对于 legacy/current 单换行显式空，只接受与 upstream 已知写法完全匹配的非零字节空表示；0-byte 和其它空白形态归为 `csv_unavailable`/`canonical_labeled_artifact_invalid`。
+  2. 如果不愿把文件字节格式变成契约，则把所有 `EmptyDataError` 视为 unavailable，并同步修改 upstream empty materialization 为可解析的 header-only artifact；这会扩大 ownership，需在计划中显式列出 `sell_put_steps.py`。
+  3. 至少增加三个独立 fixture：header-only empty、当前受控换行 empty、0-byte truncated；前两者 available，最后一个 degraded/unavailable 且无 raw fallback。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-02-未修复-高-Prepared/CLI/Agent 的相同 Markdown hash 不是现有系统保证，Canary 会产生假失败或逼迫实现扩大耦合
+- **位置**: S3 prepared-message digest、12.2 Required four surfaces、12.3 Equality criteria
+- **问题类型**: 错误假设 / 过度耦合 / 验收契约错误 / 不可直接实施
+- **当前写法**: 计划要求 prepared notification、CLI `rendered_markdown` 和 Agent Tool `rendered_markdown` 三者 SHA-256 完全相等，并只给 prepared audit 增加 `brief_id/message_sha256/message_chars`。
+- **反例/失败场景**:
+  1. production 将 `max_candidates_per_strategy` 从 3 调整为 2；notification 使用 production limits，CLI/Agent 使用 renderer defaults，即使 brief 完全相同，消息 hash 也不同。
+  2. prepared message 在 `valid_until_utc` 前生成，CLI/Agent 在有效期后读取；read path按当前时间将 LIVE 改为 PLANNING，header 改变，hash 不同。
+  3. implementation agent 为满足 hash equality，让 CLI/Agent 开始加载 production notification config或取消 read-time effective actionability，扩大 read surface依赖并破坏既有契约。
+- **为什么有问题**: “同一 source/revision”是结构化事实一致性；“同一展示文本”还依赖 renderer mode、limits和查询时刻。计划把两个不同契约绑定成一个 hash，验收失败时无法判断是 source split还是合法展示差异。
+- **直接证据**:
+  - `src/application/tick_notification_flow.py:611,650-655`：实际 notification renderer 接收 `daily_limits`。
+  - `src/application/daily_decision_brief_renderer.py:50-59`：limits 影响实际选择/截断。
+  - `src/application/agent_tools/daily_brief.py:114-128`：read surface重新计算 effective actionability并使用默认 renderer limits。
+  - `domain/domain/daily_decision_brief.py:143-164`：过期 LIVE brief读取为 PLANNING。
+  - `src/application/config_defaults.py:129-133` 和 config validator/public contract允许这些 limits被配置，而非不可变常量。
+- **影响**: production Canary 可在正确实现上失败；或实现为迎合错误验收标准而把 CLI/Agent 与 production config耦合，扩大回归面和权限边界。
+- **建议改法和验证点**:
+  1. 把“四方同源”拆成两个独立证明：
+     - **结构化 source identity**：JSON、prepared audit、CLI、Agent 对同一 `brief_id/date/revision/run_id`，CLI/Agent 的 `brief` 与持久化 JSON完全一致；
+     - **renderer integrity**：prepared `message_sha256` 等于使用同一 persisted lifecycle、原始 actionability和实际 `daily_limits` 离线重渲染出的 hash。
+  2. CLI 与 Agent Markdown可互相比较，但必须记录两次读取的 `effective_actionability`；若跨越 expiry boundary，则只比较结构化 brief，或在同一有效性状态下重取。
+  3. prepared audit应额外记录用于渲染的 bounded limits或其稳定 digest，才能独立重现 prepared hash；不要让这些字段进入 brief semantic digest/delivery key。
+  4. 明确禁止为实现 hash equality而让 CLI/Agent读取 notification config。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-03-未修复-中-Canary 已锁定 revision 却仍使用 latest read，存在 current-pointer 竞态
+- **位置**: 12.2 Required four surfaces、12.3 Equality criteria
+- **问题类型**: 状态机/并发风险 / 验收不可重复 / 测试缺口
+- **当前写法**: 计划要求先识别 Canary `run_id/date/revision`，但 CLI 命令使用 `daily-brief latest`，Agent Tool输入仅包含 account/market。
+- **反例/失败场景**: 在读取 production JSON后、执行 CLI或Agent read前，scheduled tick生成新 revision并推进 current pointer。JSON/prepared audit指向 Canary revision，而 latest read指向新 revision；四方比较失败。更危险的是，如果新 revision内容近似，人工可能误判为同一 Canary产物。
+- **为什么有问题**: production current pointer是可变引用；Canary已经拥有 immutable date/revision identity，继续读取 latest没有收益。现有公共入口原生支持 exact revision读取。
+- **直接证据**:
+  - `src/interfaces/cli/daily_brief_ops.py:23-26,40-58` 支持 `day --date --revision`。
+  - `src/application/agent_tools/daily_brief.py:70-89,182-199` 支持 `date + revision`。
+  - 计划 `12.2` 明确要求identify revision，却给出 latest/省略revision命令。
+- **影响**: Canary偶发失败、证据不可复现、错误归因到runtime-root或content fix。
+- **建议改法和验证点**:
+  1. 先从 run-scoped JSON/prepared audit锁定 `market_trading_date + revision`。
+  2. CLI必须使用 `daily-brief day --date <date> --revision <n>`。
+  3. Agent Tool必须传相同 `date` 与 `revision`。
+  4. `latest`只作为附加运维检查：确认 current pointer当时是否仍指向该 revision；它不能作为四方一致性的主证据。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Architecture boundary review
+
+- **通过**：candidate source precedence留在 `daily_decision_brief_service.py`，没有泄漏到 domain ranking或renderer。
+- **通过**：runtime root在CLI/Agent consumer入口解析，保持code/config repo root与stateful runtime root分离。
+- **通过**：event rendering延期，避免为了小展示缺陷修改schema/digest。
+- **风险**：当前Canary hash契约可能迫使CLI/Agent加载production notification config；这会破坏修订计划本身声明的read boundary。应按PR-02拆分source identity与renderer integrity。
+
+## Best-practice review
+
+- canonical empty与corrupt必须有机器可判定的编码，而不是依赖异常语义猜测；否则无法做到fail closed。
+- production Canary应固定immutable identity读取，不应以mutable `latest`作为主证据。
+- observability hash必须连同影响render的参数/模式一起记录，才能重现和审计。
+- structured payload equality应优先于presentation equality；后者只能在相同render context下比较。
+
+## Optimal-solution review
+
+总体修复方向仍是最小且合理的：
+
+1. labeled-only；
+2. read consumer复用现有resolver；
+3. renderer只澄清现有payload；
+4. no-send Canary。
+
+不需要schema v2、candidate registry、数据库或新runtime abstraction。最优修订不是扩大实现，而是把两处验收契约缩窄：明确空文件字节/格式语义，并拆分structured identity与render-context hash。
+
+## Overengineering review
+
+没有发现需要删除的大型新抽象。`message_sha256`本身是低成本、可审计的观测字段；问题不是hash存在，而是计划把不同render context的hash错误地要求相等。记录实际render limits/digest即可，无需新增message store或调试数据库。
+
+## Overcoupling review
+
+主要过度耦合风险是把：
+
+```text
+同一 brief source
+=
+相同 effective actionability
+=
+相同 renderer limits
+=
+相同 Markdown bytes
+```
+
+视为一个契约。它们应拆开验证。否则CLI、Agent、notification和production config必须同步演进，任何正常展示配置变化都会破坏Canary。
+
+## Implementation sequencing review
+
+S1 -> S2 -> S3 -> S4顺序合理，allowed files基本清楚。但在进入S1前必须先解决PR-01，否则loader实现仍需临场决定空/损坏判断；在进入S3前必须解决PR-02/03，否则observability字段和Canary脚本会围绕错误相等性实现。
+
+## Open questions
+
+1. 是否接受把当前 upstream 单换行字节表示固定为v1合法空契约，还是允许本 work unit窄改upstream以生成header-only empty artifact？前者改动最小，后者长期更清晰。
+2. Prepared audit记录完整bounded limits还是记录canonical limits digest？为可独立重放，完整三个整数更直接且不敏感。
+3. Canary是否保证在brief有效期内完成？即使保证，也应把expiry condition写成precondition，而不能依赖操作速度。
+
+## Residual risks and suggested tracking
+
+- **Event plural/singular mismatch**：已正确延期；跟踪到独立 `daily-brief-event-rendering` work unit。
+- **Release-local shadow artifacts**：运维清理项，不属于本修复。
+- **Historical mixed-source briefs**：保留历史，不回写；属于审计说明。
+- **Provider real-send behavior**：no-send无法证明；继续由真实发送授权gate承担。
+- **Raw/labeled filename pairing drift**：若上游未来改名，需要显式更新source authority contract；建议记录到AGENT_WIKI或Daily Brief source contract文档。
+
+## Required plan changes before implementation
+
+1. 为合法空artifact提供机器可判定规则，并增加0-byte/空白截断回归fixture；
+2. 将四方Canary拆成structured identity equality与render-context integrity两类验收；
+3. prepared audit记录实际render limits或其可重放表示；
+4. CLI和Agent使用同一date/revision精确读取，不以latest作为主证据；
+5. 明确expiry boundary下Markdown hash的处理规则。
+
+## Final conclusion
+
+**fail** — 修订计划已解决上一轮的主要architecture和ownership问题，但仍不是code-generation-ready。`EmptyDataError`不能区分合法空与截断损坏；同时当前“四方同源=三份Markdown hash完全相等”的验收假设与现有renderer limits和read-time actionability语义冲突。若不先修订，最可能出现两种结果：损坏artifact被静默视为空，或正确的生产Canary因合法展示差异/最新revision竞态而失败。

--- a/docs/reviews/plan-review-20260720-114038.md
+++ b/docs/reviews/plan-review-20260720-114038.md
@@ -1,0 +1,264 @@
+# Plan Review — HK Daily Decision Brief Canary Correction（最终复审）
+
+- **Reviewed target**: `docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md`
+- **Review date**: 2026-07-20
+- **Review scope**: canonical Sell Put artifact authority、empty/missing/malformed/partial semantics、raw no-fallback、runtime-root ownership、candidate/action/renderer invariants、fixture matrix、prepared-message observability、exact-revision four-surface Canary、event deferral
+- **Previous reviews**:
+  - `docs/reviews/plan-review-20260720-105521.md`
+  - `docs/reviews/plan-review-20260720-111103.md`
+- **Review posture**: adversarial；只把现实中会导致错误实现、不安全发送或不可验收的缺口视为 blocker
+- **Conclusion**: **pass-with-risks**
+
+## Goal and success signal understood
+
+计划现在定义了一条可直接实施和验证的修复路径：
+
+1. Sell Put Daily Brief 只读取 canonical labeled artifacts；
+2. raw rows从不进入ranking、candidate、action、event或summary；
+3. 合法空、缺失、损坏和partial状态有机器可判定语义；
+4. CLI和Agent Tool在各自read boundary复用现有runtime-root resolver；
+5. `actions[state=active]`是唯一执行权威，candidate仅为canonical evidence；
+6. structured source identity与renderer byte integrity分别验证；
+7. Canary使用immutable date/revision读取，不依赖可变latest pointer；
+8. no-send通过后仍需单独授权真实发送。
+
+完成信号包含focused tests、Daily Brief subsystem regression、Agent contract regression、release validation、production no-send四方取证和delivery-pointer不变性，足以判断目标是否达成。
+
+## Assumptions tested
+
+### 1. Labeled artifact 是 Sell Put 正常下游 authority
+
+**成立。**
+
+- `src/application/sell_put_steps.py:299-319` 在labeled输出上执行现金与underwriting enrich/filter。
+- `src/application/sell_put_steps.py:329-339` 的现有alert/summary同样消费labeled artifact。
+- 当前日报错误来自 `src/application/daily_decision_brief_service.py:64-74` 同时加载raw与labeled，再在 `:99-106` 合并重排。
+
+计划将修复限定在application assembly boundary，不改变domain ranking policy或策略阈值。
+
+### 2. 合法空与截断损坏已经具有可实施区分
+
+**成立。**
+
+修订后的契约规定：
+
+- header-only zero-row必须包含最小canonical列；
+- 当前upstream受控空只接受完整字节 `b"\n"` 或 `b"\r\n"`；
+- zero-byte与其它空白表示均为malformed；
+- `EmptyDataError`后先检查size，仅在size <= 2时读取最多两字节。
+
+这能在不修改upstream writer的前提下，区分当前 `pd.DataFrame().to_csv(index=False)` 受控空与最常见的0-byte截断。fixture也覆盖header-only、wrong-header、newline、CRLF、zero-byte和unrecognized whitespace。
+
+### 3. Partial detection不需要读取raw内容
+
+**成立。**
+
+同一run-account目录中的raw/labeled suffix pairing足以发现raw-only symbol key。计划允许读取文件名但禁止读取raw行，并明确labeled-only不要求raw counterpart。可靠labeled symbol保留，失败scope写gap，符合局部fail-closed。
+
+### 4. Runtime-root修改面清楚且不污染全局repo-root语义
+
+**成立。**
+
+- CLI只在 `src/interfaces/cli/daily_brief_ops.py` consumer boundary调用 `resolve_runtime_root(repo_root=repo_base_fn())`。
+- Agent Tool只在 `src/application/agent_tools/daily_brief.py` consumer boundary调用同一resolver。
+- `src/application/runtime_paths.py` 和全局 `repo_base()` 保持不变。
+
+测试使用真实read service和真实 `OM_RUNTIME_ROOT` 环境优先级，不再只证明mock转发。
+
+### 5. Candidate/action/renderer契约不需要schema v2
+
+**成立。**
+
+现有字段已能表达：
+
+- `actions`：行动authority；
+- `candidates`：canonical accepted evidence；
+- `capacity`：容量证据；
+- `status`：数据质量；
+- `actionability`：时间/执行姿态；
+- `data_gaps`：不完整证据。
+
+计划不新增candidate eligibility字段，也不让renderer重新执行策略资格判断。summary和header只是把现有事实明确呈现。
+
+### 6. Prepared-message hash现在可独立重现
+
+**成立。**
+
+计划不再要求prepared、CLI和Agent在不同render context下字节相等。它新增一个共享、公开且窄的 `resolve_daily_brief_render_limits()`，由renderer和notification flow共同使用，并在prepared audit记录实际bounded limits。
+
+Prepared完整性通过以下输入重放：
+
+- persisted original brief/actionability；
+- exact recorded render limits；
+- production `render_daily_brief_lifecycle()`；
+- prepared `delivery_kind=full`。
+
+重放结果与 `message_sha256/message_chars` 比较，不需要CLI/Agent读取production notification config。
+
+### 7. Four-surface Canary已消除latest竞态
+
+**成立。**
+
+计划先从run JSON/prepared audit冻结 `run_id/date/revision/brief_id`，随后CLI使用 `daily-brief day --date --revision`，Agent Tool传同一date/revision。`latest`只作为附加current-pointer观察，不再参与主要一致性证明。
+
+### 8. Event rendering延期不会隐藏本次安全问题
+
+**成立。**
+
+raw-only candidate在source修复后不能进入 `_candidate_events()`；event plural/singular展示缺陷不影响candidate/action authority和runtime-root。延期能减少本批renderer/schema/digest干扰，并有明确follow-up范围。
+
+## Findings
+
+**无 material findings。**
+
+没有发现仍会迫使implementation agent重新设计关键状态机、导致raw fail-open、改变delivery lifecycle、污染全局runtime path或使production Canary不可重复的未解决问题。
+
+## Previous finding closure
+
+### Previous PR-01 — EmptyDataError无法区分合法空与截断损坏
+
+**Closed.**
+
+- 明确精确字节encoding；
+- zero-byte/其它空白fail closed；
+- header-only要求最小canonical列；
+- 补齐独立fixtures；
+- byte check有明确bounded读取策略。
+
+### Previous PR-02 — Prepared/CLI/Agent Markdown hash错误绑定不同render context
+
+**Closed.**
+
+- structured identity与renderer integrity已拆分；
+- prepared audit记录resolved render limits；
+- shared normalizer避免规则复制；
+- CLI/Agent不加载notification config；
+- expiry transition被明确视为合法read-time差异。
+
+### Previous PR-03 — Canary使用latest导致revision竞态
+
+**Closed.**
+
+- CLI和Agent均改为exact date/revision；
+- mutable current/latest仅作附加观察；
+- 并发新revision不影响immutable Canary证明。
+
+## Architecture boundary review
+
+**Pass.**
+
+- artifact precedence：application assembler ownership；
+- ranking：继续复用domain engine，无日报专属评分；
+- runtime root：现有application resolver，consumer入口使用；
+- renderer：只展示payload事实；
+- repository/delivery：明确不修改；
+- observability：tick metrics，不进入semantic brief/delivery key；
+- event修复：独立follow-up。
+
+依赖方向未反转，也没有把文件名、config或runtime I/O泄漏到domain层。
+
+## Best-practice review
+
+**Pass.**
+
+计划采用：
+
+- single source of truth；
+- fail-closed partial handling；
+- immutable identity取证；
+- structured equality优先于presentation equality；
+- render context可重放；
+- no-send与delivery-pointer不变性检查；
+- focused -> subsystem -> public contract -> release -> production Canary验证梯度。
+
+这些做法与repo的生产敏感、read-first和default-off约束一致。
+
+## Optimal-solution review
+
+**Pass.**
+
+当前方案是可信选项中修改面最小的：
+
+1. 删除Daily Brief对raw rows的正常依赖；
+2. 复用现有runtime resolver；
+3. 用现有payload字段澄清行动/证据边界；
+4. 只增加三个整数render limits与message digest观测；
+5. 不新增schema、DB、queue、registry或第二发送栈。
+
+修改upstream空artifact格式会扩大发布面；当前精确兼容契约加future cleanup记录更适合本次阻塞修复。
+
+## Overengineering review
+
+**Pass.**
+
+没有无需求支撑的抽象。新增public render-limit helper有两个当前消费者，并直接避免notification与audit normalization漂移；它不是speculative abstraction。
+
+Prepared message只保存digest、length和三个bounded limits，不保存正文，也不引入message archive。
+
+## Overcoupling review
+
+**Pass.**
+
+计划已拆开：
+
+- brief source identity；
+- effective read-time actionability；
+- production notification render context；
+- CLI/Agent default read rendering。
+
+CLI/Agent不会为复现notification bytes而加载production config。共享耦合只保留在应当共享的renderer limit normalization和canonical persisted brief上。
+
+## Implementation sequencing review
+
+**Pass.**
+
+- S1先关闭source/failure semantics；
+- S2修复read authority；
+- S3只做presentation与observability；
+- S4执行回归、release和no-send Canary。
+
+每个slice有独立allowed files、focused tests和stop condition。S1/S3虽都触碰service tests，但按顺序执行且职责不同，不构成并行write conflict。
+
+## Validation review
+
+**Pass.**
+
+关键反例已有明确fixture：
+
+- labeled P430/P440 vs raw P450冲突；
+- empty header/newline/CRLF；
+- wrong header、zero-byte、unknown whitespace、parser malformed；
+- missing和partial；
+- partial Sell Put + reliable Covered Call的 `live_actionable + degraded`；
+- repo shadow vs `OM_RUNTIME_ROOT`；
+- no-send/full/pointer不推进；
+- exact revision source identity；
+- prepared message重放hash。
+
+Broad regression覆盖repository、diff、notification、CLI、Agent和公开plugin contract。
+
+## Open questions
+
+无blocking open question。
+
+实现时仍需在code review确认两个局部细节，但计划已给出唯一可接受语义：
+
+1. malformed empty artifact使用现有 `csv_unavailable` 还是更窄的reason值；无论命名如何，必须进入gap、source unavailable且不得fallback raw。
+2. `delivery_kind=none` 时digest字段选择omit还是null；测试需固定一种稳定表示。
+
+这两项不改变安全或architecture决策，可由implementation按现有style选择并由focused tests锁定。
+
+## Residual risks and suggested tracking
+
+| Risk | Classification | Tracking |
+|---|---|---|
+| 单换行empty encoding依赖当前upstream writer行为 | accepted compatibility risk；已有exact fixture和fail-closed fallback | 后续header-only empty artifact cleanup issue |
+| Event `event_types/event_dates` 与renderer singular字段不一致 | explicitly deferred | `daily-brief-event-rendering` follow-up work unit |
+| release-local shadow artifacts继续占盘 | operational, non-authoritative | guarded cleanup task，不能并入本修复 |
+| 历史mixed-source brief仍保留 | audit-preserving expected behavior | release note / operational note |
+| no-send不验证provider真实投递 | accepted gate boundary | successful Canary后单独真实发送授权 |
+| production config limits未来变化 | covered byrecorded resolved limits | renderer/notification regression tests |
+
+## Final conclusion
+
+**pass-with-risks** — 修订计划已经达到code-generation-ready。前两轮的三个blocker均已闭合：合法空与截断损坏可机器区分；structured source identity与renderer byte integrity不再错误耦合；Canary使用exact revision避免current-pointer竞态。剩余风险均已分类、可测试、可回滚，且不需要implementation agent重新设计关键契约。可以进入Gateflow implementation S1，但仍必须按计划逐slice review，并在真实发送前完成production no-send四方Canary和单独授权。

--- a/docs/reviews/pr-97-review-20260720-124138.md
+++ b/docs/reviews/pr-97-review-20260720-124138.md
@@ -1,0 +1,77 @@
+# Code Review
+
+## Scope
+
+- Mode: PR
+- Repository: `liuxie066/options-monitor`
+- Pull request: #97 — `fix: restore canonical Daily Brief canary authority`
+- URL: https://github.com/liuxie066/options-monitor/pull/97
+- Author: `liuxie066`
+- Head: `fix/daily-brief-canary-correction` at `f6102e1678d17560dddff8b75dec5f83c2810cb2`
+- Base: `main`
+- Output file: `docs/reviews/pr-97-review-20260720-124138.md`
+- Included scope: complete PR diff, 21 changed files, all production call chains and tests described in aggregate Deepreview
+- Excluded scope: post-merge release state, remote server state, and deferred `daily-brief-event-rendering` work unit
+- Parallel review coverage: 无；PR diff matches the locally aggregate-reviewed branch exactly
+
+## PR facts and scope verification
+
+- PR is draft.
+- Remote head OID matches local reviewed commit `f6102e16`.
+- `gh pr diff 97 --name-only` matches the intended Gateflow artifacts, five production/test implementation areas, and associated tests.
+- `git diff --check origin/main...HEAD` passes.
+- No unrelated dirty workspace files are present.
+
+## Review method
+
+Rechecked the PR diff against the accepted plan and followed these paths:
+
+1. run-account Sell Put artifacts -> labeled-only loader -> ranking -> candidates/actions/events/summary;
+2. CLI / Agent Tool -> runtime-root resolver -> exact repository read -> structured and Markdown view;
+3. normalized actions/candidates/status -> full/blocked/delta renderer;
+4. prepared lifecycle -> resolved render limits -> exact outgoing message -> metrics/audit digest -> no-send path;
+5. repository/delivery boundaries to confirm they are unchanged.
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Validation
+
+Local required checks already passed on the PR head:
+
+- Daily Brief subsystem: 93 passed
+- Agent public contract/smoke: 102 passed
+- S1/S2/S3 focused gates: 20 / 12 / 35 passed
+- Python compile checks: pass
+- diff hygiene: pass
+
+GitHub checks at review time:
+
+- `agent-plugin`: in progress
+- `guardrails`: in progress
+- CodeQL `Analyze (actions)`: in progress
+- CodeQL `Analyze (python)`: in progress
+
+CI completion is required before merge but does not change the code-review finding result.
+
+## Docs decision
+
+PR body accurately states root cause, implementation, safety boundaries, validation, event-rendering deferral, and no-send-only post-merge plan.
+
+## Residual Risk
+
+- GitHub CI completion is **required before merge** and owned by the current release gate.
+- Production release, remote upgrade, exact-revision four-surface Canary, pointer immutability, and zero-send evidence are **owned by the approved post-merge phase**.
+- Event rendering remains **assigned to `daily-brief-event-rendering`**.
+- Real notification sending remains **blocked pending separate explicit authorization**.
+
+## Decision
+
+- PR review result: pass
+- Findings requiring fix/re-review: none
+- Completion status: accepted PR review; ready for protected PR review commit and final push

--- a/src/application/agent_tools/daily_brief.py
+++ b/src/application/agent_tools/daily_brief.py
@@ -13,6 +13,7 @@ from src.application.daily_decision_brief_repository import (
     read_daily_decision_brief,
     read_latest_daily_decision_brief,
 )
+from src.application.runtime_paths import resolve_runtime_root
 
 
 _OUTPUT_CONTRACT: dict[str, Any] = {
@@ -189,9 +190,11 @@ def _validate_daily_brief_input(payload: dict[str, Any]) -> None:
 def _daily_brief_read_tool(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str], dict[str, Any]]:
     revision_value = payload.get("revision")
     revision = None if revision_value is None else int(revision_value)
+    repo_root = repo_base()
+    runtime_root = resolve_runtime_root(repo_root=repo_root).runtime_root
     try:
         data = read_daily_brief_view(
-            base=repo_base(),
+            base=runtime_root,
             account=str(payload.get("account") or ""),
             market=str(payload.get("market") or "US"),
             market_trading_date=(str(payload.get("date") or "").strip() or None),

--- a/src/application/daily_decision_brief_renderer.py
+++ b/src/application/daily_decision_brief_renderer.py
@@ -15,6 +15,11 @@ _ACTIONABILITY_LABELS = {
     "planning_only": "仅规划（PLANNING）",
     "blocked": "阻塞（BLOCKED）",
 }
+_STATUS_LABELS = {
+    "ready": "就绪（READY）",
+    "degraded": "降级（DEGRADED）",
+    "blocked": "阻塞（BLOCKED）",
+}
 _STATE_LABELS = {
     "active": "有效",
     "observe": "观察",
@@ -55,7 +60,7 @@ def render_full_brief(
     if str(brief.get("actionability") or "").strip().lower() == "blocked":
         return render_blocked_brief(brief, limits=limits)
 
-    cfg = _limits(limits)
+    cfg = resolve_daily_brief_render_limits(limits)
     budget = _RenderBudget()
     lines = _header(brief, title="每日决策简报")
     summary = str(brief.get("strategy_summary") or "").strip()
@@ -63,15 +68,24 @@ def render_full_brief(
         lines.extend(["", f"> {summary}"])
 
     actions = [item for item in brief.get("actions") or [] if isinstance(item, Mapping)]
+    active_actions = [item for item in actions if str(item.get("state") or "").strip().lower() == "active"]
     for priority in ("P0", "P1", "P2"):
-        priority_rows = [item for item in actions if str(item.get("priority") or "").upper() == priority]
+        priority_rows = [
+            item for item in active_actions if str(item.get("priority") or "").upper() == priority
+        ]
         if not priority_rows:
             continue
-        lines.extend(["", f"## {priority} 行动"])
+        lines.extend(["", f"## {priority} 有效行动"])
         selected = budget.take(priority_rows, cfg["max_actions_per_priority"])
         lines.extend(_action_line(item) for item in selected)
         _append_omitted(lines, len(priority_rows) - len(selected))
 
+    _append_non_active_actions(
+        lines,
+        actions,
+        budget=budget,
+        limit=cfg["max_actions_per_priority"],
+    )
     _append_positions(lines, brief, budget=budget, limit=cfg["max_actions_per_priority"])
     _append_capacity(lines, brief, budget=budget)
     _append_candidates(lines, brief, budget=budget, limit=cfg["max_candidates_per_strategy"])
@@ -86,7 +100,7 @@ def render_blocked_brief(
     *,
     limits: Mapping[str, Any] | None = None,
 ) -> str:
-    cfg = _limits(limits)
+    cfg = resolve_daily_brief_render_limits(limits)
     budget = _RenderBudget()
     lines = _header(brief, title="每日决策简报 · 当前阻塞")
     lines.extend(["", "## 阻塞原因"])
@@ -121,7 +135,7 @@ def render_delta_brief(
     *,
     limits: Mapping[str, Any] | None = None,
 ) -> str:
-    cfg = _limits(limits)
+    cfg = resolve_daily_brief_render_limits(limits)
     budget = _RenderBudget()
     lines = _header(brief, title="日内决策增量")
     lines.append(
@@ -180,8 +194,29 @@ def _header(brief: Mapping[str, Any], *, title: str) -> list[str]:
     return [
         f"# {title}",
         f"- 账号：`{account}` | 市场：`{market}` | 交易日：`{market_date}` | revision：`{revision}`",
-        f"- 状态：{_actionability_label(brief)} | 数据截至：`{data_as_of}` | 有效至：`{valid_until}`",
+        f"- 状态：{_actionability_label(brief)} | 数据质量：{_status_label(brief)} "
+        f"| 数据截至：`{data_as_of}` | 有效至：`{valid_until}`",
     ]
+
+
+def _append_non_active_actions(
+    lines: list[str],
+    actions: list[Mapping[str, Any]],
+    *,
+    budget: _RenderBudget,
+    limit: int,
+) -> None:
+    rows = [
+        item
+        for item in actions
+        if str(item.get("state") or "").strip().lower() in {"observe", "blocked", "invalidated"}
+    ]
+    if not rows:
+        return
+    lines.extend(["", "## 非执行状态（观察 / 阻塞 / 失效）"])
+    selected = budget.take(rows, limit)
+    lines.extend(_action_line(item) for item in selected)
+    _append_omitted(lines, len(rows) - len(selected))
 
 
 def _append_positions(
@@ -235,7 +270,7 @@ def _append_candidates(
         rows = [item for item in candidates.get(family) or [] if isinstance(item, Mapping)]
         if not rows:
             continue
-        lines.extend(["", f"## {labels[family]} 候选"])
+        lines.extend(["", f"## {labels[family]} 候选证据（非行动）"])
         selected = budget.take(rows, limit)
         for item in selected:
             symbol = _first(item, "symbol", default="未知标的")
@@ -368,10 +403,15 @@ def _identity_suffix(item: Mapping[str, Any]) -> str:
 
 def _actionability_label(brief: Mapping[str, Any]) -> str:
     value = str(brief.get("actionability") or "blocked").strip().lower()
-    return _ACTIONABILITY_LABELS.get(value, value)
+    return _ACTIONABILITY_LABELS.get(value, f"未知（{value.upper()}）")
 
 
-def _limits(value: Mapping[str, Any] | None) -> dict[str, int]:
+def _status_label(brief: Mapping[str, Any]) -> str:
+    value = str(brief.get("status") or "missing").strip().lower()
+    return _STATUS_LABELS.get(value, f"未知（{value.upper()}）")
+
+
+def resolve_daily_brief_render_limits(value: Mapping[str, Any] | None) -> dict[str, int]:
     src = value if isinstance(value, Mapping) else {}
     return {
         "max_actions_per_priority": _positive_int(src.get("max_actions_per_priority"), _DEFAULT_MAX_ACTIONS),
@@ -416,6 +456,7 @@ def _bounded_markdown(lines: list[str]) -> str:
 
 
 __all__ = [
+    "resolve_daily_brief_render_limits",
     "render_blocked_brief",
     "render_daily_brief_lifecycle",
     "render_delta_brief",

--- a/src/application/daily_decision_brief_service.py
+++ b/src/application/daily_decision_brief_service.py
@@ -233,11 +233,14 @@ def assemble_daily_decision_brief(
     generated_at = effective_now.isoformat()
     data_as_of = _latest_as_of(metrics, prefetch, fallback=effective_now).isoformat()
     events = _candidate_events([*selected_puts, *selected_calls, *selected_combos])
+    deduped_actions = _dedupe_actions(actions)
+    deduped_data_gaps = _dedupe_gaps(data_gaps)
     strategy_summary = _strategy_summary(
         actionability=actionability,
         blockers=blockers,
-        actions=actions,
+        actions=deduped_actions,
         candidates=candidate_payloads,
+        data_gaps=deduped_data_gaps,
     )
 
     return normalize_daily_decision_brief(
@@ -253,13 +256,13 @@ def assemble_daily_decision_brief(
             "status": status,
             "actionability": actionability,
             "strategy_summary": strategy_summary,
-            "actions": _dedupe_actions(actions),
+            "actions": deduped_actions,
             "positions": positions,
             "capacity": capacity,
             "candidates": candidate_payloads,
             "rejections": _json_safe(rejections),
             "events": events,
-            "data_gaps": _dedupe_gaps(data_gaps),
+            "data_gaps": deduped_data_gaps,
             "source_artifacts": _dedupe_source_artifacts(source_artifacts),
         }
     )
@@ -1075,14 +1078,18 @@ def _strategy_summary(
     blockers: list[str],
     actions: list[dict[str, Any]],
     candidates: Mapping[str, list[dict[str, Any]]],
+    data_gaps: list[dict[str, Any]],
 ) -> str:
     if actionability == "blocked":
         return "日报阻塞：" + "；".join(blockers)
     active = sum(1 for item in actions if item.get("state") == "active")
-    return (
-        f"可执行行动 {active} 条；Sell Put {len(candidates['sell_put'])}，"
-        f"Covered Call {len(candidates['covered_call'])}，Combo Yield {len(candidates['combo_yield'])}。"
+    summary = (
+        f"有效行动 {active} 条；候选证据：Sell Put {len(candidates['sell_put'])}，"
+        f"Covered Call {len(candidates['covered_call'])}，Combo Yield {len(candidates['combo_yield'])}"
     )
+    if data_gaps:
+        summary += f"；数据缺口 {len(data_gaps)} 条"
+    return summary + "。"
 
 
 def _dedupe_gaps(items: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/application/daily_decision_brief_service.py
+++ b/src/application/daily_decision_brief_service.py
@@ -61,14 +61,9 @@ def assemble_daily_decision_brief(
         default=_DEFAULT_MAX_CANDIDATES,
     )
 
-    put_rows, put_available = _load_candidate_family(
+    put_rows, put_available = _load_sell_put_candidates(
         run_account_dir=run_account_dir,
         market=market_norm,
-        family="sell_put",
-        paths_to_try=[
-            *sorted(run_account_dir.glob("*_sell_put_candidates_labeled.csv")),
-            *sorted(run_account_dir.glob("*_sell_put_candidates.csv")),
-        ],
         source_artifacts=source_artifacts,
         data_gaps=data_gaps,
     )
@@ -301,6 +296,53 @@ def assemble_daily_decision_briefs(
     return out
 
 
+def _load_sell_put_candidates(
+    *,
+    run_account_dir: Path,
+    market: str,
+    source_artifacts: list[dict[str, Any]],
+    data_gaps: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], bool]:
+    labeled_suffix = "_sell_put_candidates_labeled.csv"
+    raw_suffix = "_sell_put_candidates.csv"
+    labeled_paths = sorted(run_account_dir.glob(f"*{labeled_suffix}"))
+    raw_paths = sorted(run_account_dir.glob(f"*{raw_suffix}"))
+
+    if not labeled_paths and not raw_paths:
+        data_gaps.append(
+            {"scope": "strategy", "strategy_family": "sell_put", "reason": "source_artifact_missing"}
+        )
+        return [], False
+
+    labeled_keys = {path.name[: -len(labeled_suffix)] for path in labeled_paths}
+    for raw_path in raw_paths:
+        artifact_key = raw_path.name[: -len(raw_suffix)]
+        if artifact_key in labeled_keys:
+            continue
+        data_gaps.append(
+            {
+                "scope": "source",
+                "strategy_family": "sell_put",
+                "artifact_key": artifact_key,
+                "path": _source_path(run_account_dir, raw_path),
+                "reason": "canonical_labeled_artifact_missing",
+            }
+        )
+
+    if not labeled_paths:
+        return [], False
+
+    return _load_candidate_family(
+        run_account_dir=run_account_dir,
+        market=market,
+        family="sell_put",
+        paths_to_try=labeled_paths,
+        source_artifacts=source_artifacts,
+        data_gaps=data_gaps,
+        validate_empty_schema=True,
+    )
+
+
 def _load_candidate_family(
     *,
     run_account_dir: Path,
@@ -309,6 +351,7 @@ def _load_candidate_family(
     paths_to_try: list[Path],
     source_artifacts: list[dict[str, Any]],
     data_gaps: list[dict[str, Any]],
+    validate_empty_schema: bool = False,
 ) -> tuple[list[dict[str, Any]], bool]:
     rows: list[dict[str, Any]] = []
     available = False
@@ -319,7 +362,18 @@ def _load_candidate_family(
     for path in paths_to_try:
         try:
             frame = pd.read_csv(path)
-        except pd.errors.EmptyDataError:
+        except pd.errors.EmptyDataError as exc:
+            if validate_empty_schema and not _is_controlled_empty_candidate_artifact(path):
+                data_gaps.append(
+                    {
+                        "scope": "source",
+                        "strategy_family": family,
+                        "path": _source_path(run_account_dir, path),
+                        "reason": "csv_unavailable",
+                        "error_type": type(exc).__name__,
+                    }
+                )
+                continue
             available = True
             source_artifacts.append(
                 {
@@ -337,6 +391,17 @@ def _load_candidate_family(
                     "path": _source_path(run_account_dir, path),
                     "reason": "csv_unavailable",
                     "error_type": type(exc).__name__,
+                }
+            )
+            continue
+        if validate_empty_schema and frame.empty and not _has_minimum_candidate_columns(frame):
+            data_gaps.append(
+                {
+                    "scope": "source",
+                    "strategy_family": family,
+                    "path": _source_path(run_account_dir, path),
+                    "reason": "csv_unavailable",
+                    "error_type": "SchemaError",
                 }
             )
             continue
@@ -370,6 +435,23 @@ def _load_candidate_family(
         )
         rows.extend(market_rows)
     return rows, available
+
+
+def _is_controlled_empty_candidate_artifact(path: Path) -> bool:
+    try:
+        size = path.stat().st_size
+        if size > 2:
+            return False
+        with path.open("rb") as handle:
+            content = handle.read(2)
+    except OSError:
+        return False
+    return content in {b"\n", b"\r\n"}
+
+
+def _has_minimum_candidate_columns(frame: pd.DataFrame) -> bool:
+    columns = {str(column).strip() for column in frame.columns}
+    return "symbol" in columns and bool(columns.intersection({"contract_symbol", "code"}))
 
 
 def _load_close_advice(

--- a/src/application/tick_notification_flow.py
+++ b/src/application/tick_notification_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,7 +27,10 @@ from src.application.cron_runtime import (
     build_notify_summary,
     mark_accounts_notified,
 )
-from src.application.daily_decision_brief_renderer import render_daily_brief_lifecycle
+from src.application.daily_decision_brief_renderer import (
+    render_daily_brief_lifecycle,
+    resolve_daily_brief_render_limits,
+)
 from src.application.daily_decision_brief_repository import (
     confirm_daily_decision_brief_delivery,
     prepare_daily_decision_brief,
@@ -608,7 +612,7 @@ def _prepare_daily_brief_notification(
     lifecycles_by_account: dict[str, dict[str, Any]] = {}
     delivery_keys_by_account: dict[str, str] = {}
     messages_by_account: dict[str, str] = {}
-    daily_limits = _daily_brief_limits(request.base_cfg)
+    daily_limits = resolve_daily_brief_render_limits(_daily_brief_limits(request.base_cfg))
     lifecycle_audit: list[dict[str, Any]] = []
 
     for result in request.results:
@@ -629,31 +633,32 @@ def _prepare_daily_brief_notification(
             pipeline_succeeded=account in ran_pipeline_accounts,
             config=request.base_cfg,
         )
-        account_lifecycles: dict[str, dict[str, Any]] = {}
         for market in markets:
             brief = briefs.get(market)
             if brief is None:
                 raise ValueError(f"daily brief assembler did not return market {market} for {account}")
             lifecycle = prepare_daily_decision_brief(base=request.base, brief=brief)
-            account_lifecycles[market] = lifecycle
-            lifecycle_audit.append(
-                {
-                    "account": account,
-                    "market": market,
-                    "market_trading_date": lifecycle["brief"]["market_trading_date"],
-                    "revision": lifecycle["brief"]["revision"],
-                    "delivery_kind": lifecycle["delivery_kind"],
-                    "material_diff_digest": lifecycle["diff"].get("material_diff_digest"),
-                }
-            )
-
-        if len(markets) == 1:
-            lifecycle = account_lifecycles[markets[0]]
-            message = render_daily_brief_lifecycle(lifecycle, limits=daily_limits)
-            if message:
-                messages_by_account[account] = message
-                delivery_keys_by_account[account] = str(lifecycle["delivery_key"])
-                lifecycles_by_account[account] = lifecycle
+            audit_item = {
+                "account": account,
+                "market": market,
+                "market_trading_date": lifecycle["brief"]["market_trading_date"],
+                "revision": lifecycle["brief"]["revision"],
+                "brief_id": lifecycle["brief"].get("brief_id"),
+                "delivery_kind": lifecycle["delivery_kind"],
+                "material_diff_digest": lifecycle["diff"].get("material_diff_digest"),
+                "message_sha256": None,
+                "message_chars": None,
+                "render_limits": dict(daily_limits),
+            }
+            if len(markets) == 1:
+                message = render_daily_brief_lifecycle(lifecycle, limits=daily_limits)
+                if message:
+                    audit_item["message_sha256"] = hashlib.sha256(message.encode("utf-8")).hexdigest()
+                    audit_item["message_chars"] = len(message)
+                    messages_by_account[account] = message
+                    delivery_keys_by_account[account] = str(lifecycle["delivery_key"])
+                    lifecycles_by_account[account] = lifecycle
+            lifecycle_audit.append(audit_item)
 
     multi_market = len(markets) != 1
     if multi_market:

--- a/src/interfaces/cli/daily_brief_ops.py
+++ b/src/interfaces/cli/daily_brief_ops.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 from src.application.agent_tool_contracts import AgentToolError
 from src.application.agent_tools.daily_brief import read_daily_brief_view
+from src.application.runtime_paths import resolve_runtime_root
 
 
 def add_daily_brief_commands(subparsers: argparse._SubParsersAction) -> None:
@@ -48,9 +49,11 @@ def handle_daily_brief_command(
     if revision is not None and revision < 0:
         raise AgentToolError(code="INPUT_ERROR", message="revision must be non-negative")
 
+    repo_root = repo_base_fn()
+    runtime_root = resolve_runtime_root(repo_root=repo_root).runtime_root
     try:
         data = read_daily_brief_view(
-            base=repo_base_fn(),
+            base=runtime_root,
             account=args.account,
             market=args.market,
             market_trading_date=market_trading_date,

--- a/tests/test_daily_decision_brief_agent_tool.py
+++ b/tests/test_daily_decision_brief_agent_tool.py
@@ -4,13 +4,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 
-def _brief(*, valid_until: str = "2026-07-19T20:00:00+00:00") -> dict:
+def _brief(*, valid_until: str = "2026-07-19T20:00:00+00:00", run_id: str = "run-tool") -> dict:
     return {
         "market": "US",
         "market_trading_date": "2026-07-19",
         "account": "lx",
         "revision": 999,
-        "run_id": "run-tool",
+        "run_id": run_id,
         "generated_at_utc": "2026-07-19T13:40:00+00:00",
         "data_as_of_utc": "2026-07-19T13:39:00+00:00",
         "valid_until_utc": valid_until,
@@ -87,6 +87,8 @@ def test_agent_tool_is_pure_read_and_returns_structured_contract(monkeypatch, tm
 
     prepare_daily_decision_brief(base=tmp_path, brief=_brief(valid_until="2026-07-20T20:00:00+00:00"))
     monkeypatch.setattr(mod, "repo_base", lambda: tmp_path)
+    monkeypatch.delenv("OM_RUNTIME_ROOT", raising=False)
+    monkeypatch.delenv("OM_ENV_FILE", raising=False)
 
     data, warnings, meta = mod.DAILY_DECISION_BRIEF_READ_TOOL.call({"account": "lx", "market": "US"})
 
@@ -166,3 +168,35 @@ def test_agent_tool_masks_state_invalid_source_path(monkeypatch, tmp_path: Path)
     assert data["source"]["state_path"] == ".../daily_decision_brief.US.current.json"
     assert str(tmp_path) not in str(data)
     assert "error" not in data
+
+
+def test_agent_tool_reads_env_runtime_root_then_repo_fallback(monkeypatch, tmp_path: Path) -> None:
+    import src.application.agent_tools.daily_brief as mod
+    from src.application.daily_decision_brief_repository import prepare_daily_decision_brief
+
+    repo_root = tmp_path / "repo"
+    runtime_root = tmp_path / "runtime"
+    prepare_daily_decision_brief(base=repo_root, brief=_brief(run_id="repo-r0"))
+    prepare_daily_decision_brief(base=runtime_root, brief=_brief(run_id="runtime-r0"))
+    runtime_r1 = prepare_daily_decision_brief(base=runtime_root, brief=_brief(run_id="runtime-r1"))
+    monkeypatch.setattr(mod, "repo_base", lambda: repo_root)
+    monkeypatch.setenv("OM_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.delenv("OM_ENV_FILE", raising=False)
+
+    payload = {
+        "account": "lx",
+        "market": "US",
+        "date": "2026-07-19",
+        "revision": runtime_r1["brief"]["revision"],
+    }
+    runtime_data, runtime_warnings, _runtime_meta = mod.DAILY_DECISION_BRIEF_READ_TOOL.call(payload)
+    assert runtime_data["brief"]["revision"] == 1
+    assert runtime_data["brief"]["run_id"] == "runtime-r1"
+    assert runtime_warnings == []
+
+    monkeypatch.delenv("OM_RUNTIME_ROOT")
+    payload["revision"] = 0
+    repo_data, repo_warnings, _repo_meta = mod.DAILY_DECISION_BRIEF_READ_TOOL.call(payload)
+    assert repo_data["brief"]["revision"] == 0
+    assert repo_data["brief"]["run_id"] == "repo-r0"
+    assert repo_warnings == []

--- a/tests/test_daily_decision_brief_cli.py
+++ b/tests/test_daily_decision_brief_cli.py
@@ -5,6 +5,30 @@ from argparse import Namespace
 from pathlib import Path
 
 
+def _brief(*, run_id: str) -> dict:
+    return {
+        "market": "US",
+        "market_trading_date": "2026-07-19",
+        "account": "lx",
+        "revision": 999,
+        "run_id": run_id,
+        "generated_at_utc": "2026-07-19T13:40:00+00:00",
+        "data_as_of_utc": "2026-07-19T13:39:00+00:00",
+        "valid_until_utc": "2026-07-20T20:00:00+00:00",
+        "status": "ready",
+        "actionability": "live_actionable",
+        "strategy_summary": run_id,
+        "actions": [],
+        "positions": [],
+        "capacity": {},
+        "candidates": {"sell_put": [], "covered_call": [], "combo_yield": []},
+        "rejections": {},
+        "events": [],
+        "data_gaps": [],
+        "source_artifacts": [],
+    }
+
+
 def test_daily_brief_cli_parser_supports_latest_day_revision_and_json() -> None:
     from src.interfaces.cli.main import parse_args
 
@@ -103,3 +127,37 @@ def test_daily_brief_main_renders_input_errors_without_traceback(capsys) -> None
     assert payload["error"]["code"] == "INPUT_ERROR"
     assert "revision must be non-negative" in payload["error"]["message"]
     assert captured.err == ""
+
+
+def test_daily_brief_cli_reads_env_runtime_root_then_repo_fallback(monkeypatch, capsys, tmp_path: Path) -> None:
+    from src.application.daily_decision_brief_repository import prepare_daily_decision_brief
+    from src.interfaces.cli import daily_brief_ops
+
+    repo_root = tmp_path / "repo"
+    runtime_root = tmp_path / "runtime"
+    prepare_daily_decision_brief(base=repo_root, brief=_brief(run_id="repo-r0"))
+    prepare_daily_decision_brief(base=runtime_root, brief=_brief(run_id="runtime-r0"))
+    runtime_r1 = prepare_daily_decision_brief(base=runtime_root, brief=_brief(run_id="runtime-r1"))
+
+    args = Namespace(
+        daily_brief_command="day",
+        account="lx",
+        market="US",
+        market_trading_date="2026-07-19",
+        revision=runtime_r1["brief"]["revision"],
+        json=True,
+    )
+    monkeypatch.setenv("OM_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.delenv("OM_ENV_FILE", raising=False)
+
+    assert daily_brief_ops.handle_daily_brief_command(args, repo_base_fn=lambda: repo_root) == 0
+    runtime_payload = json.loads(capsys.readouterr().out)
+    assert runtime_payload["brief"]["revision"] == 1
+    assert runtime_payload["brief"]["run_id"] == "runtime-r1"
+
+    monkeypatch.delenv("OM_RUNTIME_ROOT")
+    args.revision = 0
+    assert daily_brief_ops.handle_daily_brief_command(args, repo_base_fn=lambda: repo_root) == 0
+    repo_payload = json.loads(capsys.readouterr().out)
+    assert repo_payload["brief"]["revision"] == 0
+    assert repo_payload["brief"]["run_id"] == "repo-r0"

--- a/tests/test_daily_decision_brief_notification_flow.py
+++ b/tests/test_daily_decision_brief_notification_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
@@ -229,8 +230,13 @@ def test_no_send_persists_full_artifact_without_advancing_pointer(monkeypatch, t
     bundle = _request(tmp_path, run_id="run-no-send", no_send=True)
 
     assert mod.run_tick_notification_flow(bundle.request) == 0
-    assert read_latest_daily_decision_brief(base=tmp_path, account="lx", market="US")["available"] is True
+    latest = read_latest_daily_decision_brief(base=tmp_path, account="lx", market="US")
+    assert latest["available"] is True
     assert read_daily_decision_brief_delivery(base=tmp_path, account="lx", market="US")["available"] is False
+    prepared = bundle.request.tick_metrics["daily_brief"]["prepared"][0]
+    assert prepared["brief_id"] == latest["brief"]["brief_id"]
+    assert prepared["message_chars"] > 0
+    assert len(prepared["message_sha256"]) == 64
 
 
 def test_quiet_hours_does_not_advance_pointer_or_select_provider(monkeypatch, tmp_path: Path) -> None:
@@ -285,7 +291,15 @@ def test_no_material_daily_brief_finishes_before_delivery_route_resolution(monke
     second = _request(tmp_path, run_id="run-same")
 
     assert mod.run_tick_notification_flow(second.request) == 0
-    assert second.request.tick_metrics["daily_brief"]["prepared"][0]["delivery_kind"] == "none"
+    prepared = second.request.tick_metrics["daily_brief"]["prepared"][0]
+    assert prepared["delivery_kind"] == "none"
+    assert prepared["message_sha256"] is None
+    assert prepared["message_chars"] is None
+    assert prepared["render_limits"] == {
+        "max_actions_per_priority": 5,
+        "max_candidates_per_strategy": 3,
+        "max_rejection_reasons": 5,
+    }
     assert second.completions == [{"status": "completed", "message": "no_account_notification"}]
 
 
@@ -365,3 +379,38 @@ def test_provider_success_but_local_confirmation_failure_is_not_marked_sent(monk
     assert bundle.request.audit_helper.failures == [
         ("DAILY_BRIEF_CONFIRM_FAILED", "confirm_daily_decision_brief_delivery")
     ]
+
+
+def test_prepared_audit_hashes_exact_message_with_resolved_limits(monkeypatch, tmp_path: Path) -> None:
+    import src.application.tick_notification_flow as mod
+
+    _patch_assembler(monkeypatch)
+    config = _config()
+    config["notifications"]["daily_brief"].update(
+        {
+            "max_actions_per_priority": "2",
+            "max_candidates_per_strategy": 0,
+            "max_rejection_reasons": 99,
+        }
+    )
+    bundle = _request(tmp_path, run_id="run-audit", no_send=True, config=config)
+
+    preparation = mod._prepare_daily_brief_notification(bundle.request)
+    message = preparation.prepared_messages.messages_by_account["lx"]
+    prepared = bundle.request.tick_metrics["daily_brief"]["prepared"][0]
+
+    assert prepared["brief_id"] == preparation.lifecycles_by_account["lx"]["brief"]["brief_id"]
+    assert prepared["message_sha256"] == hashlib.sha256(message.encode("utf-8")).hexdigest()
+    assert prepared["message_chars"] == len(message)
+    assert prepared["render_limits"] == {
+        "max_actions_per_priority": 2,
+        "max_candidates_per_strategy": 1,
+        "max_rejection_reasons": 20,
+    }
+    audit_event = next(
+        item
+        for item in bundle.request.audit_helper.events
+        if item["event_type"] == "daily_brief" and item["action"] == "prepared"
+    )
+    assert audit_event["extra"]["message_sha256"] == prepared["message_sha256"]
+    assert "message" not in audit_event["extra"]

--- a/tests/test_daily_decision_brief_renderer.py
+++ b/tests/test_daily_decision_brief_renderer.py
@@ -107,14 +107,14 @@ def test_full_renderer_includes_decision_sections_and_close_identity() -> None:
 
     assert message.startswith("# 每日决策简报")
     for section in (
-        "## P0 行动",
-        "## P1 行动",
-        "## P2 行动",
+        "## P0 有效行动",
+        "## P1 有效行动",
+        "## 非执行状态（观察 / 阻塞 / 失效）",
         "## 已有仓位 / Close Advice",
         "## 行动容量",
-        "## Sell Put 候选",
-        "## Covered Call 候选",
-        "## Combo Yield 候选",
+        "## Sell Put 候选证据（非行动）",
+        "## Covered Call 候选证据（非行动）",
+        "## Combo Yield 候选证据（非行动）",
         "## 主要拒绝原因",
         "## 事件",
         "## 数据缺口",
@@ -124,6 +124,9 @@ def test_full_renderer_includes_decision_sections_and_close_identity() -> None:
     assert "strategy_group_id=group-1" in message
     assert "leg_role=funding_put" in message
     assert "可执行（LIVE）" in message
+    assert "数据质量：就绪（READY）" in message
+    assert "## P2 有效行动" not in message
+    assert "[观察] 继续观察" in message
 
 
 def test_blocked_renderer_is_explicit_and_does_not_render_candidates() -> None:
@@ -148,7 +151,7 @@ def test_blocked_renderer_is_explicit_and_does_not_render_candidates() -> None:
     assert message.startswith("# 每日决策简报 · 当前阻塞")
     assert "## 阻塞原因" in message
     assert "等待下一轮 scheduled scan" in message
-    assert "## Sell Put 候选" not in message
+    assert "## Sell Put 候选证据（非行动）" not in message
     assert "阻塞（BLOCKED）" in message
 
 
@@ -181,7 +184,7 @@ def test_delta_and_recovery_render_only_material_change_summary() -> None:
     assert "position_lot_id=lot-put" in delta
     assert "strategy_group_id=group-1" in delta
     assert "leg_role=funding_put" in delta
-    assert "## Sell Put 候选" not in delta
+    assert "## Sell Put 候选证据（非行动）" not in delta
 
     recovery_diff = {
         "from_revision": 3,
@@ -235,3 +238,28 @@ def test_no_delivery_kind_renders_empty_message() -> None:
     from src.application.daily_decision_brief_renderer import render_daily_brief_lifecycle
 
     assert render_daily_brief_lifecycle({"brief": deepcopy(_brief()), "delivery_kind": "none"}) == ""
+
+
+def test_renderer_exposes_unknown_data_quality_and_shared_limit_normalization() -> None:
+    from src.application.daily_decision_brief_renderer import (
+        render_full_brief,
+        resolve_daily_brief_render_limits,
+    )
+
+    brief = _brief()
+    brief["status"] = "future_state"
+    limits = resolve_daily_brief_render_limits(
+        {
+            "max_actions_per_priority": 0,
+            "max_candidates_per_strategy": "7",
+            "max_rejection_reasons": 999,
+        }
+    )
+    message = render_full_brief(brief, limits=limits)
+
+    assert limits == {
+        "max_actions_per_priority": 1,
+        "max_candidates_per_strategy": 7,
+        "max_rejection_reasons": 20,
+    }
+    assert "数据质量：未知（FUTURE_STATE）" in message

--- a/tests/test_daily_decision_brief_service.py
+++ b/tests/test_daily_decision_brief_service.py
@@ -375,3 +375,143 @@ def test_rejection_summary_is_market_qualified(tmp_path: Path) -> None:
 
     assert brief["rejections"]["total_rejected"] == 1
     assert brief["rejections"]["top_categories"][0]["sample_symbols"] == ["0700.HK"]
+
+
+def test_sell_put_conflict_uses_only_labeled_candidates(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    labeled_rows = [
+        _put_row(symbol="0700.HK", contract="0700_P430", annualized=0.18),
+        _put_row(symbol="0700.HK", contract="0700_P440", annualized=0.20),
+    ]
+    raw_rows = [
+        *labeled_rows,
+        _put_row(symbol="0700.HK", contract="0700_P450_RAW_ONLY", annualized=0.99),
+    ]
+    pd.DataFrame(labeled_rows).to_csv(account_dir / "0700_sell_put_candidates_labeled.csv", index=False)
+    pd.DataFrame(raw_rows).to_csv(account_dir / "0700_sell_put_candidates.csv", index=False)
+
+    brief = _assemble(tmp_path, market="HK")
+
+    assert {item["contract_symbol"] for item in brief["candidates"]["sell_put"]} == {
+        "0700_P430",
+        "0700_P440",
+    }
+    assert {item["contract_symbol"] for item in brief["actions"] if item.get("contract_symbol")} == {
+        "0700_P430",
+        "0700_P440",
+    }
+    assert "0700_P450_RAW_ONLY" not in json.dumps(brief, sort_keys=True)
+    assert not any(item["path"].endswith("_sell_put_candidates.csv") for item in brief["source_artifacts"])
+
+
+def test_sell_put_controlled_newline_is_authoritative_empty(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    (account_dir / "nvda_sell_put_candidates_labeled.csv").write_bytes(b"\n")
+
+    brief = _assemble(tmp_path)
+
+    assert brief["actionability"] == "live_actionable"
+    assert brief["candidates"]["sell_put"] == []
+    assert not any(
+        item["strategy_family"] == "sell_put" and item["reason"] == "csv_unavailable"
+        for item in brief["data_gaps"]
+    )
+
+
+def test_sell_put_controlled_crlf_is_authoritative_empty(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    (account_dir / "nvda_sell_put_candidates_labeled.csv").write_bytes(b"\r\n")
+
+    brief = _assemble(tmp_path)
+
+    assert brief["actionability"] == "live_actionable"
+    assert brief["candidates"]["sell_put"] == []
+    assert not any(
+        item["strategy_family"] == "sell_put" and item["reason"] == "csv_unavailable"
+        for item in brief["data_gaps"]
+    )
+
+
+def test_sell_put_header_only_requires_minimum_schema(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    (account_dir / "nvda_sell_put_candidates_labeled.csv").write_text("symbol,annualized\n", encoding="utf-8")
+
+    brief = _assemble(tmp_path)
+
+    assert brief["actionability"] == "blocked"
+    assert any(
+        item["strategy_family"] == "sell_put"
+        and item["reason"] == "csv_unavailable"
+        and item["error_type"] == "SchemaError"
+        for item in brief["data_gaps"]
+    )
+
+
+def test_sell_put_zero_byte_is_malformed_not_empty(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    (account_dir / "nvda_sell_put_candidates_labeled.csv").write_bytes(b"")
+
+    brief = _assemble(tmp_path)
+
+    assert brief["actionability"] == "blocked"
+    assert any(
+        item["strategy_family"] == "sell_put"
+        and item["reason"] == "csv_unavailable"
+        and item["error_type"] == "EmptyDataError"
+        for item in brief["data_gaps"]
+    )
+
+
+def test_sell_put_unrecognized_whitespace_is_malformed_not_empty(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    (account_dir / "nvda_sell_put_candidates_labeled.csv").write_bytes(b"  ")
+
+    brief = _assemble(tmp_path)
+
+    assert brief["actionability"] == "blocked"
+    assert any(
+        item["strategy_family"] == "sell_put"
+        and item["reason"] == "csv_unavailable"
+        and item["error_type"] == "EmptyDataError"
+        for item in brief["data_gaps"]
+    )
+
+
+def test_sell_put_raw_only_artifact_reports_canonical_missing_without_fallback(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    pd.DataFrame([_put_row(contract="RAW_ONLY")]).to_csv(
+        account_dir / "nvda_sell_put_candidates.csv", index=False
+    )
+
+    brief = _assemble(tmp_path)
+
+    assert brief["actionability"] == "blocked"
+    assert brief["candidates"]["sell_put"] == []
+    assert "RAW_ONLY" not in json.dumps(brief, sort_keys=True)
+    assert any(
+        item["strategy_family"] == "sell_put"
+        and item["artifact_key"] == "nvda"
+        and item["reason"] == "canonical_labeled_artifact_missing"
+        for item in brief["data_gaps"]
+    )
+
+
+def test_sell_put_failure_preserves_covered_call_action_and_degrades_status(tmp_path: Path) -> None:
+    account_dir = _account_dir(tmp_path)
+    (account_dir / "nvda_sell_put_candidates_labeled.csv").write_text(
+        'symbol,contract_symbol\n"broken', encoding="utf-8"
+    )
+    pd.DataFrame([_call_row(contract="NVDA_CALL_VALID")]).to_csv(
+        account_dir / "nvda_sell_call_candidates.csv", index=False
+    )
+
+    brief = _assemble(tmp_path)
+
+    assert brief["actionability"] == "live_actionable"
+    assert brief["status"] == "degraded"
+    assert brief["candidates"]["sell_put"] == []
+    assert any(item.get("contract_symbol") == "NVDA_CALL_VALID" for item in brief["actions"])
+    assert any(
+        item["strategy_family"] == "sell_put" and item["reason"] == "csv_unavailable"
+        for item in brief["data_gaps"]
+    )

--- a/tests/test_daily_decision_brief_service.py
+++ b/tests/test_daily_decision_brief_service.py
@@ -401,6 +401,12 @@ def test_sell_put_conflict_uses_only_labeled_candidates(tmp_path: Path) -> None:
         "0700_P440",
     }
     assert "0700_P450_RAW_ONLY" not in json.dumps(brief, sort_keys=True)
+    from src.application.daily_decision_brief_renderer import render_full_brief
+
+    assert "0700_P450_RAW_ONLY" not in render_full_brief(brief)
+    assert "有效行动 2 条" in brief["strategy_summary"]
+    assert "候选证据：Sell Put 2，Covered Call 0，Combo Yield 0" in brief["strategy_summary"]
+    assert "数据缺口" in brief["strategy_summary"]
     assert not any(item["path"].endswith("_sell_put_candidates.csv") for item in brief["source_artifacts"])
 
 


### PR DESCRIPTION
## Summary

- make labeled Sell Put artifacts the only Daily Brief candidate authority and fail closed for missing, malformed, partial, and invalid-empty states
- make CLI and Agent Tool exact reads resolve the canonical `OM_RUNTIME_ROOT`
- separate active actions, candidate evidence, and data quality in the renderer
- record prepared-message `brief_id`, SHA-256, character count, and effective render limits for no-send Canary verification

## Root cause

The Daily Brief assembler mixed labeled and raw Sell Put artifacts, allowing rejected/raw-only contracts to re-enter ranking and rendered output. CLI and Agent Tool reads also used the repo root directly, which could diverge from the production runtime root used by notification preparation.

## Safety boundaries

- no schema-version, revision, semantic-digest, delivery-key, pointer, confirmation, or production-config change
- no real notification send
- event rendering remains deferred to the separate `daily-brief-event-rendering` work unit

## Validation

- `python3 -m pytest tests/test_daily_decision_brief_*.py` — 93 passed
- `python3 -m pytest tests/test_agent_plugin_contract.py tests/test_agent_plugin_smoke.py` — 102 passed
- slice-focused gates: S1 20 passed; S2 12 passed; S3 35 passed
- `git diff --check main...HEAD` — passed
- S1/S2/S3 code reviews and aggregate Deepreview — passed with no material findings

## Post-merge plan

Publish through the normal VERSION-driven release flow, upgrade the production server, then run the approved HK no-send Canary and verify one exact revision across production JSON, prepared audit, CLI, and Agent Tool. Real sending requires separate explicit authorization.
