### PR TITLE
feat: render Feishu notifications as post Markdown

### DIFF
--- a/docs/AGENT_WIKI.md
+++ b/docs/AGENT_WIKI.md
@@ -352,7 +352,9 @@ preserving `not_evaluable` rows, and formatting CSV/text output.
   `src/application/tick_notification_flow.py`
 - Read tool: `notification_perception_read`
 
-Notification text should remain Markdown-friendly and operationally direct. Do not send live notifications unless the user explicitly asks.
+Notification text should remain Markdown-friendly and operationally direct. The business renderer owns one canonical Markdown string: proactive Feishu App delivery projects it as `msg_type=post` with exactly one `zh_cn.content` `md` node and no duplicate `title`, while WeChat ClawBot sends the same string unchanged through `text_item.text`. Feishu inbound replies/outbox remain text. Do not create channel-specific business renderers or parse/rewrite the Markdown in an adapter.
+
+Feishu post delivery measures the exact final outer JSON request body as UTF-8 before token acquisition or message HTTP. Requests over the fixed 28 KiB local budget fail closed as `FEISHU_POST_TOO_LARGE`, retaining only byte counts, normalized character count, and a SHA-256 content hash. Do not truncate, fragment, retry this deterministic local failure, or automatically fall back to text. Timeouts, transient failures, confirmed sends, and ambiguous sends must also never trigger text fallback for the same business event. Live desktop/mobile canaries and any rollback to the text sender require separate explicit operator approval; after rollback, only an HTTP-before-send size failure may be explicitly replayed with a new transport UUID and linked audit.
 
 Notification perception events are compressed system evidence for Assistant
 follow-ups. They record delivery action/reason, accounts, symbol summaries,

--- a/docs/gateflow/channel-aware-notification-rendering-accepted-plan-20260721-151105.md
+++ b/docs/gateflow/channel-aware-notification-rendering-accepted-plan-20260721-151105.md
@@ -1,0 +1,39 @@
+# Gateflow Accepted Plan — Channel-aware Notification Rendering
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Gate: `plan -> plan review -> fix -> re-review`
+- Decision: `pass-with-risks`
+- Plan: `docs/plans/channel-aware-notification-rendering-plan-20260721.md`
+- Initial review: `docs/reviews/plan-review-20260721-142232.md`
+- Re-review: `docs/reviews/plan-review-20260721-150356.md`
+
+## Finding Status
+
+- Feishu post 30 KB limit versus text 150 KB: accepted, fixed in the revised plan with exact outer-request UTF-8 byte preflight, 28 KiB fail-closed budget, and structured local diagnostics.
+- Daily-Brief-only canary was not representative of the shared adapter blast radius: accepted, fixed with five renderer categories covering Daily Brief, Compact Tick, Trade Receipt, Maintenance Receipt, and Failure/Recovery notices.
+- Open accepted findings: none.
+
+## Approved Implementation Boundary
+
+1. Add `send_post_message()` in `src/infrastructure/feishu_bot.py`, preserving existing text/reply behavior.
+2. Route proactive Feishu notification delivery through the new sender and normalize local size errors.
+3. Preserve local diagnostics in scheduled notification attempts/audits without adding the deterministic size error to retryable codes.
+4. Add focused/broader regression tests and update `docs/AGENT_WIKI.md`.
+5. Do not execute the live canary/rollout slice without separate explicit authorization.
+
+## Minimality Decision
+
+The accepted solution reuses the current canonical Markdown, Feishu exception hierarchy, delivery adapter, retry state machine, and receipt error contract. It deliberately avoids a renderer registry, DTO/content enum, runtime switch, Markdown parser, truncation, fragmentation, or automatic fallback.
+
+## Validation at This Gate
+
+- Plan review conclusion: `pass-with-risks`.
+- No implementation blocker or unclassified residual risk.
+- External visual/API risks are assigned to the explicit canary gate.
+
+## Current Gate / Next Entry Point
+
+- Current gate: `accepted plan commit`
+- Next entry point after commit: `implementation`

--- a/docs/gateflow/channel-aware-notification-rendering-aggregate-deepreview-20260721-153731.md
+++ b/docs/gateflow/channel-aware-notification-rendering-aggregate-deepreview-20260721-153731.md
@@ -1,0 +1,45 @@
+# Gateflow Aggregate Deepreview — Channel-aware Notification Rendering
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Gate: `aggregate deepreview -> fix -> re-review`
+- Initial review: `docs/reviews/code-review-20260721-153650.md`
+- Re-review: `docs/reviews/code-review-20260721-153731.md`
+- Decision: `pass`
+- Artifact path: `docs/gateflow/channel-aware-notification-rendering-aggregate-deepreview-20260721-153731.md`
+
+## Reviewed Scope
+
+Complete branch diff relative to `main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`, including the accepted plan, four implementation slices, Feishu post transport/preflight, adapter normalization, scheduled retry/audit propagation, direct receipts, WeChat identity behavior, real renderer contracts, tests, and operator documentation.
+
+## Finding Decision and Status
+
+- Material findings: none.
+- Accepted findings requiring fix: none.
+- Fix gate: not applicable.
+- Re-review: passed without code changes.
+
+## Validation
+
+- Aggregate notification regression suite: `205 passed`.
+- Ruff on touched production/test Python files: passed.
+- compileall on touched production/tests and renderer modules: passed.
+- `git diff --check`: passed.
+
+## Docs Decision
+
+`docs/AGENT_WIKI.md` documents canonical Markdown ownership, Feishu post/single-md projection, WeChat identity projection, exact pre-token size preflight, local failure diagnostics, no retry/fallback semantics, replay constraints, and separate live-canary authorization.
+
+## Residual Risks and Owner
+
+- Real Feishu API acceptance and desktop/mobile rendering: operator-owned, covered by the plan's separately authorized five-category live canary.
+- Near-limit real-provider behavior: operator-owned optional canary; deterministic local boundary is covered by tests.
+- Rollback if visual/API acceptance fails: operator-controlled code/version rollback to text; no automatic fallback or same-event duplicate send.
+
+These risks are classified and do not block local implementation acceptance.
+
+## Completion Status / Next Entry Point
+
+- Current gate: `accepted deepreview commit`
+- Next entry point after commit: `ready-to-open-draft-PR`

--- a/docs/gateflow/channel-aware-notification-rendering-canary-20260721-164120.md
+++ b/docs/gateflow/channel-aware-notification-rendering-canary-20260721-164120.md
@@ -1,0 +1,75 @@
+# Gateflow Live Canary — Channel-aware Notification Rendering
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Slice: `Slice 5 — Explicitly approved canary and rollout`
+- Gate: `live canary acceptance`
+- Decision: `pass; Feishu post rollout qualified`
+- Executed on: `2026-07-21` (Asia/Shanghai)
+- Branch: `feat/channel-aware-notification-rendering`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/108`
+- Artifact path: `docs/gateflow/channel-aware-notification-rendering-canary-20260721-164120.md`
+
+## Authorization and Safety Boundary
+
+- The operator explicitly authorized sequential live canaries for all five approved categories.
+- Each canary used synthetic, clearly labeled content derived from the real renderer fixtures and a distinct canary UUID.
+- The five categories were evaluated in order. No category failed, so the controlled rollback path was not triggered.
+- No text replacement was sent for any confirmed post canary.
+- No near-28-KiB live canary was sent because that additional live boundary test was not authorized; deterministic tests remain the evidence for the size boundary.
+- Recipient evidence is limited to the redacted open-ID suffix `5c7e58`; credentials and the full recipient identifier are not stored in this artifact.
+
+## Delivery and Readback Evidence
+
+| # | Category | Canary UUID | Message ID | Request bytes | Markdown chars | Markdown SHA-256 | HTTP/API result |
+|---:|---|---|---|---:|---:|---|---|
+| 1 | Daily Brief | `om-canary-20260721-daily-brief-160405` | `om_x100b6ac631a99094b49f107d5514e74` | 946 | 428 | `0f933da2588187ef09112f0ad86158956d14d1ab0776fc09c106c4bffe4b4894` | first attempt; HTTP 200; Feishu `code=0` |
+| 2 | Compact Tick | `om-canary-20260721-2-083714` | `om_x100b6ac6b56218a0b2193d4eb02c445` | 751 | 360 | `618d2dd6feac1dc76856c2a6a29b04a56cc926e6560673e283a100b8460d9bb5` | first attempt; HTTP 200; Feishu `code=0` |
+| 3 | Trade Receipt | `om-canary-20260721-3-083715` | `om_x100b6ac6b50e8880b25203c8524299a` | 848 | 360 | `2cdb8c3a3c2c0a59a10fc99d4fec97b77d151b0f1f14f6fbdf00597f32e7d1ae` | first attempt; HTTP 200; Feishu `code=0` |
+| 4 | Maintenance Receipt | `om-canary-20260721-4-083716` | `om_x100b6ac6b518ec4cb1f83b4c16d57d1` | 708 | 314 | `a50026bf458f434181af868592ec50e9ff2ce67e084d096355f0a2b333d40e02` | first attempt; HTTP 200; Feishu `code=0` |
+| 5 | Failure/Recovery | `om-canary-20260721-5-083717` | `om_x100b6ac6b52a58a8b255bc93ca26ca2` | 551 | 237 | `3e9e252d3631db8c3fe03acb243c668e4ba4a912b1ea77ed029c447aa4c34c4c` | first attempt; HTTP 200; Feishu `code=0` |
+
+All five readbacks verified:
+
+- `msg_type=post`;
+- one `content_v2` paragraph containing exactly one `md` node;
+- empty post title;
+- `deleted=false` and `updated=false`;
+- readback Markdown character count and SHA-256 exactly matched the sent canonical Markdown;
+- request body size was below the fixed 28 KiB (`28,672` byte) budget.
+
+## Visual Acceptance
+
+- Daily Brief: the operator visually accepted the delivered canary before authorizing the remaining sequence.
+- Compact Tick, Trade Receipt, Maintenance Receipt, and Failure/Recovery: after all four were delivered and read back, the operator explicitly confirmed `第2到5条通过` in response to the desktop-and-mobile visual acceptance request.
+- Result: all five categories passed desktop and mobile visual acceptance.
+- Evidence form: manual operator confirmation. Automated desktop screenshots were not captured because the available UI inspection path required broader system screen-recording access that was not approved; that privacy boundary was not bypassed. Mobile rendering necessarily remained operator-confirmed.
+
+## Validation and Change Scope
+
+- Live delivery/readback: passed for all five categories.
+- Visual acceptance: passed for all five categories on desktop and mobile.
+- Rollback: not required.
+- Production code/tests changed during canary execution: none.
+- Runtime configuration changed: none.
+- Persistent canary scripts or payload files added: none; temporary canary helpers/evidence remained under `/tmp`.
+- Broad test rerun: not required for this docs-only evidence commit; the pre-canary implementation closeout already recorded `205 passed`, Ruff, compileall, `git diff --check`, deepreview, PR review, and passing GitHub checks.
+
+## Residual Risks / Uncovered Areas
+
+1. Near-limit real-provider behavior was not exercised with a live message.
+   - Classification: operator-owned optional follow-up; deterministic byte-boundary tests cover the enforced runtime contract.
+2. No automated screenshot artifact is stored.
+   - Classification: accepted evidence limitation; explicit operator desktop/mobile confirmation supplies the product acceptance decision without expanding screen-recording access.
+3. Future Feishu client rendering may change independently of this implementation.
+   - Classification: operational monitoring concern; use the documented controlled rollback if a future regression is observed.
+
+All residual risks are classified and none blocks rollout qualification.
+
+## Completion Status and Next Entry Point
+
+- Slice 5 status: `pass`.
+- Feishu `post` + single `md` node rollout: qualified by live API, exact readback, and desktop/mobile visual evidence.
+- Controlled text rollback: not triggered.
+- Next entry point: operator decision on Draft PR readiness, merge, release, and deployment. None of those actions is performed by this artifact.

--- a/docs/gateflow/channel-aware-notification-rendering-canary-20260721-164120.md
+++ b/docs/gateflow/channel-aware-notification-rendering-canary-20260721-164120.md
@@ -5,11 +5,19 @@
 - Work unit: `channel-aware-notification-rendering`
 - Slice: `Slice 5 — Explicitly approved canary and rollout`
 - Gate: `live canary acceptance`
-- Decision: `pass; Feishu post rollout qualified`
+- Decision: `superseded by later operator mobile-readability feedback; needs-fix`
 - Executed on: `2026-07-21` (Asia/Shanghai)
 - Branch: `feat/channel-aware-notification-rendering`
 - Draft PR: `https://github.com/liuxie066/options-monitor/pull/108`
 - Artifact path: `docs/gateflow/channel-aware-notification-rendering-canary-20260721-164120.md`
+
+## Post-canary Qualification Withdrawal
+
+- The delivery/API evidence in this artifact remains valid: all five messages were accepted as `post`, read back as one exact `md` node, and matched the sent Markdown hashes.
+- After reviewing the notification family as a whole, the operator reported that two-level indentation is difficult to read on Feishu mobile and requested a flat, unified presentation.
+- That later product feedback supersedes the initial manual visual acceptance. Slice 5 visual qualification is withdrawn and the current rollout status is `needs-fix` pending renderer changes and a separately authorized re-canary.
+- The Draft PR was unmerged and unreleased when the issue was raised. No production text rollback or duplicate replacement send is required.
+- No new live canary is authorized by this correction; a future five-category re-canary still requires explicit operator approval.
 
 ## Authorization and Safety Boundary
 
@@ -43,13 +51,14 @@ All five readbacks verified:
 
 - Daily Brief: the operator visually accepted the delivered canary before authorizing the remaining sequence.
 - Compact Tick, Trade Receipt, Maintenance Receipt, and Failure/Recovery: after all four were delivered and read back, the operator explicitly confirmed `第2到5条通过` in response to the desktop-and-mobile visual acceptance request.
-- Result: all five categories passed desktop and mobile visual acceptance.
+- Initial result at canary time: all five categories were manually accepted.
+- Current interpretation: the later mobile-readability feedback supersedes that acceptance; the transport passed, but the renderer presentation requires correction.
 - Evidence form: manual operator confirmation. Automated desktop screenshots were not captured because the available UI inspection path required broader system screen-recording access that was not approved; that privacy boundary was not bypassed. Mobile rendering necessarily remained operator-confirmed.
 
 ## Validation and Change Scope
 
 - Live delivery/readback: passed for all five categories.
-- Visual acceptance: passed for all five categories on desktop and mobile.
+- Initial visual acceptance: recorded for all five categories, then superseded by later operator feedback.
 - Rollback: not required.
 - Production code/tests changed during canary execution: none.
 - Runtime configuration changed: none.
@@ -65,11 +74,12 @@ All five readbacks verified:
 3. Future Feishu client rendering may change independently of this implementation.
    - Classification: operational monitoring concern; use the documented controlled rollback if a future regression is observed.
 
-All residual risks are classified and none blocks rollout qualification.
+The mobile-readability issue now blocks rollout qualification until the flat renderer fix is validated and explicitly re-canary-tested.
 
 ## Completion Status and Next Entry Point
 
-- Slice 5 status: `pass`.
-- Feishu `post` + single `md` node rollout: qualified by live API, exact readback, and desktop/mobile visual evidence.
-- Controlled text rollback: not triggered.
-- Next entry point: operator decision on Draft PR readiness, merge, release, and deployment. None of those actions is performed by this artifact.
+- Slice 5 status: `needs-fix`.
+- Feishu `post` + single `md` node transport: qualified by live API and exact readback.
+- Renderer visual qualification: withdrawn pending the mobile-flat fix and a separately authorized five-category re-canary.
+- Controlled text rollback: not triggered because the PR remained unmerged and unreleased; if flat Post still fails the next acceptance gate, use the documented code/version rollback to text.
+- Next entry point: complete deterministic validation and review of the mobile-flat fix, then request explicit authorization before any new live canary. No merge, release, deployment, or live send is authorized by this artifact.

--- a/docs/gateflow/channel-aware-notification-rendering-final-closeout-20260721-154521.md
+++ b/docs/gateflow/channel-aware-notification-rendering-final-closeout-20260721-154521.md
@@ -1,0 +1,77 @@
+# Gateflow Final Closeout — Channel-aware Notification Rendering
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Gate: `final closeout`
+- Decision: `final closeout pass`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/108`
+- Branch: `feat/channel-aware-notification-rendering`
+- Base: `main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`
+- Artifact path: `docs/gateflow/channel-aware-notification-rendering-final-closeout-20260721-154521.md`
+
+## What Changed
+
+- Added proactive Feishu App delivery as `msg_type=post` with exactly one `zh_cn.content` `md` node and no duplicate post title.
+- Kept the existing canonical Markdown business renderers and WeChat ClawBot text projection unchanged.
+- Kept Feishu inbound replies/outbox on the existing text path.
+- Added exact final outer JSON UTF-8 byte preflight with a fixed 28 KiB local budget before token acquisition or message HTTP.
+- Added deterministic `FEISHU_POST_TOO_LARGE` failure diagnostics without raw notification content, retry, ambiguity, duplicate risk, truncation, fragmentation, or automatic text fallback.
+- Propagated the generic local error and size diagnostics through scheduled notification attempts/audits/failure results and direct trade/maintenance receipt results.
+- Added five real-renderer payload contracts: Daily Brief, Compact Tick, Trade Receipt, Maintenance Receipt, and Failure/Recovery summary.
+
+## What Was Verified
+
+- Local aggregate notification regression suite: `205 passed`.
+- Ruff on all touched production/test Python files: passed.
+- compileall on touched production/tests and renderer modules: passed.
+- `git diff --check`: passed.
+- Aggregate deepreview and re-review: passed with no material findings.
+- PR-mode deepreview and re-review: passed with no material findings.
+- Final GitHub checks after the accepted PR review commit: Analyze (actions), Analyze (python), CodeQL, agent-plugin, and guardrails all passed.
+- Draft PR remains open and Draft; no merge, ready-for-review transition, approval, reviewer request, release, deployment, or live notification occurred.
+
+## Docs Updates
+
+`docs/AGENT_WIKI.md` now records:
+
+- canonical Markdown ownership;
+- Feishu post/single-md and WeChat identity projections;
+- pre-token exact request-body size failure;
+- local diagnostic fields and no-content logging;
+- no retry/truncation/fragmentation/automatic fallback semantics;
+- operator-controlled rollback/replay constraints;
+- separate authorization for live Feishu canaries.
+
+## Finding Status
+
+- Plan review: two high-severity findings accepted and fixed in the revised plan; second review `pass-with-risks`.
+- Slice reviews: one Slice 1 test-coverage finding fixed and re-reviewed; no remaining accepted findings.
+- Aggregate deepreview: no material findings.
+- PR review: no material findings.
+- Open blocking findings: none.
+
+## Remaining Risks / Owners
+
+1. Real Feishu API acceptance and desktop/mobile rendering differences.
+   - Owner: operator/user.
+   - Destination: separately authorized five-category live canary from the approved plan.
+2. Near-limit real-provider behavior beyond deterministic local serialization tests.
+   - Owner: operator/user.
+   - Destination: optional explicitly approved near-limit canary.
+3. Rollback if live acceptance fails.
+   - Owner: operator/user for rollout decision; implementation path is code/version rollback to the existing text sender.
+   - Constraint: no automatic same-event post-to-text fallback; only an HTTP-before-send size failure may be explicitly replayed after rollback with a new transport UUID and linked audit.
+
+All residual risks are classified; none blocks local implementation or Draft PR acceptance.
+
+## Draft PR / Issue Status
+
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/108`
+- Issue link: not applicable; no numbered issue was provided for this work unit.
+- Issue closeout comment: not applicable.
+
+## Completion Status and Next Entry Point
+
+- Work unit status: `completed` at `final closeout pass`.
+- Next entry point: review the Draft PR and, if desired, separately authorize the five-category live Feishu canary. If the canary is accepted, proceed with normal ready/merge/release decisions; if it fails, execute the documented controlled rollback to text.

--- a/docs/gateflow/channel-aware-notification-rendering-goal-confirmation-20260721-151105.md
+++ b/docs/gateflow/channel-aware-notification-rendering-goal-confirmation-20260721-151105.md
@@ -1,0 +1,51 @@
+# Gateflow Goal Confirmation — Channel-aware Notification Rendering
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Gate: `goal confirmation`
+- Decision: `pass`
+- Baseline: `main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`
+- Branch: `feat/channel-aware-notification-rendering`
+
+## Goal and Motivation
+
+Keep one canonical Markdown business rendering while projecting it by delivery channel: proactive Feishu App notifications use `post` with exactly one `md` node, and WeChat ClawBot continues to receive the same Markdown unchanged. The change must preserve delivery confirmation, idempotency, retry, and ambiguity semantics.
+
+## Success Signals
+
+- Feishu proactive payload is `msg_type=post` with `zh_cn.content=[[{"tag":"md","text": markdown}]]` and no `title`.
+- WeChat receives byte-for-byte identical canonical Markdown through its existing `text` path.
+- Oversized Feishu post requests fail before token acquisition or message HTTP, with structured non-content diagnostics and no retry/fallback.
+- Timeout, transient, confirmed, or ambiguous post attempts never auto-fallback to text.
+- Focused and broader regression suites, static checks, compileall, and diff checks pass.
+
+## Scope Boundary
+
+In scope: Feishu proactive sender payload/preflight, notification adapter normalization, scheduled-notification diagnostic propagation, tests, and Agent Wiki documentation.
+
+Out of scope: business-renderer rewrites, Feishu inbound replies/outbox, WeChat protocol changes, runtime format switches, fragmentation/truncation, production config, live notifications, release, deployment, and remote upgrade.
+
+## Direct Evidence and First-principles Judgment
+
+- `src/infrastructure/feishu_bot.py` owns Feishu message payload and transport retry behavior.
+- `src/application/notification_delivery_adapter.py` currently routes proactive Feishu notifications through `send_text_message()` while WeChat has an independent adapter.
+- `src/application/scheduled_notification.py` owns per-attempt audit/retry state and must retain provider-local deterministic failure details without learning Feishu payload shape.
+- Existing business renderers already produce the canonical Markdown required by both channels; adding channel-specific renderers or a registry would duplicate ownership without a current need.
+
+## Product Decisions Already Confirmed
+
+The user selected Feishu方案 B (`post` + single `md` node), kept WeChat Markdown, required controlled code/version rollback to text if visual acceptance fails, accepted the revised size/preflight contract, and explicitly instructed Gateflow execution using the revised plan and second review.
+
+## Blocking Open Questions
+
+None for local implementation. Real Feishu canaries remain separately authorization-gated.
+
+## Residual Risks
+
+- Feishu desktop/mobile rendering and exact live API acceptance remain external risks assigned to the separately approved canary gate.
+- The deliberate fail-closed size policy can leave an oversized notification unsent; operator replay is only allowed after controlled rollback and explicit decision.
+
+## Next Entry Point
+
+`accepted plan commit`

--- a/docs/gateflow/channel-aware-notification-rendering-mobile-flat-fix-20260721-175409.md
+++ b/docs/gateflow/channel-aware-notification-rendering-mobile-flat-fix-20260721-175409.md
@@ -1,0 +1,88 @@
+# Gateflow Fix Artifact — Mobile-flat Notification Rendering
+
+## Scope and Decision
+
+- Work unit: `channel-aware-notification-rendering`
+- Reopened gate: `Slice 5 — visual acceptance`
+- Trigger: later operator feedback that two-level Markdown indentation is difficult to read on Feishu mobile
+- Fix status: implementation, aggregate review/re-review, and deterministic validation complete; pending new canary authorization
+- Safety boundary: no runtime config change, no real notification send, no merge, no release, and no deployment
+
+The provider contract remains unchanged:
+
+- Feishu proactive notifications use `post` with exactly one `md` node.
+- WeChat ClawBot receives the same canonical Markdown string.
+- Feishu request-size preflight, idempotency, retry, delivery confirmation, and controlled text rollback semantics are unchanged.
+
+## P0 Presentation Contract
+
+All proactive notification families now follow the same mobile-first rules:
+
+1. Use one `# OM · <message family> · <account/component>` primary title when the message is standalone.
+2. Present status, market, time, conclusion, diagnostics, and business facts as flat `字段｜值` lines.
+3. Use only limited `##` sections for major groups; do not use Markdown tables.
+4. Do not emit nested Markdown lists. Candidate/position detail is flattened into adjacent field lines rather than indented child bullets.
+5. Display user-facing ISO timestamps in Beijing time without changing stored or audited timestamps.
+6. Preserve business values and safety statements, including assigned-stock confirmation-before-write and Combo Yield relation-pending behavior.
+
+## Implemented Families
+
+- Daily Brief: flat title/status/market/data shell; flat candidate, position, omission, change, and capacity lines.
+- Compact Tick and Legacy Tick: common Decision Brief title/status/time/conclusion shell; flat candidate detail, close-advice, missing-data, and cash lines.
+- No-candidate heartbeat: represented as a Decision Brief state rather than a special sentence-only template.
+- Delivery failure: flat System Alert shell and one line per failed account.
+- OpenD failure/recovery: flat System Alert/System Notice shell with Beijing time, impact/result, reason, diagnostic code, and optional detail.
+- Trade receipt: flat Receipt shell, explicit status, transaction fields, confirmation-safe assigned-stock choices, and preserved Combo Yield relation warning.
+- Position maintenance receipt: flat Receipt shell, result summary, Beijing time, completed rows, and failure rows.
+
+## Deterministic Validation
+
+Final validation after aggregate review fixes:
+
+```text
+Focused renderer/delivery suite: 178 passed
+Broad daily-brief/multi-tick/notification suite: 348 passed
+Ruff: passed
+compileall: passed
+Git diff whitespace check: passed
+```
+
+Representative tests enforce:
+
+- one primary H1 for standalone messages;
+- no `###` headings in final messages;
+- no Markdown blockquotes or nested ordered/unordered lists;
+- no Markdown tables;
+- real no-candidate pipeline fragments wrap into Legacy/Compact scheduled shells without a second H1;
+- real cash footer rows become flat `账户｜...` and `数据｜...` fields;
+- preserved business values and delivery identity projection into the Feishu single `md` node.
+
+## Aggregate Review Closure
+
+- Initial aggregate review: `docs/reviews/code-review-20260721-180557.md`
+- Re-review: `docs/reviews/code-review-20260721-181035.md`
+- `DR-MF-01` — accepted — fixed: no-candidate pipeline output is a body fragment; standalone heartbeat retains the Decision Brief shell.
+- `DR-MF-02` — accepted — fixed: actual cash footer Markdown is flattened in Legacy, Compact, and heartbeat paths.
+- Blocking open questions: none.
+- Aggregate review status: pass.
+
+## Canary State
+
+- The previous API/readback evidence remains valid.
+- The previous visual qualification is superseded and marked `needs-fix` in `docs/gateflow/channel-aware-notification-rendering-canary-20260721-164120.md`.
+- No new canary was sent during this fix.
+- A new five-category canary requires separate explicit operator authorization.
+- If the corrected flat Post presentation still fails product acceptance, follow the existing controlled code/version rollback to text; do not auto-fallback after an ambiguous or confirmed Post send.
+
+## Deferred P1 Work Unit — Renderer Consolidation
+
+P1 is intentionally excluded from this P0 fix and must run as a separate work unit with its own plan and reviews:
+
+1. Daily Brief becomes the only primary renderer for scheduled notifications.
+2. Compact Tick enters a compatibility period.
+3. Legacy Tick is marked deprecated and then removed.
+4. No-candidate becomes a Decision Brief state owned by the primary renderer.
+5. OpenD and delivery-failure messages share one System Notice shell.
+6. Trade and maintenance messages share one Receipt shell.
+
+This separation avoids combining a presentation correction with renderer ownership migration and deletion risk.

--- a/docs/gateflow/channel-aware-notification-rendering-pr-review-20260721-154242.md
+++ b/docs/gateflow/channel-aware-notification-rendering-pr-review-20260721-154242.md
@@ -1,0 +1,44 @@
+# Gateflow PR Review — Channel-aware Notification Rendering
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Gate: `PR review -> fix -> re-review`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/108`
+- Initial review: `docs/reviews/pr-108-review-20260721-154212.md`
+- Re-review: `docs/reviews/pr-108-review-20260721-154242.md`
+- Decision: `pass`
+- Artifact path: `docs/gateflow/channel-aware-notification-rendering-pr-review-20260721-154242.md`
+
+## Finding Decision and Status
+
+- Material findings: none.
+- Accepted findings requiring fix: none.
+- Fix gate: not applicable.
+- Re-review: passed without production/test changes.
+
+## Validation
+
+- Local aggregate notification regression suite: `205 passed`.
+- Ruff: passed.
+- compileall: passed.
+- `git diff --check`: passed.
+- GitHub checks: Analyze (actions), Analyze (python), CodeQL, agent-plugin, and guardrails all passed.
+
+## PR Contract Check
+
+- Draft PR title/body match implemented scope and do not claim live canary, release, deployment, or rollback execution.
+- PR is Draft and remains open; it was not marked ready, approved, merged, assigned reviewers, or externally commented on.
+- No issue association is required because this work unit was not provided as a numbered issue.
+
+## Residual Risks and Owner
+
+- Live Feishu API and desktop/mobile rendering: operator-owned, tracked by the separately authorized five-category canary/rollback gate.
+- Rollback on failed visual/API acceptance: operator-controlled code/version rollback to the text sender; no automatic fallback.
+
+Residual risks are classified and do not block `draft-PR-pass`.
+
+## Completion Status / Next Entry Point
+
+- Current gate: `accepted PR review commit`
+- Next entry point after commit and push: `draft-PR-pass -> final closeout`

--- a/docs/gateflow/channel-aware-notification-rendering-slice-1-fix-20260721-151457.md
+++ b/docs/gateflow/channel-aware-notification-rendering-slice-1-fix-20260721-151457.md
@@ -1,0 +1,36 @@
+# Gateflow Fix — Channel-aware Notification Rendering Slice 1
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Slice: `1 — Infrastructure payload and size preflight`
+- Gate: `fix`
+- Accepted finding: `S1-DR-01`
+
+## Finding Decision and Fix
+
+### S1-DR-01 — accepted — fixed
+
+Added deterministic boundary tests for both UUID states. Each test derives an ASCII Markdown length whose full serialized outer request body is exactly 28 KiB, proves that exact-budget requests reach token/HTTP once, and proves budget-plus-one requests fail before any additional token/HTTP call. The UUID case uses a smaller Markdown threshold, so omitting UUID from production accounting would make the test fail.
+
+No production abstraction or behavior change was needed.
+
+## Changed Files
+
+- `tests/test_feishu_bot.py`
+
+## Validation
+
+- `tests/test_feishu_bot.py` -> `18 passed`.
+- Ruff on Slice 1 files -> passed.
+- compileall on Slice 1 files -> passed.
+- `git diff --check` -> passed.
+
+## Residual Risks
+
+- Application adapter and scheduled-delivery semantics remain covered by later approved slices.
+- Real Feishu API/client behavior remains assigned to explicit canary approval.
+
+## Next Entry Point
+
+Slice 1 re-review.

--- a/docs/gateflow/channel-aware-notification-rendering-slice-1-implementation-20260721-151350.md
+++ b/docs/gateflow/channel-aware-notification-rendering-slice-1-implementation-20260721-151350.md
@@ -1,0 +1,43 @@
+# Gateflow Implementation — Channel-aware Notification Rendering Slice 1
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Slice: `1 — Infrastructure payload and size preflight`
+- Gate: `implementation`
+- Base commit: `bb128bb1` (`gateflow: accept plan for channel-aware-notification-rendering`)
+
+## Scope Implemented
+
+- Added `send_post_message()` at the Feishu infrastructure boundary.
+- Built `msg_type=post` with one `zh_cn.content` `md` node and no title.
+- Preserved existing open-id/Markdown strip validation, UUID inclusion, transport retry count, and log callback behavior.
+- Added exact final-payload UTF-8 byte measurement before token acquisition or message HTTP.
+- Added 28 KiB fail-closed behavior using `FeishuPermanentError` and non-content diagnostics.
+- Kept `send_text_message()` and `reply_text_message()` behavior unchanged.
+
+## Changed Files
+
+- `src/infrastructure/feishu_bot.py`
+- `tests/test_feishu_bot.py`
+
+## Validation
+
+- `PYTHONPYCACHEPREFIX=/tmp/om-channel-render python3.12 -m pytest -q -p no:cacheprovider tests/test_feishu_bot.py` -> `16 passed`.
+- `python3.12 -m ruff check src/infrastructure/feishu_bot.py tests/test_feishu_bot.py` -> passed.
+- `PYTHONPYCACHEPREFIX=/tmp/om-channel-render python3.12 -m compileall -q src/infrastructure/feishu_bot.py tests/test_feishu_bot.py` -> passed.
+- `git diff --check` -> passed.
+
+## Docs Decision
+
+No docs change in Slice 1; the approved plan assigns public/operator documentation to Slice 4.
+
+## Residual Risks and Uncovered Areas
+
+- Exact one-byte boundary behavior and UUID-induced boundary crossing require stronger deterministic tests; assigned to the Slice 1 code-review loop.
+- Application adapter normalization and scheduled retry/audit semantics are covered by approved Slices 2 and 3.
+- Real Feishu API/client rendering remains assigned to the separately authorized canary gate.
+
+## Completion Status
+
+Implementation complete; next gate is Slice 1 code review.

--- a/docs/gateflow/channel-aware-notification-rendering-slice-2-implementation-20260721-151819.md
+++ b/docs/gateflow/channel-aware-notification-rendering-slice-2-implementation-20260721-151819.md
@@ -1,0 +1,43 @@
+# Gateflow Implementation — Channel-aware Notification Rendering Slice 2
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Slice: `2 — Feishu application adapter and normalization`
+- Gate: `implementation`
+- Base commit: `c6d7a802`
+
+## Scope Implemented
+
+- Switched proactive Feishu App delivery from `send_text_message(text=...)` to `send_post_message(markdown=...)`.
+- Preserved bot credentials, resolved open ID, request path, caller idempotency key/UUID, message-ID confirmation, and failure stage.
+- Copied deterministic local size diagnostics from `FeishuPermanentError.response` without copying notification content.
+- Normalized `FEISHU_POST_TOO_LARGE` as both provider-local `local_error_code` and generic `error_code`.
+- Preserved empty HTTP-attempt history, no ambiguity, and no duplicate risk for HTTP-before-send size rejection.
+- Added an explicit regression proving Feishu receives canonical Markdown through `markdown` while WeChat receives the identical string through `text`.
+
+## Changed Files
+
+- `src/application/notification_delivery_adapter.py`
+- `tests/test_feishu_notification_sender.py`
+
+## Validation
+
+- Feishu infrastructure + notification sender suite -> `40 passed`.
+- Ruff on Slice 2 files -> passed.
+- compileall on Slice 2 files -> passed.
+- `git diff --check` -> passed.
+
+## Docs Decision
+
+No docs change in Slice 2; public/operator documentation remains assigned to Slice 4.
+
+## Residual Risks and Uncovered Areas
+
+- Scheduled retry/audit result propagation is covered by approved Slice 3.
+- Direct trade/maintenance receipt propagation and real-renderer fixture contracts are covered by Slice 4.
+- Live Feishu rendering remains assigned to separately authorized canaries.
+
+## Completion Status
+
+Implementation complete; next gate is Slice 2 code review.

--- a/docs/gateflow/channel-aware-notification-rendering-slice-3-implementation-20260721-152100.md
+++ b/docs/gateflow/channel-aware-notification-rendering-slice-3-implementation-20260721-152100.md
@@ -1,0 +1,41 @@
+# Gateflow Implementation — Channel-aware Notification Rendering Slice 3
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Slice: `3 — Audit/retry semantics`
+- Gate: `implementation`
+- Base commit: `083af082`
+
+## Scope Implemented
+
+- `_notify_error_code()` now prefers a normalized generic `error_code` before existing SEND_FAILED/SEND_UNCONFIRMED fallback logic.
+- Per-attempt records and audit extras preserve the Feishu local size error, exact body/budget bytes, normalized character count, and content hash.
+- Failed send results and per-account failure records preserve the same diagnostics.
+- `FEISHU_POST_TOO_LARGE` remains outside the retryable error-code allowlist, so it stops after one local attempt even when `max_attempts > 1`.
+- Existing timeout, exception, SEND_FAILED, and SEND_UNCONFIRMED branches were not changed.
+
+## Changed Files
+
+- `src/application/scheduled_notification.py`
+- `tests/test_scheduled_notification_application.py`
+
+## Validation
+
+- Scheduled notification application, multi-account, and existing retry contract suites -> `33 passed`.
+- Ruff on Slice 3 files -> passed.
+- compileall on Slice 3 files -> passed.
+- `git diff --check` -> passed.
+
+## Docs Decision
+
+No docs change in Slice 3; the operator contract is assigned to Slice 4.
+
+## Residual Risks and Uncovered Areas
+
+- Direct receipt error propagation, renderer fixture contracts, and docs remain in approved Slice 4.
+- Live Feishu API/client behavior remains assigned to explicit canary authorization.
+
+## Completion Status
+
+Implementation complete; next gate is Slice 3 code review.

--- a/docs/gateflow/channel-aware-notification-rendering-slice-4-implementation-20260721-152938.md
+++ b/docs/gateflow/channel-aware-notification-rendering-slice-4-implementation-20260721-152938.md
@@ -1,0 +1,60 @@
+# Gateflow Implementation — Channel-aware Notification Rendering Slice 4
+
+## Gate
+
+- Work unit: `channel-aware-notification-rendering`
+- Slice: `4 — Renderer fixtures, docs and full validation`
+- Gate: `implementation`
+- Base commit: `24ec65fd`
+
+## Scope Implemented
+
+- Added a real-renderer contract that generates and passes five current notification shapes through the Feishu post sender:
+  1. Daily Decision Brief with H1/H2, quote, ordered and nested lists, Chinese money/contracts.
+  2. Compact Tick with candidate, position, missing-data, and cash sections.
+  3. Trade Receipt with field-oriented contract details and candidate-lot confirmation.
+  4. Maintenance Receipt with field rows, applied-detail list, and error list.
+  5. Failure/Recovery summary with error code, attempts, confirmation, and message ID fields.
+- Asserted each normalized renderer output is embedded unchanged as the one `md` node and no title is added.
+- Added direct trade and maintenance receipt regressions proving normalized `FEISHU_POST_TOO_LARGE` remains a failed, unconfirmed receipt error.
+- Updated `docs/AGENT_WIKI.md` with canonical Markdown ownership, Feishu single-md post projection, WeChat identity behavior, 28 KiB HTTP-before-send fail-closed semantics, no automatic fallback, and explicit canary/rollback authorization boundaries.
+- Did not modify any business renderer implementation.
+
+## Changed Files
+
+- `tests/test_feishu_bot.py`
+- `tests/test_trades_receipt.py`
+- `tests/test_positions_maintenance_receipt.py`
+- `docs/AGENT_WIKI.md`
+
+## Validation
+
+### Focused
+
+`tests/test_feishu_bot.py tests/test_feishu_notification_sender.py tests/test_scheduled_notification_application.py` -> `54 passed`.
+
+### Broader
+
+`tests/test_scheduled_notification_multi_account_application.py tests/test_trades_receipt.py tests/test_positions_maintenance_receipt.py tests/test_multi_tick_notify_format.py tests/test_notification_compact.py tests/test_daily_decision_brief_renderer.py tests/test_daily_decision_brief_notification_flow.py` -> `93 passed`.
+
+### Static
+
+- Ruff on all changed production/test Python files -> passed.
+- compileall on changed production/tests and real renderer modules -> passed.
+- `git diff --check` -> passed.
+
+An initial fixture assertion used result fields that the existing trade receipt intentionally does not read for contract facts. The fixture was corrected to use the receipt's real payload/diagnostics contract before the passing validation above; no production behavior was changed.
+
+## Docs Decision
+
+Updated the Agent Wiki because channel projection, provider byte budget, deterministic failure behavior, replay, canary, and rollback boundaries are operator-visible safety contracts. No config key, CLI, schema, or runtime example changed.
+
+## Residual Risks and Uncovered Areas
+
+- Real Feishu post API acceptance and desktop/mobile visual behavior cannot be proven locally; assigned to Slice 5, which remains blocked on separate explicit user approval.
+- A near-28-KiB live canary was not sent; deterministic exact-boundary tests cover the local contract.
+- No production config, live notification, release, deployment, or remote state was changed.
+
+## Completion Status
+
+Local implementation complete; next gate is Slice 4 code review.

--- a/docs/plans/channel-aware-notification-rendering-plan-20260721.md
+++ b/docs/plans/channel-aware-notification-rendering-plan-20260721.md
@@ -1,0 +1,461 @@
+# 渠道感知通知渲染实施计划
+
+> 日期：2026-07-21
+> 状态：Revised after `docs/reviews/plan-review-20260721-142232.md`
+> 基线：`main@9b1e200ed313407c3f20708a33549ba0d5e46cf0` / `VERSION=1.4.0`
+
+## 1. 目标
+
+在不拆分业务 renderer、不改变微信 ClawBot Markdown、不改变通知幂等与确认语义的前提下：
+
+1. 飞书 App 主动通知改用 `msg_type=post`；
+2. 每条飞书 post 的 `zh_cn.content` 只包含一个 `md` node；
+3. 微信 ClawBot 继续收到原始 canonical Markdown；
+4. 飞书 post 不符合视觉或协议预期时，通过受控代码/版本回滚恢复 `text`；
+5. 禁止 post 已发起、超时或结果不明确后，在同一业务事件内自动补发 text；HTTP 前确定失败按第 2.3 节恢复。
+
+## 2. 已锁定决策
+
+### 2.1 渠道投影
+
+```text
+Business facts / structured brief
+        │
+        ▼
+Existing business renderer
+        │
+        ▼
+Canonical Markdown string
+        │
+        ├── Feishu adapter
+        │      └── msg_type=post
+        │          content.zh_cn.content =
+        │          [[{"tag":"md","text": markdown}]]
+        │
+        └── WeChat adapter
+               └── existing text_item.text = markdown
+```
+
+- 不创建 Feishu/WeChat 两套业务 renderer。
+- 不新增 renderer registry、message DTO、content enum、middleware 或运行时 format config。
+- 微信 projection 是 identity；不新增 `render_wechat_markdown()`。
+- `post.title` 是可选字段，但本 slice **有意省略**，继续使用 canonical Markdown 内的 H1，避免双标题。
+- Feishu inbound reply/outbox 继续使用现有 `reply_text_message()`；本计划只改变主动通知链路。
+
+### 2.2 超限策略：HTTP 前 fail-closed
+
+飞书官方限制 text 最大 150 KB、post 最大 30 KB。为避免静默丢字段，并保持“发现方案 B 不符合预期后受控回滚”的产品要求，本计划选择：
+
+- **不截断** canonical Markdown；
+- **不拆成多条消息**；
+- **不自动 fallback 到 text**；
+- 在任何 token 获取或消息 HTTP 请求前，计算最终请求体的 UTF-8 byte size；若超过安全预算，立即 fail-closed。
+
+安全预算固定为：
+
+```python
+FEISHU_POST_REQUEST_BUDGET_BYTES = 28 * 1024
+```
+
+理由：28 KiB 同时低于 30,000 bytes 和 30 KiB，为平台口径、字段增长和序列化差异保留余量。
+
+byte size 必须基于**最终完整 payload**，并使用与 `http_json()` 相同的序列化方式：
+
+```python
+len(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+```
+
+计算必须包含：
+
+- `receive_id`；
+- `msg_type`；
+- 已二次 JSON 序列化的 `content` string；
+- 可选 `uuid`。
+
+超限时使用现有 `FeishuPermanentError`，不得伪造上游 HTTP 状态或飞书业务 code：
+
+```text
+local_error_code = FEISHU_POST_TOO_LARGE
+http_status = None
+feishu_code = None
+http_attempts = []
+```
+
+错误结果至少包含：
+
+- `request_body_bytes`；
+- `request_body_budget_bytes`；
+- `normalized_markdown_chars`；
+- `normalized_markdown_sha256`；
+- `local_error_code=FEISHU_POST_TOO_LARGE`。
+
+不记录原始通知正文。
+
+`scheduled_notification` 必须保留该 local error 和大小诊断：
+
+- Feishu normalizer 同时输出 `local_error_code` 和通用 `error_code=FEISHU_POST_TOO_LARGE`；`_notify_error_code()` 优先返回 normalized `error_code`；
+- attempt/audit record 保存上述大小字段；
+- 因 `FEISHU_POST_TOO_LARGE` 不在 retryable error code 集合中，同一执行不得重复尝试；
+- 既有 failure summary 可汇总该失败，failure summary 本身仍使用同一 Feishu post sender；若 summary 也超限，则同样 fail-closed，不做 text fallback。
+
+### 2.3 幂等、重试和回滚
+
+- notification idempotency key 继续基于调用方传入的**原始 canonical Markdown**构造；算法不变。
+- 合法 post payload 在所有 HTTP retry 中复用相同 `uuid` 和完全相同的 payload。
+- 没有 UUID 时维持单次 HTTP attempt；有 UUID 时维持现有最多三次 transport retry。
+- 本地 size failure 发生在 HTTP 前：没有 ambiguous send、没有 duplicate risk、没有 transport retry。
+- timeout 或 transient failure 后禁止自动改发 text，因为 post 可能已被飞书接受。
+- 回滚是代码/版本回滚：停止 rollout，保留 evidence，把 adapter 恢复为 `send_text_message()`，跑测试并发布修复版本；使用新的 canary/run ID 验证 text。
+- 已确认送达或存在 ambiguous send 的 post，不为同一业务事件补发 text。
+- `FEISHU_POST_TOO_LARGE` 在 token/HTTP 前确定失败，已证明没有上游发送；完成 text 代码回滚后，operator 可显式决定是否以新的 transport UUID 重放该业务通知，并把重放记录关联到原 size-failure audit。不得由原执行自动 fallback。
+
+## 3. Payload Contract
+
+目标短消息 payload：
+
+```python
+payload = {
+    "receive_id": open_id,
+    "msg_type": "post",
+    "content": json.dumps(
+        {
+            "zh_cn": {
+                "content": [
+                    [
+                        {
+                            "tag": "md",
+                            "text": markdown,
+                        }
+                    ]
+                ]
+            }
+        },
+        ensure_ascii=False,
+    ),
+}
+if uuid:
+    payload["uuid"] = str(uuid)
+```
+
+不添加 `title`，不解析第一行，不把 Markdown 拆为多个 post node。
+
+输入 normalization 与现有 text sender 对齐：
+
+- `open_id = str(open_id or "").strip()`；
+- `markdown = str(markdown or "").strip()`；
+- size metadata 中的 `normalized_markdown_*` 均基于上述 strip 后、实际准备发送的 Markdown；调用方原文仍用于既有 idempotency key；
+- 空或纯空白 open ID：`ValueError("open_id is required")`；
+- 空或纯空白 Markdown：`ValueError("markdown is required")`。
+
+## 4. Implementation Boundary
+
+### 4.1 `src/infrastructure/feishu_bot.py`
+
+1. 保留 `send_text_message()` 和 `reply_text_message()` 行为不变。
+2. 新增：
+
+```python
+def send_post_message(
+    *,
+    app_id: str,
+    app_secret: str,
+    open_id: str,
+    markdown: str,
+    uuid: str | None = None,
+    log_fn: Callable[[dict[str, Any]], Any] | None = None,
+    http_json_fn: HttpJsonFn = http_json,
+) -> dict[str, Any]:
+    ...
+```
+
+3. `send_post_message()` 负责：
+   - 输入校验；
+   - 构造唯一 `md` node；
+   - 构造最终 payload；
+   - 在 token 获取和 HTTP 调用前执行 28 KiB preflight；
+   - 合法 payload 沿用现有 token/UUID/retry/logging 语义；
+   - 超限抛出带结构化 response metadata 的 `FeishuPermanentError`。
+4. 可添加小型 private helper 构造 post payload和计算 bytes；不引入类、通用 builder 或 provider-neutral abstraction。
+5. 是否抽取 text/post 公用 send helper 由实现时最小 diff 决定；不得改变现有 text tests 的行为。
+
+### 4.2 `src/application/notification_delivery_adapter.py`
+
+1. 将 Feishu 主动通知从：
+
+```python
+send_text_message(text=message, ...)
+```
+
+切换为：
+
+```python
+send_post_message(markdown=message, ...)
+```
+
+2. 保留凭据解析、bot open ID、request path、UUID、HTTP attempt logging、message ID 提取和 delivery confirmation。
+3. 捕获 size preflight 的 `FeishuPermanentError` 时，把 exception response 中的以下字段复制到 send result：
+   - `local_error_code`；
+   - `request_body_bytes`；
+   - `request_body_budget_bytes`；
+   - `normalized_markdown_chars`；
+   - `normalized_markdown_sha256`。
+4. `normalize_feishu_app_send_output()` 把这些字段原样放入 normalized extra；size failure 同时设置通用 `error_code=FEISHU_POST_TOO_LARGE`，使 scheduled notification、trade receipt 和 maintenance receipt 的既有结果组装自动保留该错误；不得把本地错误伪装成 Feishu `230025`。
+5. `request_path`、failure stage 和 tool name 保持不变。
+
+### 4.3 `src/application/scheduled_notification.py`
+
+1. `_notify_error_code()` 优先采用 normalized `error_code`，否则维持 `SEND_UNCONFIRMED` / `SEND_FAILED`。
+2. send attempt/audit record 增加 size/local-error 字段透传。
+3. 不把 `FEISHU_POST_TOO_LARGE` 加入 `NOTIFY_SEND_RETRYABLE_ERROR_CODES`。
+4. 不修改通用发送状态机、confirmation 规则、idempotency key 或 failure-summary 生成逻辑。
+
+### 4.4 不修改的业务 renderer
+
+```text
+src/application/multi_tick/notify_format.py
+src/application/daily_decision_brief_renderer.py
+src/application/trades/receipt.py
+src/application/positions/maintenance_receipt.py
+src/application/tick_notification_flow.py
+```
+
+原因：业务 renderer 继续维护 canonical Markdown；飞书容量是 provider contract，不下沉到业务层，也不缩短微信内容。
+
+## 5. Covered Notification Paths
+
+共享 `NotificationDeliveryAdapter` 的变化覆盖：
+
+- legacy/compact tick notifications；
+- Daily Decision Brief；
+- multi-account delivery failure summary；
+- OpenD failure/recovery notices；
+- trade-intake receipts；
+- option-position auto-close/maintenance receipts。
+
+当前 committed runtime route 使用 `wechat_clawbot`，且 Daily Brief 默认关闭。本 work unit 不修改任何运行时 config。
+
+## 6. Test Plan
+
+### 6.1 `tests/test_feishu_bot.py`
+
+保留所有现有 text/reply/reaction tests，并新增：
+
+1. 短消息 payload：
+   - `msg_type == "post"`；
+   - `json.loads(payload["content"]) == {"zh_cn":{"content":[[{"tag":"md","text": markdown}]]}}`；
+   - 没有 `title`；
+   - Chinese、Unicode、引号、换行保持正确。
+2. UUID/retry：
+   - 有 UUID 时 payload 包含 UUID、HTTP retry attempts 为 3；
+   - 无 UUID 时不包含 UUID、HTTP retry attempts 为 1。
+3. 校验：空 open ID、空 Markdown、纯空白 Markdown。
+4. byte preflight：
+   - ASCII、中文、emoji、引号和大量换行均按最终 outer request body 计算；
+   - 低于 28 KiB 时原文不变并发生一次 HTTP 调用；
+   - 高于 28 KiB 时抛出 `FeishuPermanentError`，`http_json_fn` 和 token 获取均未调用；
+   - error metadata 包含 bytes/budget/chars/hash，不包含原文；
+   - 有/无 UUID 的边界分别覆盖。
+
+### 6.2 `tests/test_feishu_notification_sender.py`
+
+1. mock/capture `send_post_message(markdown=...)`；验证 credentials、open ID、UUID 和 message normalization 不变。
+2. 验证 Feishu API 成功仍需 `code=0 + message_id` 才 delivery confirmed。
+3. 验证 size preflight error 被归一化为：
+   - `command_ok=False`；
+   - `delivery_confirmed=False`；
+   - `local_error_code=FEISHU_POST_TOO_LARGE`；
+   - `error_code=FEISHU_POST_TOO_LARGE`；
+   - `http_attempts=[]`；
+   - `ambiguous_send=False`；
+   - `duplicate_risk=False`。
+4. 渠道分歧回归：
+   - Feishu sender 收到原始 canonical Markdown 的 `markdown` 参数；
+   - WeChat sender 收到完全相同原文的 `text` 参数。
+
+### 6.3 `tests/test_scheduled_notification_application.py`
+
+新增 local size failure 状态机测试：
+
+- attempt record/audit 保存 `FEISHU_POST_TOO_LARGE` 和 byte diagnostics；
+- `will_retry=False`，即使 `max_attempts > 1`；
+- 不改变其他 `SEND_FAILED` / `SEND_UNCONFIRMED` retry 行为；
+- failure summary 能看到该 error code。
+
+### 6.4 Direct receipt error propagation
+
+在 `tests/test_trades_receipt.py` 和 `tests/test_positions_maintenance_receipt.py` 增加回归：
+
+- normalized sender 返回 `error_code=FEISHU_POST_TOO_LARGE` 时，receipt result 保留同一 error code；
+- `delivery_confirmed=False`、`status=failed`；
+- 不需要修改两个 receipt 的业务 renderer 或消息正文。
+
+### 6.5 Renderer fixture contract
+
+使用当前真实 renderer 生成至少以下 fixture，并把**原样输出**送入 Feishu payload test：
+
+1. Daily Brief：H1/H2、quote、ordered/nested list、bold、中文金额和合约；
+2. compact tick：候选、持仓、资金、缺数提示；
+3. trade receipt：普通字段行、候选 lot、状态和原因；
+4. maintenance receipt：普通字段行、明细列表、错误列表；
+5. failure/recovery notice：failure summary 或 OpenD recovery message。
+
+fixture test 证明 payload 未重写 canonical Markdown；视觉表现由 canary gate 验收。
+
+### 6.6 Focused validation
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om-channel-render \
+python3.12 -m pytest -q -p no:cacheprovider \
+  tests/test_feishu_bot.py \
+  tests/test_feishu_notification_sender.py \
+  tests/test_scheduled_notification_application.py
+```
+
+### 6.7 Broader regression
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om-channel-render \
+python3.12 -m pytest -q -p no:cacheprovider \
+  tests/test_scheduled_notification_multi_account_application.py \
+  tests/test_trades_receipt.py \
+  tests/test_positions_maintenance_receipt.py \
+  tests/test_multi_tick_notify_format.py \
+  tests/test_notification_compact.py \
+  tests/test_daily_decision_brief_renderer.py \
+  tests/test_daily_decision_brief_notification_flow.py
+```
+
+另运行项目支持的 Ruff/static checks、`compileall` 和 `git diff --check`。
+
+## 7. Canary Acceptance Matrix
+
+真实 canary 是通知发送，必须单独获得用户明确批准。实施、测试或 review 阶段不得自动发送。
+
+每条 canary 使用独立 canary ID/UUID，不复用真实业务事件的 idempotency key；按以下顺序发送并保存 message ID、响应摘要、桌面端和移动端截图：
+
+| 类别 | 必须使用的内容来源 | 主要验收点 |
+|---|---|---|
+| Daily Brief | 当前 renderer fixture | H1/H2、quote、ordered/nested list、bold、中文、金额、合约 |
+| Compact Tick | 当前 renderer fixture | 候选/持仓/资金分区、列表缩进、缺数提示 |
+| Trade Receipt | 当前 renderer fixture | 一字段一行仍清晰、候选 lot 不合并、状态/原因完整 |
+| Maintenance Receipt | 当前 renderer fixture | 字段行、明细列表、错误列表层次清晰 |
+| Failure/Recovery | 当前 renderer fixture | 错误 code、attempt、message ID 等诊断不丢失 |
+
+每类都必须满足：
+
+- message ID 存在且 delivery confirmed；
+- 不显示原始 `#`、`##`、`**` 等未解析标记；
+- 没有 JSON 转义泄漏；
+- 字段未丢失、未截断；
+- 中文、金额、合约数量保持；
+- 桌面端和移动端可读性不低于当前 text；
+- trade/maintenance receipt 保持“一字段一行”的视觉语义。
+
+任一关键类别失败：停止 rollout，不继续后续类别；记录 evidence，进入受控 text 回滚。不得为刚才已确认送达的 canary 补发 text。
+
+size boundary 主要由 deterministic tests 证明。除非用户另行批准，不发送接近 28 KiB 的超长真实 canary。
+
+## 8. Rollback Procedure
+
+触发条件：
+
+- API 持续拒绝 post；
+- 出现 `FEISHU_POST_TOO_LARGE` 的真实业务消息；
+- 标题、引用、列表或字段行视觉异常；
+- 字段缺失、JSON escape 泄漏或移动端明显退化；
+- delivery confirmation 行为改变。
+
+步骤：
+
+1. 停止 Feishu rollout/canary；
+2. 保留响应、message ID、local error、payload byte summary 和截图；
+3. 把 `notification_delivery_adapter.py` 的 Feishu sender 恢复为 `send_text_message(text=...)`；
+4. 保留 `send_post_message()` 与测试还是删除，由最小、清晰的 rollback diff 决定，不引入 runtime switch；
+5. 运行 focused + broader tests；
+6. 若生产已受影响，发布新的 fix version；
+7. 使用新的 canary/run ID 验证 text；
+8. 不对已确认 post 的同一业务事件补发 text。
+
+## 9. Documentation
+
+更新 `docs/AGENT_WIKI.md`：
+
+- canonical Markdown ownership；
+- Feishu `post` + single `md` node；
+- WeChat identity Markdown；
+- 28 KiB HTTP-before-send fail-closed contract；
+- 禁止自动 text fallback；
+- canary 与回滚需要显式批准。
+
+不修改运行时配置示例，不新增 format key。
+
+## 10. Implementation Slices
+
+### Slice 1 — Infrastructure payload and size preflight
+
+- 修改 `src/infrastructure/feishu_bot.py`；
+- 新增 post payload、28 KiB preflight、permanent local error；
+- 完成 `tests/test_feishu_bot.py`。
+
+**Gate**：text sender tests 全部不变；post payload 与 byte boundary tests 通过。
+
+### Slice 2 — Feishu application adapter and normalization
+
+- 修改 `src/application/notification_delivery_adapter.py`；
+- 切换 post sender；
+- 传播 local size diagnostics；
+- 完成 `tests/test_feishu_notification_sender.py`。
+
+**Gate**：delivery confirmation、UUID、retry、WeChat identity regression 通过。
+
+### Slice 3 — Audit/retry semantics
+
+- 修改 `src/application/scheduled_notification.py`；
+- 保留 local error/size fields；
+- size failure 不重试；
+- 完成 scheduled notification tests。
+
+**Gate**：size failure fail-closed 且 failure summary/audit 可诊断，其他 retry 行为无回归。
+
+### Slice 4 — Renderer fixtures, docs and full validation
+
+- 添加五类真实 renderer fixture contract；
+- 更新 `docs/AGENT_WIKI.md`；
+- 运行 focused/broader/static checks。
+
+**Gate**：所有本地 checks 通过；不发送 canary。
+
+### Slice 5 — Explicitly approved canary and rollout
+
+- 仅在用户明确批准后执行五类 canary；
+- 逐类验收，任一失败立即停止并回滚。
+
+**Gate**：五类全部通过后才可判定 Feishu post rollout 合格。
+
+## 11. Success Criteria
+
+实施完成必须同时满足：
+
+1. 短消息 Feishu payload 严格为 post + single md node；
+2. WeChat 获得与改动前相同的 canonical Markdown；
+3. post 请求体不超过 28 KiB；超限在 HTTP 前失败、无重试、无歧义、可审计；
+4. UUID、retry、message ID confirmation 和 failure stage 不变；
+5. 五类 renderer fixture contract tests 通过；
+6. focused、broader、static checks 全部通过；
+7. 未经批准不发送真实 canary；
+8. 获批后，五类 canary 在桌面端和移动端全部通过；
+9. 若 canary 触发 rollback，恢复 text 后使用新 run ID 验证；已发送或发送状态不明确的事件不得重复。HTTP 前 size failure 可由 operator 在回滚后显式重放，并关联原 audit。
+
+## 12. Explicit Non-goals
+
+- Feishu interactive cards、模板、按钮或 callback；
+- post 多 node 或多消息分片；
+- 自动 text fallback；
+- runtime format feature flag；
+- 改写业务 renderer 以迎合飞书；
+- 修改 Daily Brief lifecycle/revision/diff/confirmation pointer；
+- persisted schema migration；
+- 修改 idempotency key algorithm；
+- inbound Assistant reply 或 Feishu WS reply outbox；
+- 修改微信 sender；
+- 生产 config、release、remote upgrade 或真实通知发送。

--- a/docs/reviews/code-review-20260721-151350.md
+++ b/docs/reviews/code-review-20260721-151350.md
@@ -1,0 +1,34 @@
+# Code Review — Channel-aware Notification Rendering Slice 1
+
+## Findings
+
+### S1-DR-01-未修复-中-测试没有证明精确 28 KiB 边界和 UUID 对最终请求体边界的影响
+- **入口/函数**: `send_post_message()` request-body preflight
+- **文件(行号)**: `src/infrastructure/feishu_bot.py` post byte check; `tests/test_feishu_bot.py` oversized/under-budget tests
+- **输入场景**: 最终 outer JSON body 恰好等于 28 KiB，或同一 Markdown 在无 UUID 时不超限、加入 UUID 后刚好超限。
+- **实际分支**: 生产代码使用 `request_body_bytes > FEISHU_POST_REQUEST_BUDGET_BYTES`；现有测试只覆盖明显低于预算和远高于预算的输入，没有锁定等于预算是否发送、预算加一是否失败，也没有证明 UUID 字段确实参与临界值计算。
+- **预期行为**: 精确等于 28 KiB 应发送；大于预算一个 byte 应在 token/HTTP 前失败；UUID 导致最终 body 越界时也应失败。
+- **实际行为**: 当前实现看起来符合预期，但测试无法防止后续把 `>` 改成 `>=`、改为只量 content、或漏量 UUID 的回归。
+- **直接证据**: 现有 under-budget fixture 约 10 KiB，oversized fixture 远超预算；两者都不是边界输入。oversized test 虽参数化 UUID，但无 UUID 与有 UUID 都远超上限，无法证明 UUID 对 byte accounting 的贡献。
+- **影响**: provider transport safety contract 的核心边界可能在重构后悄然漂移，造成合法临界消息被拒绝，或越界请求进入 token/HTTP。
+- **建议改法和验证点**: 在测试中用与生产完全相同的 outer JSON 结构求出最大可发送 Markdown 长度；断言 body==budget 时发送、body==budget+1 时 fail-closed，并构造无 UUID 可发送但加入 UUID 越界的用例。不要为此增加生产抽象。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Application adapter、scheduled retry/audit、真实客户端视觉尚未进入本 slice；分别由后续 approved slices 和 canary gate 覆盖。
+
+## Review Scope and Decision
+
+- Mode: current changes
+- Base: `bb128bb1`
+- Reviewed target: Slice 1 production and test changes only
+- Project instruction / architecture check: passed; provider payload and size contract remain in infrastructure, no new generalized builder/config/parser introduced.
+- Adversarial failure pass: preflight timing, Unicode serialization, UUID retry, empty input, content disclosure, exact boundary.
+- Overcoupling / semantic ownership drift: none found.
+- Decision: `fail` pending S1-DR-01 fix and re-review.

--- a/docs/reviews/code-review-20260721-151457.md
+++ b/docs/reviews/code-review-20260721-151457.md
@@ -1,0 +1,39 @@
+# Code Re-review — Channel-aware Notification Rendering Slice 1
+
+## Findings
+
+未发现实质性问题。
+
+## Finding Status
+
+- `S1-DR-01`: **已修复**. Exact-budget and budget-plus-one behavior is now locked for both absent and present UUIDs; token/HTTP non-entry on overflow is asserted.
+
+## Review Scope
+
+- Mode: current changes
+- Base: `bb128bb1`
+- Reviewed target: Slice 1 production implementation, tests, implementation artifact, initial review, and fix.
+- Entry path reviewed: input normalization -> single-md payload -> final outer-body serialization -> preflight -> token -> HTTP -> UUID retry/log options.
+- Failure paths reviewed: empty input, Unicode/escaping growth, exact boundary, over-budget, with/without UUID, content disclosure, pre-token failure.
+- Architecture/ownership: provider payload and budget remain in infrastructure; text/reply behavior is unchanged; no renderer/config/state-machine abstraction added.
+- Overcoupling / semantic ownership drift: none.
+
+## Validation Evidence
+
+- `PYTHONPYCACHEPREFIX=/tmp/om-channel-render python3.12 -m pytest -q -p no:cacheprovider tests/test_feishu_bot.py` -> `18 passed`.
+- `python3.12 -m ruff check src/infrastructure/feishu_bot.py tests/test_feishu_bot.py` -> passed.
+- compileall -> passed.
+- `git diff --check` -> passed.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Application normalization and scheduled audit/retry behavior are intentionally outside Slice 1 and covered by approved Slices 2 and 3.
+- Live Feishu API/client rendering remains outside local review and requires explicit canary authorization.
+
+## Decision
+
+`pass`. Slice 1 is ready for accepted slice commit.

--- a/docs/reviews/code-review-20260721-151819.md
+++ b/docs/reviews/code-review-20260721-151819.md
@@ -1,0 +1,42 @@
+# Code Review — Channel-aware Notification Rendering Slice 2
+
+## Findings
+
+未发现实质性问题。
+
+## Review Scope
+
+- Mode: current changes
+- Base: `c6d7a802`
+- Reviewed target: proactive Feishu adapter switch, exception adaptation, normalized delivery contract, and channel identity tests.
+- Entry path: notification channel registry -> Feishu process adapter -> proactive sender -> raw send result -> normalizer -> delivery DTO.
+- Failure path: infrastructure local size error -> application result -> normalized generic/local error -> no HTTP attempts -> no ambiguity/duplicate risk.
+- Regression path: Feishu credentials/open ID/UUID/message-ID confirmation and WeChat identity Markdown.
+
+## Architecture / Safety Review
+
+- Payload construction and byte budget remain owned by infrastructure.
+- Application normalization only transports generic diagnostics; it does not parse Markdown or learn post payload structure.
+- WeChat implementation is unchanged and receives the same canonical Markdown.
+- No automatic text fallback, runtime switch, registry expansion, DTO, parser, or renderer split was added.
+- No raw Markdown is retained in deterministic local error results.
+
+## Validation Evidence
+
+- `tests/test_feishu_bot.py tests/test_feishu_notification_sender.py` -> `40 passed`.
+- Ruff -> passed.
+- compileall -> passed.
+- `git diff --check` -> passed.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Scheduled state-machine propagation and direct receipt contracts are outside Slice 2 and assigned to approved later slices.
+- Real Feishu API/client rendering requires explicit canary authorization.
+
+## Decision
+
+`pass`; no fix required. Re-review may record no-change acceptance before the slice commit.

--- a/docs/reviews/code-review-20260721-151832.md
+++ b/docs/reviews/code-review-20260721-151832.md
@@ -1,0 +1,32 @@
+# Code Re-review — Channel-aware Notification Rendering Slice 2
+
+## Findings
+
+未发现实质性问题。
+
+## Finding Status
+
+- Initial review contained no accepted findings.
+- Fix gate: not applicable; no code or test correction was required.
+
+## Re-review Evidence
+
+Re-read the unchanged Slice 2 diff after the pass decision, including normal and local-error paths. Confirmed that `error_code` is only specialized for the deterministic local size failure, while existing Feishu HTTP/business-code normalization remains unchanged. Confirmed that process adapters retain raw diagnostics and WeChat receives the identical canonical Markdown.
+
+- Feishu infrastructure + notification sender suite: `40 passed`.
+- Ruff: passed.
+- compileall: passed.
+- `git diff --check`: passed.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Scheduled state-machine and direct-receipt propagation remain assigned to approved later slices.
+- External visual/API risk remains assigned to explicit live canaries.
+
+## Decision
+
+`pass`. Slice 2 is ready for accepted slice commit.

--- a/docs/reviews/code-review-20260721-152100.md
+++ b/docs/reviews/code-review-20260721-152100.md
@@ -1,0 +1,40 @@
+# Code Review — Channel-aware Notification Rendering Slice 3
+
+## Findings
+
+未发现实质性问题。
+
+## Review Scope
+
+- Mode: current changes
+- Base: `083af082`
+- Reviewed target: normalized error selection, send retry predicate interaction, attempt/audit records, failed result propagation, per-account failures, and summary rendering.
+- State machine paths: deterministic local failure, retryable SEND_FAILED, local-receipt SEND_UNCONFIRMED, timeout, exception, confirmed success.
+
+## Architecture / State-machine Review
+
+- Scheduled notification consumes only the generic normalized error contract; it does not depend on Feishu post payload shape.
+- The retry allowlist remains the single authority for retryable application errors; no provider-local code was added.
+- Deterministic size failure is terminal for the current execution, with no sleep, retry, ambiguity, duplicate risk, or text fallback.
+- Existing retry/idempotency behavior is unchanged and covered by the broader retry suites.
+- Audit records retain only size metadata/hash, not raw Markdown.
+
+## Validation Evidence
+
+- Scheduled notification + multi-account + retry contract suites -> `33 passed`.
+- Ruff -> passed.
+- compileall -> passed.
+- `git diff --check` -> passed.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Direct receipt and real-renderer contracts remain assigned to approved Slice 4.
+- Live Feishu visual/API behavior remains assigned to separately approved canaries.
+
+## Decision
+
+`pass`; no fix required.

--- a/docs/reviews/code-review-20260721-152112.md
+++ b/docs/reviews/code-review-20260721-152112.md
@@ -1,0 +1,32 @@
+# Code Re-review — Channel-aware Notification Rendering Slice 3
+
+## Findings
+
+未发现实质性问题。
+
+## Finding Status
+
+- Initial review contained no accepted findings.
+- Fix gate: not applicable; no code/test changes were required after review.
+
+## Re-review Evidence
+
+Rechecked the unchanged state-machine diff. `FEISHU_POST_TOO_LARGE` is selected from normalized `error_code`, is absent from `NOTIFY_SEND_RETRYABLE_ERROR_CODES`, produces `will_retry=False`, and retains local diagnostics through attempt, audit, final result, and per-account failure assembly. Existing retry branches remain controlled by the same allowlist and message-ID guards.
+
+- Scheduled notification + multi-account + retry suites: `33 passed`.
+- Ruff: passed.
+- compileall: passed.
+- `git diff --check`: passed.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Direct receipt/renderer/docs work remains in approved Slice 4.
+- Real provider behavior remains canary-gated.
+
+## Decision
+
+`pass`. Slice 3 is ready for accepted slice commit.

--- a/docs/reviews/code-review-20260721-152938.md
+++ b/docs/reviews/code-review-20260721-152938.md
@@ -1,0 +1,42 @@
+# Code Review — Channel-aware Notification Rendering Slice 4
+
+## Findings
+
+未发现实质性问题。
+
+## Review Scope
+
+- Mode: current changes
+- Base: `24ec65fd`
+- Reviewed target: five real-renderer payload contracts, direct receipt error propagation, operator documentation, and full planned validation.
+- Renderer ownership checked: Daily Brief, compact tick, trade receipt, maintenance receipt, and failure summary implementations are unchanged.
+- Channel boundary checked: tests feed renderer output into infrastructure; renderers do not import or depend on Feishu/WeChat.
+
+## Architecture / Adversarial Review
+
+- Real fixtures cover heading/quote/list Markdown and field-oriented receipts without creating a renderer registry or channel-specific business renderers.
+- The payload assertion allows only the existing sender normalization (`strip`) and otherwise requires exact single-node content identity.
+- Direct receipts consume only normalized generic `error_code`; no Feishu payload details leak into receipt logic.
+- Docs match the implemented pre-token size failure, no fallback, ambiguity, replay, and authorization boundaries.
+- No runtime configuration, notification side effect, version, service, or deployment path was changed.
+
+## Validation Evidence
+
+- Focused suite: `54 passed`.
+- Broader suite: `93 passed`.
+- Ruff: passed.
+- compileall: passed.
+- `git diff --check`: passed.
+
+## Open Questions
+
+无 local implementation blocker. Live canary approval is intentionally separate.
+
+## Residual Risk
+
+- Feishu API/client visual behavior is external and remains assigned to the explicit five-category canary gate.
+- Near-limit live behavior remains unverified by design; local byte boundaries are deterministic.
+
+## Decision
+
+`pass`; no fix required.

--- a/docs/reviews/code-review-20260721-152950.md
+++ b/docs/reviews/code-review-20260721-152950.md
@@ -1,0 +1,32 @@
+# Code Re-review — Channel-aware Notification Rendering Slice 4
+
+## Findings
+
+未发现实质性问题。
+
+## Finding Status
+
+- Initial review contained no accepted findings.
+- Fix gate: not applicable; no post-review changes were required.
+
+## Re-review Evidence
+
+Rechecked the unchanged Slice 4 diff and validation records. All five real renderer categories are exercised through the post payload without modifying renderer ownership; direct receipts retain the normalized size error; documentation states the same fail-closed/no-fallback/canary boundaries as code and plan.
+
+- Focused suite: `54 passed`.
+- Broader suite: `93 passed`.
+- Ruff: passed.
+- compileall: passed.
+- `git diff --check`: passed.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Live Feishu API and desktop/mobile rendering remain the only material uncovered area and require separate explicit authorization.
+
+## Decision
+
+`pass`. Slice 4 is ready for accepted slice commit. Slice 5 is not authorized and must not run.

--- a/docs/reviews/code-review-20260721-153650.md
+++ b/docs/reviews/code-review-20260721-153650.md
@@ -1,0 +1,79 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `feat/channel-aware-notification-rendering`
+- Base: `main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`
+- Output file: `docs/reviews/code-review-20260721-153650.md`
+- Included scope: complete accepted plan and four implementation slices; Feishu proactive post payload construction; final-request UTF-8 byte preflight; token/HTTP retry and UUID behavior; delivery adapter normalization; scheduled notification retry/audit propagation; direct trade and maintenance receipts; WeChat identity path; five real renderer contracts; operator documentation; all committed Gateflow artifacts
+- Excluded scope: live Feishu API mutation and desktop/mobile rendering canaries; production configuration; release/deployment; inbound Feishu reply/outbox behavior beyond confirming it remains on the existing text path
+- Parallel review coverage: 无；the combined change was reviewed as one end-to-end notification delivery chain
+
+## Intent and Contract Alignment
+
+The accepted design keeps one canonical Markdown business rendering and changes only the proactive Feishu projection to `msg_type=post` with one `zh_cn.content` `md` node. WeChat ClawBot remains on its existing `text_item.text` projection. Feishu inbound replies remain on `reply_text_message()`.
+
+The current official Feishu message-content documentation was rechecked during review. It recommends the `post` message `md` tag for Markdown, documents the nested rich-text content structure, requires the outer `content` field to be a JSON-serialized string, and states a 30 KB maximum request body for rich-text messages. The implementation's exact outer-body measurement and 28 KiB fail-closed budget are consistent with that contract.
+
+## End-to-End Execution Path Reviewed
+
+```text
+business renderer
+-> canonical Markdown
+-> channel adapter selection
+-> Feishu send_feishu_app_message()
+-> send_post_message()
+-> normalized open_id/Markdown
+-> post + single md payload construction
+-> exact outer JSON UTF-8 byte preflight
+-> tenant token acquisition
+-> message HTTP with stable payload/UUID retry
+-> raw result/FeishuError
+-> normalize_feishu_app_send_output()
+-> scheduled retry/audit or direct receipt result
+```
+
+The WeChat sibling path was followed independently from adapter selection through `send_wechat_clawbot_message()` to `client.send_text_message(text=message)` and remains unchanged.
+
+## Adversarial Failure Review
+
+- Exact 28 KiB final request body is allowed; 28 KiB + 1 byte raises `FeishuPermanentError` before token acquisition or message HTTP, both with and without UUID.
+- Local oversize failure contains no raw Markdown, upstream HTTP status, or fabricated Feishu business code. It retains only the local error code, byte counts, normalized character count, hash, and empty HTTP attempts.
+- The provider-local error becomes normalized `error_code=FEISHU_POST_TOO_LARGE`, remains outside the application retry allowlist, produces one scheduled attempt, no sleep/retry, and no ambiguity or duplicate risk.
+- HTTP transient/rate-limit retries reuse the payload and UUID already constructed by `send_post_message()`; no post-to-text fallback path exists.
+- Missing UUID preserves the prior single HTTP attempt behavior, while scheduled delivery continues to provide a compact provider-safe UUID derived from the original canonical Markdown idempotency key.
+- Direct trade and maintenance receipts consume only the generic normalized error code and do not learn Feishu payload details.
+- Failure-summary notices route through the same sender and therefore fail closed under the same budget rather than changing transport format.
+
+## Architecture and Ownership Review
+
+- Business renderers were not modified and remain the sole owners of notification content.
+- Feishu-specific payload and byte-budget rules remain in infrastructure; scheduled notification only consumes generic normalized diagnostics.
+- No renderer registry, message DTO/content enum, Markdown parser, runtime format switch, truncation, fragmentation, or fallback state machine was introduced.
+- The existing Feishu inbound reply/outbox text sender and WeChat protocol implementation were not changed.
+- Five real renderer outputs exercise the shared Feishu sender without creating reverse dependencies from renderers to channel code.
+
+## Findings
+
+未发现实质性问题。
+
+## Validation Evidence
+
+- Aggregate notification regression suite: `205 passed`.
+- Ruff on all touched production/test Python files: passed.
+- compileall on touched production/tests and real renderer modules: passed.
+- `git diff --check main...HEAD`: passed.
+- Branch/worktree: clean before this review artifact was written; commits are scoped to the accepted plan and four accepted slices.
+
+## Open Questions
+
+无 local implementation blocker。
+
+## Residual Risk
+
+- Real Feishu API acceptance and desktop/mobile rendering remain unverified because live notification canaries require separate explicit user authorization.
+- The 28 KiB threshold is a conservative local budget below the documented 30 KB limit, not proof of every client/API edge case. If a live canary fails, the approved owner/action is operator-controlled code/version rollback to the existing text sender; no automatic fallback is permitted.
+- Near-limit live traffic has not been sent by design. Deterministic serialization/boundary behavior is covered locally.
+
+All residual risks are assigned to the plan's separately authorized live-canary/rollback gate; none is an unclassified implementation blocker.

--- a/docs/reviews/code-review-20260721-153731.md
+++ b/docs/reviews/code-review-20260721-153731.md
@@ -1,0 +1,43 @@
+# Code Re-review — Channel-aware Notification Rendering Aggregate
+
+## Scope
+
+- Mode: current changes re-review
+- Branch: `feat/channel-aware-notification-rendering`
+- Base: `main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`
+- Initial aggregate review: `docs/reviews/code-review-20260721-153650.md`
+- Output file: `docs/reviews/code-review-20260721-153731.md`
+
+## Findings
+
+未发现实质性问题。
+
+## Finding Status
+
+- Initial aggregate review contained no accepted findings.
+- Fix gate: not applicable; no production code or test changes were required after aggregate review.
+- Re-review status: `pass`.
+
+## Re-review Evidence
+
+Rechecked the unchanged end-to-end path from canonical Markdown through channel selection, Feishu post construction, exact byte preflight, token/HTTP boundary, normalization, scheduled retry/audit, and direct receipt result assembly. Rechecked the WeChat identity path and the separate Feishu inbound text reply path.
+
+The local oversize error remains deterministic and terminal: `error_code=FEISHU_POST_TOO_LARGE`, zero HTTP attempts, no retry, no ambiguity, no duplicate risk, no raw content, and no text fallback. HTTP-attempted post outcomes likewise have no automatic text fallback path.
+
+- Aggregate notification regression suite: `205 passed`.
+- Ruff: passed.
+- compileall: passed.
+- `git diff --check`: passed.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Live Feishu API/client visual behavior remains the only material uncovered area and is assigned to the separately authorized canary/rollback gate.
+- No live notification, production configuration, release, deployment, or remote mutation was performed.
+
+## Decision
+
+`pass`. The aggregate deepreview loop is complete and ready for the accepted deepreview commit.

--- a/docs/reviews/code-review-20260721-180557.md
+++ b/docs/reviews/code-review-20260721-180557.md
@@ -1,0 +1,49 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `feat/channel-aware-notification-rendering`
+- Base: `HEAD@9eaa28f671110d6c6f7ecab9ad13d7db631ef9c7`
+- Output file: `docs/reviews/code-review-20260721-180557.md`
+- Included scope: uncommitted P0 mobile-flat notification rendering delta, including Daily Brief, Compact Tick, Legacy Tick, no-candidate output, OpenD failure/recovery, delivery failure, trade receipt, maintenance receipt, shared format assertions, and Gateflow evidence updates
+- Excluded scope: the already-reviewed Feishu `post` transport implementation; P1 renderer consolidation/deprecation; live Feishu or WeChat canary; runtime configuration; merge, release, and deployment
+- Parallel review coverage: 无；本轮由主 reviewer 对 renderer input/output chain、scheduled wrapping、dynamic text flattening、tests、project instructions、over-coupling、semantic ownership drift 和 adversarial mobile-rendering paths 做聚合审查
+
+## Findings
+
+### DR-MF-01-未修复-高-无候选正文自带完整 H1，Scheduled Tick 再包装后产生双主标题并把状态误放进候选区
+- **入口/函数**: `run_pipeline_notification_stage()` -> `build_notification()` -> `build_no_candidate_notification_text(include_account_header=False)` -> `AccountResult.notification_text` -> `build_account_message_compact()` / `build_account_message()`
+- **文件(行号)**: `domain/domain/multi_tick_result.py:34`; `src/application/notify_symbols.py:1071-1072`; `src/application/account_run.py:607, 697-700, 791`; `src/application/multi_tick/notify_format.py:175-192, 429-459`
+- **输入场景**: 某账户本轮没有候选；pipeline 仍生成 `symbols_notification.txt`，随后 scheduled notification 使用 Compact Tick 或 Legacy Tick renderer 包装该正文；可同时存在平仓建议或拒绝摘要。
+- **实际分支**: 无候选 builder 在 `include_account_header=False` 时仍返回 `# OM · 决策简报`、`状态｜扫描完成`、`结论｜...` 的完整 standalone shell。Compact renderer 的 `_compact_candidate_lines()` 只识别旧的“暂无符合条件的候选”句式，不会剥离这个 H1/shell；Legacy renderer也只把 `###` 降为 `##`，不会处理内部 `#`。
+- **预期行为**: pipeline 产出的无候选内容应保持为可被 Scheduled Tick 外壳消费的 body/state fragment；最终主动通知只能有一个 H1，状态/结论应属于外壳而不是 `## 候选` 的候选行。
+- **实际行为**: 最终消息包含外层 `# OM · 决策简报 · <account>` 和内层 `# OM · 决策简报` 两个 H1；Compact Tick 还会把内层状态和结论当作候选内容展示，违反本轮“一条 standalone 消息只有一个 H1”的核心合同。
+- **直接证据**: `build_no_candidate_notification_text()` 的非 account-header 返回值从 body placeholder 改成完整 H1 shell；`build_notification()` 在 `not any(groups.values())` 时直接返回该值；`account_run.py` 原样读取为 `notification_text` 并可能追加 close advice；Compact candidate normalization 没有处理 `# OM`、`状态｜` 或当前新句式，Legacy 只执行 `^### -> ##`。现有测试只分别测试 direct no-candidate preview 和人工构造的旧占位文本，没有把真实 `build_notification('', '')` 输出送入两个 scheduled wrappers。
+- **影响**: 常见的无候选 scheduled 通知继续违反移动端扁平合同，视觉上出现双标题/错误分区；格式断言无法覆盖真实组合链路，重新 canary 时可能再次失败。
+- **建议改法和验证点**: 利用现有 `include_account_header` 边界：非 standalone 分支只返回无候选 body/state fragment，standalone heartbeat 分支继续生成完整 Decision Brief；让 Compact normalization 识别新无候选句式。新增真实链路回归测试，将 `build_notification('', '', account_label='LX')` 的结果分别送入 Compact/Legacy wrapper，断言 exactly one H1、结论正确、无内层 shell。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-MF-02-未修复-高-真实资金脚注保留 blockquote，三条 scheduled 路径仍在移动端产生缩进
+- **入口/函数**: `cash_footer_for_account()` -> `build_account_message()` / `build_account_message_compact()` / `build_no_candidate_notification_text(include_account_header=True)`
+- **文件(行号)**: `domain/domain/multi_tick.py:387-409`; `domain/domain/multi_tick_result.py:25-31`; `src/application/multi_tick/notify_format.py:195-198, 403-417, 462-465`
+- **输入场景**: scheduled tick 成功查询账户现金 footer；真实 footer 包含 `**💰 现金 CNY**`、`- **LX** ...` 和 `> 截至 ...`。
+- **实际分支**: Legacy 和 heartbeat 仅删除 `- ` 前缀，保留粗体 header 与 `> 截至`；Compact 会过滤 emoji header、清除 bullet/粗体，但仍原样保留 `> 截至`。因此 `## 资金` 下继续出现 Markdown blockquote。
+- **预期行为**: 资金区应与本轮规范一致，使用平级 `字段｜值` 行，例如 `账户｜...`、`数据｜截至 ...`，不依赖 list 或 blockquote 产生层级。
+- **实际行为**: Daily scheduled compatibility renderer、Compact renderer 和 no-candidate heartbeat 都会在真实现金数据存在时输出 `> 截至 ...`；Feishu mobile 仍会显示缩进，直接复现触发本轮修复的可读性问题。
+- **直接证据**: upstream `cash_footer_for_account()` 明确保留 `> 截至`；三个 modified renderer 没有移除 `>` 或转换为字段行。当前测试使用 `LX 持有 ...` 等简化 footer，没有覆盖 upstream 的真实四行 shape。使用真实 shape 的本地生成结果可直接观察三个消息均保留 blockquote。
+- **影响**: 即使候选/回执主体已经扁平化，scheduled 通知最常见的资金区仍有缩进；P0 视觉验收不完整，下一次五类 canary 仍存在重复失败风险。
+- **建议改法和验证点**: 在各现有 renderer ownership boundary 做最小 footer projection：跳过装饰性现金标题，将 account row 转为 `账户｜...`，将 `> 截至` 转为 `数据｜截至 ...`，并把 ASCII ` | ` 转为全角 `｜`。不要在本次引入 P1 shared renderer abstraction。用真实 `cash_footer_for_account()` shape 为 Legacy、Compact、heartbeat 各加回归断言，并执行 shared mobile-flat assertion。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 真实 Feishu/WeChat 客户端视觉效果仍需单独授权的五类 re-canary；本 review 不授权发送。
+- P1 renderer ownership consolidation、Compact compatibility period、Legacy deprecation/removal、System Notice shell 和 Receipt shell 合并仍归后续独立 work unit。
+- 动态 provider/user fields 可能包含 Markdown control characters；本轮只对已知会产生多行/缩进的 OpenD detail、maintenance errors 和 cash footer 做确定性收束，未引入通用 Markdown escaping 层。

--- a/docs/reviews/code-review-20260721-181035.md
+++ b/docs/reviews/code-review-20260721-181035.md
@@ -1,0 +1,38 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes re-review
+- Branch or PR: `feat/channel-aware-notification-rendering`
+- Base: `HEAD@9eaa28f671110d6c6f7ecab9ad13d7db631ef9c7`
+- Prior review: `docs/reviews/code-review-20260721-180557.md`
+- Output file: `docs/reviews/code-review-20260721-181035.md`
+- Included scope: fixes and regression coverage for `DR-MF-01` and `DR-MF-02`, plus the complete uncommitted P0 mobile-flat delta for regression/conflict review
+- Excluded scope: P1 renderer consolidation/deprecation; live canary; runtime config; merge, release, and deployment
+- Parallel review coverage: 无；主 reviewer 复核真实 pipeline no-candidate composition、Legacy/Compact scheduled wrappers、heartbeat path、真实 cash footer shape、shared mobile-flat assertions and focused regression results
+
+## Findings
+
+### DR-MF-01-已修复-高-无候选正文自带完整 H1，Scheduled Tick 再包装后产生双主标题并把状态误放进候选区
+- **裁决**: accepted
+- **修复**: `build_no_candidate_notification_text(include_account_header=False)` 现在只返回 `当前没有通过筛选的候选。` body fragment；`include_account_header=True` 仍拥有完整 standalone Decision Brief shell。Compact candidate normalization 同时识别旧无候选句式和新 body fragment。
+- **直接证据**: `domain/domain/multi_tick_result.py:24-49`; `src/application/multi_tick/notify_format.py:259-276`。
+- **验证**: `tests/test_multi_tick_notify_format.py:98-118` 将真实 `build_notification('', '', account_label='LX')` 输出分别送入 Legacy 和 Compact scheduled renderer，断言最终恰好一个 H1、账户主标题保留、无内层 shell、无候选结论存在，并通过 shared mobile-flat assertion。
+- **最终状态**: 已修复
+
+### DR-MF-02-已修复-高-真实资金脚注保留 blockquote，三条 scheduled 路径仍在移动端产生缩进
+- **裁决**: accepted
+- **修复**: 在现有 P0 renderer ownership 内做最小 projection；装饰性现金标题被跳过，账户行转为 `账户｜...`，`> 截至` 转为 `数据｜截至 ...`，ASCII ` | ` 转为全角 `｜`。Legacy 和 Compact 共用其现有 `notify_format.py` 私有 helper；heartbeat 在现有 domain message owner 内保持独立私有 helper，没有引入 P1 cross-family shell abstraction。
+- **直接证据**: `domain/domain/multi_tick_result.py:6-21, 44-46`; `src/application/multi_tick/notify_format.py:195-197, 402-419, 464-468`; `tests/notification_format_assertions.py:9-16`。
+- **验证**: Legacy、Compact 和 heartbeat tests 均使用 upstream 的真实四行 footer shape，断言扁平账户/数据字段；shared assertion 现在明确拒绝任何 `>` blockquote。定向 renderer/delivery suite 结果为 `178 passed`，Ruff 和 `git diff --check` 通过。
+- **最终状态**: 已修复
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 真实 Feishu/WeChat 客户端视觉效果仍需单独授权的五类 re-canary；本 re-review 不授权发送。
+- P1 renderer consolidation/deprecation and shared System Notice/Receipt shells remain assigned to the separate follow-up work unit defined by the operator.
+- Dynamic Markdown control characters outside the known multiline/error/footer paths remain an operational hardening opportunity, not a blocking finding for this presentation-only P0 slice.

--- a/docs/reviews/plan-review-20260721-142232.md
+++ b/docs/reviews/plan-review-20260721-142232.md
@@ -1,0 +1,110 @@
+# Plan Review — 渠道感知通知渲染：飞书 post/md，微信 Markdown
+
+## Reviewed Target and Scope
+
+- **评审目标**：当前会话中已锁定的 implementation plan：
+  - 业务层继续产出一份 canonical Markdown；
+  - 飞书 App 通知改为 `msg_type=post`，`content.zh_cn.content` 仅包含一个 `md` node；
+  - 微信 ClawBot 继续原样发送 canonical Markdown；
+  - 飞书效果不符合预期时，使用受控代码/版本回滚恢复 `text`，禁止同次发送自动 fallback；
+  - 主要变更边界为 `src/infrastructure/feishu_bot.py`、`src/application/notification_delivery_adapter.py` 及对应测试/文档。
+- **代码基线**：`main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`，`VERSION=1.4.0`。
+- **评审范围**：飞书外部协议、架构 ownership、共享发送链路 blast radius、大小限制、幂等/重试/回滚、测试与 canary 可验收性。
+- **非评审范围**：实现代码、真实通知发送、生产配置修改、发布或远端升级。
+- **基线验证**：
+  - `tests/test_feishu_bot.py tests/test_feishu_notification_sender.py`：`25 passed`；
+  - 未发送真实通知。
+
+## Direct Evidence Reviewed
+
+### 飞书官方协议
+
+- [发送消息内容结构](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json.md)：官方推荐 Markdown 使用 `post` 内的 `md` 标签；`md` 支持 CommonMark 0.31 + GFM；官方请求示例即 `content: [[{"tag":"md","text":"..."}]]`；单个 `\n` 通常解析为软换行，需要分隔块级元素时建议使用 `\n\n`。
+- [发送消息 API](https://open.feishu.cn/document/server-docs/im-v1/message/create.md)：文本消息最大 150 KB，卡片及富文本消息最大 30 KB；超限返回 `230025`；`uuid` 在 1 小时内去重且最大 50 字符。
+
+### 当前代码事实
+
+- `src/application/notification_delivery_adapter.py:69-105`：所有 `feishu_app` 主动通知统一经过 `send_feishu_app_message()`，当前调用 `send_text_message()`；切换该点会同时影响所有复用该 adapter 的通知/回执。
+- `src/infrastructure/feishu_bot.py:83-125`：现有 text sender 统一持有 token、UUID、重试和 attempt logging 语义。
+- `src/application/daily_decision_brief_renderer.py:10-14,1091-1096`：Daily Brief 上限为 **12,000 个 Python 字符**，不是 UTF-8/序列化后的 byte budget。
+- `src/application/trades/receipt.py:204-255`、`src/application/positions/maintenance_receipt.py:285-314`：部分回执采用“普通字段行 + 单换行”组织，不是标题/列表为主的 Markdown。
+- `src/application/scheduled_notification.py:496-518`：多账户失败摘要同样会经过共享 sender。
+- `tests/test_feishu_notification_sender.py:114-168`：现有 sender 测试验证凭据、目标和 UUID；计划中的 payload 测试可以覆盖协议形状，但不能证明客户端视觉呈现。
+
+## Assumptions Tested
+
+| Assumption | Result | Evidence / Counterexample |
+|---|---|---|
+| `post` + 单个 `md` node 是合法飞书 payload | **成立** | 官方示例与目标结构一致。 |
+| 业务 Markdown 应继续由业务 renderer 持有，provider sender 只做传输序列化 | **成立** | 符合现有 import/ownership 边界，也避免双业务 renderer。 |
+| 微信可保持 identity projection | **成立** | 当前 WeChat sender 直接把 `message` 作为 `text` 发送，无需新增 renderer。 |
+| `post` 与现有 `text` 具有等价大小容量 | **不成立** | 官方限制：text 150 KB，post 30 KB。 |
+| 现有 12,000-character Daily Brief 一定能放入 30 KB post | **不成立** | `"文" * 12000` 序列化为目标 `content` 后为 36,053 UTF-8 bytes，已超过 30 KB。 |
+| 一个 Daily Brief canary 可以代表共享 adapter 覆盖的所有消息 | **不成立** | trade/maintenance receipt 是单换行字段布局，failure/recovery/tick 又是不同 Markdown 形态。 |
+| 同次失败自动回退到 text 是安全的 | **不成立，计划已正确禁止** | timeout 可能是已接收但响应丢失，自动 text fallback 会制造重复通知。 |
+| 必须因为 v1 不支持 `post.title` 才省略 title | **不成立，但不阻塞 payload** | 官方文档明确 `title` 为可选字段；本方案可以有意省略，以避免与 canonical Markdown H1 重复。 |
+
+## Findings
+
+### PR-01-未修复-高-计划遗漏 post 30 KB 新上限，现有 12,000 字符契约可生成必然被拒绝的 payload
+- **位置**: Feishu payload contract、测试要求、canary/rollback；以及“业务 renderer 不变”的范围声明
+- **问题类型**: 契约缺失 / 外部协议边界 / 测试缺口 / 不可直接实施
+- **当前写法**: 计划只要求把原始 Markdown 放入单个 `md` node，并保持现有 renderer、idempotency、retry 和 normalization 不变；没有定义 post 的 serialized byte budget、超限行为或可观测字段。
+- **反例/失败场景**: Daily Brief 允许输出最多 12,000 个字符。若内容以中文为主，目标 `content` JSON 可超过 30 KB；实测 12,000 个中文字符构成的单 `md` node 序列化后为 36,053 UTF-8 bytes。飞书会以 `230025` 拒绝，而同样内容在原 text 150 KB 上限内可正常发送。
+- **为什么有问题**: 这是从 text 切换 post 后新增的硬协议退化，不是视觉偏好。当前计划既没有在生成端收紧，也没有在 provider projection 端做 byte-safe 处理；implementation agent 只能猜测“截断、拒绝、拆分还是改全局 renderer”。拆分又会违反“单条消息、单个 md node”和现有幂等/回执语义。
+- **直接证据**: 飞书发送消息 API 明确 text 最大 150 KB、富文本最大 30 KB；`src/application/daily_decision_brief_renderer.py:14,1091-1096` 使用 12,000 character cap；目标 payload 的 UTF-8 计算结果为 36,053 bytes。
+- **影响**: 大型飞书通知会从当前成功变为确定失败；失败可能只在真实数据量较大时出现，普通 canary 无法发现；发布后可能触发通知缺失和被迫紧急回滚。
+- **建议改法和验证点**:
+  1. 在实施前明确 **Feishu post 超限策略**。推荐把它定义为 provider projection 的职责，从而不改变 WeChat canonical Markdown；禁止静默丢内容。
+  2. 若选择截断：按完整序列化后的 UTF-8 byte size 预算，保留完整行并追加明确截断标记；输出/receipt 至少记录 `original_chars`、`content_bytes`、`truncated`，且相同输入必须产生确定性相同 payload。
+  3. 若选择 fail-closed：必须返回专门的本地 size error，不能先调用飞书；同时计划要接受“超限通知不送达”这一产品行为，并给出 operator recovery 路径。
+  4. 增加边界测试：刚好低于限制、中文/emoji/引号/换行导致的 byte expansion、刚好超限、超长单行、截断标记仍在预算内；验证 UUID 和 message hash/receipt 语义没有漂移。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-02-未修复-高-共享 sender 的 blast radius 大于 canary 和测试矩阵，无法证明所有回执在 md 中仍可读
+- **位置**: Covered Notification/Receipt Paths、Test Requirements、Canary Acceptance Criteria
+- **问题类型**: 测试缺口 / rollout 风险 / open question 未收敛
+- **当前写法**: 计划明确一次 adapter 替换覆盖 tick、Daily Brief、失败摘要、OpenD 通知、trade receipt、position maintenance receipt，但视觉 canary 只给出一份标题/引用/列表型 Daily Brief 示例；自动化测试主要验证 JSON shape 和参数透传。
+- **反例/失败场景**: trade receipt 与 maintenance receipt 使用普通字段行和单个 `\n` 分隔。官方说明单个 `\n` 通常是 soft break，块级分隔建议 `\n\n`。即使 Daily Brief 的 H1/H2、quote、list 全部通过，字段型回执仍可能在客户端被压缩成段落、层次变弱或移动端难读。OpenD/failure summary 也有不同结构，不能由 Daily Brief canary 代表。
+- **为什么有问题**: 计划选择的是共享 transport boundary，因此验收也必须覆盖该 boundary 的主要消息类别。当前单一 canary 只能证明一种 Markdown 形态，不能证明用户实际关心的“回执格式”整体优化成功；而 payload unit test 无法验证飞书客户端渲染。
+- **直接证据**: `src/application/trades/receipt.py:204-255`、`src/application/positions/maintenance_receipt.py:285-314` 使用 line-oriented plain fields；`src/application/scheduled_notification.py:496-518` 使用失败摘要结构；官方 Markdown 文档说明 soft break 与 block separation 规则。
+- **影响**: 计划可能在技术上发送成功并拿到 message ID，却在部分关键回执上造成可读性回归；由于没有代表性验收，问题会在真实交易/维护事件出现时才暴露。
+- **建议改法和验证点**:
+  1. 将 canary/acceptance matrix 扩为至少四类：Daily Brief、compact tick、trade/maintenance line-oriented receipt、failure/recovery notice。
+  2. 每类使用**当前真实 renderer 输出**作为 fixture，不另造“更漂亮”的示例；验证桌面和移动端的换行、标题、列表、金额、合约、中文和截断表现。
+  3. 自动化测试继续验证 Feishu 收到原始 canonical Markdown、WeChat identity projection 不变；再补 renderer fixture 的 payload contract 测试，防止只覆盖手写示例。
+  4. 明确验收决策：任一关键消息类别出现字段合并、丢失、截断或明显可读性下降，则停止 rollout 并按既定版本回滚到 text；不要为同一业务事件补发 text。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+## Architecture Boundary Review
+
+- **通过**：canonical Markdown 由业务 renderer 产生，Feishu/WeChat sender 分别负责 provider serialization；不新增双 renderer、DTO、registry、format config，符合项目的最小 ownership 边界。
+- **通过**：保留 `reply_text_message()`，不把 inbound reply/outbox 协议一并切换，避免无关 blast radius。
+- **需修正**：byte budget 是 provider protocol contract，应在 Feishu projection/transport 边界显式拥有，而不是依赖业务层的 character cap 偶然满足。
+
+## Best-Practice / Optimal-Solution / Overengineering / Overcoupling Review
+
+- **Best practice**：禁止 timeout 后自动 fallback 到 text 是正确的；UUID 去重和 delivery confirmation 应保持不变。
+- **Optimal solution**：单 `md` node 是当前目标下最小且官方推荐的方案，比把 Markdown 解析为多个 post node 更简单，也避免维护自建 parser。
+- **Overengineering**：计划正确拒绝 renderer registry、content enum、通用 DTO 和 runtime format switch；这些都没有当前需求支撑。
+- **Overcoupling**：共享 adapter 本身不是问题，但 rollout 验收不能只覆盖 Daily Brief。大小处理若被放入所有业务 renderer，会把 Feishu 30 KB 限制耦合到 WeChat；应避免。
+
+## Open Questions
+
+1. Feishu post 超过安全 byte budget 时，产品决策是：provider-specific 可见截断，还是 fail-closed 并不发送？该问题必须在 `/execute` 前锁定。
+2. trade/maintenance receipt 是否要求保持“一字段一行”的视觉语义？若答案为是，应把该语义写入 canary acceptance，而不是等上线后主观判断。
+
+## Residual Risks and Tracking Destination
+
+- 飞书文档提示部分样式需要较新客户端；即使协议正确，仍需在实际使用的桌面端和移动端 canary。
+- `post.title` 是可选而非不支持。建议计划改写为“有意省略 title，保留 Markdown H1，避免双标题”，无需因此扩展实现。
+- `md` 在旧 `content` readback 中会被兼容转换，原始 Markdown 应从 `content_v2` 读取；当前发送回执只依赖 message ID，因此不构成本 slice blocker，但后续若增加消息内容审计需单独跟踪。
+- 建议 tracking destination：先修订当前 channel-aware notification plan；两个 finding 关闭后再进入 `/execute`，不需要为此引入新的架构 issue。
+
+## Final Plan Review Conclusion
+
+**fail**
+
+方案的核心架构方向正确，单 `md` node 也与飞书官方协议一致；但当前计划遗漏了 text 150 KB → post 30 KB 的硬容量退化，并且共享 sender 的视觉验收矩阵不足。两个问题都可能让实现“测试通过、API 结构正确”但真实通知失败或关键回执变难读，因此暂不应直接交给 implementation agent。

--- a/docs/reviews/plan-review-20260721-150356.md
+++ b/docs/reviews/plan-review-20260721-150356.md
@@ -1,0 +1,124 @@
+# Plan Re-review — 渠道感知通知渲染：飞书 post/md，微信 Markdown
+
+## Reviewed Target and Scope
+
+- **目标计划**：`docs/plans/channel-aware-notification-rendering-plan-20260721.md`
+- **前次评审**：`docs/reviews/plan-review-20260721-142232.md`
+- **代码基线**：`main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`，`VERSION=1.4.0`
+- **本轮重点**：确认前次两个高严重度 finding 是否已被完整关闭，并重新检查 architecture boundary、external protocol、size/retry/idempotency/recovery、direct receipt、test matrix、canary 和 rollback。
+- **非目标**：不实施代码、不发送真实通知、不修改生产配置、不发布或远端升级。
+
+## Previous Finding Closure
+
+### PR-01 — post 30 KB 容量退化 — 已修复
+
+修订计划已把容量限制变成 code-generation-ready 的 provider contract：
+
+- 使用 `FEISHU_POST_REQUEST_BUDGET_BYTES = 28 * 1024`；
+- 按与 `http_json()` 相同的 `json.dumps(payload, ensure_ascii=False).encode("utf-8")` 计算最终完整 request body；
+- 计算包含 outer payload、二次序列化后的 `content`、`receive_id` 和可选 `uuid`；
+- preflight 发生在 token 和消息 HTTP 调用前；
+- 超限不截断、不分片、不自动 text fallback，使用现有 permanent error fail-closed；
+- 本地错误不伪造飞书 `230025`，并携带 byte budget、normalized Markdown chars/hash；
+- normalizer 同时输出 provider-local code 和通用 `error_code=FEISHU_POST_TOO_LARGE`；
+- scheduled notification 不重试，并把诊断写入 attempt/audit；direct trade/maintenance receipt 通过既有 `normalized.error_code` 保留失败原因；
+- HTTP 前确定失败与 ambiguous/confirmed send 的重放规则已经分开：前者可由 operator 在代码回滚后显式重放，后者禁止重复。
+
+该修复解决了前次“12,000 中文字符可超过 post 30 KB，但计划没有策略”的 blocker，同时没有把 Feishu 限制下沉到业务 renderer 或缩短 WeChat 内容。
+
+### PR-02 — 共享 sender 的 canary/test blast radius 不足 — 已修复
+
+修订计划已建立五类真实 renderer fixture 与 canary acceptance matrix：
+
+1. Daily Brief；
+2. Compact Tick；
+3. Trade Receipt；
+4. Maintenance Receipt；
+5. Failure/Recovery Notice。
+
+每类都要求使用当前 renderer 的真实输出，自动化测试证明 canonical Markdown 未被 adapter 重写；真实 canary 分别验证桌面/移动端标题、quote、列表、字段换行、金额、合约、错误诊断、JSON escape 和 message ID。任一类别失败即停止 rollout 并进入受控 text 回滚。
+
+该修复关闭了前次“单一 Daily Brief canary 不能代表 trade/maintenance/failure 等消息形态”的 blocker。
+
+## Assumptions Tested
+
+| Assumption | Result | Evidence / Counterexample |
+|---|---|---|
+| 单 `md` node payload 合法且无需自建 Markdown parser | **成立** | 飞书官方 `post` 示例与目标 payload 一致；provider 只序列化，不解析业务 Markdown。 |
+| 28 KiB preflight 与实际 request serialization 一致 | **成立** | `src/infrastructure/feishu_bitable.py:238-240` 使用 `json.dumps(payload, ensure_ascii=False).encode("utf-8")`；计划要求同一表达式和完整 payload。 |
+| size failure 能在任何上游发送前确定 | **成立** | payload 构造只依赖 open ID、Markdown、UUID；token/HTTP 不参与 size 计算，计划测试明确断言 token/http 均未调用。 |
+| size failure 不会被通用 retry 状态机重复尝试 | **成立** | `src/application/scheduled_notification.py:467-488` 只重试固定 error-code allowlist；计划不把 `FEISHU_POST_TOO_LARGE` 加入 allowlist。 |
+| direct receipt 能保留 provider-local size error | **成立** | trade/maintenance receipt 已读取 normalized `error_code`；修订计划要求 Feishu normalizer 同时设置通用 `error_code` 并新增 direct receipt regression。 |
+| idempotency 和 payload retry 不发生漂移 | **成立** | idempotency key 继续基于调用方原始 Markdown；合法 payload 在 token/HTTP retry 前一次性确定，并复用同一 UUID/payload。 |
+| 微信不受 Feishu byte budget 影响 | **成立** | budget 只存在于 Feishu infrastructure sender；WeChat adapter 仍 identity-send 原始 Markdown。 |
+| 所有主要视觉形态都有验收代表 | **成立** | 五类 fixture/canary 覆盖 heading/list/quote 和 line-oriented receipts，以及 failure/recovery diagnostics。 |
+| rollback 不会在 ambiguous send 后制造重复 | **成立** | 自动 fallback 被禁止；confirmed/ambiguous 与 HTTP 前 size failure 的 recovery 语义已明确分开。 |
+
+## Architecture Boundary Review
+
+- **通过**：业务 renderer 仍是 canonical Markdown 唯一 owner；Feishu 28 KiB 是 provider transport contract，没有污染 domain/application renderer。
+- **通过**：WeChat sender 和 inbound Feishu reply/outbox 均不修改。
+- **通过**：没有新增 format config、runtime switch、renderer registry、DTO、parser、分片状态机或持久化 schema。
+- **通过**：`scheduled_notification.py` 的改动只传播通用 error code 和 audit diagnostics，不承担 Feishu payload 构造。
+- **通过**：direct receipt 不需要修改消息正文；normalizer 使用通用 `error_code` 复用现有 receipt result contract。
+
+## Best-practice Review
+
+- 完整 request-body byte preflight 比 character cap 更符合 Unicode/JSON escaping 的真实边界。
+- 本地 deterministic permanent failure 不进入 retry allowlist，避免无效重试。
+- 不伪造上游 HTTP/Feishu code，保留 local error provenance。
+- 预发送确定失败与 timeout/ambiguous send 分开处理，恢复规则符合幂等和重复风险要求。
+- payload shape、failure semantics、direct receipt、renderer fixtures 和 live visual canary 分层验证，测试职责清晰。
+
+## Optimal-solution Review
+
+在当前约束下，修订方案是可信 alternatives 中最实际的路径：
+
+- 自动 text fallback 会破坏统一 post 决策，并在 ambiguous send 时有重复风险；
+- 静默截断与“字段不得丢失/截断”的验收目标冲突；
+- 多消息分片需要部分成功、多个 message ID、分片 UUID、重试和恢复状态机，明显超出本 work unit；
+- 全局缩短 canonical Markdown 会让 WeChat 为 Feishu 限制买单；
+- 因此 provider-side HTTP-before-send fail-closed + controlled rollback 是最小且安全的方案。
+
+## Overengineering Review
+
+未发现 material overengineering：
+
+- 复用现有 `FeishuPermanentError`，不新增 exception hierarchy；
+- 复用 normalized adapter extra 和 receipt `error_code`，不新增 DTO/schema；
+- 只增加一个 byte-budget constant 和小型 private payload/size helper；
+- 五类 canary 对应共享 sender 的真实 blast radius，不是 speculative coverage。
+
+## Overcoupling Review
+
+未发现 material overcoupling：
+
+- Feishu size contract 不进入 renderer 或 WeChat；
+- scheduled notification 只认识通用 normalized error，不依赖 post payload shape；
+- direct receipts 只消费通用 `error_code`；
+- canary matrix 使用真实 renderer 输出，但不反向要求 renderer 感知渠道。
+
+## Findings
+
+无 material findings。
+
+## Open Questions
+
+无 implementation blocker。
+
+真实 canary 仍需用户单独明确批准；这属于计划内 rollout gate，不是 implementation open question。
+
+## Residual Risks and Tracking Destination
+
+1. **客户端版本/视觉差异**：CommonMark/GFM 的最终显示仍取决于实际飞书桌面端和移动端；由 Slice 5 的五类 canary 关闭。
+2. **28 KiB 是保守预算而非平台保证证明**：它低于两种常见 30 KB 解释并按完整 request body 计算，但只有真实 API 能最终证明；若仍被拒绝，按 plan 记录 evidence 并回滚 text。
+3. **超限消息 fail-closed**：该方案有意选择“不送达优于静默截断”。真实业务首次出现 `FEISHU_POST_TOO_LARGE` 时会触发 rollback；HTTP 前确定未发送的事件可由 operator 在 rollback 后显式重放。
+4. **近上限 live canary 未默认执行**：避免发送超长噪声消息；byte boundary 主要由 deterministic tests 证明。若后续需要实证，可作为单独、显式批准的 canary。
+
+Tracking destination：以上风险均已在目标 plan 的 canary/rollback gate 中登记，无需新增 architecture issue。
+
+## Final Plan Review Conclusion
+
+**pass-with-risks**
+
+前次两个高严重度 finding 均已关闭。修订计划已经足够具体，可安全交给 implementation agent；剩余风险是实际飞书客户端/API 的外部行为，已由显式 canary 和受控 rollback 管理。

--- a/docs/reviews/pr-108-review-20260721-154212.md
+++ b/docs/reviews/pr-108-review-20260721-154212.md
@@ -1,0 +1,63 @@
+# Pull Request Review
+
+## Scope
+
+- Mode: PR
+- Repository: `liuxie066/options-monitor`
+- PR: `#108` — `feat: render Feishu notifications as post Markdown`
+- Author: `liuxie066`
+- URL: `https://github.com/liuxie066/options-monitor/pull/108`
+- Head branch: `feat/channel-aware-notification-rendering`
+- Head SHA reviewed: `5f832616ae29e79bb3988cf7d22179f87f91c4fd`
+- Base branch: `main`
+- Base SHA: `9b1e200ed313407c3f20708a33549ba0d5e46cf0`
+- Output file: `docs/reviews/pr-108-review-20260721-154212.md`
+- Included scope: complete 30-file PR diff, six commits, production delivery chain, tests, Gateflow/plan/review artifacts, operator documentation, PR metadata, and GitHub checks
+- Excluded scope: live Feishu sends, desktop/mobile rendering canaries, release/deployment, production configuration
+- Parallel review coverage: 无；PR head/base exactly match the locally aggregate-reviewed commit and baseline
+
+## PR Facts
+
+- State: open Draft PR.
+- Mergeability at review time: mergeable.
+- PR head/base SHAs exactly match the aggregate deepreview scope.
+- GitHub checks: `Analyze (actions)`, `Analyze (python)`, `CodeQL`, `agent-plugin`, and `guardrails` all passed.
+
+## End-to-End Review
+
+Revalidated the PR diff from the public notification entry paths through adapter selection, Feishu post payload construction, exact final-body byte preflight, token and HTTP retry semantics, raw failure/result normalization, scheduled retry/audit state, direct receipt result assembly, and the unchanged WeChat identity path.
+
+Key contracts remain coherent across the complete PR:
+
+- proactive Feishu uses `post` with one `zh_cn.content` `md` node and no `title`;
+- canonical Markdown remains owned by existing business renderers;
+- WeChat receives the original Markdown through the existing text field;
+- Feishu inbound replies/outbox remain on the existing text sender;
+- oversize requests fail before token/message HTTP with non-content diagnostics and no retry/fallback;
+- HTTP-attempted, confirmed, transient, timeout, or ambiguous post outcomes have no text fallback path;
+- UUID/idempotency, message confirmation, and application retry guards remain on the existing authority paths.
+
+## Findings
+
+未发现实质性问题。
+
+## Validation Evidence
+
+- Local aggregate notification regression suite: `205 passed`.
+- Local Ruff, compileall, and diff checks: passed.
+- GitHub checks: all passed.
+- Aggregate deepreview and re-review: passed with no material findings.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- Live Feishu API acceptance and desktop/mobile visual rendering remain unverified because notification sends require separate explicit user authorization.
+- The owner/destination is the plan's five-category canary/rollback gate. If acceptance fails, rollback is operator-controlled code/version rollback to text; the implementation deliberately provides no automatic same-event fallback.
+- No unclassified residual risk blocks Draft PR acceptance.
+
+## Decision
+
+`pass`; no fix required.

--- a/docs/reviews/pr-108-review-20260721-154242.md
+++ b/docs/reviews/pr-108-review-20260721-154242.md
@@ -1,0 +1,39 @@
+# Pull Request Re-review — PR #108
+
+## Scope
+
+- Mode: PR re-review
+- PR: `liuxie066/options-monitor#108`
+- Initial review: `docs/reviews/pr-108-review-20260721-154212.md`
+- Reviewed head: `5f832616ae29e79bb3988cf7d22179f87f91c4fd`
+- Base: `main@9b1e200ed313407c3f20708a33549ba0d5e46cf0`
+- Output file: `docs/reviews/pr-108-review-20260721-154242.md`
+
+## Findings
+
+未发现实质性问题。
+
+## Finding Status
+
+- Initial PR review contained no accepted findings.
+- Fix gate: not applicable; no production code or tests changed after review.
+- Re-review status: `pass`.
+
+## Re-review Evidence
+
+- PR head/base still match the aggregate deepreview scope.
+- All GitHub checks passed: Analyze (actions), Analyze (python), CodeQL, agent-plugin, and guardrails.
+- Local aggregate suite remains `205 passed`; Ruff, compileall, and diff checks passed.
+- Residual live-provider risk remains explicitly assigned to a separate operator-approved canary/rollback gate.
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+No new or unclassified residual risk. Live Feishu API/client behavior remains the sole material uncovered area; no live notification was sent in this work unit.
+
+## Decision
+
+`pass`. PR review loop is complete and ready for the accepted PR review commit.

--- a/domain/domain/multi_tick_result.py
+++ b/domain/domain/multi_tick_result.py
@@ -3,6 +3,24 @@ from __future__ import annotations
 from typing import Any, Callable
 
 
+def _flat_cash_footer_lines(lines: list[str] | None) -> list[str]:
+    out: list[str] = []
+    for raw in lines or []:
+        text = str(raw or '').strip()
+        if not text or '💰' in text:
+            continue
+        text = text.replace('**', '').removeprefix('- ').strip()
+        if text.startswith('> '):
+            detail = text[2:].strip()
+            out.append(f"数据｜{detail}" if detail.startswith('截至 ') else f"说明｜{detail}")
+            continue
+        text = text.replace('总现金折算 ', '总现金 ')
+        text = text.replace('担保后可用 ', '担保后 ')
+        text = text.replace(' | ', '｜')
+        out.append(f"账户｜{text}")
+    return out
+
+
 def build_no_candidate_notification_text(
     *,
     account_label: str | None = None,
@@ -15,20 +33,20 @@ def build_no_candidate_notification_text(
     if include_account_header and acct:
         lines.extend(
             [
-                f"Options Monitor 账户提醒（{acct}）",
+                f"# OM · 决策简报 · {acct}",
                 '',
+                "状态｜扫描完成",
             ]
         )
         if now_bj:
-            lines.extend([f"北京时间 {now_bj}", ''])
-        lines.extend([f"【账户 {acct}】监控正常触发，本轮无候选。", ''])
-        footer = [str(line) for line in (cash_footer_lines or []) if str(line).strip()]
+            lines.append(f"时间｜{now_bj} 北京时间")
+        lines.extend(["结论｜当前没有通过筛选的候选。", ''])
+        footer = _flat_cash_footer_lines(cash_footer_lines)
         if footer:
-            lines.extend(footer)
-            lines.append('')
+            lines.extend(["## 资金", *footer, ''])
         return '\n'.join(lines).strip() + '\n'
 
-    return '📋 本轮扫描完成，暂无符合条件的候选。\n'
+    return '当前没有通过筛选的候选。\n'
 
 
 def build_account_messages(

--- a/src/application/daily_decision_brief_renderer.py
+++ b/src/application/daily_decision_brief_renderer.py
@@ -195,59 +195,85 @@ def render_daily_brief_lifecycle(
 
 def _render_user_view(view: Mapping[str, Any]) -> str:
     lines = [
-        f"# OM · {view['account']} · {view['market_label']}",
-        f"> {view['phase_line']}",
-        str(view["data_as_of"]),
+        f"# OM · 决策简报 · {view['account']}",
+        "",
+        f"状态｜{view['phase_line']}",
+        f"市场｜{view['market_label']}",
+        f"数据｜{_strip_display_label(view['data_as_of'], '数据截至：')}",
     ]
     planning_notice = str(view.get("planning_notice") or "")
     if planning_notice:
-        lines.extend(["", planning_notice])
+        lines.extend(["", f"提示｜{planning_notice}"])
 
     if bool(view.get("blocked")):
         lines.extend(
             [
                 "",
-                str(view.get("blocked_summary") or "本轮关键数据不可用，暂时无法形成可靠决策。"),
-                "系统将在后续批次自动重新评估。",
+                f"结论｜{view.get('blocked_summary') or '本轮关键数据不可用，暂时无法形成可靠决策。'}",
+                "后续｜系统将在后续批次自动重新评估。",
             ]
         )
         return _bounded_markdown(lines)
 
     changes = [str(item) for item in view.get("change_summaries") or [] if str(item).strip()]
     if changes:
-        lines.extend(["", "；".join(changes) + "。"])
+        lines.extend(["", "变化｜" + "；".join(changes) + "。"])
 
     candidates = [item for item in view.get("candidates") or [] if isinstance(item, Mapping)]
     lines.extend(["", "## 候选"])
     if not candidates:
-        lines.append("- 当前没有通过筛选的候选。")
+        lines.append("当前没有通过筛选的候选。")
     else:
         for index, item in enumerate(candidates, start=1):
-            lines.append(f"{index}. {item['title']}")
+            lines.extend(["", f"**{index}｜{_flat_title(item['title'])}**"])
             for detail in item.get("details") or []:
-                lines.append(f"   - {detail}")
+                lines.append(f"{_candidate_detail_label(detail)}｜{detail}")
             for leg in item.get("legs") or []:
-                lines.append(f"   - {leg}")
+                lines.append(_flat_field_line(leg))
         for note in view.get("candidate_omissions") or []:
-            lines.append(f"- {note}")
+            lines.append(f"补充｜{note}")
 
     positions = [item for item in view.get("positions") or [] if isinstance(item, Mapping)]
     if positions:
         lines.extend(["", "## 持仓"])
         for item in positions:
-            lines.append(f"- {item['title']}：{item['status']}")
+            lines.extend(["", f"**{_flat_title(item['title'])}｜{item['status']}**"])
             for detail in item.get("details") or []:
-                lines.append(f"  - {detail}")
+                lines.append(f"参考｜{detail}")
         position_omitted = _whole_number(view.get("position_omitted")) or 0
         if position_omitted:
-            lines.append(f"- 另有 {position_omitted} 个持仓未展开")
+            lines.append(f"补充｜另有 {position_omitted} 个持仓未展开")
 
     capacity = [str(item) for item in view.get("capacity") or [] if str(item).strip()]
     if capacity:
         lines.extend(["", "## 资金"])
-        lines.extend(f"- {item}" for item in capacity)
+        lines.extend(_flat_field_line(item) for item in capacity)
 
     return _bounded_markdown(lines)
+
+
+def _strip_display_label(value: Any, prefix: str) -> str:
+    text = str(value or "").strip()
+    return text.removeprefix(prefix).strip()
+
+
+def _flat_title(value: Any) -> str:
+    return str(value or "").strip().replace(" · ", "｜")
+
+
+def _flat_field_line(value: Any) -> str:
+    text = str(value or "").strip()
+    if "：" in text:
+        label, body = text.split("：", 1)
+        return f"{label}｜{body}"
+    return text
+
+
+def _candidate_detail_label(value: Any) -> str:
+    text = str(value or "").strip()
+    if "执行前" in text or text.startswith(("近期事件", "已确认", "预计")):
+        return "事件"
+    return "指标"
 
 
 def _candidate_views(

--- a/src/application/multi_tick/notify_format.py
+++ b/src/application/multi_tick/notify_format.py
@@ -178,25 +178,23 @@ def build_account_message(
     acct = str(result.account).strip().lower()
 
     lines: list[str] = []
-    lines.append("# 📊 Options Monitor")
-    lines.append(f"## 账户提醒（{acct}）")
+    lines.append(f"# OM · 决策简报 · {acct}")
     lines.append('')
-    lines.append(f"北京时间 {now_bj}")
-    lines.append('')
-    lines.append(f"### 账户 {acct} · 本轮候选")
-    counts_line = f"- {SELL_PUT_SECTION_LABEL} {put_n} / {COVERED_CALL_SECTION_LABEL} {call_n}"
+    lines.append("状态｜扫描完成")
+    lines.append(f"时间｜{now_bj} 北京时间")
+    counts_line = f"Sell Put {put_n} · Covered Call {call_n}"
     if enhancement_n > 0:
-        counts_line += f" / Combo Yield {enhancement_n}"
-    lines.append(counts_line)
+        counts_line += f" · Combo Yield {enhancement_n}"
+    lines.append(f"结论｜{counts_line}")
     lines.append('')
     body = annotate_notification(result.account, '\n'.join(kept).strip() + '\n').strip()
+    body = re.sub(r"(?m)^### ", "## ", body)
     lines.append(body)
     lines.append('')
 
-    footer_lines = cash_footer_lines or []
+    footer_lines = _flat_cash_footer_lines(cash_footer_lines or [])
     if footer_lines:
-        lines.extend(list(footer_lines))
-        lines.append('')
+        lines.extend(["## 资金", *footer_lines, ''])
 
     return '\n'.join(lines).strip() + '\n'
 
@@ -265,7 +263,7 @@ def _compact_candidate_lines(lines: list[str]) -> list[str]:
         s = str(raw or "").strip()
         if not s:
             continue
-        if "暂无符合条件的候选" in s:
+        if "暂无符合条件的候选" in s or "当前没有通过筛选的候选" in s:
             saw_no_candidate = True
             continue
         if s.startswith("📋 本轮扫描完成"):
@@ -274,7 +272,7 @@ def _compact_candidate_lines(lines: list[str]) -> list[str]:
     while out and out[-1] == "":
         out.pop()
     if not out and saw_no_candidate:
-        return ["- 无符合承保条件候选"]
+        return ["当前没有通过筛选的候选。"]
     return out
 
 
@@ -362,7 +360,7 @@ def _compact_close_gap_line(line: str) -> str:
 
 def _compact_close_lines(lines: list[str], *, max_gap_items: int = 3) -> tuple[list[str], int, int]:
     if not lines:
-        return ["- 无平仓建议"], 0, 0
+        return ["当前没有平仓建议。"], 0, 0
     action_count = sum(1 for line in lines if _is_close_action_line(line))
     gap_lines = [str(line).strip() for line in lines if _is_displayable_close_gap_line(str(line))]
     gap_count = len(gap_lines)
@@ -379,29 +377,29 @@ def _compact_close_lines(lines: list[str], *, max_gap_items: int = 3) -> tuple[l
             continue
         if "本次无 strong/medium 平仓建议" in s or "本次未生成 strong/medium 提醒" in s:
             if not action_count:
-                out.append("- 无平仓建议")
+                out.append("当前没有平仓建议。")
             continue
         if s == "- 待补数据:" or s == "待补数据:":
             in_gap = True
             if gap_count:
-                out.append("- 待补:")
+                out.append("待补｜以下持仓需要补充数据")
             continue
         if in_gap:
             if _is_displayable_close_gap_line(s):
                 if shown_gap < max_gap_items:
-                    out.append(_compact_close_gap_line(s))
+                    out.append(_compact_close_gap_line(s).removeprefix("- ").strip())
                 shown_gap += 1
             continue
-        out.append(s)
+        out.append(s.removeprefix("- ").strip())
 
     if gap_count > max_gap_items:
-        out.append(f"- 另有 {gap_count - max_gap_items} 条待补数据")
+        out.append(f"补充｜另有 {gap_count - max_gap_items} 条待补数据")
     if not out:
-        out.append("- 无平仓建议")
+        out.append("当前没有平仓建议。")
     return out, action_count, gap_count
 
 
-def _compact_cash_footer_lines(footer_lines: list[str]) -> list[str]:
+def _flat_cash_footer_lines(footer_lines: list[str]) -> list[str]:
     out: list[str] = []
     for raw in footer_lines:
         s = str(raw or "").strip()
@@ -409,12 +407,15 @@ def _compact_cash_footer_lines(footer_lines: list[str]) -> list[str]:
             continue
         if "💰" in s:
             continue
-        cleaned = s.replace("**", "")
-        if cleaned.startswith("- "):
-            cleaned = cleaned[2:].strip()
+        cleaned = s.replace("**", "").removeprefix("- ").strip()
+        if cleaned.startswith("> "):
+            detail = cleaned[2:].strip()
+            out.append(f"数据｜{detail}" if detail.startswith("截至 ") else f"说明｜{detail}")
+            continue
         cleaned = cleaned.replace("总现金折算 ", "总现金 ")
         cleaned = cleaned.replace("担保后可用 ", "担保后 ")
-        out.append(f"- {cleaned}")
+        cleaned = cleaned.replace(" | ", "｜")
+        out.append(f"账户｜{cleaned}")
     return out
 
 
@@ -436,29 +437,31 @@ def build_account_message_compact(
     acct = str(result.account).strip().lower()
 
     lines: list[str] = []
-    lines.append(f"# OM · {acct} · {now_bj} BJ")
+    lines.append(f"# OM · 决策简报 · {acct}")
     lines.append('')
+    lines.append("状态｜扫描完成")
+    lines.append(f"时间｜{now_bj} 北京时间")
     overview_parts = [f"Put {put_n}", f"Call {call_n}"]
     if enhancement_n > 0:
         overview_parts.append(f"组合 {enhancement_n}")
     overview_parts.append(f"平仓 {close_action_n}")
     if close_gap_n > 0:
         overview_parts.append(f"待补 {close_gap_n}")
-    lines.append(' · '.join(overview_parts))
+    lines.append(f"结论｜{' · '.join(overview_parts)}")
     lines.append('')
 
     lines.append("## 候选")
     if candidate_lines:
         lines.extend(candidate_lines)
     else:
-        lines.append("- 无符合承保条件候选")
+        lines.append("当前没有通过筛选的候选。")
     lines.append('')
 
     lines.append("## 持仓")
     lines.extend(close_lines)
     lines.append('')
 
-    cash_lines = _compact_cash_footer_lines(cash_footer_lines or [])
+    cash_lines = _flat_cash_footer_lines(cash_footer_lines or [])
     if cash_lines:
         lines.append("## 资金")
         lines.extend(cash_lines)

--- a/src/application/multi_tick/opend_guard.py
+++ b/src/application/multi_tick/opend_guard.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from src.application.notification_delivery_adapter import normalize_notification_delivery_result, select_notification_delivery_adapter
 from src.application.notification_delivery_route import resolve_notification_delivery_route
+from src.application.trade_time_format import format_iso_time_beijing
 from src.infrastructure.io_utils import read_json, atomic_write_json as write_json, utc_now
 
 
@@ -193,6 +194,13 @@ def _send_notification(base: Path, cfg: dict, *, message: str) -> bool:
         return False
 
 
+def _flat_notice_value(value: object, *, limit: int | None = None) -> str:
+    text = str(value or "")
+    if limit is not None:
+        text = text[:limit]
+    return " · ".join(part.strip() for part in text.splitlines() if part.strip())
+
+
 def send_opend_alert(base: Path, cfg: dict, *, error_code: str, message_text: str, detail: str = '', no_send: bool = False, skip_consecutive_gate: bool = False) -> bool:
     cooldown_sec = 600
     burst_window_sec = 900
@@ -240,14 +248,17 @@ def send_opend_alert(base: Path, cfg: dict, *, error_code: str, message_text: st
     ):
         return False
 
+    now_utc = utc_now()
     msg = (
-        f"options-monitor OpenD 告警\n"
-        f"error_code: {error_code}\n"
-        f"message: {message_text}\n"
-        f"time_utc: {utc_now()}"
+        "# OM · 系统告警 · OpenD\n\n"
+        "状态｜❌ 不可用\n"
+        f"时间｜{format_iso_time_beijing(now_utc) or now_utc}\n"
+        "影响｜本轮行情与交易数据可能不完整\n"
+        f"原因｜{_flat_notice_value(message_text) or '-'}\n"
+        f"诊断｜`{error_code}`"
     )
     if detail:
-        msg += f"\ndetail: {detail[:1200]}"
+        msg += f"\n详情｜{_flat_notice_value(detail, limit=1200)}"
 
     sent = _send_notification(base, cfg, message=msg)
     if sent:
@@ -292,9 +303,12 @@ def send_opend_recovery_notice(base: Path, cfg: dict, *, scope: str = 'project',
     if no_send:
         return False
 
+    now_utc = utc_now()
     msg = (
-        f"options-monitor OpenD 已恢复\n"
-        f"time_utc: {utc_now()}"
+        "# OM · 系统通知 · OpenD\n\n"
+        "状态｜✅ 已恢复\n"
+        f"时间｜{format_iso_time_beijing(now_utc) or now_utc}\n"
+        "结果｜数据连接已恢复，后续批次将自动重新评估"
     )
 
     return _send_notification(base, cfg, message=msg)

--- a/src/application/notification_delivery_adapter.py
+++ b/src/application/notification_delivery_adapter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -22,7 +22,7 @@ from src.application.channels.wechat_clawbot.notification import (
 )
 from src.application.secret_resolver import resolve_feishu_bot_config
 from src.infrastructure.feishu_bitable import FeishuError
-from src.infrastructure.feishu_bot import send_text_message
+from src.infrastructure.feishu_bot import send_post_message
 
 
 @dataclass(frozen=True)
@@ -95,11 +95,11 @@ def send_feishu_app_message(
     request_path = f"/open-apis/im/v1/messages?receive_id_type={receive_id_type}"
     http_attempts: list[dict[str, Any]] = []
     try:
-        response_json = send_text_message(
+        response_json = send_post_message(
             app_id=bot_cfg.app_id,
             app_secret=bot_cfg.app_secret,
             open_id=receive_id,
-            text=str(message or ""),
+            markdown=str(message or ""),
             uuid=idempotency_key,
             log_fn=http_attempts.append,
         )
@@ -123,16 +123,23 @@ def send_feishu_app_message(
                     response_json = parsed
             except Exception:
                 pass
+        response_http_attempts = response.get("http_attempts")
         return {
             "ok": False,
             "http_status": response.get("http_status"),
+            "feishu_code": response.get("feishu_code"),
             "request_path": request_path,
             "response_json": response_json,
             "response_tail": body_text[-500:],
             "error_type": type(exc).__name__,
             "error_message": str(exc),
+            "local_error_code": response.get("local_error_code"),
+            "request_body_bytes": response.get("request_body_bytes"),
+            "request_body_budget_bytes": response.get("request_body_budget_bytes"),
+            "normalized_markdown_chars": response.get("normalized_markdown_chars"),
+            "normalized_markdown_sha256": response.get("normalized_markdown_sha256"),
             "idempotency_key": idempotency_key,
-            "http_attempts": http_attempts,
+            "http_attempts": response_http_attempts if isinstance(response_http_attempts, list) else http_attempts,
         }
 
 
@@ -145,7 +152,10 @@ def normalize_feishu_app_send_output(*, send_result: dict[str, Any]) -> dict[str
     message_id = data.get("message_id")
     http_status = result.get("http_status")
     feishu_code = response_json.get("code") if isinstance(response_json.get("code"), int) else None
+    if feishu_code is None and isinstance(result.get("feishu_code"), int):
+        feishu_code = result.get("feishu_code")
     feishu_msg = str(response_json.get("msg") or result.get("error_message") or "").strip()
+    local_error_code = str(result.get("local_error_code") or "").strip() or None
     request_path = str(result.get("request_path") or "/open-apis/im/v1/messages?receive_id_type=open_id")
     response_tail = str(result.get("response_tail") or "")
     idempotency_key = str(result.get("idempotency_key") or "").strip() or None
@@ -174,6 +184,17 @@ def normalize_feishu_app_send_output(*, send_result: dict[str, Any]) -> dict[str
             parts.append(f"response_tail={response_tail}")
         message = " ".join(parts)
 
+    local_diagnostics = {
+        key: result.get(key)
+        for key in (
+            "request_body_bytes",
+            "request_body_budget_bytes",
+            "normalized_markdown_chars",
+            "normalized_markdown_sha256",
+        )
+        if result.get(key) is not None
+    }
+
     return normalize_subprocess_adapter_payload(
         adapter="notify",
         tool_name="feishu_app_message_send",
@@ -196,6 +217,9 @@ def normalize_feishu_app_send_output(*, send_result: dict[str, Any]) -> dict[str
             "retry_attempt_count": retry_attempt_count,
             "ambiguous_send": ambiguous_send,
             "duplicate_risk": duplicate_risk,
+            "local_error_code": local_error_code,
+            "error_code": local_error_code,
+            **local_diagnostics,
         },
     )
 

--- a/src/application/notify_symbols.py
+++ b/src/application/notify_symbols.py
@@ -4,9 +4,8 @@
 This is the same logic as the previous notify_watchlist.py, renamed for clarity.
 
 NOTE (template ownership):
-- This file is the *single source of truth* for notification layout (Put/Covered Call sections, blank lines, bullet lists).
-- For multi-account per-account notifications, src.application.multi_account_tick must treat account notification text as opaque
-  and must NOT reformat individual candidates.
+- This file owns the per-candidate facts and field ordering for Put/Covered Call notification bodies.
+- Final notification shells may normalize headings and flat spacing, but must not reinterpret individual candidate facts.
 """
 
 from __future__ import annotations
@@ -288,20 +287,29 @@ def _build_notification_block(
     extra_detail_line: str = '',
 ) -> str:
     out = [
-        f"### [{account_label}] {symbol_name} · {action_label}",
-        f"- {symbol_name} {action_label} {contract}",
-        income_line,
-        contract_line,
-        risk_line,
-        detail_line,
+        f"**[{account_label}] {symbol_name}｜{action_label}｜{contract}**",
+        _flat_notification_field(income_line),
+        _flat_notification_field(contract_line),
+        _flat_notification_field(risk_line),
+        _flat_notification_field(detail_line),
     ]
     if extra_detail_line:
-        out.append(extra_detail_line)
+        out.extend(_flat_notification_field(line) for line in extra_detail_line.splitlines() if line.strip())
     if suggestion:
-        out.append(f"- 操作: 建议挂单={suggestion}")
-    out.append(f"- 备注: {note}")
-    out.append("---")
+        out.append(f"操作｜建议挂单={suggestion}")
+    out.append(f"备注｜{note}")
     return "\n".join(out)
+
+
+def _flat_notification_field(value: str) -> str:
+    text = str(value or '').strip()
+    if text.startswith('- '):
+        text = text[2:].strip()
+    for separator in (': ', '：'):
+        if separator in text:
+            label, body = text.split(separator, 1)
+            return f"{label}｜{body}"
+    return text
 
 
 def _fmt_date_compact(contract: str) -> str:
@@ -425,7 +433,7 @@ def _build_notification_block_compact(
     if dte_match:
         l2_parts.append(_fmt_dte_compact(dte_match.group(1)))
 
-    l2 = f"- {' · '.join(l2_parts)}" if l2_parts else ''
+    l2 = f"收益｜{' · '.join(l2_parts)}" if l2_parts else ''
 
     l3_parts = []
     risk_match = re.search(r'风险[=:]([^|]+)', risk_line)
@@ -464,7 +472,7 @@ def _build_notification_block_compact(
             else:
                 l3_parts.append(f"担保 {_fmt_money_compact(margin_val)}")
 
-    l3 = f"- {' · '.join(l3_parts)}" if l3_parts else ''
+    l3 = f"风险｜{' · '.join(l3_parts)}" if l3_parts else ''
 
     l4 = ''
     if not is_enhancement and extra_detail_line:
@@ -475,9 +483,9 @@ def _build_notification_block_compact(
             if event_text:
                 l4_parts.append(f"事件 {event_text}")
         if l4_parts:
-            l4 = f"- {' · '.join(l4_parts)}"
+            l4 = f"事件｜{' · '.join(l4_parts)}"
 
-    out_lines = [l1]
+    out_lines = [f"**{l1}**"]
     if l2:
         out_lines.append(l2)
     if l3:
@@ -575,22 +583,21 @@ def _format_staggered_combo_alert(
     if compact:
         return "\n".join(
             [
-                f"🧩 组合·跨期 {parsed.symbol_name} {put_strike}P+{call_strike}C",
-                f"- Put 卖 {put_strike}P · {put_expiration_text}/{put_dte_text}天 · bid {put_bid_text} · 估算净收 {put_net_credit_text}{ccy_tail}",
-                f"- Call 买 {call_strike}C · {call_expiration_text}/{call_dte_text}天 · ask {call_ask_text} · Δ {call_delta_text} · 估算成本 {call_total_cost_text}{ccy_tail}",
-                f"- 组合 覆盖 {coverage_text} · 净现金流 {combo_net_credit_text}{ccy_tail}",
-                f"- 安全边界 {safety_text} · 现金 {cash_required} · Call晚{expiry_gap_text}天",
+                f"**🧩 组合·跨期 {parsed.symbol_name} {put_strike}P+{call_strike}C**",
+                f"Put｜卖 {put_strike}P · {put_expiration_text}/{put_dte_text}天 · bid {put_bid_text} · 估算净收 {put_net_credit_text}{ccy_tail}",
+                f"Call｜买 {call_strike}C · {call_expiration_text}/{call_dte_text}天 · ask {call_ask_text} · Δ {call_delta_text} · 估算成本 {call_total_cost_text}{ccy_tail}",
+                f"组合｜覆盖 {coverage_text} · 净现金流 {combo_net_credit_text}{ccy_tail}",
+                f"风险｜安全边界 {safety_text} · 现金 {cash_required} · Call晚{expiry_gap_text}天",
             ]
         )
 
     return "\n".join(
         [
-            f"### [{account_label}] {parsed.symbol_name} · 组合收益",
-            f"- Put: 卖 {put_strike}P | {put_expiration}/{put_dte_text}天 | bid={put_bid_text} | 估算净收={put_net_credit_text}{ccy_tail}",
-            f"- Call: 买 {call_strike}C | {call_expiration}/{call_dte_text}天 | ask={call_ask_text} | delta={call_delta_text} | 估算成本={call_total_cost_text}{ccy_tail}",
-            f"- 组合: 覆盖率={coverage_text} | 净现金流={combo_net_credit_text}{ccy_tail}",
-            f"- 风控: Put安全边界={safety_text} | 现金={cash_required} | Call晚{expiry_gap_text}天",
-            "---",
+            f"**[{account_label}] {parsed.symbol_name}｜组合收益**",
+            f"Put｜卖 {put_strike}P · {put_expiration}/{put_dte_text}天 · bid={put_bid_text} · 估算净收={put_net_credit_text}{ccy_tail}",
+            f"Call｜买 {call_strike}C · {call_expiration}/{call_dte_text}天 · ask={call_ask_text} · delta={call_delta_text} · 估算成本={call_total_cost_text}{ccy_tail}",
+            f"组合｜覆盖率={coverage_text} · 净现金流={combo_net_credit_text}{ccy_tail}",
+            f"风险｜Put安全边界={safety_text} · 现金={cash_required} · Call晚{expiry_gap_text}天",
         ]
     )
 

--- a/src/application/positions/maintenance_receipt.py
+++ b/src/application/positions/maintenance_receipt.py
@@ -16,6 +16,7 @@ from src.application.notification_delivery_adapter import (
     select_notification_delivery_adapter,
 )
 from src.application.notification_delivery_route import resolve_notification_delivery_route
+from src.application.trade_time_format import format_iso_time_beijing
 
 _AUTO_CLOSE_RECEIPT_STATE_NAME = "auto_close_receipts.json"
 _AUTO_CLOSE_RECEIPT_STATE_MAX_ITEMS = 200
@@ -267,49 +268,42 @@ def build_auto_close_receipt_message(
     mode = str(result.get("mode") or "").strip().lower()
 
     if dry_run or mode == "dry_run":
-        title = "[预览] 过期自动平仓未写入 option_positions"
-        status_text = "预览"
+        status_text = "ℹ️ 预览"
     elif errors and applied > 0:
-        title = "[未完全记录] 过期自动平仓部分写入 option_positions"
-        status_text = "部分失败"
+        status_text = "⚠️ 部分完成"
     elif errors:
-        title = "[未记录] 过期自动平仓未写入 option_positions"
-        status_text = "失败"
+        status_text = "❌ 失败"
     elif applied > 0:
-        title = "[已记录] 过期自动平仓已写入 option_positions"
-        status_text = "已记录"
+        status_text = "✅ 已完成"
     else:
-        title = "[无变更] 过期自动平仓未写入 option_positions"
-        status_text = "无变更"
+        status_text = "ℹ️ 无变更"
 
+    account = _display(result.get("account"))
     lines = [
-        title,
+        f"# OM · 持仓维护 · {account}",
         "",
-        f"账户：{_display(result.get('account'))}",
-        f"券商：{_display(result.get('broker'))}",
-        f"规则：到期 + {_display(result.get('grace_days'))} 天",
-        f"状态：{status_text}",
-        f"平仓：{applied}/{candidates}",
-        f"错误：{len(errors)}",
+        f"状态｜{status_text}",
+        f"券商｜{_display(result.get('broker'))}",
+        f"规则｜到期后 {_display(result.get('grace_days'))} 天",
+        f"结果｜成功 {applied} · 候选 {candidates} · 错误 {len(errors)}",
     ]
-    as_of = _optional_str(result.get("as_of_utc"))
+    as_of = format_iso_time_beijing(result.get("as_of_utc"))
     if as_of:
-        lines.append(f"时间：{as_of}")
+        lines.append(f"时间｜{as_of}")
 
     applied_items = [item for item in list(result.get("applied") or []) if isinstance(item, dict)]
     if applied_items:
-        lines.extend(["", "明细："])
+        lines.extend(["", "## 已完成"])
         for item in applied_items[:6]:
             lines.append(_applied_line(item))
         if len(applied_items) > 6:
-            lines.append(f"- 另有 {len(applied_items) - 6} 条已省略")
+            lines.append(f"补充｜另有 {len(applied_items) - 6} 条未展开")
 
     if errors:
-        lines.extend(["", "错误："])
-        for error in errors[:5]:
-            lines.append(f"- {error}")
+        lines.extend(["", "## 失败"])
+        lines.extend(errors[:5])
         if len(errors) > 5:
-            lines.append(f"- 另有 {len(errors) - 5} 条错误已省略")
+            lines.append(f"补充｜另有 {len(errors) - 5} 条错误未展开")
 
     return "\n".join(lines).strip()
 
@@ -566,17 +560,21 @@ def _int_value(value: Any) -> int:
 def _errors(result: dict[str, Any]) -> list[str]:
     raw = result.get("errors")
     if isinstance(raw, list):
-        return [str(item) for item in raw]
+        return [_flat_error(item) for item in raw]
     if raw:
-        return [str(raw)]
+        return [_flat_error(raw)]
     return []
+
+
+def _flat_error(value: Any) -> str:
+    return " · ".join(part.strip() for part in str(value).splitlines() if part.strip())
 
 
 def _applied_line(item: dict[str, Any]) -> str:
     record_id = _display(item.get("record_id"))
     position_id = _display(item.get("position_id"))
     expiration = _display(item.get("expiration_ymd") or item.get("expiration_ms"))
-    return f"- {record_id} | {position_id} | exp={expiration}"
+    return f"{record_id}｜{position_id}｜到期 {expiration}"
 
 
 def _display(value: Any) -> str:

--- a/src/application/scheduled_notification.py
+++ b/src/application/scheduled_notification.py
@@ -503,12 +503,15 @@ def build_notify_failure_summary_message(
     notify_failures: list[dict[str, object]],
 ) -> str:
     lines = [
-        "# 多账户通知投递异常",
+        "# OM · 系统告警 · 通知投递",
         "",
-        f"- run_id: `{run_id}`",
-        f"- 已确认账户: {', '.join(sent_accounts) if sent_accounts else '无'}",
-        "- 失败账户:",
+        "状态｜⚠️ 部分失败",
+        f"批次｜`{run_id}`",
+        f"已确认｜{', '.join(sent_accounts) if sent_accounts else '无'}",
+        f"失败｜{len(notify_failures)} 个账户",
     ]
+    if notify_failures:
+        lines.extend(["", "## 失败明细"])
     for failure in notify_failures:
         account = str(failure.get("account") or "").strip() or "unknown"
         error_code = str(failure.get("error_code") or "SEND_FAILED")
@@ -516,8 +519,16 @@ def build_notify_failure_summary_message(
         message_id = failure.get("message_id") or "none"
         confirmed = bool(failure.get("delivery_confirmed"))
         provider_response_code = failure.get("provider_response_code")
-        provider_part = "" if provider_response_code is None else f" provider_response_code={provider_response_code}"
-        lines.append(f"  - {account}: {error_code} attempts={attempts} confirmed={confirmed} message_id={message_id}{provider_part}")
+        parts = [
+            error_code,
+            f"尝试 {attempts} 次",
+            "已确认" if confirmed else "未确认",
+        ]
+        if message_id != "none":
+            parts.append(f"message_id={message_id}")
+        if provider_response_code is not None:
+            parts.append(f"provider_code={provider_response_code}")
+        lines.append(f"{account}｜{' · '.join(parts)}")
     return "\n".join(lines).strip()
 
 

--- a/src/application/scheduled_notification.py
+++ b/src/application/scheduled_notification.py
@@ -434,6 +434,9 @@ def mark_no_candidate_notification_metrics(
 
 
 def _notify_error_code(send_tool_dto: dict[str, Any]) -> str:
+    normalized_error = str(send_tool_dto.get("error_code") or "").strip()
+    if normalized_error:
+        return normalized_error
     return "SEND_UNCONFIRMED" if bool(send_tool_dto.get("command_ok")) else "SEND_FAILED"
 
 
@@ -618,6 +621,11 @@ def send_account_message_with_retry(
                 "retry_attempt_count": int(send_tool_dto.get("retry_attempt_count") or 0),
                 "ambiguous_send": bool(send_tool_dto.get("ambiguous_send")),
                 "duplicate_risk": bool(send_tool_dto.get("duplicate_risk")),
+                "local_error_code": send_tool_dto.get("local_error_code"),
+                "request_body_bytes": send_tool_dto.get("request_body_bytes"),
+                "request_body_budget_bytes": send_tool_dto.get("request_body_budget_bytes"),
+                "normalized_markdown_chars": send_tool_dto.get("normalized_markdown_chars"),
+                "normalized_markdown_sha256": send_tool_dto.get("normalized_markdown_sha256"),
             }
         except subprocess.TimeoutExpired as exc:
             message_id = None
@@ -772,6 +780,11 @@ def send_account_message_with_retry(
         "retry_attempt_count": int(final.get("retry_attempt_count") or 0),
         "ambiguous_send": bool(final.get("ambiguous_send")),
         "duplicate_risk": bool(final.get("duplicate_risk")),
+        "local_error_code": final.get("local_error_code"),
+        "request_body_bytes": final.get("request_body_bytes"),
+        "request_body_budget_bytes": final.get("request_body_budget_bytes"),
+        "normalized_markdown_chars": final.get("normalized_markdown_chars"),
+        "normalized_markdown_sha256": final.get("normalized_markdown_sha256"),
     }
 
 
@@ -855,6 +868,11 @@ def execute_per_account_delivery(
                     "retry_attempt_count": int(send_result.get("retry_attempt_count") or 0),
                     "ambiguous_send": bool(send_result.get("ambiguous_send")),
                     "duplicate_risk": bool(send_result.get("duplicate_risk")),
+                    "local_error_code": send_result.get("local_error_code"),
+                    "request_body_bytes": send_result.get("request_body_bytes"),
+                    "request_body_budget_bytes": send_result.get("request_body_budget_bytes"),
+                    "normalized_markdown_chars": send_result.get("normalized_markdown_chars"),
+                    "normalized_markdown_sha256": send_result.get("normalized_markdown_sha256"),
                 }
             )
             continue

--- a/src/application/trade_time_format.py
+++ b/src/application/trade_time_format.py
@@ -25,6 +25,19 @@ def format_trade_time_beijing(ms: Any) -> str | None:
     return dt.strftime("%Y-%m-%d %H:%M:%S 北京时间")
 
 
+def format_iso_time_beijing(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return text
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(BEIJING_TZ).strftime("%Y-%m-%d %H:%M:%S 北京时间")
+
+
 def add_trade_time_beijing(row: dict[str, Any], *, key: str = "trade_time_ms", field: str = "trade_time_beijing") -> dict[str, Any]:
     out = dict(row)
     formatted = format_trade_time_beijing(out.get(key))

--- a/src/application/trades/receipt.py
+++ b/src/application/trades/receipt.py
@@ -177,11 +177,14 @@ def build_trade_intake_receipt_message(
     diagnostics = cast(dict[str, Any], diagnostics_raw) if isinstance(diagnostics_raw, dict) else {}
     needs_lot_confirmation = status == "unresolved" and reason == "ambiguous_assigned_stock_sale"
     if status == "failed" and reason == "projection_verification_failed":
-        title = "[写入异常] 成交事件已写入但持仓投影未确认"
+        status_text = "❌ 写入异常"
     elif needs_lot_confirmation:
-        title = "[待确认] 成交未写入 option_positions"
+        status_text = "⚠️ 待确认"
+    elif applied:
+        status_text = "✅ 已完成"
     else:
-        title = "[已记录] 成交已写入 option_positions" if applied else "[未记录] 成交未写入 option_positions"
+        status_text = "❌ 未记录"
+
     account = _value("account", deal, result, payload) or "-"
     symbol = _value("symbol", deal, result, payload) or "-"
     action = _action_text(deal, result, payload)
@@ -202,56 +205,44 @@ def build_trade_intake_receipt_message(
     first_check = cast(dict[str, Any], checks[0]) if checks and isinstance(checks[0], dict) else {}
 
     lines = [
-        title,
+        f"# OM · 成交回执 · {account}",
         "",
-        f"账户：{account}",
-        f"动作：{action}",
-        f"标的：{symbol}",
+        f"状态｜{status_text}",
+        f"动作｜{action}",
+        f"标的｜{symbol}",
     ]
     contract_parts = [part for part in (expiration, strike, _option_type_text(option_type)) if part not in (None, "")]
     if contract_parts:
-        lines.append(f"合约：{' '.join(str(part) for part in contract_parts)}")
+        lines.append(f"合约｜{' '.join(str(part) for part in contract_parts)}")
     if contracts not in (None, ""):
-        lines.append(f"数量：{contracts} 张")
+        lines.append(f"数量｜{contracts} 张")
     if price not in (None, ""):
-        lines.append(f"成交价：{price}")
+        lines.append(f"成交｜{price}")
     funds = _premium_cashflow_text(deal, result, payload)
     if funds:
-        lines.append(f"资金：{funds}")
+        lines.append(f"资金｜{funds}")
     if trade_time:
-        lines.append(f"成交时间：{trade_time}")
-    status_text = (
-        "已记录"
-        if applied
-        else "写入异常"
-        if status == "failed" and reason == "projection_verification_failed"
-        else "待确认"
-        if needs_lot_confirmation
-        else "未记录"
-    )
-    lines.append(f"状态：{status_text}")
+        lines.append(f"时间｜{trade_time}")
     if projection_status:
-        lines.append(f"投影状态：{projection_status}")
+        lines.append(f"投影｜{projection_status}")
     if first_check:
         lines.append(
-            "目标持仓："
-            f"{first_check.get('contracts_open_before')} -> {first_check.get('actual_contracts_open_after')}"
-            f" / expected {first_check.get('expected_contracts_open_after')}"
+            "目标持仓｜"
+            f"{first_check.get('contracts_open_before')} → {first_check.get('actual_contracts_open_after')}"
+            f" · 预期 {first_check.get('expected_contracts_open_after')}"
         )
     if ledger_store:
-        lines.append(f"账本：{ledger_store.get('sqlite_path') or '-'}")
+        lines.append(f"账本｜{ledger_store.get('sqlite_path') or '-'}")
     if _combo_yield_relation_pending(diagnostics):
-        lines.append("组合关系待确认：未提供 pair_intent_id，已按单腿正常记录，未自动归入 Combo Yield 组。")
-    lines.append(f"原因：{reason}")
+        lines.append("组合｜关系待确认；未提供 pair_intent_id，当前按单腿记录，未自动归入 Combo Yield 组。")
+    lines.append(f"诊断｜{reason}")
     if needs_lot_confirmation:
         candidate_lines = _assigned_stock_candidate_lines(diagnostics)
         if candidate_lines:
-            lines.append("")
-            lines.append("需要确认本次卖出对应哪一批 assigned-stock lot；确认前不会自动写入。")
-            lines.append("候选 lot：")
-            lines.extend(candidate_lines)
-            lines.append("请确认要匹配的选项，例如：选择 A。")
-    lines.append(f"deal_id：{deal_id}")
+            lines.extend(["说明｜需要确认卖出对应的 assigned-stock lot；确认前不会自动写入。", "", "## 可选批次"])
+            lines.extend(line.replace("：", "｜", 1) for line in candidate_lines)
+            lines.append("下一步｜回复“选择 A”")
+    lines.append(f"编号｜`{deal_id}`")
     return "\n".join(lines)
 
 

--- a/src/infrastructure/feishu_bot.py
+++ b/src/infrastructure/feishu_bot.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Any, Callable
 from urllib.parse import quote
 
-from src.infrastructure.feishu_bitable import http_json, with_tenant_token_retry
+from src.infrastructure.feishu_bitable import FeishuPermanentError, http_json, with_tenant_token_retry
 
 
 HttpJsonFn = Callable[..., dict[str, Any]]
@@ -120,6 +121,84 @@ def send_text_message(
     }
     if uuid:
         payload["uuid"] = str(uuid)
+
+    def _send(tenant_token: str) -> dict[str, Any]:
+        return http_json_fn(
+            "POST",
+            url,
+            payload,
+            headers={
+                "Authorization": f"Bearer {tenant_token}",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            retry_max_attempts=(3 if uuid else 1),
+            log_fn=log_fn,
+            log_success_attempts=bool(log_fn),
+        )
+
+    return with_tenant_token_retry(app_id, app_secret, _send)
+
+
+FEISHU_POST_REQUEST_BUDGET_BYTES = 28 * 1024
+FEISHU_POST_TOO_LARGE = "FEISHU_POST_TOO_LARGE"
+
+
+def send_post_message(
+    *,
+    app_id: str,
+    app_secret: str,
+    open_id: str,
+    markdown: str,
+    uuid: str | None = None,
+    log_fn: Callable[[dict[str, Any]], Any] | None = None,
+    http_json_fn: HttpJsonFn = http_json,
+) -> dict[str, Any]:
+    open_id_value = str(open_id or "").strip()
+    markdown_value = str(markdown or "").strip()
+    if not open_id_value:
+        raise ValueError("open_id is required")
+    if not markdown_value:
+        raise ValueError("markdown is required")
+
+    request_path = "/open-apis/im/v1/messages?receive_id_type=open_id"
+    url = f"https://open.feishu.cn{request_path}"
+    payload = {
+        "receive_id": open_id_value,
+        "msg_type": "post",
+        "content": json.dumps(
+            {
+                "zh_cn": {
+                    "content": [
+                        [
+                            {
+                                "tag": "md",
+                                "text": markdown_value,
+                            }
+                        ]
+                    ]
+                }
+            },
+            ensure_ascii=False,
+        ),
+    }
+    if uuid:
+        payload["uuid"] = str(uuid)
+
+    request_body_bytes = len(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+    if request_body_bytes > FEISHU_POST_REQUEST_BUDGET_BYTES:
+        raise FeishuPermanentError(
+            "feishu post request exceeds local byte budget",
+            response={
+                "local_error_code": FEISHU_POST_TOO_LARGE,
+                "http_status": None,
+                "feishu_code": None,
+                "http_attempts": [],
+                "request_body_bytes": request_body_bytes,
+                "request_body_budget_bytes": FEISHU_POST_REQUEST_BUDGET_BYTES,
+                "normalized_markdown_chars": len(markdown_value),
+                "normalized_markdown_sha256": hashlib.sha256(markdown_value.encode("utf-8")).hexdigest(),
+            },
+        )
 
     def _send(tenant_token: str) -> dict[str, Any]:
         return http_json_fn(

--- a/tests/notification_format_assertions.py
+++ b/tests/notification_format_assertions.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import re
+
+
+_NESTED_LIST_RE = re.compile(r"^(?:\t+| {2,})(?:[-*+]|\d+\.)\s", re.MULTILINE)
+
+
+def assert_mobile_flat_markdown(message: str, *, require_title: bool = True) -> None:
+    lines = str(message or "").splitlines()
+    if require_title:
+        assert sum(line.startswith("# ") for line in lines) == 1
+    assert not any(line.startswith("###") for line in lines)
+    assert not any(line.startswith(">") for line in lines)
+    assert _NESTED_LIST_RE.search(message) is None
+    assert not any(line.strip().startswith("|") and line.strip().endswith("|") for line in lines)

--- a/tests/test_daily_decision_brief_notification_flow.py
+++ b/tests/test_daily_decision_brief_notification_flow.py
@@ -556,8 +556,8 @@ def test_scheduled_notification_renders_batch_and_localized_data_time(monkeypatc
     prepared = mod._prepare_daily_brief_notification(bundle.request)
     message = prepared.prepared_messages.messages_by_account["lx"]
 
-    assert "> 今日首次 · 10:00 批次" in message
-    assert "数据截至：美东 09:39 / 北京 21:39" in message
+    assert "状态｜今日首次 · 10:00 批次" in message
+    assert "数据｜美东 09:39 / 北京 21:39" in message
     assert "2026-07-19T" not in message
     lifecycle = prepared.lifecycles_by_account["lx"]
     assert "scheduled_target_market" not in lifecycle["brief"]
@@ -584,5 +584,5 @@ def test_force_notification_says_manual_and_ignores_scheduler_batch(monkeypatch,
     prepared = mod._prepare_daily_brief_notification(bundle.request)
     message = prepared.prepared_messages.messages_by_account["lx"]
 
-    assert "> 手动触发" in message
+    assert "状态｜手动触发" in message
     assert "10:00 批次" not in message

--- a/tests/test_daily_decision_brief_renderer.py
+++ b/tests/test_daily_decision_brief_renderer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 
 def _candidate(
     *,
@@ -213,23 +215,25 @@ def test_full_renderer_is_compact_human_readable_and_allowlisted() -> None:
     )
     message = render_daily_brief_lifecycle(lifecycle, context=_scheduled_context())
 
-    assert message.startswith("# OM · lx · 美股")
-    assert "> 今日首次 · 10:00 批次" in message
-    assert "数据截至：美东 10:03 / 北京 22:03" in message
+    assert message.startswith("# OM · 决策简报 · lx")
+    assert "状态｜今日首次 · 10:00 批次" in message
+    assert "市场｜美股" in message
+    assert "数据｜美东 10:03 / 北京 22:03" in message
     assert "## 候选" in message
     assert "## 持仓" in message
     assert "## 资金" in message
-    assert "MSFT · Sell Put · 08-21 $400 Put（首选）" in message
-    assert "NVDA · Sell Put · 08-21 $100 Put（备选 2）" in message
-    assert "AAPL · Covered Call · 08-21 $250 Call（首选）" in message
-    assert "TSLA · 组合增强（首选）" in message
-    assert "Put：08-21 $300 Put" in message
-    assert "Call：09-18 $400 Call" in message
-    assert "PDD · 组合增强（Put 侧）：暂无法评估（行情覆盖不足）" in message
-    assert "FUTU · Sell Put：暂无法评估（价格不可用）" in message
-    assert "MSFT 08-21 $400 Put：按当前现金最多 2 手" in message
-    assert "NVDA 08-21 $100 Put：按当前现金最多 5 手" in message
+    assert "MSFT｜Sell Put｜08-21 $400 Put（首选）" in message
+    assert "NVDA｜Sell Put｜08-21 $100 Put（备选 2）" in message
+    assert "AAPL｜Covered Call｜08-21 $250 Call（首选）" in message
+    assert "TSLA｜组合增强（首选）" in message
+    assert "Put｜08-21 $300 Put" in message
+    assert "Call｜09-18 $400 Call" in message
+    assert "PDD｜组合增强（Put 侧）｜暂无法评估（行情覆盖不足）" in message
+    assert "FUTU｜Sell Put｜暂无法评估（价格不可用）" in message
+    assert "MSFT 08-21 $400 Put｜按当前现金最多 2 手" in message
+    assert "NVDA 08-21 $100 Put｜按当前现金最多 5 手" in message
     assert "备选方案共享同一现金额度，数量不可相加" in message
+    assert_mobile_flat_markdown(message)
     _assert_no_internal_leak(message)
     _assert_no_internal_leak(view)
 
@@ -260,9 +264,9 @@ def test_hk_actionable_close_renders_price_locked_profit_and_remaining_yield() -
 
     message = render_full_brief(brief)
 
-    assert "- 3690.HK · Sell Put · 08-28 HK$65 Put：建议平仓" in message
+    assert "3690.HK｜Sell Put｜08-28 HK$65 Put｜建议平仓" in message
     assert (
-        "  - 参考平仓价 HK$0.52（mid） · 预计锁定收益 HK$474.50 · 剩余年化 4.2%"
+        "参考｜参考平仓价 HK$0.52（mid） · 预计锁定收益 HK$474.50 · 剩余年化 4.2%"
         in message
     )
 
@@ -326,7 +330,7 @@ def test_close_details_use_signed_pnl_and_degrade_without_inventing_values() -> 
     message = render_full_brief(brief)
 
     assert "预计平仓损益 -HK$125.50" in message
-    assert "PARTIAL.HK · Sell Put · 08-28 HK$55 Put：建议平仓" in message
+    assert "PARTIAL.HK｜Sell Put｜08-28 HK$55 Put｜建议平仓" in message
     assert "参考平仓价 HK$0.30（mid）" in message
     assert "nan" not in message.lower()
     assert "invalid" not in message.lower()
@@ -344,7 +348,7 @@ def test_combo_position_attribution_is_independent_from_new_combo_candidates() -
     message = render_full_brief(brief)
 
     assert "TSLA · 组合增强" not in message
-    assert "PDD · 组合增强（Put 侧）：暂无法评估（行情覆盖不足）" in message
+    assert "PDD｜组合增强（Put 侧）｜暂无法评估（行情覆盖不足）" in message
     assert "combo-pdd-secret" not in message
     assert "funding_put" not in message
 
@@ -360,10 +364,10 @@ def test_blocked_renderer_is_short_safe_and_has_no_candidate_snapshot() -> None:
         context=_scheduled_context(),
     )
 
-    assert message.startswith("# OM · lx · 美股")
-    assert "> 数据异常 · 10:00 批次" in message
-    assert "本轮行情覆盖不足，暂时无法形成可靠决策。" in message
-    assert "系统将在后续批次自动重新评估。" in message
+    assert message.startswith("# OM · 决策简报 · lx")
+    assert "状态｜数据异常 · 10:00 批次" in message
+    assert "结论｜本轮行情覆盖不足，暂时无法形成可靠决策。" in message
+    assert "后续｜系统将在后续批次自动重新评估。" in message
     assert "## 候选" not in message
     assert "## 持仓" not in message
     assert "MSFT" not in message
@@ -410,10 +414,10 @@ def test_delta_and_recovery_add_change_banner_but_keep_current_snapshot() -> Non
         },
         context=_scheduled_context(),
     )
-    assert "> 盘中更新 · 10:00 批次" in delta
+    assert "状态｜盘中更新 · 10:00 批次" in delta
     assert "较上一轮：新增 1 个 Sell Put 候选" in delta
     assert "MSFT 08-21 $400 Put 条件容量 1 → 2 手" in delta
-    assert "MSFT · Sell Put · 08-21 $400 Put（首选）" in delta
+    assert "MSFT｜Sell Put｜08-21 $400 Put（首选）" in delta
     assert "secret-in-diff" not in delta
 
     recovery = render_daily_brief_lifecycle(
@@ -424,9 +428,9 @@ def test_delta_and_recovery_add_change_banner_but_keep_current_snapshot() -> Non
         },
         context=_scheduled_context(),
     )
-    assert "> 数据已恢复 · 10:00 批次" in recovery
+    assert "状态｜数据已恢复 · 10:00 批次" in recovery
     assert "数据已恢复，以下为当前结果。" in recovery
-    assert "MSFT · Sell Put · 08-21 $400 Put（首选）" in recovery
+    assert "MSFT｜Sell Put｜08-21 $400 Put（首选）" in recovery
 
 
 def test_old_candidate_diff_vocabulary_is_not_mislabeled_as_position_change() -> None:
@@ -480,10 +484,10 @@ def test_position_statuses_use_safe_allowlisted_fallbacks() -> None:
     ]
     message = render_full_brief(brief)
 
-    assert "A · Sell Put：暂无法评估（行情覆盖不足）" in message
-    assert "B · Sell Put：暂无法评估（价格不可用）" in message
-    assert "C · Sell Put：暂无法评估（数据暂不可用）" in message
-    assert "D · Sell Put：继续观察" in message
+    assert "A｜Sell Put｜暂无法评估（行情覆盖不足）" in message
+    assert "B｜Sell Put｜暂无法评估（价格不可用）" in message
+    assert "C｜Sell Put｜暂无法评估（数据暂不可用）" in message
+    assert "D｜Sell Put｜继续观察" in message
     assert "future_state" not in message
 
 
@@ -511,9 +515,10 @@ def test_malformed_fields_and_unknown_enums_do_not_echo_raw_values() -> None:
     }
     message = render_full_brief(brief)
 
-    assert message.startswith("# OM · lx · 市场")
-    assert "数据截至：数据时间未知" in message
-    assert "TCOM · Sell Put · 合约信息不完整（首选）" in message
+    assert message.startswith("# OM · 决策简报 · lx")
+    assert "市场｜市场" in message
+    assert "数据｜数据时间未知" in message
+    assert "TCOM｜Sell Put｜合约信息不完整（首选）" in message
     for raw in (
         "FUTURE_MARKET",
         "FUTURE_STATE",
@@ -539,7 +544,7 @@ def test_manual_trigger_omits_scheduled_batch_and_planning_is_plain_language() -
         },
     )
 
-    assert "> 手动触发" in message
+    assert "状态｜手动触发" in message
     assert "10:00 批次" not in message
     assert "当前已不在可执行时段，仅供规划参考。" in message
     assert "PLANNING" not in message
@@ -584,15 +589,15 @@ def test_renderer_honors_section_limits() -> None:
         },
     )
 
-    assert "P0 · Sell Put" in message
-    assert "P1 · Sell Put" in message
-    assert "P2 · Sell Put" not in message
+    assert "P0｜Sell Put" in message
+    assert "P1｜Sell Put" in message
+    assert "P2｜Sell Put" not in message
     assert "另有 6 个持仓未展开" in message
-    assert "C6 · Sell Put" in message
-    assert "C7 · Sell Put" not in message
+    assert "C6｜Sell Put" in message
+    assert "C7｜Sell Put" not in message
     assert "Sell Put 另有 13 个候选未展开" in message
-    assert "C6 08-21 $106 Put：按当前现金最多 1 手" in message
-    assert "C7 08-21 $107 Put：按当前现金最多 1 手" not in message
+    assert "C6 08-21 $106 Put｜按当前现金最多 1 手" in message
+    assert "C7 08-21 $107 Put｜按当前现金最多 1 手" not in message
 
 
 def test_material_candidates_break_soft_limit_and_keep_funds_in_sync() -> None:
@@ -638,13 +643,13 @@ def test_material_candidates_break_soft_limit_and_keep_funds_in_sync() -> None:
         limits={"max_candidates_per_strategy": 1},
     )
 
-    assert "C2 · Sell Put · 08-21 $102 Put（备选 3）" in message
-    assert "C3 · Sell Put · 08-21 $103 Put（备选 4）" in message
-    assert "C0 · Sell Put" not in message
+    assert "C2｜Sell Put｜08-21 $102 Put（备选 3）" in message
+    assert "C3｜Sell Put｜08-21 $103 Put（备选 4）" in message
+    assert "C0｜Sell Put" not in message
     assert "Sell Put 另有 2 个候选未展开" in message
-    assert "C2 08-21 $102 Put：按当前现金最多 3 手" in message
-    assert "C3 08-21 $103 Put：按当前现金最多 4 手" in message
-    assert "C0 08-21 $100 Put：按当前现金最多 1 手" not in message
+    assert "C2 08-21 $102 Put｜按当前现金最多 3 手" in message
+    assert "C3 08-21 $103 Put｜按当前现金最多 4 手" in message
+    assert "C0 08-21 $100 Put｜按当前现金最多 1 手" not in message
 
 
 def test_invalidated_candidate_banner_keeps_removed_contract_identifiable() -> None:
@@ -722,7 +727,7 @@ def test_material_position_uses_exact_lot_before_same_contract_siblings() -> Non
         limits={"max_actions_per_priority": 1},
     )
 
-    assert "PDD · 组合增强（Put 侧） · 08-21 $95 Put：建议平掉 Put，保留 Call" in view_message
+    assert "PDD｜组合增强（Put 侧）｜08-21 $95 Put｜建议平掉 Put，保留 Call" in view_message
     assert "继续观察" not in view_message
     assert "另有 2 个持仓未展开" in view_message
     assert "lot-2" not in view_message
@@ -876,7 +881,7 @@ def test_event_date_change_summary_names_candidate_and_expiry_relation() -> None
 
     assert "较上一轮：NVDA 08-21 $100 Put 财报日期调整至 8 月 5 日，现在早于当前 Put 到期日。" in message
     assert message.count("进入当前合约关注窗口") == 0
-    assert "NVDA · Sell Put · 08-21 $100 Put（备选 2）" in message
+    assert "NVDA｜Sell Put｜08-21 $100 Put（备选 2）" in message
 
 
 def test_event_evidence_degradation_summary_does_not_claim_event_removal() -> None:

--- a/tests/test_feishu_bot.py
+++ b/tests/test_feishu_bot.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from src.infrastructure import feishu_bot
+from tests.notification_format_assertions import assert_mobile_flat_markdown
 
 
 def _post_request_body_bytes(markdown: str, *, uuid: str | None = None) -> int:
@@ -511,14 +512,16 @@ def test_real_notification_renderers_are_embedded_unchanged_in_single_md_node(
         "failure-recovery": failure_recovery,
     }
 
-    assert daily_brief.startswith("# OM · lx · 美股\n> ")
-    assert "\n## 候选\n1. " in daily_brief
-    assert "\n   - " in daily_brief
+    assert daily_brief.startswith("# OM · 决策简报 · lx")
+    assert "状态｜当前简报" in daily_brief
+    assert "\n## 候选\n\n**1｜" in daily_brief
     assert all(section in compact_tick for section in ("## 候选", "## 持仓", "## 资金"))
-    assert "合约：2026-08-21 100 Put" in trade_receipt
-    assert "候选 lot：" in trade_receipt
-    assert "明细：" in maintenance_receipt and "错误：" in maintenance_receipt
-    assert "FEISHU_POST_TOO_LARGE attempts=1" in failure_recovery
+    assert "合约｜2026-08-21 100 Put" in trade_receipt
+    assert "## 可选批次" in trade_receipt
+    assert "## 已完成" in maintenance_receipt and "## 失败" in maintenance_receipt
+    assert "FEISHU_POST_TOO_LARGE · 尝试 1 次" in failure_recovery
+    for message in messages.values():
+        assert_mobile_flat_markdown(message)
 
     payloads: list[dict] = []
     monkeypatch.setattr(

--- a/tests/test_feishu_bot.py
+++ b/tests/test_feishu_bot.py
@@ -365,3 +365,184 @@ def test_send_post_message_enforces_exact_final_request_boundary(
 
     assert len(token_calls) == 1
     assert len(http_calls) == 1
+
+
+def test_real_notification_renderers_are_embedded_unchanged_in_single_md_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.application.daily_decision_brief_renderer import render_full_brief
+    from src.application.multi_tick.misc import AccountResult
+    from src.application.multi_tick.notify_format import build_account_message_compact
+    from src.application.positions.maintenance_receipt import build_auto_close_receipt_message
+    from src.application.scheduled_notification import build_notify_failure_summary_message
+    from src.application.trades.receipt import build_trade_intake_receipt_message
+
+    daily_brief = render_full_brief(
+        {
+            "market": "US",
+            "account": "lx",
+            "actionability": "live_actionable",
+            "data_as_of_utc": "2026-07-21T14:03:00+00:00",
+            "candidates": {
+                "sell_put": [
+                    {
+                        "rank": 1,
+                        "symbol": "NVDA",
+                        "option_type": "put",
+                        "expiration": "2026-08-21",
+                        "strike": 100,
+                        "priority": "P1",
+                        "metrics": {
+                            "mid": 5.25,
+                            "annualized_net_return_on_cash_basis": 0.181,
+                            "delta": -0.24,
+                            "dte": 32,
+                            "net_income": 480,
+                        },
+                        "capacity": {"contracts_available": 1, "reason": "cash_supported"},
+                    }
+                ],
+                "covered_call": [],
+                "combo_yield": [],
+            },
+            "positions": [
+                {
+                    "symbol": "NVDA",
+                    "strategy_family": "sell_put",
+                    "expiration": "2026-08-21",
+                    "strike": 100,
+                    "option_type": "put",
+                    "close_action": "close",
+                    "evaluation_status": "evaluable",
+                    "quote_status": "priced",
+                    "metrics": {
+                        "close_mid": 0.52,
+                        "realized_if_close": 474.5,
+                        "remaining_annualized_return": 0.042,
+                    },
+                }
+            ],
+            "capacity": {"sell_put": {"contracts_available": 1, "reason": "cash_supported"}},
+        }
+    )
+    compact_tick = build_account_message_compact(
+        AccountResult(
+            account="lx",
+            ran_scan=True,
+            should_notify=True,
+            decision_reason="dense",
+            notification_text=(
+                "### Sell Put\n"
+                "🟢 Sell Put NVDA 100P @ 08-21 | 🎯建议挂单 5.25\n"
+                "- 权利金 5.25USD · 年化 18.1% · 32天\n\n"
+                "### [lx] 平仓建议 (1)\n"
+                "- NVDA Put 2026-08-21 100P · 建议平仓\n"
+                "- 待补数据:\n"
+                "- PDD Put 2026-08-21 95P · 无法评估 | 当前未取得可用价格\n"
+            ),
+        ),
+        now_bj="2026-07-21 22:03:00",
+        cash_footer_lines=["💰 现金 USD", "LX 持有 $10,000 | 可用 $2,000"],
+    )
+    trade_receipt = build_trade_intake_receipt_message(
+        deal=None,
+        result={
+            "status": "unresolved",
+            "reason": "ambiguous_assigned_stock_sale",
+            "deal_id": "deal-1",
+            "account": "lx",
+            "action": "close",
+            "diagnostics": {
+                "candidates": [
+                    {
+                        "symbol": "NVDA",
+                        "currency": "USD",
+                        "shares_remaining": 100,
+                        "stock_cost_per_share": 100,
+                        "stock_lot_id": "lot-1",
+                    }
+                ]
+            },
+        },
+        payload={
+            "symbol": "NVDA",
+            "option_type": "put",
+            "expiration_ymd": "2026-08-21",
+            "strike": 100,
+            "qty": 1,
+            "price": 5.25,
+            "side": "sell",
+        },
+    )
+    maintenance_receipt = build_auto_close_receipt_message(
+        dry_run=False,
+        result={
+            "mode": "applied",
+            "account": "lx",
+            "broker": "富途",
+            "grace_days": 2,
+            "applied_closed": 1,
+            "candidates_should_close": 2,
+            "as_of_utc": "2026-07-21T14:03:00+00:00",
+            "applied": [
+                {"record_id": "rec_1", "position_id": "pos_1", "expiration_ymd": "2026-07-18"}
+            ],
+            "errors": ["rec_2 pos_2: sqlite locked"],
+        },
+    )
+    failure_recovery = build_notify_failure_summary_message(
+        run_id="run-1",
+        sent_accounts=["sy"],
+        notify_failures=[
+            {
+                "account": "lx",
+                "error_code": "FEISHU_POST_TOO_LARGE",
+                "attempts": 1,
+                "delivery_confirmed": False,
+                "message_id": None,
+            }
+        ],
+    )
+    messages = {
+        "daily-brief": daily_brief,
+        "compact-tick": compact_tick,
+        "trade-receipt": trade_receipt,
+        "maintenance-receipt": maintenance_receipt,
+        "failure-recovery": failure_recovery,
+    }
+
+    assert daily_brief.startswith("# OM · lx · 美股\n> ")
+    assert "\n## 候选\n1. " in daily_brief
+    assert "\n   - " in daily_brief
+    assert all(section in compact_tick for section in ("## 候选", "## 持仓", "## 资金"))
+    assert "合约：2026-08-21 100 Put" in trade_receipt
+    assert "候选 lot：" in trade_receipt
+    assert "明细：" in maintenance_receipt and "错误：" in maintenance_receipt
+    assert "FEISHU_POST_TOO_LARGE attempts=1" in failure_recovery
+
+    payloads: list[dict] = []
+    monkeypatch.setattr(
+        feishu_bot,
+        "with_tenant_token_retry",
+        lambda app_id, app_secret, fn: fn("tenant_token"),
+    )
+
+    def _http_json(method: str, url: str, payload: dict, headers: dict, **kwargs) -> dict:
+        payloads.append(payload)
+        return {"code": 0, "data": {"message_id": f"om_{len(payloads)}"}}
+
+    for name, message in messages.items():
+        feishu_bot.send_post_message(
+            app_id="app_1",
+            app_secret="secret_1",
+            open_id="ou_1",
+            markdown=message,
+            uuid=f"fixture-{name}",
+            http_json_fn=_http_json,
+        )
+
+    assert len(payloads) == len(messages)
+    for payload, expected in zip(payloads, messages.values(), strict=True):
+        content = json.loads(payload["content"])
+        assert content == {"zh_cn": {"content": [[{"tag": "md", "text": expected.strip()}]]}}
+        assert "title" not in content["zh_cn"]

--- a/tests/test_feishu_bot.py
+++ b/tests/test_feishu_bot.py
@@ -1,8 +1,25 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 import pytest
 
 from src.infrastructure import feishu_bot
+
+
+def _post_request_body_bytes(markdown: str, *, uuid: str | None = None) -> int:
+    payload = {
+        "receive_id": "ou_1",
+        "msg_type": "post",
+        "content": json.dumps(
+            {"zh_cn": {"content": [[{"tag": "md", "text": markdown}]]}},
+            ensure_ascii=False,
+        ),
+    }
+    if uuid:
+        payload["uuid"] = uuid
+    return len(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
 
 
 def test_add_message_reaction_posts_feishu_reaction_payload(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -147,3 +164,204 @@ def test_send_text_message_without_uuid_disables_ambiguous_retry(monkeypatch: py
 
     assert "uuid" not in calls[0]["payload"]
     assert calls[0]["kwargs"]["retry_max_attempts"] == 1
+
+
+def test_send_post_message_posts_single_md_node_without_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict] = []
+    markdown = '# 决策简报\n\n> 中文 "quote" 🙂\n\n- **NVDA**\n  - 合约: 1'
+
+    monkeypatch.setattr(
+        feishu_bot,
+        "with_tenant_token_retry",
+        lambda app_id, app_secret, fn: fn("tenant_token"),
+    )
+
+    def _http_json(method: str, url: str, payload: dict, headers: dict, **kwargs) -> dict:
+        calls.append({"method": method, "url": url, "payload": payload, "headers": headers, "kwargs": kwargs})
+        return {"code": 0, "data": {"message_id": "om_1"}}
+
+    out = feishu_bot.send_post_message(
+        app_id="app_1",
+        app_secret="secret_1",
+        open_id="  ou_1  ",
+        markdown=f"  {markdown}  ",
+        uuid="idem-1",
+        http_json_fn=_http_json,
+    )
+
+    assert out["code"] == 0
+    payload = calls[0]["payload"]
+    assert payload["receive_id"] == "ou_1"
+    assert payload["msg_type"] == "post"
+    assert payload["uuid"] == "idem-1"
+    assert json.loads(payload["content"]) == {
+        "zh_cn": {"content": [[{"tag": "md", "text": markdown}]]}
+    }
+    assert "title" not in json.loads(payload["content"])["zh_cn"]
+    assert calls[0]["kwargs"]["retry_max_attempts"] == 3
+
+
+def test_send_post_message_without_uuid_disables_ambiguous_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict] = []
+
+    monkeypatch.setattr(
+        feishu_bot,
+        "with_tenant_token_retry",
+        lambda app_id, app_secret, fn: fn("tenant_token"),
+    )
+
+    def _http_json(method: str, url: str, payload: dict, headers: dict, **kwargs) -> dict:
+        calls.append({"payload": payload, "kwargs": kwargs})
+        return {"code": 0, "data": {"message_id": "om_1"}}
+
+    feishu_bot.send_post_message(
+        app_id="app_1",
+        app_secret="secret_1",
+        open_id="ou_1",
+        markdown="# hello",
+        http_json_fn=_http_json,
+    )
+
+    assert "uuid" not in calls[0]["payload"]
+    assert calls[0]["kwargs"]["retry_max_attempts"] == 1
+
+
+@pytest.mark.parametrize("open_id", ["", "   ", None])
+def test_send_post_message_requires_open_id(open_id: object) -> None:
+    with pytest.raises(ValueError, match="open_id is required"):
+        feishu_bot.send_post_message(
+            app_id="app_1",
+            app_secret="secret_1",
+            open_id=open_id,  # type: ignore[arg-type]
+            markdown="# hello",
+        )
+
+
+@pytest.mark.parametrize("markdown", ["", "   ", None])
+def test_send_post_message_requires_markdown(markdown: object) -> None:
+    with pytest.raises(ValueError, match="markdown is required"):
+        feishu_bot.send_post_message(
+            app_id="app_1",
+            app_secret="secret_1",
+            open_id="ou_1",
+            markdown=markdown,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("uuid", [None, "idem-1"])
+def test_send_post_message_rejects_oversized_final_request_before_token_or_http(
+    monkeypatch: pytest.MonkeyPatch,
+    uuid: str | None,
+) -> None:
+    token_calls: list[object] = []
+    http_calls: list[object] = []
+    markdown = ("中🙂\"\n" * feishu_bot.FEISHU_POST_REQUEST_BUDGET_BYTES).strip()
+
+    monkeypatch.setattr(
+        feishu_bot,
+        "with_tenant_token_retry",
+        lambda *args, **kwargs: token_calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(feishu_bot.FeishuPermanentError) as raised:
+        feishu_bot.send_post_message(
+            app_id="app_1",
+            app_secret="secret_1",
+            open_id="ou_1",
+            markdown=markdown,
+            uuid=uuid,
+            http_json_fn=lambda *args, **kwargs: http_calls.append((args, kwargs)),
+        )
+
+    assert token_calls == []
+    assert http_calls == []
+    response = raised.value.response
+    assert response == {
+        "local_error_code": feishu_bot.FEISHU_POST_TOO_LARGE,
+        "http_status": None,
+        "feishu_code": None,
+        "http_attempts": [],
+        "request_body_bytes": response["request_body_bytes"],
+        "request_body_budget_bytes": feishu_bot.FEISHU_POST_REQUEST_BUDGET_BYTES,
+        "normalized_markdown_chars": len(markdown),
+        "normalized_markdown_sha256": hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
+    }
+    assert response["request_body_bytes"] > response["request_body_budget_bytes"]
+    assert markdown not in repr(response)
+
+
+def test_send_post_message_measures_full_outer_request_and_sends_under_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+    markdown = ("中🙂\"\n" * 1000).strip()
+
+    monkeypatch.setattr(
+        feishu_bot,
+        "with_tenant_token_retry",
+        lambda app_id, app_secret, fn: fn("tenant_token"),
+    )
+
+    def _http_json(method: str, url: str, payload: dict, headers: dict, **kwargs) -> dict:
+        calls.append({"payload": payload, "kwargs": kwargs})
+        return {"code": 0, "data": {"message_id": "om_1"}}
+
+    feishu_bot.send_post_message(
+        app_id="app_1",
+        app_secret="secret_1",
+        open_id="ou_1",
+        markdown=markdown,
+        uuid="idem-1",
+        http_json_fn=_http_json,
+    )
+
+    payload = calls[0]["payload"]
+    assert len(json.dumps(payload, ensure_ascii=False).encode("utf-8")) < feishu_bot.FEISHU_POST_REQUEST_BUDGET_BYTES
+    assert json.loads(payload["content"])["zh_cn"]["content"][0][0]["text"] == markdown
+
+
+@pytest.mark.parametrize("uuid", [None, "idem-1"])
+def test_send_post_message_enforces_exact_final_request_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    uuid: str | None,
+) -> None:
+    token_calls: list[tuple[str, str]] = []
+    http_calls: list[dict] = []
+    one_char_overhead = _post_request_body_bytes("a", uuid=uuid) - 1
+    exact_markdown = "a" * (feishu_bot.FEISHU_POST_REQUEST_BUDGET_BYTES - one_char_overhead)
+
+    assert _post_request_body_bytes(exact_markdown, uuid=uuid) == feishu_bot.FEISHU_POST_REQUEST_BUDGET_BYTES
+    assert _post_request_body_bytes(exact_markdown + "a", uuid=uuid) == (
+        feishu_bot.FEISHU_POST_REQUEST_BUDGET_BYTES + 1
+    )
+
+    def _with_token(app_id: str, app_secret: str, fn):  # type: ignore[no-untyped-def]
+        token_calls.append((app_id, app_secret))
+        return fn("tenant_token")
+
+    def _http_json(method: str, url: str, payload: dict, headers: dict, **kwargs) -> dict:
+        http_calls.append(payload)
+        return {"code": 0, "data": {"message_id": "om_1"}}
+
+    monkeypatch.setattr(feishu_bot, "with_tenant_token_retry", _with_token)
+
+    feishu_bot.send_post_message(
+        app_id="app_1",
+        app_secret="secret_1",
+        open_id="ou_1",
+        markdown=exact_markdown,
+        uuid=uuid,
+        http_json_fn=_http_json,
+    )
+    with pytest.raises(feishu_bot.FeishuPermanentError):
+        feishu_bot.send_post_message(
+            app_id="app_1",
+            app_secret="secret_1",
+            open_id="ou_1",
+            markdown=exact_markdown + "a",
+            uuid=uuid,
+            http_json_fn=_http_json,
+        )
+
+    assert len(token_calls) == 1
+    assert len(http_calls) == 1

--- a/tests/test_feishu_notification_sender.py
+++ b/tests/test_feishu_notification_sender.py
@@ -119,11 +119,11 @@ def test_send_feishu_app_message_uses_bot_user_open_id_when_target_empty(monkeyp
     monkeypatch.setenv("OM_FEISHU_BOT_USER_OPEN_ID", "ou_1")
     captured: dict[str, str] = {}
 
-    def _send_text_message(**kwargs):  # type: ignore[no-untyped-def]
-        captured.update({key: str(value) for key, value in kwargs.items() if key in {"app_id", "app_secret", "open_id", "text", "uuid"}})
+    def _send_post_message(**kwargs):  # type: ignore[no-untyped-def]
+        captured.update({key: str(value) for key, value in kwargs.items() if key in {"app_id", "app_secret", "open_id", "markdown", "uuid"}})
         return {"code": 0, "msg": "success", "data": {"message_id": "om_1"}}
 
-    monkeypatch.setattr(service, "send_text_message", _send_text_message)
+    monkeypatch.setattr(service, "send_post_message", _send_post_message)
 
     out = service.send_feishu_app_message(
         base=tmp_path,
@@ -138,7 +138,7 @@ def test_send_feishu_app_message_uses_bot_user_open_id_when_target_empty(monkeyp
     assert captured["app_id"] == "cli_1"
     assert captured["app_secret"] == "sec_1"
     assert captured["open_id"] == "ou_1"
-    assert captured["text"] == "hello"
+    assert captured["markdown"] == "hello"
     assert captured["uuid"] == "idem-1"
 
 
@@ -150,11 +150,11 @@ def test_send_feishu_app_message_ignores_config_target_for_bot_channel(monkeypat
     monkeypatch.setenv("OM_FEISHU_BOT_USER_OPEN_ID", "ou_bot")
     captured: dict[str, str] = {}
 
-    def _send_text_message(**kwargs):  # type: ignore[no-untyped-def]
+    def _send_post_message(**kwargs):  # type: ignore[no-untyped-def]
         captured.update({key: str(value) for key, value in kwargs.items() if key in {"open_id"}})
         return {"code": 0, "msg": "success", "data": {"message_id": "om_1"}}
 
-    monkeypatch.setattr(service, "send_text_message", _send_text_message)
+    monkeypatch.setattr(service, "send_post_message", _send_post_message)
 
     out = service.send_feishu_app_message(
         base=tmp_path,
@@ -566,3 +566,114 @@ def test_select_notification_delivery_adapter_rejects_unknown_provider() -> None
         raise AssertionError("expected ValueError")
     except ValueError as exc:
         assert "unsupported notification provider" in str(exc)
+
+
+
+def test_feishu_size_preflight_error_preserves_local_diagnostics(monkeypatch, tmp_path: Path) -> None:
+    from src.application import notification_delivery_adapter as service
+    from src.infrastructure.feishu_bitable import FeishuPermanentError
+
+    monkeypatch.setenv("OM_FEISHU_BOT_APP_ID", "cli_1")
+    monkeypatch.setenv("OM_FEISHU_BOT_APP_SECRET", "sec_1")
+    monkeypatch.setenv("OM_FEISHU_BOT_USER_OPEN_ID", "ou_1")
+    diagnostics = {
+        "local_error_code": "FEISHU_POST_TOO_LARGE",
+        "http_status": None,
+        "feishu_code": None,
+        "http_attempts": [],
+        "request_body_bytes": 28673,
+        "request_body_budget_bytes": 28672,
+        "normalized_markdown_chars": 12000,
+        "normalized_markdown_sha256": "a" * 64,
+    }
+
+    def _send_post_message(**kwargs):  # type: ignore[no-untyped-def]
+        raise FeishuPermanentError("feishu post request exceeds local byte budget", response=diagnostics)
+
+    monkeypatch.setattr(service, "send_post_message", _send_post_message)
+
+    send_result = service.send_feishu_app_message(
+        base=tmp_path,
+        channel="feishu_app",
+        target="",
+        message="# 简报",
+        notifications={},
+        idempotency_key="idem-1",
+    )
+    normalized = service.normalize_feishu_app_send_output(send_result=send_result)
+
+    assert send_result["http_attempts"] == []
+    assert normalized["command_ok"] is False
+    assert normalized["delivery_confirmed"] is False
+    assert normalized["local_error_code"] == "FEISHU_POST_TOO_LARGE"
+    assert normalized["error_code"] == "FEISHU_POST_TOO_LARGE"
+    assert normalized["http_status"] is None
+    assert normalized["feishu_code"] is None
+    assert normalized["http_attempts"] == []
+    assert normalized["ambiguous_send"] is False
+    assert normalized["duplicate_risk"] is False
+    for key in (
+        "request_body_bytes",
+        "request_body_budget_bytes",
+        "normalized_markdown_chars",
+        "normalized_markdown_sha256",
+    ):
+        assert normalized[key] == diagnostics[key]
+    assert "# 简报" not in repr(send_result)
+    assert "# 简报" not in repr(normalized)
+
+
+def test_feishu_and_wechat_receive_identical_canonical_markdown(monkeypatch, tmp_path: Path) -> None:
+    from src.application import notification_delivery_adapter as service
+    from src.application.channels.wechat_clawbot.notification import send_wechat_clawbot_message
+
+    canonical_markdown = '# 决策简报\n\n> 中文 "quote" 🙂\n\n- **NVDA**\n  - 合约: 1'
+    captured: dict[str, str] = {}
+
+    monkeypatch.setenv("OM_FEISHU_BOT_APP_ID", "cli_1")
+    monkeypatch.setenv("OM_FEISHU_BOT_APP_SECRET", "sec_1")
+    monkeypatch.setenv("OM_FEISHU_BOT_USER_OPEN_ID", "ou_1")
+
+    def _send_post_message(**kwargs):  # type: ignore[no-untyped-def]
+        captured["feishu"] = kwargs["markdown"]
+        return {"code": 0, "msg": "success", "data": {"message_id": "om_1"}}
+
+    monkeypatch.setattr(service, "send_post_message", _send_post_message)
+    service.send_feishu_app_message(
+        base=tmp_path,
+        channel="feishu_app",
+        target="",
+        message=canonical_markdown,
+        notifications={},
+        idempotency_key="idem-1",
+    )
+
+    class FakeClient:
+        def __init__(self, *, bot_token: str, base_url: str, timeout: int) -> None:
+            del bot_token, base_url, timeout
+
+        def send_text_message(self, **kwargs):  # type: ignore[no-untyped-def]
+            captured["wechat"] = kwargs["text"]
+            return {"ret": 0, "data": {"message_id": "wx_1"}}
+
+    state_dir = tmp_path / "wechat-identity"
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text(
+        json.dumps({"bot_token": "bot_1", "base_url": "https://example.invalid"}),
+        encoding="utf-8",
+    )
+    (state_dir / "bindings.json").write_text(
+        json.dumps({"bindings": {"ops": {"to_user_id": "wx_user_1", "context_token": "ctx_1"}}}),
+        encoding="utf-8",
+    )
+    send_wechat_clawbot_message(
+        base=tmp_path,
+        channel="wechat_clawbot",
+        target="ops",
+        message=canonical_markdown,
+        notifications={"wechat_clawbot_state_dir": str(state_dir)},
+        idempotency_key="idem-1",
+        client_factory=FakeClient,
+    )
+
+    assert captured == {"feishu": canonical_markdown, "wechat": canonical_markdown}

--- a/tests/test_multi_tick_domain_step2.py
+++ b/tests/test_multi_tick_domain_step2.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 
 def test_apply_scan_run_decision_force_and_smoke_keep_existing_semantics() -> None:
     from domain.domain.multi_tick import apply_scan_run_decision
@@ -362,13 +364,22 @@ def test_build_no_candidate_account_messages_emits_monitor_heartbeat() -> None:
         results=results,
         now_bj='BJ_NOW',
         cash_footer_lines=['cash'],
-        cash_footer_for_account_fn=lambda lines, account: [f"{account}:{len(lines)}"],
+        cash_footer_for_account_fn=lambda lines, account: [
+            "**💰 现金 CNY**",
+            f"- **{account.upper()}** 总现金折算 ¥1,000 | 担保后可用 ¥200",
+            "",
+            "> 截至 2026-07-21 18:00:00 北京时间",
+        ],
     )
 
     assert list(out) == ['a']
-    assert '监控正常触发，本轮无候选' in out['a']
-    assert '北京时间 BJ_NOW' in out['a']
-    assert 'a:1' in out['a']
+    assert out['a'].startswith('# OM · 决策简报 · a')
+    assert '状态｜扫描完成' in out['a']
+    assert '结论｜当前没有通过筛选的候选。' in out['a']
+    assert '时间｜BJ_NOW 北京时间' in out['a']
+    assert '账户｜A 总现金 ¥1,000｜担保后 ¥200' in out['a']
+    assert '数据｜截至 2026-07-21 18:00:00 北京时间' in out['a']
+    assert_mobile_flat_markdown(out['a'])
 
 
 def test_build_no_account_notification_payloads_keeps_existing_fields() -> None:

--- a/tests/test_multi_tick_notify_format.py
+++ b/tests/test_multi_tick_notify_format.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 
 def test_account_message_is_plain_text_for_weixin() -> None:
     from src.application.multi_tick.misc import AccountResult
@@ -13,6 +15,9 @@ def test_account_message_is_plain_text_for_weixin() -> None:
         "Covered Call\n"
         "英伟达 Covered Call 2026-06-18 180C\n"
         "覆盖 1张 cover 1\n"
+        "\n"
+        "### [lx] 平仓建议 (1)\n"
+        "- NVDA Put 2026-06-19 150P · 建议平仓\n"
     )
     message = build_account_message(
         AccountResult(
@@ -23,15 +28,25 @@ def test_account_message_is_plain_text_for_weixin() -> None:
             notification_text=notif,
         ),
         now_bj='2026-04-08 22:31:00',
-        cash_footer_lines=["💰 现金 CNY", "LX 持有 ¥1,000 (CNY) | 可用 ¥200 (CNY)"],
+        cash_footer_lines=[
+            "**💰 现金 CNY**",
+            "- **LX** 总现金折算 ¥1,000 (CNY) | 担保后可用 ¥200 (CNY)",
+            "",
+            "> 截至 2026-04-08 22:30:00 北京时间",
+        ],
     )
 
-    assert "# 📊 Options Monitor\n## 账户提醒（lx）" in message
-    assert "北京时间 2026-04-08 22:31:00" in message
-    assert "### 账户 lx · 本轮候选\n- Put 1 / Covered Call 1" in message
-    assert "LX 持有 ¥1,000 (CNY) | 可用 ¥200 (CNY)" in message
+    assert message.startswith("# OM · 决策简报 · lx")
+    assert "状态｜扫描完成" in message
+    assert "时间｜2026-04-08 22:31:00 北京时间" in message
+    assert "结论｜Sell Put 1 · Covered Call 1" in message
+    assert "## 资金" in message
+    assert "账户｜LX 总现金 ¥1,000 (CNY)｜担保后 ¥200 (CNY)" in message
+    assert "数据｜截至 2026-04-08 22:30:00 北京时间" in message
+    assert "## [lx] 平仓建议 (1)" in message
     assert "**" not in message
     assert "\n>" not in message
+    assert_mobile_flat_markdown(message)
 
 
 def test_account_message_skips_accounts_without_notification_text() -> None:
@@ -77,7 +92,30 @@ def test_account_message_counts_yield_enhancement_when_present() -> None:
         cash_footer_lines=[],
     )
 
-    assert "### 账户 lx · 本轮候选\n- Put 1 / Covered Call 0 / Combo Yield 1" in message
+    assert "结论｜Sell Put 1 · Covered Call 0 · Combo Yield 1" in message
+
+
+def test_real_no_candidate_fragment_wraps_once_in_scheduled_renderers() -> None:
+    from src.application.multi_tick.misc import AccountResult
+    from src.application.multi_tick.notify_format import build_account_message, build_account_message_compact
+    from src.application.notify_symbols import build_notification
+
+    body = build_notification('', '', account_label='LX')
+    result = AccountResult(
+        account='lx',
+        ran_scan=True,
+        should_notify=True,
+        decision_reason='dense',
+        notification_text=body,
+    )
+
+    for renderer in (build_account_message, build_account_message_compact):
+        message = renderer(result, now_bj='2026-07-21 18:10:00', cash_footer_lines=[])
+        assert sum(line.startswith('# ') for line in message.splitlines()) == 1
+        assert message.startswith('# OM · 决策简报 · lx')
+        assert '当前没有通过筛选的候选。' in message
+        assert '# OM · 决策简报\n' not in message
+        assert_mobile_flat_markdown(message)
 
 
 def test_compact_account_overview_ignores_reject_summary_strategy_names() -> None:
@@ -103,11 +141,12 @@ def test_compact_account_overview_ignores_reject_summary_strategy_names() -> Non
         cash_footer_lines=[],
     )
 
-    assert "Put 0 · Call 0 · 平仓 0\n" in message
-    assert "## 候选\n- 无符合承保条件候选" in message
+    assert "结论｜Put 0 · Call 0 · 平仓 0\n" in message
+    assert "## 候选\n当前没有通过筛选的候选。" in message
     assert "- 主要过滤：" not in message
     assert "通过 184 条" not in message
     assert "组合收益 1" not in message
+    assert_mobile_flat_markdown(message)
 
 
 def test_compact_account_overview_counts_candidate_lines_only() -> None:
@@ -137,7 +176,7 @@ def test_compact_account_overview_counts_candidate_lines_only() -> None:
         cash_footer_lines=[],
     )
 
-    assert "Put 0 · Call 1 · 组合 1 · 平仓 0\n" in message
+    assert "结论｜Put 0 · Call 1 · 组合 1 · 平仓 0\n" in message
     assert "## 候选\nCall" in message
     assert "- 主要过滤：" not in message
 
@@ -198,10 +237,11 @@ def test_compact_account_overview_does_not_count_gap_as_close_action() -> None:
     )
 
     assert "Put 0 · Call 1 · 平仓 0 · 待补 1" in message
-    assert "## 持仓\n- 无平仓建议\n- 待补:" in message
+    assert "## 持仓\n当前没有平仓建议。\n待补｜以下持仓需要补充数据" in message
     assert "9992.HK Call 2026-07-30 200.00C · 持仓对应合约已定位，但当前未取得可用价格" in message
     assert "0700.HK Call 2026-07-30 520.00C" not in message
     assert "价差过宽" not in message
+    assert_mobile_flat_markdown(message)
 
 
 def test_compact_account_overview_hides_non_data_gap_count() -> None:
@@ -229,6 +269,6 @@ def test_compact_account_overview_hides_non_data_gap_count() -> None:
         cash_footer_lines=[],
     )
 
-    assert "Put 0 · Call 0 · 平仓 0\n" in message
+    assert "结论｜Put 0 · Call 0 · 平仓 0\n" in message
     assert "待补" not in message
     assert "价差过宽" not in message

--- a/tests/test_notification_compact.py
+++ b/tests/test_notification_compact.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 
 def test_build_notification_block_compact_sell_put() -> None:
     from src.application.notify_symbols import _build_notification_block_compact
@@ -17,8 +19,8 @@ def test_build_notification_block_compact_sell_put() -> None:
     )
 
     assert "🟢 Put 腾讯 460P · 04-29 · 挂单 2.3" in out
-    assert "- 权利金 2.3 · 年化 12% · 29天" in out
-    assert "- 保守 · Δ 0.25 · 担保 ¥46000" in out
+    assert "收益｜权利金 2.3 · 年化 12% · 29天" in out
+    assert "风险｜保守 · Δ 0.25 · 担保 ¥46000" in out
     assert "---" not in out
 
 
@@ -37,8 +39,8 @@ def test_build_notification_block_compact_yield_enhancement() -> None:
     )
 
     assert "💎 组合·同期 英伟达 95P+110C · 06-19" in out
-    assert "- 净权利金 95 · 年化 8.0% · 45天" in out
-    assert "- 中性 · Call Δ 0.15" in out
+    assert "收益｜净权利金 95 · 年化 8.0% · 45天" in out
+    assert "风险｜中性 · Call Δ 0.15" in out
     assert "评分" not in out
     assert "预期波动" not in out
     assert "---" not in out
@@ -108,15 +110,16 @@ def test_build_notification_compact_style_uses_markdown_enhancement_heading() ->
     assert "卖0.950/买1.2" not in out
 
 
-def test_build_notification_legacy_style_unchanged() -> None:
+def test_build_notification_legacy_style_uses_flat_fields() -> None:
     from src.application.notify_symbols import build_notification
 
     alerts_text = "## 高优先级\n腾讯 | sell_put | 2026-04-29 460 | 年化 12% | 净收入 2300 | DTE 29 | Strike 460 | mid 2.3 | ccy USD | 风险 保守 | 通过准入\n"
     out = build_notification("", alerts_text, render_style="legacy")
 
     assert "Put" in out
-    assert "### [当前账户] 腾讯 · 卖Put" in out
-    assert "---" in out
+    assert "**[当前账户] 腾讯｜卖Put｜2026-04-29 460**" in out
+    assert "收益｜" in out
+    assert "---" not in out
 
 
 def test_build_notification_compact_keeps_medium_strategy_with_total_limit() -> None:
@@ -214,15 +217,23 @@ def test_build_account_message_compact() -> None:
             notification_text=notif,
         ),
         now_bj="2026-05-12 22:31:00",
-        cash_footer_lines=["LX 持有 ¥1,000 (CNY) | 可用 ¥200 (CNY)"],
+        cash_footer_lines=[
+            "**💰 现金 CNY**",
+            "- **LX** 总现金折算 ¥1,000 (CNY) | 担保后可用 ¥200 (CNY)",
+            "",
+            "> 截至 2026-05-12 22:30:00 北京时间",
+        ],
     )
 
-    assert "# OM · lx · 2026-05-12 22:31:00 BJ" in message
-    assert "Put 1 · Call 0 · 平仓 1" in message
+    assert "# OM · 决策简报 · lx" in message
+    assert "时间｜2026-05-12 22:31:00 北京时间" in message
+    assert "结论｜Put 1 · Call 0 · 平仓 1" in message
     assert "## 候选\nPut\n- 腾讯 卖Put 2026-04-29 460P" in message
-    assert "## 持仓\n- NVDA Put 2026-06-19 150P · 强烈建议平仓" in message
-    assert "## 资金\n- LX 持有 ¥1,000 (CNY) | 可用 ¥200 (CNY)" in message
+    assert "## 持仓\nNVDA Put 2026-06-19 150P · 强烈建议平仓" in message
+    assert "## 资金\n账户｜LX 总现金 ¥1,000 (CNY)｜担保后 ¥200 (CNY)" in message
+    assert "数据｜截至 2026-05-12 22:30:00 北京时间" in message
     assert "──────────────" not in message
+    assert_mobile_flat_markdown(message)
 
 
 def test_build_account_message_compact_without_close_advice() -> None:
@@ -246,7 +257,8 @@ def test_build_account_message_compact_without_close_advice() -> None:
         cash_footer_lines=None,
     )
 
-    assert "# OM · sy · 2026-05-12 22:31:00 BJ" in message
-    assert "Put 1 · Call 0 · 平仓 0" in message
-    assert "## 持仓\n- 无平仓建议" in message
+    assert "# OM · 决策简报 · sy" in message
+    assert "结论｜Put 1 · Call 0 · 平仓 0" in message
+    assert "## 持仓\n当前没有平仓建议。" in message
     assert "\n## 资金\n" not in message
+    assert_mobile_flat_markdown(message)

--- a/tests/test_notify_symbols_markdown.py
+++ b/tests/test_notify_symbols_markdown.py
@@ -6,6 +6,8 @@ import json
 
 import pandas as pd
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 
 def _render_via_alert_engine(summary_row: dict, *, render_style: str = "legacy") -> str:
     from domain.domain import normalize_processor_row
@@ -62,17 +64,16 @@ def test_notify_symbols_markdown_put_layout() -> None:
 
     expected = """Put
 
-### [lx] 腾讯 · 卖Put
-- 腾讯 卖Put 2026-04-29 460P
-- 收益: 权利金=5.720 (HKD) | 年化 17.21% | 净收 557
-- 合约: 行权价=460 | 数量=1张(默认) | DTE=26
-- 风控: 风险=中性 | delta=-0.23 | IV=缺失(告警未提供iv)
-- 资金: 保证金占用=¥110,720 (CNY)
-- 操作: 建议挂单=5.720
-- 备注: 通过准入后，收益/风险组合较强，值得优先看。
----
+**[lx] 腾讯｜卖Put｜2026-04-29 460P**
+收益｜权利金=5.720 (HKD) | 年化 17.21% | 净收 557
+合约｜行权价=460 | 数量=1张(默认) | DTE=26
+风控｜风险=中性 | delta=-0.23 | IV=缺失(告警未提供iv)
+资金｜保证金占用=¥110,720 (CNY)
+操作｜建议挂单=5.720
+备注｜通过准入后，收益/风险组合较强，值得优先看。
 """
     assert out == expected
+    assert_mobile_flat_markdown(out, require_title=False)
 
 
 def test_notify_symbols_no_candidate_message_is_heartbeat() -> None:
@@ -80,8 +81,9 @@ def test_notify_symbols_no_candidate_message_is_heartbeat() -> None:
 
     out = build_notification('', '', account_label='LX')
 
-    assert '📋 本轮扫描完成，暂无符合条件的候选。' in out
+    assert out == '当前没有通过筛选的候选。\n'
     assert '今日无需要主动提醒的内容。' not in out
+    assert_mobile_flat_markdown(out, require_title=False)
 
 
 def test_notify_symbols_markdown_put_layout_missing_fields_have_reasons() -> None:
@@ -117,9 +119,9 @@ def test_notify_symbols_markdown_call_layout_ignores_changes_input() -> None:
 """
     out = build_notification(changes, alerts, account_label="SY")
 
-    assert "### [sy] 英伟达 · Covered Call" in out
+    assert "**[sy] 英伟达｜Covered Call｜2026-06-18 180C**" in out
     assert "数量=2张(可覆盖)" in out
-    assert "持仓: 总股数=200 | 已占用=0 | 可用=200 | 可覆盖=2张" in out
+    assert "持仓｜总股数=200 | 已占用=0 | 可用=200 | 可覆盖=2张" in out
     assert "变化" not in out
     assert "Top pick" not in out
 
@@ -139,7 +141,7 @@ def test_notify_symbols_markdown_call_layout_missing_fields_have_reasons() -> No
     assert "年化 缺失(告警未提供年化)" in out
     assert "delta=缺失(告警未提供delta)" in out
     assert "IV=缺失(告警未提供iv)" in out
-    assert "持仓: 总股数=缺失(告警未提供shares) | 已占用=缺失(告警未提供shares) | 可用=缺失(告警未提供shares) | 可覆盖=缺失(告警未提供cover)张" in out
+    assert "持仓｜总股数=缺失(告警未提供shares) | 已占用=缺失(告警未提供shares) | 可用=缺失(告警未提供shares) | 可覆盖=缺失(告警未提供cover)张" in out
 
 
 def test_notify_symbols_markdown_put_chain_uses_upstream_fields_when_available() -> None:
@@ -204,7 +206,7 @@ def test_notify_symbols_markdown_put_chain_shows_event_risk() -> None:
     out = build_notification("", alerts, account_label="SY")
 
     assert "event earnings@2026-06-10" in alerts
-    assert "- 事件: earnings@2026-06-10" in out
+    assert "事件｜earnings@2026-06-10" in out
 
 
 def test_notify_symbols_markdown_put_chain_shows_same_symbol_usage_from_summary_fields() -> None:
@@ -253,7 +255,7 @@ def test_notify_symbols_markdown_put_chain_uses_total_cny_cash_guard_for_alert_e
         }
     )
 
-    assert "备注: 所需担保现金约 ¥39,280，但当前现金类资产扣担保后余量约 ¥11,666" in out
+    assert "备注｜所需担保现金约 ¥39,280，但当前现金类资产扣担保后余量约 ¥11,666" in out
 
 
 def test_notify_symbols_markdown_put_chain_uses_usd_cash_guard_for_alert_engine() -> None:
@@ -276,7 +278,7 @@ def test_notify_symbols_markdown_put_chain_uses_usd_cash_guard_for_alert_engine(
         }
     )
 
-    assert "备注: 所需担保现金约 $18,000，但当前账户可用担保现金约 $15,000" in out
+    assert "备注｜所需担保现金约 $18,000，但当前账户可用担保现金约 $15,000" in out
 
 
 def test_notify_symbols_markdown_put_falls_back_to_usd_margin_when_cny_margin_missing() -> None:
@@ -364,7 +366,7 @@ def test_notify_symbols_markdown_put_chain_shows_linked_call_hint() -> None:
         }
     )
 
-    assert "组合收益: 推荐Call=2026-06-19 110C" in out
+    assert "组合收益｜推荐Call=2026-06-19 110C" in out
     assert "候选Call=2个" in out
     assert "参考买价=1.500" in out
     assert "净权利金=145.33" in out
@@ -402,7 +404,7 @@ def test_notify_symbols_markdown_yield_enhancement_layout() -> None:
     )
 
     assert "Combo Yield" in out
-    assert "### [sy] NVDA · 组合收益" in out
+    assert "**[sy] NVDA｜组合收益｜2026-06-19 95P+110C**" in out
     assert "组合净权利金=145.33" in out
     assert "场景评分=4.58%" in out
     assert "Put=95" in out
@@ -604,11 +606,11 @@ def test_build_notification_keeps_per_strategy_capacity() -> None:
 
     out = build_notification("", alerts, account_label="LX")
 
-    assert out.count("· 卖Put") == 5
+    assert out.count("｜卖Put｜") == 5
     assert "PUT5" in out
     assert "PUT6" not in out
     assert "CALL1" in out
-    assert out.count("· Covered Call") == 1
+    assert out.count("｜Covered Call｜") == 1
 
 
 def test_build_notification_keeps_medium_strategy_when_high_exists() -> None:
@@ -640,13 +642,13 @@ def test_build_notification_keeps_medium_strategy_when_high_exists() -> None:
 def test_notify_symbols_staggered_combo_is_high_priority_and_uses_separate_leg_copy() -> None:
     out = _render_via_alert_engine(_staggered_combo_summary())
 
-    assert "### [sy] NVDA · 组合收益" in out
-    assert "卖 100P | 2026-08-21/35天 | bid=2.35 | 估算净收=228 USD" in out
-    assert "买 120C | 2026-10-16/91天 | ask=2.1 | delta=0.31 | 估算成本=218 USD" in out
+    assert "**[sy] NVDA｜组合收益**" in out
+    assert "Put｜卖 100P · 2026-08-21/35天 · bid=2.35 · 估算净收=228 USD" in out
+    assert "Call｜买 120C · 2026-10-16/91天 · ask=2.1 · delta=0.31 · 估算成本=218 USD" in out
     assert "覆盖率=104.59%" in out
     assert "净现金流=10 USD" in out
-    assert "Put安全边界=18% | 现金=$10,000 | Call晚56天" in out
-    assert "备注:" not in out
+    assert "风险｜Put安全边界=18% · 现金=$10,000 · Call晚56天" in out
+    assert "备注｜" not in out
     assert "资金利用率" not in out
     assert "两腿各1张" not in out
     assert "当前组合收益推荐未通过优先级阈值" not in out
@@ -658,10 +660,10 @@ def test_notify_symbols_staggered_combo_compact_copy_is_concise() -> None:
     out = _render_via_alert_engine(_staggered_combo_summary(), render_style="compact")
 
     assert "🧩 组合·跨期 NVDA 100P+120C" in out
-    assert "Put 卖 100P · 08-21/35天 · bid 2.35 · 估算净收 228 USD" in out
-    assert "Call 买 120C · 10-16/91天 · ask 2.1 · Δ 0.31 · 估算成本 218 USD" in out
-    assert "组合 覆盖 104.59% · 净现金流 10 USD" in out
-    assert "安全边界 18% · 现金 $10,000 · Call晚56天" in out
-    assert "备注:" not in out
+    assert "Put｜卖 100P · 08-21/35天 · bid 2.35 · 估算净收 228 USD" in out
+    assert "Call｜买 120C · 10-16/91天 · ask 2.1 · Δ 0.31 · 估算成本 218 USD" in out
+    assert "组合｜覆盖 104.59% · 净现金流 10 USD" in out
+    assert "风险｜安全边界 18% · 现金 $10,000 · Call晚56天" in out
+    assert "备注｜" not in out
     assert "资金利用率" not in out
     assert "两腿各1张" not in out

--- a/tests/test_opend_watchdog_alerts.py
+++ b/tests/test_opend_watchdog_alerts.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from tempfile import TemporaryDirectory
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 
 def _ensure_repo_path() -> None:
     import sys
@@ -84,6 +86,7 @@ def test_opend_alert_routes_wechat_clawbot_through_delivery_adapter(monkeypatch)
         return SimpleNamespace(send_fn=fake_send, normalize_fn=lambda **_: {}, failure_stage="send_wechat_clawbot_message")
 
     monkeypatch.setattr(opend_guard, "select_notification_delivery_adapter", fake_select)
+    monkeypatch.setattr(opend_guard, "utc_now", lambda: "2026-07-21T08:30:00+00:00")
 
     with TemporaryDirectory() as td:
         base = Path(td)
@@ -92,14 +95,23 @@ def test_opend_alert_routes_wechat_clawbot_through_delivery_adapter(monkeypatch)
             base,
             cfg,
             error_code="OPEND_RATE_LIMIT",
-            message_text="rate limited",
+            message_text="rate limited\n  - retry exhausted",
+            detail="first line\n    - nested detail",
         )
 
     assert ok is True
     assert captured["provider"] == "wechat_clawbot"
     assert captured["channel"] == "wechat_clawbot"
     assert captured["target"] == "clawbot:test"
-    assert "options-monitor OpenD 告警" in str(captured["message"])
+    message = str(captured["message"])
+    assert message.startswith("# OM · 系统告警 · OpenD")
+    assert "状态｜❌ 不可用" in message
+    assert "时间｜2026-07-21 16:30:00 北京时间" in message
+    assert "影响｜本轮行情与交易数据可能不完整" in message
+    assert "原因｜rate limited · - retry exhausted" in message
+    assert "诊断｜`OPEND_RATE_LIMIT`" in message
+    assert "详情｜first line · - nested detail" in message
+    assert_mobile_flat_markdown(message)
 
 
 def test_send_opend_alert_no_send_does_not_consume_rate_limit(monkeypatch) -> None:
@@ -380,7 +392,10 @@ def test_consecutive_threshold_gates_alert() -> None:
             }
         }
 
-        with mock.patch.object(opend_guard, "select_notification_delivery_adapter", fake_select):
+        with (
+            mock.patch.object(opend_guard, "select_notification_delivery_adapter", fake_select),
+            mock.patch.object(opend_guard, "utc_now", lambda: "2026-07-21T08:30:00+00:00"),
+        ):
             # First two calls should be gated (below threshold).
             r1 = opend_guard.send_opend_alert(base, cfg, error_code="OPEND_PORT_CLOSED", message_text="test")
             assert r1 is False, "should be gated at count=1"
@@ -418,7 +433,10 @@ def test_consecutive_threshold_skip_gate_sends_immediately() -> None:
                 "opend_alert_cooldown_sec": 1,
             }
         }
-        with mock.patch.object(opend_guard, "select_notification_delivery_adapter", fake_select):
+        with (
+            mock.patch.object(opend_guard, "select_notification_delivery_adapter", fake_select),
+            mock.patch.object(opend_guard, "utc_now", lambda: "2026-07-21T08:30:00+00:00"),
+        ):
             r = opend_guard.send_opend_alert(
                 base, cfg,
                 error_code="OPEND_NEEDS_PHONE_VERIFY",
@@ -456,7 +474,10 @@ def test_send_opend_recovery_notice_after_threshold_failures() -> None:
             }
         }
 
-        with mock.patch.object(opend_guard, "select_notification_delivery_adapter", fake_select):
+        with (
+            mock.patch.object(opend_guard, "select_notification_delivery_adapter", fake_select),
+            mock.patch.object(opend_guard, "utc_now", lambda: "2026-07-21T08:30:00+00:00"),
+        ):
             # No failures recorded yet; recovery notice should NOT be sent.
             r = opend_guard.send_opend_recovery_notice(base, cfg)
             assert r is False
@@ -472,7 +493,11 @@ def test_send_opend_recovery_notice_after_threshold_failures() -> None:
             assert len(calls) == 1
             # Message should indicate recovery.
             sent_msg = str(calls[0]["message"])
-            assert "已恢复" in sent_msg
+            assert sent_msg.startswith("# OM · 系统通知 · OpenD")
+            assert "状态｜✅ 已恢复" in sent_msg
+            assert "时间｜2026-07-21 16:30:00 北京时间" in sent_msg
+            assert "结果｜数据连接已恢复，后续批次将自动重新评估" in sent_msg
+            assert_mobile_flat_markdown(sent_msg)
 
             # Counter reset: second recovery sends nothing.
             r = opend_guard.send_opend_recovery_notice(base, cfg)

--- a/tests/test_positions_maintenance_receipt.py
+++ b/tests/test_positions_maintenance_receipt.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 from src.application.positions.maintenance_receipt import (
     build_auto_close_receipt_message,
     build_auto_close_receipt_identity,
@@ -144,9 +146,11 @@ def test_send_auto_close_receipt_uses_existing_route_and_sender(tmp_path: Path) 
     assert out["delivery_confirmed"] is True
     assert out["message_id"] == "msg-auto-1"
     assert calls[0]["target"] == "wechat:ops"
-    assert "过期自动平仓已写入 option_positions" in calls[0]["message"]
-    assert "账户：lx" in calls[0]["message"]
-    assert "rec_1 | pos_1 | exp=2026-05-01" in calls[0]["message"]
+    assert "# OM · 持仓维护 · lx" in calls[0]["message"]
+    assert "状态｜✅ 已完成" in calls[0]["message"]
+    assert "时间｜2026-05-03 08:00:00 北京时间" in calls[0]["message"]
+    assert "rec_1｜pos_1｜到期 2026-05-01" in calls[0]["message"]
+    assert_mobile_flat_markdown(calls[0]["message"])
     assert out["attempt_count"] == 1
 
 
@@ -243,14 +247,15 @@ def test_build_auto_close_receipt_message_marks_partial_failure() -> None:
             "grace_days": 2,
             "applied_closed": 1,
             "candidates_should_close": 2,
-            "errors": ["rec_2 pos_2: sqlite locked"],
+            "errors": ["rec_2 pos_2: sqlite locked\n    - retry later"],
             "applied": [{"record_id": "rec_1", "position_id": "pos_1", "expiration_ymd": "2026-05-01"}],
         },
     )
 
-    assert "[未完全记录]" in msg
-    assert "平仓：1/2" in msg
-    assert "sqlite locked" in msg
+    assert "状态｜⚠️ 部分完成" in msg
+    assert "结果｜成功 1 · 候选 2 · 错误 1" in msg
+    assert "sqlite locked · - retry later" in msg
+    assert_mobile_flat_markdown(msg)
 
 
 def test_auto_close_receipt_preserves_normalized_feishu_size_error(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_positions_maintenance_receipt.py
+++ b/tests/test_positions_maintenance_receipt.py
@@ -251,3 +251,31 @@ def test_build_auto_close_receipt_message_marks_partial_failure() -> None:
     assert "[未完全记录]" in msg
     assert "平仓：1/2" in msg
     assert "sqlite locked" in msg
+
+
+def test_auto_close_receipt_preserves_normalized_feishu_size_error(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OM_FEISHU_BOT_USER_OPEN_ID", "ou_bot")
+    out = send_auto_close_receipt(
+        base=tmp_path,
+        config={"notifications": {"provider": "feishu_app"}},
+        receipt_config={},
+        dry_run=False,
+        result={
+            "mode": "applied",
+            "account": "lx",
+            "applied_closed": 1,
+            "candidates_should_close": 1,
+            "errors": [],
+        },
+        send_fn=lambda **_kwargs: {
+            "command_ok": False,
+            "delivery_confirmed": False,
+            "returncode": 1,
+            "error_code": "FEISHU_POST_TOO_LARGE",
+        },
+        normalize_fn=lambda send_result: send_result,
+    )
+
+    assert out["status"] == "failed"
+    assert out["delivery_confirmed"] is False
+    assert out["error_code"] == "FEISHU_POST_TOO_LARGE"

--- a/tests/test_scheduled_notification_application.py
+++ b/tests/test_scheduled_notification_application.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 
 def test_build_per_account_delivery_batch_supports_one_account_message() -> None:
     from src.application.scheduled_notification import build_per_account_delivery_batch
@@ -504,4 +506,5 @@ def test_local_feishu_size_failure_is_audited_and_never_retried() -> None:
             }
         ],
     )
-    assert "lx: FEISHU_POST_TOO_LARGE attempts=1 confirmed=False" in summary
+    assert "lx｜FEISHU_POST_TOO_LARGE · 尝试 1 次 · 未确认" in summary
+    assert_mobile_flat_markdown(summary)

--- a/tests/test_scheduled_notification_application.py
+++ b/tests/test_scheduled_notification_application.py
@@ -405,3 +405,103 @@ def test_mark_no_candidate_notification_metrics_updates_matching_accounts_only()
     assert tick_metrics["accounts"][1]["meaningful"] is True
     assert tick_metrics["accounts"][1]["notification_type"] == "no_candidate"
     assert tick_metrics["accounts"][2] == {"account": "other", "meaningful": False}
+
+
+def test_local_feishu_size_failure_is_audited_and_never_retried() -> None:
+    from src.application.scheduled_notification import (
+        build_notify_failure_summary_message,
+        send_account_message_with_retry,
+    )
+
+    send_calls: list[dict[str, object]] = []
+    sleep_calls: list[float] = []
+    audit_events: list[dict[str, object]] = []
+    runlog_events: list[dict[str, object]] = []
+    diagnostics = {
+        "local_error_code": "FEISHU_POST_TOO_LARGE",
+        "error_code": "FEISHU_POST_TOO_LARGE",
+        "request_body_bytes": 28673,
+        "request_body_budget_bytes": 28672,
+        "normalized_markdown_chars": 12000,
+        "normalized_markdown_sha256": "a" * 64,
+    }
+
+    class FakeRunlog:
+        def safe_event(self, step: str, status: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            runlog_events.append({"step": step, "status": status, **kwargs})
+
+    def _send_fn(**kwargs):  # type: ignore[no-untyped-def]
+        send_calls.append(dict(kwargs))
+        return {
+            "ok": False,
+            "returncode": 1,
+            "command_ok": False,
+            "delivery_confirmed": False,
+            "message_id": None,
+            "http_attempts": [],
+            "retry_attempt_count": 0,
+            "ambiguous_send": False,
+            "duplicate_risk": False,
+            **diagnostics,
+        }
+
+    result = send_account_message_with_retry(
+        base="/tmp/base",
+        channel="feishu_app",
+        target="",
+        account="lx",
+        message="# 简报",
+        run_id="run-size-failure",
+        runlog=FakeRunlog(),
+        audit_fn=lambda kind, action, **kwargs: audit_events.append(
+            {"kind": kind, "action": action, **kwargs}
+        ),
+        send_fn=_send_fn,
+        normalize_fn=lambda **_kwargs: {},
+        safe_data_fn=lambda payload: payload,
+        failure_fields_builder=lambda **_kwargs: {},
+        max_attempts=3,
+        sleep_fn=lambda seconds: sleep_calls.append(seconds),
+    )
+
+    assert len(send_calls) == 1
+    assert sleep_calls == []
+    assert result["ok"] is False
+    assert result["attempts"] == 1
+    assert result["error_code"] == "FEISHU_POST_TOO_LARGE"
+    assert result["local_error_code"] == "FEISHU_POST_TOO_LARGE"
+    assert result["ambiguous_send"] is False
+    assert result["duplicate_risk"] is False
+    final = result["final"]
+    assert isinstance(final, dict)
+    assert final["will_retry"] is False
+    assert final["http_attempts"] == []
+    for key, value in diagnostics.items():
+        assert final[key] == value
+        if key != "error_code":
+            assert result[key] == value
+
+    send_fail = next(event for event in audit_events if event["action"] == "send_fail")
+    assert send_fail["error_code"] == "FEISHU_POST_TOO_LARGE"
+    assert isinstance(send_fail["extra"], dict)
+    for key, value in diagnostics.items():
+        assert send_fail["extra"][key] == value
+
+    error_event = next(event for event in runlog_events if event["status"] == "error")
+    assert error_event["error_code"] == "FEISHU_POST_TOO_LARGE"
+    assert error_event["data"]["will_retry"] is False
+    assert error_event["data"]["request_body_bytes"] == 28673
+
+    summary = build_notify_failure_summary_message(
+        run_id="run-size-failure",
+        sent_accounts=[],
+        notify_failures=[
+            {
+                "account": "lx",
+                "error_code": result["error_code"],
+                "attempts": result["attempts"],
+                "delivery_confirmed": result["delivery_confirmed"],
+            }
+        ],
+    )
+    assert "lx: FEISHU_POST_TOO_LARGE attempts=1 confirmed=False" in summary

--- a/tests/test_trade_time_format.py
+++ b/tests/test_trade_time_format.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from src.application.parse_option_message import parse_fill_timestamp
-from src.application.trade_time_format import format_trade_time_beijing
+from src.application.trade_time_format import format_iso_time_beijing, format_trade_time_beijing
 
 
 def _ms_utc(year: int, month: int, day: int, hour: int, minute: int, second: int) -> int:
@@ -22,3 +22,10 @@ def test_format_trade_time_beijing_converts_us_source_epoch() -> None:
 
     assert ms == _ms_utc(2026, 4, 26, 19, 30, 0)
     assert format_trade_time_beijing(ms) == "2026-04-27 03:30:00 北京时间"
+
+
+def test_format_iso_time_beijing_converts_utc_and_preserves_invalid_text() -> None:
+    assert format_iso_time_beijing("2026-07-21T08:30:00Z") == "2026-07-21 16:30:00 北京时间"
+    assert format_iso_time_beijing("2026-07-21T08:30:00") == "2026-07-21 16:30:00 北京时间"
+    assert format_iso_time_beijing("unknown") == "unknown"
+    assert format_iso_time_beijing(None) is None

--- a/tests/test_trades_receipt.py
+++ b/tests/test_trades_receipt.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+from tests.notification_format_assertions import assert_mobile_flat_markdown
+
 from src.application.trades.receipt import (
     build_trade_intake_receipt_message,
     decide_trade_intake_receipt,
@@ -190,10 +192,12 @@ def test_send_trade_intake_receipt_uses_existing_route_and_sender(tmp_path: Path
     assert out["delivery_confirmed"] is True
     assert out["message_id"] == "msg-1"
     assert calls[0]["target"] == "wechat:ops"
-    assert "成交已写入 option_positions" in calls[0]["message"]
-    assert "资金：权利金毛流入 USD 123.00" in calls[0]["message"]
-    assert "成交时间：2026-05-19 13:08:31 北京时间" in calls[0]["message"]
-    assert "deal_id：deal-1" in calls[0]["message"]
+    assert "# OM · 成交回执 · lx" in calls[0]["message"]
+    assert "状态｜✅ 已完成" in calls[0]["message"]
+    assert "资金｜权利金毛流入 USD 123.00" in calls[0]["message"]
+    assert "时间｜2026-05-19 13:08:31 北京时间" in calls[0]["message"]
+    assert "编号｜`deal-1`" in calls[0]["message"]
+    assert_mobile_flat_markdown(calls[0]["message"])
 
 
 def test_send_trade_intake_receipt_uses_feishu_bot_target(monkeypatch, tmp_path: Path) -> None:
@@ -235,7 +239,7 @@ def test_build_trade_intake_receipt_message_marks_unresolved() -> None:
         payload={"symbol": "9992.HK", "qty": 1, "price": 6.3},
     )
 
-    assert "[未记录]" in msg
+    assert "状态｜❌ 未记录" in msg
     assert "missing_required_fields:multiplier" in msg
     assert "9992.HK" in msg
 
@@ -275,13 +279,13 @@ def test_build_trade_intake_receipt_message_marks_ambiguous_assigned_stock_sale_
         payload={"symbol": "FUTU", "qty": 100, "price": 100.0},
     )
 
-    assert "[待确认]" in msg
-    assert "状态：待确认" in msg
+    assert "状态｜⚠️ 待确认" in msg
     assert "确认前不会自动写入" in msg
-    assert "A：FUTU USD；剩余 100 股；成本 120.0/股" in msg
-    assert "B：FUTU USD；剩余 100 股；成本 117.45/股" in msg
-    assert "请确认要匹配的选项，例如：选择 A" in msg
-    assert "[未记录]" not in msg
+    assert "A｜FUTU USD；剩余 100 股；成本 120.0/股" in msg
+    assert "B｜FUTU USD；剩余 100 股；成本 117.45/股" in msg
+    assert "下一步｜回复“选择 A”" in msg
+    assert "状态｜❌ 未记录" not in msg
+    assert_mobile_flat_markdown(msg)
 
 
 def test_build_trade_intake_receipt_message_marks_projection_verification_failure() -> None:
@@ -297,9 +301,8 @@ def test_build_trade_intake_receipt_message_marks_projection_verification_failur
         payload={"symbol": "0700.HK", "qty": 2, "price": 1.2},
     )
 
-    assert "[写入异常]" in msg
-    assert "[已记录]" not in msg
-    assert "状态：写入异常" in msg
+    assert "状态｜❌ 写入异常" in msg
+    assert "状态｜✅ 已完成" not in msg
     assert "projection_verification_failed" in msg
 
 
@@ -333,9 +336,9 @@ def test_build_trade_intake_receipt_message_marks_staggered_combo_relation_pendi
         },
     )
 
-    assert "[已记录]" in msg
-    assert "资金：权利金毛流出 USD 73.00" in msg
-    assert "组合关系待确认" in msg
+    assert "状态｜✅ 已完成" in msg
+    assert "资金｜权利金毛流出 USD 73.00" in msg
+    assert "组合｜关系待确认" in msg
     assert "未自动归入 Combo Yield 组" in msg
 
 

--- a/tests/test_trades_receipt.py
+++ b/tests/test_trades_receipt.py
@@ -337,3 +337,28 @@ def test_build_trade_intake_receipt_message_marks_staggered_combo_relation_pendi
     assert "资金：权利金毛流出 USD 73.00" in msg
     assert "组合关系待确认" in msg
     assert "未自动归入 Combo Yield 组" in msg
+
+
+def test_trade_receipt_preserves_normalized_feishu_size_error(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OM_FEISHU_BOT_USER_OPEN_ID", "ou_bot")
+    out = send_trade_intake_receipt(
+        base=tmp_path,
+        config={"notifications": {"provider": "feishu_app"}},
+        receipt_config={},
+        apply_changes=True,
+        state={},
+        deal=None,
+        result={"status": "applied", "reason": "applied_open", "deal_id": "deal-1", "account": "lx"},
+        payload={"deal_id": "deal-1"},
+        send_fn=lambda **_kwargs: {
+            "command_ok": False,
+            "delivery_confirmed": False,
+            "returncode": 1,
+            "error_code": "FEISHU_POST_TOO_LARGE",
+        },
+        normalize_fn=lambda send_result: send_result,
+    )
+
+    assert out["status"] == "failed"
+    assert out["delivery_confirmed"] is False
+    assert out["error_code"] == "FEISHU_POST_TOO_LARGE"


### PR DESCRIPTION
## Summary

- send proactive Feishu App notifications as `msg_type=post` with a single `zh_cn.content` `md` node and no duplicate transport title
- keep WeChat ClawBot on the canonical Markdown identity path; leave Feishu inbound replies/outbox unchanged
- render Daily Brief, Compact/Legacy Tick, no-candidate heartbeat, delivery/OpenD notices, trade receipts, and maintenance receipts with one standalone H1, limited H2 sections, and flat `字段｜值` rows
- remove nested-list and blockquote indentation from mobile-facing output, including real cash footer rows
- keep no-candidate pipeline output as a body fragment so scheduled wrappers do not produce a second H1
- retain the 28 KiB Feishu request-size preflight, idempotency, confirmation, retry, ambiguity, and controlled text rollback semantics; never auto-fallback an attempted post to text

## Validation

- focused renderer/delivery suite: `178 passed`
- broad daily-brief/multi-tick/notification suite: `348 passed`
- Ruff passed on all touched production/test Python files
- compileall passed on touched production/test modules
- `git diff --check` passed
- aggregate DeepReview found two high-severity mobile-format gaps; both were accepted, fixed, regression-tested, and passed re-review

## Canary and rollout state

- On July 21, 2026, the original five Feishu canaries passed API delivery and exact readback as `post` with one `md` node.
- The original manual visual acceptance was later superseded by operator feedback that two-level indentation was difficult to read on Feishu mobile.
- The corrected mobile-flat renderers have **not** been re-canary-tested; a new five-category live canary requires separate explicit operator authorization.
- This PR remains Draft. No merge, release, deployment, runtime-config change, or live resend is included.
- If corrected Post presentation still fails live acceptance, rollback remains an operator-controlled code/version rollback to the text sender; there is no automatic same-event fallback.

## Deferred P1 work unit

- Daily Brief becomes the only scheduled notification primary renderer
- Compact Tick enters a compatibility period
- Legacy Tick is deprecated and eventually removed
- no-candidate becomes a Decision Brief state owned by the primary renderer
- OpenD and delivery failure share one System Notice shell
- trade and maintenance share one Receipt shell
