### PR TITLE
docs: close out HK Daily Brief Canary with stable identity acceptance

### DIFF
--- a/docs/gateflow/daily-decision-brief-canary-fix-acceptance-amendment-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-acceptance-amendment-20260720.md
@@ -1,0 +1,118 @@
+# Gateflow Plan Amendment — Stable HK Daily Brief Canary Identity Acceptance
+
+- **Work unit**: `daily-decision-brief-canary-correction`
+- **Date**: 2026-07-20
+- **Decision owner**: CEO/product
+- **Status**: accepted; final plan re-review passed
+- **Supersedes**: only the live-production contract-specific bullets in section 12.5 of `daily-decision-brief-canary-fix-plan-20260720.md`
+- **Does not supersede**: deterministic fixture expectations in sections 5.2 and 10
+- **Initial review**: `docs/reviews/plan-review-20260720-134335.md` (`fail`; four findings)
+- **Final re-review**: `docs/reviews/plan-review-20260720-134503.md` (`pass`)
+
+## 1. Reason for amendment
+
+The v1.3.2 and v1.3.3 production-root no-send Canaries proved that live artifact membership is volatile: P450 was present in the exact run's canonical labeled artifact, so its presence was not raw fallback. A live rule that hard-codes P450 as rejected confuses a deterministic fixture fact with a changing production input fact.
+
+The safety property is not a particular strike. The safety property is provenance:
+
+- candidate-derived outputs may use only identities present in the exact run/account canonical labeled artifacts;
+- identities present only in raw artifacts must not enter candidate-derived outputs or rendered messages.
+
+## 2. Scope
+
+This amendment changes only production Canary acceptance and closeout evaluation. It does not change:
+
+- application code, candidate ranking, labeling, capacity, underwriting, event policy, or renderer behavior;
+- artifact schemas, Daily Brief schema, revision allocation, semantic digest, delivery keys, or pointers;
+- deterministic conflict fixtures or their P430/P440/P450 expected values;
+- the separate requirement for explicit user authorization before real sending.
+
+## 3. Exact-run identity sets
+
+For one immutable `run_id` and one account, read only the run-scoped account directory and construct:
+
+```text
+L = normalized contract_symbol identities from *_sell_put_candidates_labeled.csv
+R = normalized contract_symbol identities from *_sell_put_candidates.csv
+U = R - L
+C = normalized contract_symbol identities from brief.candidates.sell_put
+A = normalized contract_symbol identities from Sell Put actions with action_type=open_candidate
+```
+
+Normalization is:
+
+```text
+trim(contract_symbol).upper()
+```
+
+An empty identity in `C` or `A` fails closed. Build `L` as an identity-to-core-fields map, where core fields are symbol normalized through the existing `domain.domain.symbol_identity.canonical_symbol()`, ISO expiration, and numeric strike normalized through decimal value equality. Exact duplicate labeled rows may deduplicate. If one normalized identity maps to conflicting core fields, the labeled authority is malformed and the Canary fails closed. Every row in `C` and `A` must match the unique labeled core fields when those fields are present. Numeric normalization must treat equivalent forms such as `450` and `450.0` as equal.
+
+Sets are scoped by exact run and account. They must not be built from mutable `current` paths or unioned across accounts or runs.
+
+Raw artifact reads are audit-only and occur after the production run outputs are frozen. Raw rows must never be passed to Daily Brief assembly, ranking, candidate/action/event builders, or renderers. Any reusable audit helper belongs in test/operations evidence code, not the normal `daily_decision_brief_service.py` candidate-loading path.
+
+Non-candidate actions—position close, observe, blocked, or invalidated lifecycle actions—are outside `A` because their authority is position/close-advice state rather than candidate CSVs.
+
+## 4. Acceptance invariants
+
+The Sell Put production Canary authority check passes only when:
+
+```text
+C subset-of L
+A subset-of L
+(C union A) intersect U = empty
+```
+
+And all of these checks pass:
+
+1. Every Sell Put candidate and Sell Put `open_candidate` action has a source path ending in `_sell_put_candidates_labeled.csv`.
+2. Every identity in `U` is absent from `candidates.sell_put`, Sell Put `open_candidate` actions, and candidate-derived events carrying a contract identity. Renderer checks apply to candidate/action/event recommendation sections. Explicitly labeled rejection or provenance diagnostics may mention a rejected identity without making it actionable.
+3. A valid labeled artifact does not require a raw counterpart; absent raw artifacts yield an empty `R`/`U`, not a Canary failure.
+4. Candidate rows with missing/invalid identity, conflicting labeled core fields, or core fields inconsistent with the unique labeled row cannot enter candidates or candidate-derived actions.
+5. Capacity, candidate/action/summary, four-surface, renderer-integrity, no-send, config, delivery-pointer, and scheduler-notify checks remain unchanged.
+6. Real sending remains blocked until the amended plan review passes, the saved exact-run evidence is re-evaluated under this standard, and the user separately authorizes sending.
+
+## 5. Fixture boundary
+
+P430/P440/P450 remain mandatory fixed-fixture values:
+
+- labeled: P430 and P440;
+- raw: P430, P440, plus attractive P450 raw-only;
+- expected: P430/P440 may enter; P450 is absent from normalized brief and renderer.
+
+This fixture proves the implementation rejects a known raw-only counterexample. It is not a claim that live production P450 must always be rejected.
+
+## 6. Evidence reuse
+
+A new market-data scan is not required solely because the acceptance oracle changed. The immutable v1.3.3 evidence may be re-evaluated if it contains:
+
+- exact run/account raw and labeled artifacts;
+- canonical and run-scoped briefs;
+- exact-revision CLI and Agent Tool outputs;
+- prepared audit plus render limits and message digest;
+- config, delivery-pointer, and scheduler-notify before/after evidence.
+
+The original audit report must remain unchanged. Before re-evaluation, generate a sorted SHA-256 manifest covering every consumed raw/labeled CSV, canonical and run-scoped brief, CLI and Agent output, prepared metrics, diff, renderer replay input, and config/delivery/scheduler safety snapshot. The derived amended-acceptance report records the manifest SHA-256, original audit SHA-256, release version, run ID, account scope, and amended standard version. Missing files, manifest drift, or evidence-generation mixing fails closed.
+
+## 7. Stop conditions
+
+Keep the real-send gate blocked if any of these occur:
+
+- `C` or `A` is not a subset of `L`;
+- `(C union A) intersect U` is non-empty;
+- any `U` identity appears in candidate-derived normalized or rendered recommendation output;
+- identity is empty, cannot be normalized, maps to conflicting labeled core fields, or disagrees with the unique labeled row;
+- raw rows enter any normal runtime candidate/ranking/render path;
+- evidence mixes run IDs, accounts, revisions, mutable `current` state, or does not match its sorted SHA-256 manifest;
+- any existing four-surface, renderer, capacity, no-send, config, pointer, or scheduler-notify safety check fails.
+
+## 8. Intended gate transition
+
+```text
+amendment drafted
+-> planreview
+-> accepted amendment
+-> immutable v1.3.3 evidence re-evaluation
+-> final closeout pass
+-> real send remains pending separate explicit user authorization
+```

--- a/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
@@ -3,7 +3,7 @@
 - **Work unit**: `daily-decision-brief-canary-correction`
 - **Date**: 2026-07-20
 - **Branch**: `ops/hk-daily-brief-canary-closeout`
-- **Status**: **final closeout pass under amended identity-set Canary standard**
+- **Status**: **PR review fix in progress; final closeout not yet re-entered**
 - **Code/release work**: merged and released
 - **Stable source-identity and no-send safety checks**: pass
 - **Amended Canary acceptance**: pass
@@ -221,11 +221,18 @@ Named P430/P440/P450 assertions remain only in deterministic fixtures.
 - Accepted plan amendment: complete; final plan re-review `pass`.
 - Current v1.3.3 no-send technical/safety evidence: pass.
 - Amended exact-run identity-set re-evaluation: pass.
-- Gateflow final closeout: **pass**.
+- Draft PR: `#100`, open against `main`, mergeable.
+- Pre-review PR checks: `agent-plugin`, `guardrails`, and all CodeQL checks passed.
+- PR review artifact: `docs/reviews/pr-100-review-20260720-143616.md`.
+- PR review finding `PR100-1`: accepted; this edit removes the premature final-closeout claim.
+- Current Gateflow gate: **fix -> PR re-review**.
+- Gateflow final closeout: **not yet re-entered**.
 - Production Daily Brief config: remains default-off.
 - Real sending: **not authorized by this amendment**.
 
-Next entry points:
+Next entry point:
 
-1. if desired, separately authorize one real HK Daily Brief send under the existing delivery state machine; or
-2. open the deferred event-rendering work unit.
+1. re-review `PR100-1`;
+2. commit and push the accepted PR-review checkpoint;
+3. verify final PR checks and record `draft-PR-pass`;
+4. only then re-enter final closeout and expose the product follow-up choices.

--- a/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
@@ -3,7 +3,7 @@
 - **Work unit**: `daily-decision-brief-canary-correction`
 - **Date**: 2026-07-20
 - **Branch**: `ops/hk-daily-brief-canary-closeout`
-- **Status**: **PR review fix in progress; final closeout not yet re-entered**
+- **Status**: **draft-PR-pass; final closeout pass under amended identity-set Canary standard**
 - **Code/release work**: merged and released
 - **Stable source-identity and no-send safety checks**: pass
 - **Amended Canary acceptance**: pass
@@ -221,18 +221,20 @@ Named P430/P440/P450 assertions remain only in deterministic fixtures.
 - Accepted plan amendment: complete; final plan re-review `pass`.
 - Current v1.3.3 no-send technical/safety evidence: pass.
 - Amended exact-run identity-set re-evaluation: pass.
-- Draft PR: `#100`, open against `main`, mergeable.
-- Pre-review PR checks: `agent-plugin`, `guardrails`, and all CodeQL checks passed.
-- PR review artifact: `docs/reviews/pr-100-review-20260720-143616.md`.
-- PR review finding `PR100-1`: accepted; this edit removes the premature final-closeout claim.
-- Current Gateflow gate: **fix -> PR re-review**.
-- Gateflow final closeout: **not yet re-entered**.
+- Draft PR: `#100`, open against `main`, mergeable, and still Draft.
+- Initial PR review: `docs/reviews/pr-100-review-20260720-143616.md` (`fail`; one accepted process finding).
+- PR re-review: `docs/reviews/pr-100-review-20260720-144233.md` (`pass`; `PR100-1` fixed).
+- Accepted PR-review checkpoint: `54bf750c16dd1f724190f52db1dcc8d7298dd7e0`.
+- Final checkpoint push: local and `origin/ops/hk-daily-brief-canary-closeout` matched at `54bf750c16dd1f724190f52db1dcc8d7298dd7e0` before this closeout-only commit.
+- Checkpoint checks: `agent-plugin`, `guardrails`, `CodeQL`, `Analyze (python)`, and `Analyze (actions)` passed.
+- `draft-PR-pass`: **pass**.
+- Gateflow final closeout: **pass**.
 - Production Daily Brief config: remains default-off.
 - Real sending: **not authorized by this amendment**.
+- Merge / Ready for review: **not authorized and not performed**.
 
-Next entry point:
+Product follow-up choices:
 
-1. re-review `PR100-1`;
-2. commit and push the accepted PR-review checkpoint;
-3. verify final PR checks and record `draft-PR-pass`;
-4. only then re-enter final closeout and expose the product follow-up choices.
+1. explicitly authorize moving PR #100 out of Draft and/or merging it;
+2. separately authorize one real HK Daily Brief send under the existing delivery state machine; or
+3. open the deferred event-rendering work unit.

--- a/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
@@ -1,0 +1,215 @@
+# Gateflow Final Closeout — HK Daily Decision Brief Canary Correction
+
+- **Work unit**: `daily-decision-brief-canary-correction`
+- **Date**: 2026-07-20
+- **Branch**: `ops/hk-daily-brief-canary-closeout`
+- **Status**: **blocked at real-send authorization gate**
+- **Code/release work**: merged and released
+- **Stable source-identity and no-send safety checks**: pass
+- **Accepted plan's literal P450 content check**: fail
+
+## 1. What changed
+
+The merged correction established one authoritative Daily Brief path:
+
+- Sell Put candidates read only canonical `*_sell_put_candidates_labeled.csv` artifacts.
+- Normal Daily Brief assembly does not fall back to raw `*_sell_put_candidates.csv` artifacts.
+- CLI and Agent Tool exact reads honor `OM_RUNTIME_ROOT` and read the production runtime root when explicitly set.
+- Candidate evidence, active actions, data quality, and actionability remain separate concepts in payloads and rendered Markdown.
+- Prepared notification audit records effective render limits, UTF-8 message SHA-256, and character count.
+
+Delivery/repository semantics were intentionally unchanged: no schema bump, no new revision policy, no delivery-key change, and no delivery confirmation change.
+
+## 2. Code and release references
+
+- Feature PR: `#97`
+- Feature merge commit: `daf5311ef7c1772bab8ca14c2caa5aec18b87e14`
+- Release PR: `#98`
+- v1.3.2 release merge commit: `12ccdd6f509c8973c15741382add8f5e7ca5c81d`
+- v1.3.2 release commit: `b1ab99c6b843a3871e3c7fc972cf486d4be8b440`
+- Subsequent main/release: v1.3.3, commit `35e63f1afa90b4706f9e5ac30924221fdaa919a1` (`#99`)
+
+The first valid production-root Canary ran on v1.3.2. Because the active server later advanced to v1.3.3, a second no-send Canary was run against the exact currently deployed release.
+
+## 3. Negative control retained
+
+The first attempt under:
+
+```text
+/tmp/om-daily-brief-canary-20260720T050709Z
+```
+
+resolved runtime state under the release directory rather than `/var/lib/options-monitor`. It is not acceptance evidence. Its shadow artifacts were intentionally retained as the runtime-root negative control and were not deleted.
+
+## 4. v1.3.2 production-root Canary
+
+- Evidence directory: `/tmp/om-daily-brief-canary-20260720T051222Z-prod`
+- Runtime root: `/var/lib/options-monitor`
+- Run ID: `20260720T051404Z-96dc77`
+- Execution: `--no-send`, without `--force`
+- Audit report SHA-256: `039da72cd434c07138a4b2883dabfd1ffda62a55419c6d030b8d3ae5b30f43a7`
+
+### lx
+
+- Revision: `1`
+- Brief ID: `daily-brief-9d162cfc284612c8583f730a`
+- Active actions: `6`
+- Candidates: Sell Put `3`, Covered Call `2`, Combo Yield `0`
+- Data gaps: `0`
+- Prepared message SHA-256: `c2fb54a952876ae4042cb650b75131071efe9a2b59e721872875f528886fa568`
+- Prepared message characters: `2317`
+
+### sy
+
+- Revision: `1`
+- Brief ID: `daily-brief-826cfaf8040082a09fb8c41d`
+- Active actions: `6`
+- Candidates: Sell Put `3`, Covered Call `3`, Combo Yield `0`
+- Data gaps: `0`
+- Prepared message SHA-256: `85bbfb99a031c23270fd91a576e4c1dec03f3d604f9e8b7413a08f838f239a3f`
+- Prepared message characters: `2447`
+
+For both accounts, canonical revision JSON equaled the run-scoped brief, CLI and Agent Tool returned the same structured brief, and renderer replay reproduced the prepared message SHA and character count.
+
+## 5. v1.3.3 current-production Canary
+
+- Evidence directory: `/tmp/om-daily-brief-canary-20260720T052757Z-v133-prod`
+- Active release path at execution: `/home/liuxie/apps/releases/1.3.3`
+- Runtime root: `/var/lib/options-monitor`
+- Run ID: `20260720T053303Z-595bab`
+- Market time: 2026-07-20 13:33 Asia/Hong_Kong
+- Execution: `--no-send`, without `--force`
+- Audit report SHA-256: `7ade79f428df5ccde3bed86bc3191b2ed317d7e83371bc6024dba9c8e817eed4`
+
+### lx
+
+- Revision: `2`
+- Brief ID: `daily-brief-9d162cfc284612c8583f730a`
+- Status/actionability: `ready` / `live_actionable`
+- Active actions: `5`
+- Candidates: Sell Put `3`, Covered Call `2`, Combo Yield `0`
+- Data gaps: `0`
+- Prepared message SHA-256: `86700f6a38de689a0d64129647c8f1772afa6cf689ccd07ace8fb5bfa68d4078`
+- Prepared message characters: `2344`
+
+### sy
+
+- Revision: `2`
+- Brief ID: `daily-brief-826cfaf8040082a09fb8c41d`
+- Status/actionability: `ready` / `live_actionable`
+- Active actions: `6`
+- Candidates: Sell Put `3`, Covered Call `3`, Combo Yield `0`
+- Data gaps: `0`
+- Prepared message SHA-256: `491e53539c50c83949f35148fbf56a8c050651c13bbb114d67b3b439b5b7b624`
+- Prepared message characters: `2400`
+
+## 6. Four-surface and renderer result
+
+For both v1.3.3 account revisions:
+
+- canonical immutable revision JSON equals the run-scoped brief JSON;
+- CLI exact-revision `brief` equals canonical JSON;
+- Agent Tool exact-revision `brief` equals canonical JSON;
+- prepared audit, persisted brief, CLI, and Agent agree on account, market, date, run ID, brief ID, and revision;
+- active-action count, candidates by family, data-gap count, status, and actionability agree;
+- CLI and Agent Markdown hashes agree because both reads retained the same effective actionability;
+- v1.3.3 renderer replay with the recorded effective limits reproduces the exact prepared SHA and character count;
+- candidate sections contain `候选证据（非行动）`;
+- only `actions[state=active]` are counted as executable;
+- no candidate lacking accepted capacity becomes an active open-candidate action;
+- summary active-action counts equal the actual number of active actions.
+
+## 7. Canonical labeled/raw authority result
+
+The stable identity-based authority check passes for both accounts.
+
+### v1.3.3 lx
+
+- Raw Sell Put contracts: `70`
+- Labeled Sell Put contracts: `15`
+- Raw-only contracts: `55`
+- Raw-only contracts present in candidates/actions: `0`
+
+### v1.3.3 sy
+
+- Raw Sell Put contracts: `70`
+- Labeled Sell Put contracts: `15`
+- Raw-only contracts: `55`
+- Raw-only contracts present in candidates/actions: `0`
+
+All Sell Put candidate and open-candidate action sources end in `_sell_put_candidates_labeled.csv`; no candidate identity falls outside the labeled identity set.
+
+## 8. Safety result
+
+The v1.3.3 Canary passed all recorded safety checks:
+
+```text
+reason=no_send
+send_attempted_count=0
+send_confirmed_count=0
+send_failed_count=0
+retry_attempt_count=0
+ambiguous_send_count=0
+duplicate_risk_count=0
+provider_message_id=ABSENT
+```
+
+Additional evidence:
+
+- production `config.yaml` hash was unchanged before/after;
+- production `config.hk.json` hash was unchanged before/after;
+- production Daily Brief remains default-off;
+- `lx` delivery pointer remained `ABSENT -> ABSENT`;
+- `sy` delivery pointer remained `ABSENT -> ABSENT`;
+- scheduler `last_notify_utc` and `last_notify_utc_by_account` were unchanged;
+- scheduler `last_run_utc_by_account` advanced as expected for a completed no-send scan;
+- no production config was replaced by the temporary Canary config.
+
+No real provider delivery was attempted or confirmed.
+
+## 9. Blocking mismatch: hard-coded P450 criterion
+
+The accepted plan's live-content examples state:
+
+- P430/P440 may appear if accepted and labeled;
+- rejected/raw-only P450 must not appear.
+
+That literal condition is not true for either production Canary. In the v1.3.3 run, P430, P440, and P450 were all present in the canonical labeled artifact. P450 therefore appeared through the correct labeled source and was not a raw fallback. The identity-based invariant passes, but the literal `P450 absent` assertion fails.
+
+This is a plan/data assumption mismatch, not evidence of raw-only leakage. Nevertheless, section 12.6 of the accepted plan says any mismatch is a stop condition. The real-send gate therefore remains blocked rather than silently rewriting the acceptance rule after execution.
+
+## 10. Findings and remaining risks
+
+| Finding | Status | Owner / next decision |
+|---|---|---|
+| Canonical labeled-only Sell Put authority | Pass | Product/runtime |
+| CLI/Agent `OM_RUNTIME_ROOT` convergence | Pass | Runtime |
+| Four-surface exact-revision identity | Pass | Runtime |
+| Prepared renderer integrity | Pass | Notification |
+| No-send and pointer safety | Pass | Operations |
+| Scheduler notified pointer unchanged | Pass | Operations |
+| Literal P450 absence criterion | **Fail / blocker** | Product decision |
+| Event rendering | Deferred by approved scope | Follow-up work unit |
+| Real provider behavior | Not exercised | Requires separate authorization after blocker resolution |
+
+## 11. Recommended resolution
+
+Prefer revising the live Canary content criterion from hard-coded strikes to the stable source-identity rule:
+
+> Every Sell Put candidate/open-candidate action must be a member of the exact run's canonical labeled identity set, and must be disjoint from that run's raw-only identity set.
+
+Keep named P430/P440/P450 cases in deterministic fixtures, where artifact membership is frozen and reproducible. Do not use volatile live market membership as the primary production acceptance oracle.
+
+If the CEO instead intends P450 to be rejected as a business-policy requirement regardless of labeling, this is a separate strategy/label-policy defect and requires root-cause investigation before another Canary.
+
+## 12. Gate decision and next entry point
+
+- Code/release implementation: complete.
+- Current v1.3.3 no-send technical/safety evidence: pass.
+- Gateflow final closeout: **blocked**, because the accepted literal content criterion does not pass.
+- Real sending: **not authorized**.
+
+Next entry point requires one explicit product decision:
+
+1. approve a narrow plan amendment replacing the volatile P450 live assertion with the identity-based acceptance rule, followed by final plan review and closeout re-evaluation; or
+2. preserve the P450 requirement and open a new investigation into why P450 is labeled/active.

--- a/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md
@@ -3,10 +3,11 @@
 - **Work unit**: `daily-decision-brief-canary-correction`
 - **Date**: 2026-07-20
 - **Branch**: `ops/hk-daily-brief-canary-closeout`
-- **Status**: **blocked at real-send authorization gate**
+- **Status**: **final closeout pass under amended identity-set Canary standard**
 - **Code/release work**: merged and released
 - **Stable source-identity and no-send safety checks**: pass
-- **Accepted plan's literal P450 content check**: fail
+- **Amended Canary acceptance**: pass
+- **Real provider sending**: pending separate explicit user authorization
 
 ## 1. What changed
 
@@ -79,7 +80,10 @@ For both accounts, canonical revision JSON equaled the run-scoped brief, CLI and
 - Run ID: `20260720T053303Z-595bab`
 - Market time: 2026-07-20 13:33 Asia/Hong_Kong
 - Execution: `--no-send`, without `--force`
-- Audit report SHA-256: `7ade79f428df5ccde3bed86bc3191b2ed317d7e83371bc6024dba9c8e817eed4`
+- Original audit report SHA-256: `7ade79f428df5ccde3bed86bc3191b2ed317d7e83371bc6024dba9c8e817eed4`
+- Amended acceptance standard: `daily_brief_canary_identity_acceptance.v1`
+- Evidence manifest: `48` files; SHA-256 `7d85fd515f617adf23c1e504123839b5bf1afb02dbe994e5196d9d447bce3307`
+- Derived amended-acceptance report SHA-256: `1e621427fee47f127336eebec76af5a417142eb7ea20bb858acaa68a770150b6`
 
 ### lx
 
@@ -137,7 +141,7 @@ The stable identity-based authority check passes for both accounts.
 - Raw-only contracts: `55`
 - Raw-only contracts present in candidates/actions: `0`
 
-All Sell Put candidate and open-candidate action sources end in `_sell_put_candidates_labeled.csv`; no candidate identity falls outside the labeled identity set.
+All Sell Put candidate and open-candidate action sources end in `_sell_put_candidates_labeled.csv`; no candidate identity falls outside the labeled identity set. Under the amended standard, both accounts had `L=15`, `R=70`, `U=55`, `C=3`, and `A=3`; `(C union A) intersect U` was empty. No labeled identity conflict, malformed labeled identity, candidate/action core-field mismatch, event leakage, or rendered recommendation leakage was found.
 
 ## 8. Safety result
 
@@ -167,49 +171,61 @@ Additional evidence:
 
 No real provider delivery was attempted or confirmed.
 
-## 9. Blocking mismatch: hard-coded P450 criterion
+## 9. Resolved plan/data mismatch
 
-The accepted plan's live-content examples state:
+The original live-content bullets treated P430/P440/P450 fixture membership as if it were stable production data. The v1.3.3 run correctly labeled P430, P440, and P450, proving that the literal live P450 exclusion was not a valid authority oracle.
 
-- P430/P440 may appear if accepted and labeled;
-- rejected/raw-only P450 must not appear.
+The CEO approved a narrow amendment:
 
-That literal condition is not true for either production Canary. In the v1.3.3 run, P430, P440, and P450 were all present in the canonical labeled artifact. P450 therefore appeared through the correct labeled source and was not a raw fallback. The identity-based invariant passes, but the literal `P450 absent` assertion fails.
+- live Canary uses exact-run/account identity sets `L`, `R`, `U`, `C`, and `A`;
+- `C subset-of L`;
+- `A subset-of L`;
+- `(C union A) intersect U = empty`;
+- conflicting labeled core fields, empty identities, cross-run/account mixing, manifest drift, or raw rows entering normal runtime fail closed;
+- P430/P440/P450 remain unchanged in deterministic fixtures.
 
-This is a plan/data assumption mismatch, not evidence of raw-only leakage. Nevertheless, section 12.6 of the accepted plan says any mismatch is a stop condition. The real-send gate therefore remains blocked rather than silently rewriting the acceptance rule after execution.
+Planreview initially returned `fail` with four findings: duplicate/conflicting identity semantics, whole-brief diagnostic false positives, missing audit-only raw ownership, and incomplete evidence manifests. All four were fixed. Final re-review returned `pass`.
+
+The immutable v1.3.3 evidence was then re-evaluated without a new market scan. The original audit remained unchanged, a 48-file sorted SHA-256 manifest was frozen, and the derived amended-acceptance report passed for both accounts.
 
 ## 10. Findings and remaining risks
 
 | Finding | Status | Owner / next decision |
 |---|---|---|
 | Canonical labeled-only Sell Put authority | Pass | Product/runtime |
+| Exact-run identity membership and raw-only disjointness | Pass | Operations |
+| Conflicting/malformed labeled identity detection | Pass | Operations |
 | CLI/Agent `OM_RUNTIME_ROOT` convergence | Pass | Runtime |
 | Four-surface exact-revision identity | Pass | Runtime |
 | Prepared renderer integrity | Pass | Notification |
-| No-send and pointer safety | Pass | Operations |
+| No-send and delivery-pointer safety | Pass | Operations |
 | Scheduler notified pointer unchanged | Pass | Operations |
-| Literal P450 absence criterion | **Fail / blocker** | Product decision |
+| P430/P440/P450 fixed fixture | Preserved | Tests |
+| Live hard-coded P450 assertion | Superseded by approved amendment | Product |
 | Event rendering | Deferred by approved scope | Follow-up work unit |
-| Real provider behavior | Not exercised | Requires separate authorization after blocker resolution |
+| Real provider behavior | Not exercised | Requires separate explicit authorization |
 
-## 11. Recommended resolution
+## 11. Applied acceptance standard
 
-Prefer revising the live Canary content criterion from hard-coded strikes to the stable source-identity rule:
+The accepted live Canary rule is:
 
-> Every Sell Put candidate/open-candidate action must be a member of the exact run's canonical labeled identity set, and must be disjoint from that run's raw-only identity set.
+> Every Sell Put candidate and Sell Put `open_candidate` action must belong to the exact run/account canonical labeled identity map, must match its unique labeled core fields, and must be disjoint from the exact run/account raw-only identity set.
 
-Keep named P430/P440/P450 cases in deterministic fixtures, where artifact membership is frozen and reproducible. Do not use volatile live market membership as the primary production acceptance oracle.
+Raw reads are audit-only after the run is frozen and may not feed normal Daily Brief assembly, ranking, candidate/action/event builders, or renderer inputs. Explicit rejection/provenance diagnostics may retain rejected evidence without making it actionable.
 
-If the CEO instead intends P450 to be rejected as a business-policy requirement regardless of labeling, this is a separate strategy/label-policy defect and requires root-cause investigation before another Canary.
+Named P430/P440/P450 assertions remain only in deterministic fixtures.
 
 ## 12. Gate decision and next entry point
 
 - Code/release implementation: complete.
+- Accepted plan amendment: complete; final plan re-review `pass`.
 - Current v1.3.3 no-send technical/safety evidence: pass.
-- Gateflow final closeout: **blocked**, because the accepted literal content criterion does not pass.
-- Real sending: **not authorized**.
+- Amended exact-run identity-set re-evaluation: pass.
+- Gateflow final closeout: **pass**.
+- Production Daily Brief config: remains default-off.
+- Real sending: **not authorized by this amendment**.
 
-Next entry point requires one explicit product decision:
+Next entry points:
 
-1. approve a narrow plan amendment replacing the volatile P450 live assertion with the identity-based acceptance rule, followed by final plan review and closeout re-evaluation; or
-2. preserve the P450 requirement and open a new investigation into why P450 is labeled/active.
+1. if desired, separately authorize one real HK Daily Brief send under the existing delivery state machine; or
+2. open the deferred event-rendering work unit.

--- a/docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md
+++ b/docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md
@@ -134,6 +134,8 @@ The production-shaped conflict fixture contains:
 - raw rows: the same rows plus a higher-ranked P450 contract that was not accepted;
 - expected result: only P430/P440 may appear in Sell Put candidates/actions and P450 must be absent from the whole brief and rendered message.
 
+This P430/P440/P450 assertion is a deterministic fixture oracle only. It must not be reused as a live-production Canary oracle because live labeling membership can change with market data, capacity, and underwriting inputs.
+
 ## 6. Runtime-root ownership and exact file scope
 
 The existing resolver is authoritative:
@@ -531,14 +533,40 @@ If `delivery_kind=none` because the exact semantic brief was already delivered, 
 
 ### 12.5 Content criteria
 
-For the production-shaped HK evidence:
+> **Amended 2026-07-20**: live Canary acceptance uses exact-run artifact identity sets. Named P430/P440/P450 contracts remain deterministic fixture cases only and are not live-market acceptance constants. See `docs/gateflow/daily-decision-brief-canary-fix-acceptance-amendment-20260720.md`.
 
-- accepted labeled 0700 P430/P440 rows may appear according to canonical ranking and display limits;
-- rejected/raw-only P450 must not appear anywhere in production brief JSON, CLI Markdown, Agent Tool Markdown, or the reproduced prepared notification message whose hash matches `message_sha256`;
+For each exact `run_id` and account, construct these sets from the immutable run-scoped account directory:
+
+- `L`: normalized non-empty `contract_symbol` identities from canonical `*_sell_put_candidates_labeled.csv` artifacts;
+- `R`: normalized non-empty `contract_symbol` identities from matching raw `*_sell_put_candidates.csv` artifacts;
+- `U = R - L`: raw-only identities for that exact run and account;
+- `C`: normalized `contract_symbol` identities in `candidates.sell_put`;
+- `A`: normalized `contract_symbol` identities in Sell Put actions where `action_type=open_candidate`. Close/observe/blocked position actions are not candidate-derived and are outside `A`.
+
+Identity normalization is trim plus uppercase on non-empty `contract_symbol`. A Sell Put candidate or open-candidate action with an empty identity cannot satisfy membership and is a Canary failure. Build `L` as an identity-to-core-fields map using symbol normalized through the existing `domain.domain.symbol_identity.canonical_symbol()`, ISO expiration, and numeric strike normalized through decimal value equality. Exact duplicates may deduplicate; conflicting labeled core fields for one identity fail closed. Candidate/action core fields must match the unique labeled row. Numeric formatting such as `450` versus `450.0` must compare equal. Sets must never be unioned across accounts, runs, or mutable `current` paths.
+
+Raw reads used to construct `R` and `U` are audit-only after run outputs are frozen. Raw rows must never enter Daily Brief assembly, ranking, candidate/action/event builders, or renderer inputs; audit helpers must remain outside the normal `daily_decision_brief_service.py` candidate-loading path.
+
+The production Canary passes the Sell Put authority check only if all of the following hold:
+
+```text
+C subset-of L
+A subset-of L
+(C union A) intersect U = empty
+```
+
+Additionally:
+
+- every Sell Put candidate and Sell Put `open_candidate` action reports a source path ending in `_sell_put_candidates_labeled.csv`;
+- every identity in `U` is absent from `candidates.sell_put`, Sell Put `open_candidate` actions, candidate-derived events carrying a contract identity, and their rendered recommendation sections; explicitly labeled rejection/provenance diagnostics may mention rejected identities without making them actionable;
+- a missing raw counterpart does not invalidate a valid labeled artifact; `R` and `U` may therefore be empty;
+- the re-evaluation consumes a sorted SHA-256 manifest of every raw/labeled, four-surface, prepared/diff/renderer, and safety input; missing files or manifest drift fail closed;
 - no candidate lacking required capacity may appear as an active action;
 - candidate evidence is visibly identified as non-action evidence;
 - if partial/missing evidence remains, `status=degraded` and the relevant `data_gaps` are visible while reliable active actions remain usable;
 - summary active-action count equals the number of `actions[state=active]`.
+
+The P430/P440/P450 conflict remains required in the fixed test fixture from sections 5.2 and 10; fixture assertions prove the known raw-only counterexample, while live Canary assertions prove exact-run set membership without assuming which strikes are labeled that day.
 
 ### 12.6 Safety criteria
 
@@ -564,7 +592,9 @@ Any mismatch is a stop condition. Do not authorize real sending on a partial pas
 
 Stop implementation or rollout if:
 
-- any raw-only contract appears in candidates/actions/events/rendered message;
+- any exact-run identity in `U = R - L` appears in candidates, candidate-derived actions/events, or rendered recommendation sections;
+- one labeled identity maps to conflicting core fields, or candidate/action core fields disagree with the unique labeled row;
+- raw audit rows enter the normal runtime candidate/ranking/render path, or re-evaluation inputs do not match their sorted SHA-256 manifest;
 - a valid empty labeled artifact causes raw fallback;
 - CLI or Agent Tool still reads release-local shadow state when `OM_RUNTIME_ROOT` is set;
 - one read surface points to a different revision;

--- a/docs/reviews/plan-review-20260720-134335.md
+++ b/docs/reviews/plan-review-20260720-134335.md
@@ -1,0 +1,78 @@
+# Plan Review — Stable HK Daily Brief Canary Identity Acceptance Amendment
+
+- **Reviewed target**: `docs/gateflow/daily-decision-brief-canary-fix-acceptance-amendment-20260720.md`
+- **Related plan section**: `docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md` section 12.5
+- **Review scope**: exact-run identity construction, normal-runtime/raw boundary, candidate-derived action scope, deterministic evidence reuse, and real-send safety gate
+- **Review posture**: adversarial
+
+## Assumptions tested
+
+1. `contract_symbol` is sufficient as the primary set-membership identity.
+2. Reading raw artifacts during Canary audit does not reintroduce raw fallback into normal runtime.
+3. The amended rule scopes candidate authority without accidentally rejecting valid diagnostic provenance.
+4. The existing immutable v1.3.3 evidence is sufficient for deterministic re-evaluation.
+5. Passing the amended Canary cannot itself authorize a provider send.
+
+## Findings
+
+### PR-A1-未修复-中-重复或冲突的labeled identity未定义fail-closed行为
+- **位置**: amendment sections 3-4; main plan section 12.5 identity normalization
+- **问题类型**: 契约缺失 / 测试缺口
+- **当前写法**: `L` is a set of normalized `contract_symbol` values; symbol, expiration, and strike are consistency fields.
+- **反例/失败场景**: one labeled artifact contains the same normalized `contract_symbol` twice with different symbol, expiration, or strike values. Set construction collapses both rows, and a candidate can satisfy `C subset-of L` even though the labeled authority is internally contradictory.
+- **为什么有问题**: the amended rule claims deterministic provenance, but a bare set cannot prove which conflicting labeled row authorized the candidate.
+- **直接证据**: amendment section 3 defines only a set and does not define duplicate/conflict handling; production candidate rows carry symbol, expiration, and strike in addition to `contract_symbol`.
+- **影响**: corrupted or mixed labeled artifacts could pass Canary membership and hide a source-integrity defect.
+- **建议改法和验证点**: construct an identity-to-core-fields map. Exact duplicate rows may dedupe; conflicting duplicates must fail closed. Candidate/action core fields must match the unique labeled record after symbol normalization and numeric strike normalization.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### PR-A2-未修复-中-whole-brief字符串禁入超出用户要求并会误伤诊断证据
+- **位置**: amendment section 4 item 2; main plan section 12.5 additional criteria
+- **问题类型**: 范围漂移 / 非最优方案
+- **当前写法**: every `U` identity must be absent from the entire normalized brief and all rendered output.
+- **反例/失败场景**: a future rejection/provenance section safely names a rejected raw-only contract as diagnostic evidence while candidates and open-candidate actions remain clean. The whole-document string scan fails even though the user-approved authority invariant is satisfied.
+- **为什么有问题**: the requested stable rule is about candidate/action authority. Diagnostic provenance is not an executable recommendation, and banning it globally couples the Canary to unrelated future presentation changes.
+- **直接证据**: the user decision explicitly requires candidate/action membership and disjointness; the brief already has a separate `rejections` evidence surface.
+- **影响**: false rollout blockers and pressure to suppress useful rejection diagnostics.
+- **建议改法和验证点**: scope structural assertions to `candidates.sell_put`, Sell Put `open_candidate` actions, and candidate-derived events carrying contract identity. Scope renderer checks to candidate/action/event recommendation sections; allow explicitly labeled rejection/provenance diagnostics to mention rejected identities without implying actionability.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### PR-A3-未修复-中-raw读取边界未明确为audit-only
+- **位置**: amendment sections 2-4; main plan section 12.5
+- **问题类型**: 架构边界 / 最佳实践偏离
+- **当前写法**: the re-evaluator reads raw artifacts to construct `R`, but does not explicitly prohibit sharing that reader or data with Daily Brief assembly.
+- **反例/失败场景**: a future implementation extracts a common raw/labeled loader and accidentally lets normal runtime consume raw rows again, arguing that the amended plan requires raw reads.
+- **为什么有问题**: the work unit's strongest safety boundary is strict no-raw fallback in normal runtime. Audit evidence collection is a different trust boundary and must not weaken it.
+- **直接证据**: main plan section 5 forbids raw rows from normal Daily Brief ranking/assembly; amendment section 3 requires raw rows for audit set construction without an explicit ownership boundary.
+- **影响**: architectural regression to the original bug class.
+- **建议改法和验证点**: state that raw reading is verification-only, runs after production output is frozen, and must not share candidate rows with assembly/ranking/renderer inputs. Any reusable audit helper belongs in test/ops evidence code, not `daily_decision_brief_service.py` normal path.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### PR-A4-未修复-中-evidence reuse缺少完整输入manifest
+- **位置**: amendment section 6
+- **问题类型**: 可审计性 / 测试缺口
+- **当前写法**: the derived report records the original audit SHA and standard version.
+- **反例/失败场景**: a run-scoped raw or labeled CSV changes after the original audit report was generated while the original report file remains unchanged. Re-evaluation produces a different set against silently changed input but still cites only the old report SHA.
+- **为什么有问题**: the amended gate relies on raw/labeled files that were not the primary four-surface equality inputs. The original report SHA alone does not freeze every input to the new oracle.
+- **直接证据**: amendment section 6 lists required evidence but does not require per-file hashes or a manifest covering raw/labeled CSVs, canonical/run brief, CLI/Agent outputs, prepared metrics, and safety snapshots.
+- **影响**: re-evaluation may not be reproducible and can mix evidence generations.
+- **建议改法和验证点**: generate a sorted SHA-256 manifest for every consumed file before evaluation; embed the manifest SHA, original audit SHA, release version, run ID, account, and standard version in the derived report. Refuse missing or changed files.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open questions
+
+None. Each finding has a local documentation/audit-contract fix and does not require application code changes.
+
+## Residual risks
+
+- Live market data can legitimately change labeled membership between runs; exact-run scoping controls this but cannot make two different runs semantically identical.
+- A no-send Canary still does not exercise provider delivery behavior; separate explicit authorization remains mandatory.
+- Event rendering remains deferred under the existing work-unit scope.
+
+## Conclusion
+
+**fail** — the direction is correct, but the amendment is not yet audit-ready until duplicate/conflict semantics, candidate-derived presentation scope, raw audit ownership, and complete evidence manifest requirements are explicit.

--- a/docs/reviews/plan-review-20260720-134503.md
+++ b/docs/reviews/plan-review-20260720-134503.md
@@ -1,0 +1,51 @@
+# Plan Re-review — Stable HK Daily Brief Canary Identity Acceptance Amendment
+
+- **Reviewed target**: revised `docs/gateflow/daily-decision-brief-canary-fix-acceptance-amendment-20260720.md`
+- **Related plan section**: revised `docs/gateflow/daily-decision-brief-canary-fix-plan-20260720.md` section 12.5
+- **Prior review**: `docs/reviews/plan-review-20260720-134335.md`
+- **Scope**: closure of PR-A1 through PR-A4 and readiness for immutable v1.3.3 evidence re-evaluation
+
+## Assumptions re-tested
+
+1. Identity membership cannot pass when labeled artifacts contain conflicting duplicate identities.
+2. The new oracle tests candidate-derived authority rather than banning legitimate rejection/provenance evidence.
+3. Raw rows remain confined to post-run audit and cannot weaken the normal no-raw runtime boundary.
+4. Re-evaluation is reproducible from a complete immutable SHA-256 input manifest.
+5. A Canary pass still cannot trigger or authorize provider delivery.
+
+## Prior finding disposition
+
+### PR-A1-已修复-中-重复或冲突的labeled identity未定义fail-closed行为
+
+Resolved. `L` is now an identity-to-core-fields map. Exact duplicates may deduplicate; conflicting symbol/expiration/normalized-strike records fail closed. Candidate/action rows must match the unique labeled record.
+
+### PR-A2-已修复-中-whole-brief字符串禁入超出用户要求并会误伤诊断证据
+
+Resolved. Structural checks now target Sell Put candidates, Sell Put `open_candidate` actions, and candidate-derived events/recommendation rendering. Explicitly labeled rejection/provenance diagnostics may retain rejected identity evidence without becoming actionable.
+
+### PR-A3-已修复-中-raw读取边界未明确为audit-only
+
+Resolved. The amendment states that raw reads occur only after run outputs are frozen, cannot feed assembly/ranking/builders/renderers, and must remain outside the normal Daily Brief candidate-loading path.
+
+### PR-A4-已修复-中-evidence reuse缺少完整输入manifest
+
+Resolved. Re-evaluation now requires a sorted SHA-256 manifest covering every consumed raw/labeled, four-surface, prepared/diff/renderer, and safety input. The derived report must record the manifest SHA, original audit SHA, release/run/account identity, and standard version; drift fails closed.
+
+## New findings
+
+No material findings.
+
+## Open questions
+
+None.
+
+## Residual risks
+
+- Contract-symbol canonicalization still relies on upstream contract identifiers being stable within one run; conflicting labeled metadata now fails closed rather than guessing.
+- Rejection/provenance presentation must remain visibly non-actionable if it later includes contract-level identities.
+- No-send cannot verify provider behavior; a separate explicit user authorization remains required.
+- Event rendering remains deferred under the existing work-unit scope.
+
+## Conclusion
+
+**pass** — the amendment is specific, fail-closed, preserves the normal-runtime raw boundary, keeps deterministic P430/P440/P450 fixtures, and is ready for immutable v1.3.3 evidence re-evaluation.

--- a/docs/reviews/pr-100-review-20260720-143616.md
+++ b/docs/reviews/pr-100-review-20260720-143616.md
@@ -1,0 +1,66 @@
+# PR #100 Deep Review — HK Daily Brief Canary Closeout
+
+- **Repository**: `liuxie066/options-monitor`
+- **PR**: `#100`
+- **Title**: `docs: close out HK Daily Brief Canary with stable identity acceptance`
+- **Author**: `liuxie066`
+- **Base**: `main`
+- **Head**: `ops/hk-daily-brief-canary-closeout`
+- **Mode**: PR Review
+- **Reviewed head**: `c522ec24f1f00689c8189f91925301ca80b8c10a`
+- **Review time**: 2026-07-20 14:36:16 Asia/Shanghai
+
+## Findings
+
+### PR100-1-未修复-中-final-closeout在PR-review和draft-PR-pass之前被声明为pass
+
+- **位置**: `docs/gateflow/daily-decision-brief-canary-fix-final-closeout-20260720.md:218-224`
+- **入口**: operator or future Gateflow continuation reads the durable closeout artifact to determine the current gate and next permitted action.
+- **触发输入**: PR #100 is still an open Draft PR and no PR-review artifact, accepted PR-review checkpoint, or draft-PR-pass record exists on the reviewed head.
+- **实际分支**: the document declares `Gateflow final closeout: pass` and presents only product follow-up entry points.
+- **预期行为**: the artifact must not declare final closeout until PR review, any fix/re-review, the accepted PR-review checkpoint, final push, and draft-PR-pass have been recorded. While review is active, it must identify PR review as the current gate.
+- **实际行为**: a consumer can conclude that the deterministic Gateflow state machine is complete even though its PR gate chain has not run.
+- **直接证据**: PR #100 is `OPEN`, `isDraft=true`; reviewed head contains no `pr-100-review-*` artifact; the closeout currently records `Gateflow final closeout: pass` at line 224. The Gateflow contract forbids entering final closeout before the PR review chain and draft-PR-pass.
+- **影响**: operational governance evidence is internally inconsistent. A later operator may skip PR review or treat the branch as fully closed without an accepted PR-review checkpoint.
+- **建议改法和验证点**: temporarily set the closeout state to `PR review in progress`, record PR #100 and the passing pre-review CI, create this review artifact, then perform a re-review. After the accepted PR-review commit is pushed and checks pass, update the final closeout with the checkpoint commit and `draft-PR-pass` evidence before declaring final closeout pass again.
+- **修复风险**: 低
+- **严重程度**: 中
+
+## Adversarial failure pass
+
+- Stable identity acceptance is exact-run/account scoped and does not hard-code a live strike.
+- `C subset-of L`, `A subset-of L`, and `(C union A) intersect U = empty` are consistent across the plan, amendment, and closeout.
+- Conflicting duplicate labeled identities fail closed; empty candidate/action identities fail closed.
+- Raw artifact reads are audit-only and cannot feed normal assembly, ranking, candidate/action/event builders, or renderer inputs.
+- Fixed P430/P440/P450 assertions remain in deterministic service fixtures and are not production Canary constants.
+- The custom 48-entry SHA-256/size manifest was revalidated against the saved evidence and exact run directory with zero missing, size-mismatched, or hash-mismatched inputs.
+- The original audit, manifest, and amended report SHA-256 values match the closeout.
+- Current production runtime config has `notifications.daily_brief.enabled=false`; no real send is authorized by this PR.
+- PR #100 changes documentation only; no runtime schema, code path, config, pointer, or provider behavior changes.
+
+## Validation evidence
+
+- `git diff --check origin/main...HEAD`: pass
+- PR mergeability: `MERGEABLE`
+- `agent-plugin`: pass
+- `guardrails`: pass
+- `CodeQL / Analyze (python)`: pass
+- `CodeQL / Analyze (actions)`: pass
+- `CodeQL`: pass
+- deterministic conflict fixture: `tests/test_daily_decision_brief_service.py:380-410`
+- remote evidence manifest: 48 entries, custom verification pass with zero errors
+- production Daily Brief effective switch: false
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- A no-send Canary does not exercise provider delivery; real sending remains a separate explicit-authorization action.
+- Event rendering remains deferred to a separate approved work unit.
+- Current production config hashes have changed since the frozen Canary snapshot, but the saved before/pre-run/after hashes are equal and the current effective Daily Brief switch remains false. This is later runtime drift, not evidence mutation.
+
+## Conclusion
+
+**fail** — the technical acceptance evidence is sound, but PR100-1 must be fixed before the PR gate chain can reach draft-PR-pass and final closeout.

--- a/docs/reviews/pr-100-review-20260720-144233.md
+++ b/docs/reviews/pr-100-review-20260720-144233.md
@@ -1,0 +1,48 @@
+# PR #100 Re-review — HK Daily Brief Canary Closeout
+
+- **Repository**: `liuxie066/options-monitor`
+- **PR**: `#100`
+- **Base**: `main`
+- **Head branch**: `ops/hk-daily-brief-canary-closeout`
+- **Prior review**: `docs/reviews/pr-100-review-20260720-143616.md`
+- **Reviewed state**: local PR100-1 fix before accepted checkpoint commit
+- **Review time**: 2026-07-20 14:42:33 Asia/Shanghai
+
+## Findings
+
+未发现新的实质性问题。
+
+## Prior finding disposition
+
+### PR100-1-已修复-中-final-closeout在PR-review和draft-PR-pass之前被声明为pass
+
+- The closeout header now states `PR review fix in progress; final closeout not yet re-entered`.
+- Section 12 records Draft PR #100, the passing pre-review checks, the initial review artifact, and the accepted finding.
+- The current gate is explicitly `fix -> PR re-review`.
+- The premature `Gateflow final closeout: pass` declaration is absent.
+- The documented next entry point now requires accepted checkpoint commit/push, final PR checks, and `draft-PR-pass` before final closeout can be re-entered.
+
+Status: **已修复**.
+
+## Revalidation
+
+- PR100-1 mechanical assertions: pass
+- `git diff --check`: pass
+- exact-run identity-set acceptance text: unchanged
+- fixed P430/P440/P450 fixture boundary: unchanged
+- no-send/provider authorization boundary: unchanged
+- production runtime/config/pointer behavior: untouched by the fix
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Final closeout is intentionally pending until this accepted PR-review checkpoint is committed and pushed, PR checks pass on the pushed checkpoint, and `draft-PR-pass` is recorded.
+- Real provider delivery remains untested and separately authorization-gated.
+- Event rendering remains deferred to a separate work unit.
+
+## Conclusion
+
+**pass** — PR100-1 is fixed with no new material finding. The accepted PR-review checkpoint is ready to commit and push; final closeout remains correctly pending.


### PR DESCRIPTION
## Summary

- record the production HK Daily Brief no-send Canary evidence and safety closeout
- replace volatile live-contract assertions with exact-run/account identity-set acceptance
- require Sell Put candidates and `open_candidate` actions to belong to the labeled identity set and remain disjoint from the raw-only identity set
- preserve P430/P440/P450 only as deterministic fixture assertions
- include the initial adversarial plan review, fixes, and final passing re-review

## Why

The production Canary showed that a specific contract such as P450 can legitimately be present in the exact run's labeled artifact. A hard-coded live-contract exclusion therefore tests changing market membership rather than the intended labeled-only provenance boundary. The amended rule validates the stable safety property without weakening fail-closed handling or allowing normal-path raw fallback.

## Impact

Documentation and operational acceptance artifacts only. This PR does not change application code, production configuration, delivery pointers, scheduler notification state, release VERSION, or provider sending behavior. Real sending remains subject to separate explicit authorization.

## Validation

- acceptance-contract consistency check: pass
- live hard-coded contract exclusion absent from plan section 12.5
- deterministic P430/P440/P450 fixture oracle preserved
- final plan re-review: pass
- `git diff --check`: pass
- worktree clean before push
