### PR TITLE
fix: suppress daily brief for notification-denied no-op ticks

### DIFF
--- a/docs/gateflow/daily-brief-noop-notification-fix/aggregate-deepreview.md
+++ b/docs/gateflow/daily-brief-noop-notification-fix/aggregate-deepreview.md
@@ -1,0 +1,12 @@
+# Aggregate Deepreview Artifact — Daily Brief No-op Notification Fix
+
+- Gate: aggregate deepreview
+- Review artifact: `docs/reviews/code-review-20260721-101327.md`
+- Reviewed base: `4576a1c106f6521b704877ed753ffe24683fa285`
+- Reviewed commits: `85375d79`, `df813a4c`
+- Findings: none
+- Prior accepted finding `CR-01`: 已修复 and re-reviewed
+- Validation: 53 focused tests, 46 broader tests, Ruff, and diff check pass
+- Docs decision: no public docs required
+- Residual risks: classified in aggregate review
+- Completion status: pass; ready for accepted deepreview commit

--- a/docs/gateflow/daily-brief-noop-notification-fix/draft-pr-readiness.md
+++ b/docs/gateflow/daily-brief-noop-notification-fix/draft-pr-readiness.md
@@ -1,0 +1,42 @@
+# Draft PR Readiness — Daily Brief No-op Notification Fix
+
+- Gate: ready-to-open-draft-PR
+- Date/time artifact id: 20260721-101651
+- Branch: `codex-fix-daily-brief-noop-notification`
+- PR base: `origin/main` / GitHub `main`
+- Rebase base: `502c0332` (v1.3.5)
+- Final plan commit: `69a5a102`
+- Final slice commit: `f4393a3d`
+- Final accepted deepreview commit: `0c73333c`
+
+## Integration Boundary
+
+The work unit was initially developed from `4576a1c1`, but the two touched runtime/test files were byte-identical between that commit and `origin/main`. The three work-unit commits were cleanly replayed onto `origin/main` so the PR contains no candidate-event-risk commits.
+
+## Intended Diff
+
+- four-line explicit notification denial guard in `tick_notification_flow.py`;
+- four focused regression scenarios plus fixture support;
+- Gateflow plan/review/implementation/deepreview artifacts.
+
+Untracked Paseo manager metadata `paseo.json` is excluded.
+
+## Final Validation on PR Base
+
+- Focused: `47 passed`.
+- Broader notification/tick: `46 passed`.
+- Ruff changed Python files: pass.
+- `git diff --check origin/main...HEAD`: pass.
+- Aggregate code decision: pass; no unresolved findings.
+
+## Docs Decision
+
+No public docs change required. Public commands, config, schema, and notification wording are unchanged.
+
+## Residual Risks
+
+- Stale global scheduler target remains a separate diagnostics work unit.
+- Historical remote false revision is not mutated.
+- Remote release/deployment is not part of this draft PR gate.
+
+All residual risks are classified. Status: ready to push and open draft PR.

--- a/docs/gateflow/daily-brief-noop-notification-fix/final-closeout.md
+++ b/docs/gateflow/daily-brief-noop-notification-fix/final-closeout.md
@@ -1,0 +1,71 @@
+# Final Closeout — Daily Brief No-op Notification Fix
+
+## Work Unit Status
+
+- Work unit: `daily-brief-noop-notification-fix`
+- Date: 2026-07-21
+- Status: final closeout pass pending final artifact push/checks
+- Branch: `codex-fix-daily-brief-noop-notification`
+- Draft PR: #103
+- PR base: `main`
+
+## What Changed
+
+- Daily Brief notification preparation now treats explicit account `should_notify=false` as an absorbing no-delivery decision.
+- Denied/no-op accounts are skipped before current-run artifact assembly, revision/diff persistence, rendering, delivery-key generation, provider routing, and sending.
+- Missing-field mappings remain compatible.
+- Genuine attempted pipeline failures with `should_notify=true` remain eligible and continue to generate blocked “数据异常” briefs.
+- Legitimate `lx` and `sy` scheduled messages remain per-account.
+
+## Validation
+
+### Local on `origin/main` / v1.3.5 base
+
+- Focused Daily Brief/service/account suite: `47 passed`.
+- Broader notification/tick suite: `46 passed`.
+- Ruff changed Python files: pass.
+- Diff check: pass.
+
+### Review gates
+
+- Plan review: one semantic-authority finding fixed and re-reviewed.
+- Slice code review: one production-object test finding fixed and re-reviewed.
+- Aggregate deepreview: pass, no findings.
+- PR review: pass, no findings.
+
+### GitHub checks after PR review checkpoint
+
+- Analyze (actions): pass.
+- Analyze (python): pass.
+- CodeQL: pass.
+- agent-plugin: pass.
+- guardrails: pass.
+
+## Docs Decision
+
+No public/operator docs update required. Public commands, configuration, schemas, notification wording, and safety boundaries are unchanged. Gateflow artifacts provide the audit trail.
+
+## Finding Status
+
+- Plan finding PR-01: 已修复.
+- Code review finding CR-01: 已修复.
+- Aggregate deepreview findings: none.
+- PR review findings: none.
+
+## Remaining Risks / Owners
+
+- Global scheduler snapshot can retain a stale scheduled target: separate diagnostics/state-consistency work unit; owner is future explicitly approved work.
+- Historical remote false revision remains in audit/runtime history: intentionally preserved; production cleanup requires separate approval.
+- Production does not contain this fix until PR merge plus a VERSION-driven release and explicit remote upgrade: owner is CEO release decision.
+
+All residual risks are classified; none blocks merge of this PR.
+
+## Draft PR / Issue Status
+
+- Draft PR: #103.
+- No GitHub issue number was supplied; no issue linkage or closeout comment is required.
+- PR remains draft; this workflow does not mark ready, approve, merge, or deploy.
+
+## Next Entry Point
+
+CEO may review/merge PR #103. After merge, if user-facing recovery is desired, execute the repository's VERSION-driven release flow followed by explicitly approved remote `liuxie-incus` upgrade and verification.

--- a/docs/gateflow/daily-brief-noop-notification-fix/pr-review.md
+++ b/docs/gateflow/daily-brief-noop-notification-fix/pr-review.md
@@ -1,0 +1,8 @@
+# PR Review Gate — Daily Brief No-op Notification Fix
+
+- PR: #103
+- Review artifact: `docs/reviews/pr-103-review-20260721-102026.md`
+- Findings: none
+- Local validation: 47 focused + 46 broader tests; Ruff and diff check pass
+- GitHub checks: all pass before artifact commit
+- Status: accepted; ready for PR review checkpoint commit

--- a/docs/gateflow/daily-brief-noop-notification-fix/slice-1-fix.md
+++ b/docs/gateflow/daily-brief-noop-notification-fix/slice-1-fix.md
@@ -1,0 +1,25 @@
+# Fix Artifact — Daily Brief No-op Notification Fix Slice 1
+
+## Gate
+
+- Gate: code review fix
+- Finding: `CR-01`
+- Status: 已修复
+
+## Fix
+
+- Changed the test helper result type to accept production-shaped objects.
+- Changed the no-op end-to-end regression to use the real `AccountResult` dataclass.
+- Changed the true pipeline-failure preservation regression to use the real `AccountResult` dataclass.
+- Retained mapping-based explicit-denial and mixed-account tests to cover the compatibility adapter branch.
+
+## Validation
+
+- Focused service/account/notification tests: `53 passed`.
+- Broader notification/tick tests: `46 passed`.
+- Ruff: pass.
+- `git diff --check`: pass.
+
+## Residual Risks
+
+No new residual risk. Original classified risks remain assigned outside this slice.

--- a/docs/gateflow/daily-brief-noop-notification-fix/slice-1-implementation.md
+++ b/docs/gateflow/daily-brief-noop-notification-fix/slice-1-implementation.md
@@ -1,0 +1,62 @@
+# Implementation Artifact — Daily Brief No-op Notification Fix Slice 1
+
+## Gate / Scope
+
+- Gate: implementation
+- Work unit: `daily-brief-noop-notification-fix`
+- Slice: 1 — Gate explicitly denied account briefs
+- Base: accepted plan commit `85375d79`
+- Status: implementation complete; awaiting code review
+
+## Changed Files
+
+- `src/application/tick_notification_flow.py`
+- `tests/test_daily_decision_brief_notification_flow.py`
+
+## Implementation
+
+`_prepare_daily_brief_notification()` now reads the account result's `should_notify` field from either a mapping or object and immediately skips the account when the value is explicitly `False`.
+
+The guard executes before:
+
+- Daily Brief assembly from current-run artifacts;
+- repository revision/diff persistence;
+- rendering;
+- delivery-key creation;
+- provider routing and send preparation.
+
+Missing `should_notify` remains eligible for compatibility. Explicit `True` remains eligible, including genuine pipeline failures excluded from `ran_pipeline_accounts`, which continue through blocked-brief assembly.
+
+## Regression Coverage Added
+
+- no-op account does not assemble, resolve delivery, persist a prepared lifecycle, or send;
+- completed scan with explicit notification denial is skipped;
+- mixed accounts prepare only the eligible account;
+- pipeline failure with notification allowed still produces a blocked “数据异常” brief.
+
+## Validation
+
+- Red test before implementation: 3 new tests failed because denied accounts were assembled.
+- Focused notification flow after implementation: `15 passed`.
+- Focused service/account suite: `53 passed`.
+- Broader notification/tick suite: `46 passed`.
+- Ruff on changed Python files: pass.
+- `git diff --check`: pass.
+
+## Docs Decision
+
+No public/operator docs changed because command, configuration, payload, schema, renderer text, and deployment behavior are unchanged. Plan/review/implementation artifacts document the behavior.
+
+## Residual Risks
+
+- Production account results are objects while the newly added explicit-denial tests currently use mappings. Classification: code review must verify or request a production-shape test.
+- Stale global scheduler target remains visible in diagnostics. Classification: separate work unit.
+- Historical remote false revision remains. Classification: separate production-approval-gated cleanup.
+- Per-account `lx`/`sy` delivery remains intentional. Classification: accepted product behavior.
+
+## Code Review Outcome
+
+- Review: `docs/reviews/code-review-20260721-101032.md`
+- Accepted finding `CR-01`: 已修复
+- Re-review: `docs/reviews/code-rereview-20260721-101153.md`
+- Final slice status: accepted for checkpoint commit

--- a/docs/plans/daily-brief-noop-notification-fix-plan-20260721.md
+++ b/docs/plans/daily-brief-noop-notification-fix-plan-20260721.md
@@ -1,0 +1,152 @@
+# Gateflow Plan — Daily Brief No-op Notification Fix
+
+## Gate / Work Unit
+
+- Gate: plan
+- Work unit: `daily-brief-noop-notification-fix`
+- Branch: `codex-fix-daily-brief-noop-notification`
+- Base commit: `4576a1c106f6521b704877ed753ffe24683fa285`
+- Date: 2026-07-21
+- Status: accepted after plan review revision 2
+
+## Goal / Motivation / Success Signal
+
+### Goal
+
+Prevent an account scheduler no-op (`ran_scan=false` and `should_notify=false`) from creating, diffing, persisting, or delivering a new Daily Decision Brief from an empty current run directory.
+
+### Motivation
+
+Remote HK evidence from 2026-07-21 showed:
+
+- the 09:40 account scans completed and delivered revision 0;
+- the 09:50 timer invocation correctly returned account results with `ran_scan=false`, `should_notify=false`, and “09:40 already processed”;
+- `tick_notification_flow._prepare_daily_brief_notification()` nevertheless assembled revision 1 for both accounts;
+- the assembler read the empty 09:50 run directories, classified all four decision sources as `source_artifact_missing`, changed the brief from `ready` to `blocked`, and delivered a false “数据异常 · 09:40 批次” delta.
+
+### Success signals
+
+1. An account result with explicit `should_notify=false` does not call `assemble_daily_decision_briefs()` or `prepare_daily_decision_brief()`.
+2. A no-op-only tick (`ran_scan=false`, `should_notify=false`) produces no account messages and follows the existing `no_account_notification` finalization path.
+3. A mixed tick skips only no-op accounts and still prepares eligible account briefs.
+4. A genuine due-scan pipeline failure remains eligible for a blocked brief because its account result has `ran_scan=true`, `should_notify=true`, while `ran_pipeline_accounts` excludes it.
+5. Existing full, delta, no-send, quiet-hour, multi-market, delivery-confirmation, and render-context tests continue to pass.
+
+## Non-goals / Scope Boundary
+
+- Do not change the systemd HK timer cadence.
+- Do not change account-scoped scheduler state or global scheduler snapshot semantics.
+- Do not merge `lx` and `sy` notifications; legitimate scheduled runs remain per-account.
+- Do not change Daily Brief schemas, repository revision rules, delivery keys, renderer wording, or provider delivery behavior.
+- Do not edit production config, runtime state, services, or remote deployment.
+- Do not incorporate the unrelated uncommitted candidate-event-risk changes from the original worktree.
+
+## First-principles Judgment and Direct Code Evidence
+
+- The side-effect owner is `src/application/tick_notification_flow.py::_prepare_daily_brief_notification`: it decides which account results enter assembly, revision persistence, rendering, and delivery preparation.
+- `src/application/account_run.py` returns scheduler no-ops as `AccountResult(ran_scan=false, should_notify=false, notification_text="")`.
+- The same module returns a failed attempted pipeline with `ran_scan=true` in the tested pipeline failure contract, while `ran_pipeline_accounts` remains false for that account. This preserves true blocked alerts.
+- `src/application/daily_decision_brief_service.py` correctly marks missing current-run artifacts as blockers when asked to assemble a failed/incomplete attempted run; changing that policy would hide real failures.
+- Therefore the smallest owning-boundary fix is an eligibility guard before assembly, not renderer suppression or a repository workaround.
+
+## Affected Files / Modules
+
+### Allowed implementation files
+
+- `src/application/tick_notification_flow.py`
+- `tests/test_daily_decision_brief_notification_flow.py`
+
+### Gateflow artifacts
+
+- `docs/plans/daily-brief-noop-notification-fix-plan-20260721.md`
+- review/implementation/deepreview/closeout artifacts under `docs/reviews/` and `docs/gateflow/`
+
+No other runtime module is expected to change.
+
+## Contract / Schema / State-machine / Public Interface Changes
+
+- Public CLI/API: unchanged.
+- Persisted schema: unchanged.
+- Delivery key/idempotency contract: unchanged.
+- State-machine refinement:
+  - explicit notification denial (`should_notify=false`, regardless of `ran_scan`) -> no Daily Brief preparation -> existing no-account finalization when no other account is eligible;
+  - attempted success (`should_notify=true`, pipeline succeeded) -> existing ready/degraded preparation;
+  - attempted failure (`should_notify=true`, pipeline not in `ran_pipeline_accounts`) -> existing blocked preparation;
+  - notify-only result (`ran_scan=false`, `should_notify=true`) -> preserve existing preparation behavior;
+  - missing `should_notify` (`None`) -> preserve compatibility and existing preparation behavior rather than treating absence as an explicit denial.
+
+## Implementation Decision
+
+Inside `_prepare_daily_brief_notification()`:
+
+1. Extract `account` and `should_notify` from either mapping or object account results.
+2. If `should_notify is False`, skip that account before calling the assembler or repository. Use explicit identity comparison so a missing field remains backward-compatible instead of becoming an implicit denial.
+3. Leave all downstream preparation, audit, rendering, diff, and delivery logic unchanged.
+4. Do not add a new helper, DTO field, config key, or persisted skip artifact; existing account metrics and no-account notification audit already expose the reason.
+
+This is deliberately minimal: one guard at the side-effect owner and focused regression tests.
+
+## Implementation Slice
+
+### Slice 1 — Gate no-op account briefs
+
+- Objective: prevent false blocked revisions and duplicate notifications for already-processed account schedule points.
+- Allowed runtime file: `src/application/tick_notification_flow.py`.
+- Allowed test file: `tests/test_daily_decision_brief_notification_flow.py`.
+- Exact changes:
+  - normalize test fixtures so ordinary eligible results explicitly carry `ran_scan=true`, `should_notify=true`;
+  - add a no-op-only flow test asserting assembler is not called, `daily_brief.prepared` is empty, no send occurs, and completion is `no_account_notification`;
+  - add a scan-completed but `should_notify=false` test proving the notification decision is authoritative;
+  - add a mixed-account preparation test asserting only accounts not explicitly denied are assembled;
+  - add a real pipeline-failure preparation test asserting a blocked message is produced when `ran_scan=true`, `should_notify=true`, and the account is absent from `ran_pipeline_accounts`;
+  - add the production eligibility guard.
+- Expected outcome: the 09:40-success -> 09:50-no-op sequence cannot create revision 1 or send a false anomaly.
+- Stop condition: evidence that a required user-visible alert intentionally carries `should_notify=false`, because that would contradict the existing notification-decision contract.
+
+## Tests / Validation
+
+### Focused
+
+```bash
+./.venv/bin/python -m pytest tests/test_daily_decision_brief_notification_flow.py tests/test_daily_decision_brief_service.py tests/test_account_run.py
+```
+
+### Broader notification/tick regression
+
+```bash
+./.venv/bin/python -m pytest \
+  tests/test_daily_decision_brief_scenarios.py \
+  tests/test_multi_account_tick.py \
+  tests/test_multi_tick_notify_format.py \
+  tests/test_unified_tick_entrypoint.py
+```
+
+### Static analysis
+
+Use the repository-supported Ruff invocation on changed Python files if available; otherwise run `python -m compileall` on the changed module and report the unavailable tool explicitly.
+
+## Docs Decision
+
+No operator/user documentation change is required because public commands, payloads, config, message wording, and safety boundaries are unchanged. Gateflow artifacts document the bug and decision.
+
+## Risks / Open Questions
+
+### Classified risks
+
+- `ran_scan=false, should_notify=true` and missing-`should_notify` semantics are preserved. Classification: preserved existing behavior and compatibility.
+- The global scheduler snapshot may still display stale `scheduled_target_market`. Classification: separate diagnostics/state-consistency work unit; no user-visible duplicate remains once no-op delivery is suppressed.
+- Existing historical false revision remains in remote runtime state. Classification: production cleanup is out of scope and requires separate approval.
+- Legitimate per-account `lx`/`sy` messages remain two deliveries. Classification: explicitly accepted product behavior.
+
+### Blocking open questions
+
+None after user confirmation of isolated worktree and per-account delivery preservation.
+
+## Completion Report Format
+
+- changed files and behavior;
+- focused/broader validation commands and results;
+- review/deepreview finding status;
+- docs decision;
+- residual risks and owners;
+- commits, branch, and draft PR status if Gateflow reaches that gate.

--- a/docs/reviews/code-rereview-20260721-101153.md
+++ b/docs/reviews/code-rereview-20260721-101153.md
@@ -1,0 +1,48 @@
+# Code Re-review
+
+## Scope
+
+- Gate: code re-review
+- Branch: `codex-fix-daily-brief-noop-notification`
+- Base: `85375d79`
+- Prior review: `docs/reviews/code-review-20260721-101032.md`
+- Fix artifact: `docs/gateflow/daily-brief-noop-notification-fix/slice-1-fix.md`
+- Status: pass
+
+## Finding Status
+
+### CR-01 — 已修复 — Production AccountResult shape is covered
+
+The no-op end-to-end and pipeline-failure preservation tests now instantiate `src.application.multi_tick.misc.AccountResult`, exercising the production object/getattr branch. Mapping tests remain for compatibility.
+
+Evidence:
+
+- no-op production object reaches no-account finalization without assembler or delivery resolution;
+- failed attempted pipeline production object remains eligible and renders a blocked “数据异常” brief;
+- focused suite: `53 passed`;
+- broader suite: `46 passed`;
+- Ruff and diff check: pass.
+
+## Adversarial Re-check
+
+- Explicit notification denial is absorbing before all Daily Brief side effects.
+- Missing-field mappings remain compatible.
+- Eligible sibling accounts remain independent.
+- Real pipeline failures with notification permission remain visible.
+- Delivery idempotency, confirmation, quiet hours, no-send, and multi-market behavior are unchanged.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Stale global scheduler target: separate work unit.
+- Historical remote false revision: separately approval-gated.
+- PR/CI: later Gateflow gates.
+
+All residual risks are classified.
+
+## Conclusion
+
+**pass** — all accepted code review findings are fixed and re-reviewed.

--- a/docs/reviews/code-review-20260721-101032.md
+++ b/docs/reviews/code-review-20260721-101032.md
@@ -1,0 +1,55 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `codex-fix-daily-brief-noop-notification`
+- Base: `85375d79` (accepted plan commit)
+- Output file: `docs/reviews/code-review-20260721-101032.md`
+- Included scope: Slice 1 runtime guard, focused tests, implementation artifact, direct account-run result production path
+- Excluded scope: previously committed plan artifacts except as intent; unrelated `paseo.json`; remote deployment/runtime mutation
+- Parallel review coverage: 无；范围为单一四行门控与同文件回归测试
+
+## Findings
+
+### CR-01-未修复-中-回归测试未覆盖生产使用的 AccountResult 对象分支
+
+- **入口/函数**: `run_tick_notification_flow()` -> `_prepare_daily_brief_notification()`
+- **文件(行号)**: `src/application/tick_notification_flow.py:619-629`; `tests/test_daily_decision_brief_notification_flow.py:346-459`
+- **输入场景**: 真实 `account_run.py` 返回 `AccountResult` dataclass，且账户调度结果为 `should_notify=False`。
+- **实际分支**: 生产进入 `else` / `getattr(result, "should_notify", None)` 分支；新增 no-op、explicit-denial、mixed 和 pipeline-failure tests 全部传入 dict，进入另一个分支。
+- **预期行为**: 至少一个关键回归测试应使用真实 `AccountResult` shape，证明生产分支在 no-op 时不组装、不持久化、不发送，并证明真实失败 shape 在 `should_notify=True` 时仍可生成 blocked brief。
+- **实际行为**: 当前测试只证明 mapping adaptation 正确，无法防止对象分支未来被删除、拼错或默认化后复发远端错误。
+- **直接证据**: 生产 `src/application/account_run.py` 三处构造 `AccountResult(...)`；新增测试结果均为字典字面量。
+- **影响**: 当前实现静态阅读正确，但关键用户可见回归的自动化证明未经过真实生产数据形态，后续重构可能静默恢复错误发送。
+- **建议改法和验证点**: 将 no-op end-to-end 与 pipeline-failure preservation tests 改为传入 `src.application.multi_tick.misc.AccountResult`；保留至少一个 dict test 覆盖 mapping compatibility。重新运行 focused/broader suites。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Adversarial Failure Pass
+
+- No-op false/false: runtime guard prevents assembler/repository/render/delivery side effects.
+- Scan true / notification false: runtime guard treats notification decision as authoritative.
+- True attempted pipeline failure: explicit true remains eligible and `pipeline_succeeded=False` reaches blocked assembly.
+- Mixed accounts: denied account does not suppress eligible sibling account.
+- Missing field: identity comparison preserves existing compatibility rather than converting absence to denial.
+- Retry/idempotency/confirmation: untouched downstream paths; existing tests pass.
+- Multi-market: unchanged; eligible accounts still persist partitioned artifacts and suppress outbound as before.
+
+## Project Instruction / Architecture Review
+
+- Root-cause fix is at the notification side-effect owner; no renderer/repository/domain workaround.
+- Import boundaries unchanged.
+- No config, schema, service, runtime state, or production send mutation.
+- Change is parsimonious and does not add entities, states, layers, or dependencies.
+- No overcoupling or semantic ownership drift found after plan correction to `should_notify` authority.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Global scheduler snapshot may retain a stale target label; separate work unit, no longer user-visible when denied accounts cannot deliver.
+- Historical remote false revision remains untouched; production cleanup requires separate approval.
+- PR/CI not yet evaluated at this gate.

--- a/docs/reviews/code-review-20260721-101327.md
+++ b/docs/reviews/code-review-20260721-101327.md
@@ -1,0 +1,87 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes (aggregate deepreview)
+- Branch: `codex-fix-daily-brief-noop-notification`
+- Base: `4576a1c106f6521b704877ed753ffe24683fa285`
+- Output file: `docs/reviews/code-review-20260721-101327.md`
+- Included scope: complete work unit commits `85375d79` and `df813a4c`; plan/review artifacts; notification eligibility guard; account-run result contract; Daily Brief assembly/repository/render/delivery chain; focused and broader tests
+- Excluded scope: untracked Paseo manager metadata `paseo.json`; remote deployment and historical runtime state; unrelated candidate-event-risk dirty changes in the original worktree
+- Parallel review coverage: 无；runtime delta is one four-line guard with one focused test file
+
+## Findings
+
+未发现实质性问题。
+
+## Adversarial Failure Pass
+
+### Normal scheduled success
+
+`AccountResult.should_notify=True` remains eligible. Assembly, repository revision, rendering, delivery key, provider send, and confirmation pointer behavior are unchanged.
+
+### Already-processed scheduler no-op
+
+Production `AccountResult(False, False, ...)` enters the object branch, is skipped before assembly, produces no lifecycle/message, avoids route resolution, and follows existing `no_account_notification` finalization.
+
+### Scan completed but notification denied
+
+Explicit `should_notify=False` remains authoritative regardless of `ran_scan`, matching legacy message construction semantics and preventing delivery outside an account notification decision.
+
+### Genuine attempted pipeline failure
+
+`account_run.py` reports tested pipeline failures with `ran_scan=True`; when scheduler notification permission is true and the account is absent from `ran_pipeline_accounts`, the account remains eligible and the assembler receives `pipeline_succeeded=False`, preserving blocked “数据异常” alerts.
+
+### Mixed accounts
+
+Filtering occurs per result before assembly; a denied account does not suppress an eligible sibling. Per-account delivery identity remains unchanged.
+
+### Missing or compatibility mappings
+
+Only identity-equal `False` denies preparation. Missing `should_notify` remains eligible, avoiding an implicit contract change for internal mapping callers while production account results continue to supply booleans.
+
+### Persistence / retry / idempotency
+
+The guard is before all persistence and delivery side effects. Existing repository diff, delivery key, transport idempotency, retry, confirmation, no-send, quiet-hours, and multi-market code is untouched and covered by passing regressions.
+
+## Project Instruction Check
+
+- Root-cause fix is at the outbound side-effect owner.
+- No domain/application import boundary change.
+- No config, schema, public CLI, notification wording, service, or production runtime mutation.
+- Original dirty worktree remains untouched; implementation was isolated from base commit `4576a1c1`.
+- Change is parsimonious: no new helper, entity, layer, state, config key, dependency, or workflow.
+
+## Architecture / Ownership Review
+
+- Scheduler/account execution owns the `should_notify` fact.
+- Tick notification flow enforces it before creating externally visible brief state.
+- Daily Brief service continues to own representation of genuine failed attempted scans.
+- Repository continues to own revision/diff/delivery pointer semantics.
+- Renderer continues to own user-facing phase/batch wording.
+- No semantic ownership drift or cross-layer correction was introduced.
+
+## Validation Evidence
+
+- Focused notification flow: `15 passed`.
+- Focused service/account/notification group: `53 passed`.
+- Broader notification/tick group: `46 passed`.
+- Ruff changed files: pass.
+- `git diff --check`: pass.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Global scheduler snapshot may retain a stale scheduled target. Classification: separate diagnostics/state-consistency work unit; not user-visible through Daily Brief when `should_notify=False` is enforced.
+- Historical remote false revision remains in runtime history. Classification: production cleanup requires separate explicit approval; no cleanup is necessary for code correctness.
+- Legitimate `lx` and `sy` scheduled messages remain separate. Classification: accepted product behavior confirmed by the user.
+- CI/remote deployment not yet performed. Classification: later draft-PR/release gates; no remote mutation authorized in this work unit.
+
+All residual risks are classified.
+
+## Conclusion
+
+**pass** — no accepted findings remain; the work unit is ready for the accepted deepreview checkpoint.

--- a/docs/reviews/plan-rereview-daily-brief-noop-notification-fix-20260721.md
+++ b/docs/reviews/plan-rereview-daily-brief-noop-notification-fix-20260721.md
@@ -1,0 +1,35 @@
+# Plan Re-review — Daily Brief No-op Notification Fix
+
+## Reviewed Target
+
+- Target: `docs/plans/daily-brief-noop-notification-fix-plan-20260721.md` revision 2
+- Prior review: `docs/reviews/plan-review-daily-brief-noop-notification-fix-20260721.md`
+- Gate: plan re-review
+- Status: pass
+
+## Finding Re-review
+
+### PR-01 — 已修复 — Delivery eligibility follows explicit `should_notify`
+
+Revision 2 now treats explicit `should_notify=false` as the no-delivery authority regardless of `ran_scan`, preserves missing-field compatibility through identity comparison, and retains preparation for true attempted failures with `should_notify=true`.
+
+Required tests are specified for no-op, scan-completed notification denial, mixed accounts, and genuine pipeline failure.
+
+## Architecture / State-machine Decision
+
+- Account scheduler owns the notification authorization fact.
+- Tick notification flow owns enforcement before persistence/rendering/delivery side effects.
+- Daily Brief service remains responsible for representing a genuinely attempted but failed scan as blocked.
+- Repository and renderer contracts remain unchanged.
+
+## Residual Risks
+
+- Stale global scheduler labels: assigned to a separate work unit.
+- Historical remote false revision: separately production-approval-gated.
+- Missing `should_notify` compatibility: accepted; production account results supply the field.
+
+All residual risks are classified. No blocking open question remains.
+
+## Conclusion
+
+**pass-with-classified-risks** — revision 2 is code-generation-ready and avoids both under-filtering and accidental suppression of true failure alerts.

--- a/docs/reviews/plan-review-daily-brief-noop-notification-fix-20260721.md
+++ b/docs/reviews/plan-review-daily-brief-noop-notification-fix-20260721.md
@@ -1,0 +1,60 @@
+# Plan Review — Daily Brief No-op Notification Fix
+
+## Reviewed Target and Scope
+
+- Gate: plan review
+- Target: `docs/plans/daily-brief-noop-notification-fix-plan-20260721.md` revision 1
+- Work unit: `daily-brief-noop-notification-fix`
+- Status: changes required
+
+## Executive Decision
+
+**changes-required** — the proposed owning boundary is correct, but the planned eligibility predicate uses the wrong semantic authority and can still permit notifications that the account scheduler explicitly denied.
+
+## Findings
+
+### PR-01 — High — Delivery eligibility must follow `should_notify`, not a compound no-op heuristic
+
+- Location: plan sections “State-machine refinement” and “Implementation Decision”.
+- Planned behavior: skip only when `ran_scan=false && should_notify=false`.
+- Direct evidence:
+  - `AccountResult.should_notify` is the account-scoped notification decision passed into notification preparation.
+  - The legacy notification path filters account output using `result.should_notify`.
+  - `ran_scan` describes whether work ran; it is not authorization to send.
+- Counterexample: `ran_scan=true, should_notify=false` can occur for a forced/smoke/closed-window or future scheduler path. Revision 1 would still assemble and deliver a Daily Brief despite the explicit notification denial.
+- Required fix:
+  - skip an account when `should_notify is False`;
+  - use identity comparison so a missing field (`None`) is not silently reinterpreted as denial for compatibility with existing mapping fixtures/callers;
+  - preserve `ran_scan=false, should_notify=true` and `ran_scan=true, should_notify=true` preparation, allowing intentional alerts and real pipeline-failure blocked briefs.
+- Required tests:
+  - no-op false/false is skipped end to end;
+  - ran-scan true / should-notify false is also skipped;
+  - pipeline failure with explicit should-notify true is still prepared as blocked;
+  - mixed accounts prepare only accounts not explicitly denied.
+
+Status: **accepted; plan revision required**.
+
+## Assumptions / State-machine Review
+
+- Real failed attempted pipelines currently expose `ran_scan=true` and retain the scheduler `should_notify` decision: supported by `tests/test_account_run.py` and `src/application/account_run.py`.
+- Explicit `should_notify=false` is terminal for this tick's outbound account notification: supported by the account result contract and legacy preparation behavior.
+- Missing `should_notify` should not be treated as false during this narrow bug fix because `TickNotificationRequest.results` accepts mappings without schema validation in focused tests and potentially internal callers.
+
+## Special Review Lenses
+
+- Architecture boundary: pass after required predicate fix; `tick_notification_flow` owns outbound preparation eligibility.
+- State machine: changes required; `should_notify=false` must be an absorbing no-delivery decision for the tick.
+- Semantic ownership drift: revision 1 incorrectly lets `ran_scan` participate in delivery authorization.
+- Overcoupling: pass; no scheduler/repository/renderer changes are needed.
+- Overengineering: pass; one explicit guard and tests are sufficient.
+- Testing: changes required as listed in PR-01.
+
+## Open Questions
+
+None blocking after PR-01 is incorporated.
+
+## Residual Risks
+
+- Stale global `scheduled_target_market`: assigned to a separate diagnostics/state-consistency work unit.
+- Historical remote revision 1: production cleanup remains separately approval-gated.
+- Missing `should_notify` mappings remain eligible for compatibility: accepted internal-contract risk; production `AccountResult` always supplies the field.

--- a/docs/reviews/pr-103-review-20260721-102026.md
+++ b/docs/reviews/pr-103-review-20260721-102026.md
@@ -1,0 +1,71 @@
+# Pull Request Review
+
+## Scope
+
+- Mode: PR review
+- Repository: `liuxie066/options-monitor`
+- PR: #103 — `fix: suppress daily brief for notification-denied no-op ticks`
+- Author: `liuxie066`
+- Head: `codex-fix-daily-brief-noop-notification`
+- Base: `main`
+- Draft: true
+- Mergeability at review: MERGEABLE
+- Output file: `docs/reviews/pr-103-review-20260721-102026.md`
+- Included scope: complete GitHub PR diff, four commits, runtime/test changes, Gateflow artifacts, CI rollup
+- Excluded scope: remote production deployment/runtime state; untracked local `paseo.json`
+- Parallel review coverage: 无；single narrow runtime guard
+
+## Findings
+
+未发现实质性问题。
+
+## PR Diff Verification
+
+- GitHub reports only the intended branch commits based on `main`.
+- Runtime change is limited to explicit `should_notify is False` filtering before Daily Brief side effects.
+- Test change covers production `AccountResult`, mapping compatibility, mixed accounts, notification denial, and true pipeline failure preservation.
+- No candidate-event-risk source changes are present.
+- No config, schema, CLI, service, renderer wording, or runtime-state mutation is present.
+
+## Adversarial Review
+
+- No-op account cannot reach assembly/repository/render/delivery.
+- Explicit denial remains authoritative even if a scan completed.
+- True attempted failure with notification allowed remains blocked and visible.
+- Mixed-account independence is preserved.
+- Missing-field compatibility remains unchanged.
+- Retry, idempotency, confirmation, quiet-hour, no-send, and multi-market paths are untouched.
+- No reverse imports, cross-layer policy leak, semantic ownership drift, overcoupling, or speculative abstraction introduced.
+
+## Validation
+
+### Local on PR base
+
+- Focused suite: `47 passed`.
+- Broader notification/tick suite: `46 passed`.
+- Ruff: pass.
+- Diff check: pass.
+
+### GitHub checks before PR review artifact commit
+
+- Analyze (actions): pass.
+- Analyze (python): pass.
+- CodeQL: pass.
+- agent-plugin: pass.
+- guardrails: pass.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Global scheduler snapshot stale target remains a separate diagnostics work unit.
+- Historical remote false revision remains untouched and does not require code cleanup.
+- Production release/deployment remains separately authorization-gated.
+
+All residual risks are classified.
+
+## Conclusion
+
+**pass** — no PR review finding requires a code change. Ready for accepted PR review commit and final push.

--- a/src/application/tick_notification_flow.py
+++ b/src/application/tick_notification_flow.py
@@ -619,10 +619,14 @@ def _prepare_daily_brief_notification(
     for result in request.results:
         if isinstance(result, dict):
             account = str(result.get("account") or "").strip().lower()
+            should_notify = result.get("should_notify")
         else:
             account = str(getattr(result, "account", "") or "").strip().lower()
+            should_notify = getattr(result, "should_notify", None)
         if not account:
             raise ValueError("daily brief account result is missing account")
+        if should_notify is False:
+            continue
 
         briefs = assemble_daily_decision_briefs(
             base=request.base,

--- a/tests/test_daily_decision_brief_notification_flow.py
+++ b/tests/test_daily_decision_brief_notification_flow.py
@@ -85,7 +85,8 @@ def _request(
     tmp_path: Path,
     *,
     run_id: str,
-    results: list[dict] | None = None,
+    results: list[object] | None = None,
+    ran_pipeline_accounts: tuple[str, ...] | None = None,
     markets: tuple[str, ...] = ("US",),
     no_send: bool = False,
     config: dict | None = None,
@@ -111,7 +112,11 @@ def _request(
         markets_to_run=markets,
         scheduler_markets=markets,
         scheduler_decision={"in_run_window": True},
-        ran_pipeline_accounts=tuple(str(item["account"]) for item in (results or [{"account": "lx"}])),
+        ran_pipeline_accounts=(
+            ran_pipeline_accounts
+            if ran_pipeline_accounts is not None
+            else tuple(str(item["account"]) for item in (results or [{"account": "lx"}]))
+        ),
     )
     return SimpleNamespace(request=request, completions=completions)
 
@@ -335,6 +340,115 @@ def test_prepare_and_confirmation_are_account_isolated(monkeypatch, tmp_path: Pa
     assert set(preparation.prepared_messages.messages_by_account) == {"lx", "sy"}
     assert set(preparation.lifecycles_by_account) == {"lx", "sy"}
     assert preparation.delivery_keys_by_account["lx"] != preparation.delivery_keys_by_account["sy"]
+
+
+def test_noop_account_does_not_prepare_or_send_daily_brief(monkeypatch, tmp_path: Path) -> None:
+    import src.application.tick_notification_flow as mod
+    from src.application.multi_tick.misc import AccountResult
+
+    monkeypatch.setattr(
+        mod,
+        "assemble_daily_decision_briefs",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("no-op account must not be assembled")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "resolve_notification_delivery_route",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("no-op account must not resolve delivery")),
+    )
+    monkeypatch.setattr(mod, "finalize_no_account_notification", lambda **_kwargs: 0)
+    bundle = _request(
+        tmp_path,
+        run_id="run-noop",
+        results=[AccountResult("lx", False, False, "already processed", "")],
+        ran_pipeline_accounts=(),
+    )
+
+    assert mod.run_tick_notification_flow(bundle.request) == 0
+    assert bundle.request.tick_metrics["daily_brief"]["prepared"] == []
+    assert bundle.completions == [{"status": "completed", "message": "no_account_notification"}]
+
+
+def test_explicit_notification_denial_skips_even_completed_scan(monkeypatch, tmp_path: Path) -> None:
+    import src.application.tick_notification_flow as mod
+
+    monkeypatch.setattr(
+        mod,
+        "assemble_daily_decision_briefs",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("denied account must not be assembled")),
+    )
+    bundle = _request(
+        tmp_path,
+        run_id="run-notify-denied",
+        results=[{"account": "lx", "ran_scan": True, "should_notify": False}],
+    )
+
+    preparation = mod._prepare_daily_brief_notification(bundle.request)
+
+    assert preparation.prepared_messages.messages_by_account == {}
+    assert preparation.lifecycles_by_account == {}
+    assert bundle.request.tick_metrics["daily_brief"]["prepared"] == []
+
+
+def test_mixed_accounts_prepare_only_accounts_not_explicitly_denied(monkeypatch, tmp_path: Path) -> None:
+    import src.application.tick_notification_flow as mod
+
+    assembled: list[str] = []
+
+    def _assemble(*, run_id, account, markets_to_run, **_kwargs):
+        assembled.append(account)
+        return {
+            market: _brief(run_id=run_id, account=account, market=market)
+            for market in markets_to_run
+        }
+
+    monkeypatch.setattr(mod, "assemble_daily_decision_briefs", _assemble)
+    bundle = _request(
+        tmp_path,
+        run_id="run-mixed",
+        results=[
+            {"account": "lx", "ran_scan": False, "should_notify": False},
+            {"account": "sy", "ran_scan": True, "should_notify": True},
+        ],
+        ran_pipeline_accounts=("sy",),
+    )
+
+    preparation = mod._prepare_daily_brief_notification(bundle.request)
+
+    assert assembled == ["sy"]
+    assert set(preparation.prepared_messages.messages_by_account) == {"sy"}
+    assert set(preparation.lifecycles_by_account) == {"sy"}
+
+
+def test_pipeline_failure_with_notification_allowed_still_prepares_blocked_brief(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.tick_notification_flow as mod
+    from src.application.multi_tick.misc import AccountResult
+
+    def _assemble(*, run_id, account, markets_to_run, pipeline_succeeded, **_kwargs):
+        assert pipeline_succeeded is False
+        return {
+            market: _brief(run_id=run_id, account=account, market=market, blocked=True)
+            for market in markets_to_run
+        }
+
+    monkeypatch.setattr(mod, "assemble_daily_decision_briefs", _assemble)
+    bundle = _request(
+        tmp_path,
+        run_id="run-pipeline-failed",
+        results=[
+            AccountResult("lx", True, True, "pipeline failed", "")
+        ],
+        ran_pipeline_accounts=(),
+    )
+
+    preparation = mod._prepare_daily_brief_notification(bundle.request)
+
+    assert set(preparation.prepared_messages.messages_by_account) == {"lx"}
+    assert preparation.lifecycles_by_account["lx"]["brief"]["status"] == "blocked"
+    assert "数据异常" in preparation.prepared_messages.messages_by_account["lx"]
 
 
 def test_provider_success_but_local_confirmation_failure_is_not_marked_sent(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- stop Daily Brief preparation when an account result explicitly denies notification (`should_notify=false`)
- prevent already-processed timer no-ops from creating false blocked revisions from empty run directories
- preserve genuine attempted pipeline-failure alerts when notification remains allowed
- preserve per-account `lx` / `sy` delivery behavior

## Root cause

The Daily Brief path assembled every account result even when the account scheduler returned `ran_scan=false` and `should_notify=false`. The empty no-op run directory was interpreted as missing strategy artifacts, producing and sending a false `数据异常` delta.

## Validation

- `47 passed`: Daily Brief notification flow, service, and account-run tests
- `46 passed`: Daily Brief scenarios, multi-account tick, notification formatting, unified tick entrypoint
- Ruff changed Python files: pass
- diff check: pass
- plan review, slice code review/re-review, and aggregate deepreview: pass

## Scope

No config, schema, public CLI, renderer wording, service, runtime state, or remote deployment changes.
