### PR TITLE
feat: automate Close Advice evidence collection

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 751 (`src`: 411, `domain`: 63, `scripts`: 7, `tests`: 270)
-- Internal import edges: 4360 total, 1929 production/script edges excluding tests
+- Internal import edges: 4378 total, 1929 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -43,11 +43,11 @@ flowchart LR
   scripts -->|7| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|1707| application
+  tests -->|1721| application
   tests -->|374| domain
   tests -->|2| domain_services
   tests -->|111| infrastructure
-  tests -->|182| interfaces
+  tests -->|186| interfaces
   tests -->|10| scripts
   tests -->|16| storage
 ```
@@ -73,9 +73,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 1707 |
+| tests | application | 1721 |
 | tests | domain | 374 |
-| tests | interfaces | 182 |
+| tests | interfaces | 186 |
 | tests | infrastructure | 111 |
 | tests | storage | 16 |
 | tests | scripts | 10 |

--- a/docs/DEPLOY_LINUX_MAC.md
+++ b/docs/DEPLOY_LINUX_MAC.md
@@ -152,9 +152,11 @@ cd "$REPO"
 
 这个开关会生成三类独立 timer：
 
-- `options-monitor-strategy-lab-build.timer`：每 6 小时幂等构建 latest scanned run 对应的 Shadow Replay dataset；dataset id 默认使用 run id，已存在就跳过，不覆盖已有 mark path。build 只建立 cohort，不占用 mark/settle 维护批次。
-- `options-monitor-strategy-lab-sample.timer`：每 2 小时只执行 mark path 采样，单次最多处理 `--strategy-lab-recorder-max-datasets` 个 dataset。`--strategy-lab-recorder-source opend` 要求 OpenD 已可用；如果同一次 render 也包含 `--include-opend`，systemd unit 会声明对 `options-monitor-opend.service` 的依赖。
-- `options-monitor-strategy-lab-settle.timer`：每天北京时间 07:20 尝试 settle 所有到期的 outcome facts；settlement 只读取本地 dataset，不占用 OpenD 采样批次。
+- `options-monitor-strategy-lab-build.timer`：每 6 小时分别幂等构建 latest scanned candidate run 与 latest non-empty Close Advice run 对应的 Shadow Replay dataset；dataset id 默认使用 run id，同 run 只生成一个 close-aware dataset，已存在就跳过，不覆盖已有 mark/outcome。Close 正式 evidence 不完整时 build fail-closed，但 candidate build 仍独立执行。build 只建立 cohort，不占用 mark/settle 维护批次。
+- `options-monitor-strategy-lab-sample.timer`：每 2 小时只执行 candidate / close mark path 采样，单次最多处理 `--strategy-lab-recorder-max-datasets` 个 dataset。`--strategy-lab-recorder-source opend` 要求 OpenD 已可用；如果同一次 render 也包含 `--include-opend`，systemd unit 会声明对 `options-monitor-opend.service` 的依赖。
+- `options-monitor-strategy-lab-settle.timer`：每天北京时间 07:20 尝试 settle 所有到期的 candidate outcome facts 与 close outcomes；settlement 只读取本地 dataset，不占用 OpenD 采样批次。
+
+build 的 6 小时 cadence 是策略研究采样覆盖，不是每个 tick 的完整 Close Advice 事件日志。`service.profile.json.strategy_lab_recorder.include_close_decisions=true` 用于证明部署后的 recorder 已启用该 evidence facet；它不是 production Close Advice 策略开关。
 
 recorder 只写 `$RUNTIME`/repo 下的本地 research artifact、Shadow Replay dataset、required-data / OpenD cache / rate-limit state 和 receipt。它不发通知，不运行 experiment/proposal，不调用在线 AI，不修改 runtime config、交易状态、Feishu 或 broker-facing state。升级时 `service.profile.json` 会保留 `strategy_lab_recorder` opt-in，service drift reconcile 会继续渲染这些 timer；不传该开关则默认不启用。
 

--- a/docs/SHADOW_REPLAY_RUNBOOK.md
+++ b/docs/SHADOW_REPLAY_RUNBOOK.md
@@ -10,7 +10,7 @@ Shadow Replay = 反事实复盘引擎
 Strategy Lab = 策略进化产品入口
 ```
 
-因此，本文是底层复盘引擎手册。面向策略参数自我进化的上层 PRD 和技术方案见 [Strategy Lab Design](STRATEGY_LAB_DESIGN.md)。Strategy Lab 当前已提供 update、只读 readiness、experiment、advisory proposal 和 llm-context 入口；Shadow Replay 继续作为它的反事实 evaluator 和 dataset / mark / outcome 生命周期引擎，而不是被删除。`strategy-lab update` 现在包装本文的 latest scanned run dataset build、status / run-data-plan：默认 dry-run，显式 `--build-dataset --write` 才构建本地 dataset，显式 `--write` 才执行本地 collect / settle。远端持续记录通过 `./om service render --include-strategy-lab-recorder` 显式启用，生成低频 timer 维护 dataset、mark path 和 outcome facts；默认部署不会开启。
+因此，本文是底层复盘引擎手册。面向策略参数自我进化的上层 PRD 和技术方案见 [Strategy Lab Design](STRATEGY_LAB_DESIGN.md)。Strategy Lab 当前已提供 update、只读 readiness、experiment、advisory proposal 和 llm-context 入口；Shadow Replay 继续作为它的反事实 evaluator 和 dataset / mark / outcome 生命周期引擎，而不是被删除。`strategy-lab update` 现在包装本文的 latest scanned run dataset build、status / run-data-plan：默认 dry-run，显式 `--build-dataset --write` 才构建本地 dataset；再加 `--include-close-decisions` 时独立选择 latest non-empty Close Advice run，严格构建 close decision facet。显式 `--write` 才执行本地 collect / settle。远端持续记录通过 `./om service render --include-strategy-lab-recorder` 显式启用，生成低频 timer 维护 dataset、mark path 和 outcome facts；默认部署不会开启。
 
 Strategy Lab 会按 strategy domain adapter 区分 Sell Put、Covered Call 和 Combo Yield。统一的是 evidence / readiness / experiment / scorecard / proposal workflow；分开的是决策单元、目标函数、参数空间、硬约束和 proposal target。Sell Put / Covered Call 可以先复用单腿 candidate-impact；Combo Yield 必须按 `strategy_group_id` / legs 形成 group-level decision instance，不能被拆成彼此独立的单腿参数实验。
 
@@ -63,7 +63,7 @@ Shadow Replay 的分析结论使用 [Opportunity Quality](OPPORTUNITY_QUALITY.md
   --strategy-lab-recorder-source opend
 ```
 
-生成的 build timer 默认按 latest scanned run id 幂等构建 dataset；sample timer 采样 mark path；settle timer 维护 `outcome_facts.jsonl`。这些 timer 只写本地 replay artifact、required-data / OpenD cache / rate-limit state 和 receipt，不运行 Strategy Lab experiment/proposal，也不改生产配置、交易状态或通知。
+生成的 build timer 每 6 小时分别按 latest scanned candidate run 和 latest non-empty Close Advice run 幂等构建 dataset；同 run 时只生成一个 close-aware dataset。Close 正式 evidence 不完整会 fail-closed，但 candidate build 仍独立执行。sample timer 每 2 小时采样 candidate / close mark path；settle timer 每天维护 `outcome_facts.jsonl` 与 close outcomes。这些 timer 只写本地 replay artifact、required-data / OpenD cache / rate-limit state 和 receipt，不运行 Strategy Lab experiment/proposal，也不改生产配置、交易状态或通知。6 小时 cadence 是采样覆盖，不是每个 tick 的完整事件日志。
 
 ## 候选影响对比
 

--- a/docs/TOOL_REFERENCE.md
+++ b/docs/TOOL_REFERENCE.md
@@ -902,7 +902,7 @@ om-agent run --tool notification_perception_read --input-json '{"conversation_id
 - 可选嵌入 `healthcheck` snapshot，但不取代 `healthcheck` 的 readiness 职责
 - Shadow Replay 基于已有候选、reject、trace、mark、outcome 和归档 run 证据做离线复盘
 - `review_readiness` 判断是否具备人工策略复盘条件；`candidate-impact` / `candidate-impact-report` 比较显式阈值 variants 对候选集合的影响
-- Strategy Lab update 默认 dry-run 汇总 Shadow Replay status / data-plan；显式 `--build-dataset --write` 才从 latest scanned run 构建本地 replay dataset，显式 `--write` 才执行本地 collect / settle 维护动作
+- Strategy Lab update 默认 dry-run 汇总 Shadow Replay status / data-plan；显式 `--build-dataset --write` 才从 latest scanned run 构建本地 replay dataset；再加 `--include-close-decisions` 时会独立选择 latest non-empty Close Advice run，构建正式 close decision facet。显式 `--write` 才执行本地 collect / settle 维护动作
 - Strategy Lab readiness 把 replay dataset 归一成 `decision_instance`，按 Sell Put / Covered Call / Combo Yield 输出 domain readiness 和 blocker
 - Strategy Lab experiment 自动生成 Sell Put / Covered Call 受控 hypotheses，复用 candidate-impact evaluator，并输出固定/历史百分位 IV/RV × 生产/去重排序的四格 observed-universe 对照和 scorecard；Combo Yield 输出独立的 group-level observed-universe experiment
 - Strategy Lab proposal 从 experiment artifact 生成 advisory-only proposal 和 Markdown；Sell Put / Covered Call 只有 `closed_replay` gate 通过才输出 dry-run patch，Combo Yield 只输出 group advisory，不应用生产配置
@@ -921,7 +921,7 @@ om research shadow-replay status --min-sample 30
 om research shadow-replay candidate-impact-report --params params.json --market us --start-date 2026-06-03 --account lx --min-sample 30
 om research shadow-replay analyze --dataset output_shared/research/shadow_replay/datasets/<dataset-id> --min-sample 30
 om research strategy-lab update --latest
-om research strategy-lab update --latest --build-dataset --write
+om research strategy-lab update --latest --build-dataset --include-close-decisions --write
 om research strategy-lab readiness --dataset output_shared/research/shadow_replay/datasets/<dataset-id> --min-sample 30
 om research strategy-lab readiness --market us --account lx --start-date 2026-06-03 --end-date 2026-06-03 --min-sample 30
 om research strategy-lab experiment --dataset output_shared/research/shadow_replay/datasets/<dataset-id> --min-sample 30 --auto
@@ -955,7 +955,7 @@ broker-facing data。
 
 Strategy Lab recorder 是同一条本地 artifact 写入路径的服务化封装：
 
-- latest-run build timer 默认用 scanned run id 作为 dataset id；目标 dataset 已存在时跳过，避免覆盖后续 mark path。
+- latest-run build timer 同时维护 latest scanned candidate run 与 latest non-empty Close Advice run，均默认用 run id 作为 dataset id；目标 dataset 已存在时跳过，避免覆盖后续 mark / outcome。Close Advice 非空但正式 evidence 不完整时 fail-closed，candidate build 仍独立执行。
 - mark sampler timer 默认每 2 小时维护最近 dataset，`--strategy-lab-recorder-source opend` 需要可用 OpenD。
 - outcome settler timer 默认每天北京时间 07:20 维护 `outcome_facts.jsonl`。
 - recorder opt-in 会写入 `service.profile.json.strategy_lab_recorder`，让 upgrade/service drift reconcile 保留这些 timer；默认 `service render` 不启用。
@@ -975,8 +975,9 @@ output_shared/research/strategy_lab/
 - `include_healthcheck=true` 只在 `quality` / `full` scope 下有意义。
 - `--shadow-replay-min-sample` 只影响 Research bundle 里的 `candidate_evidence.shadow_replay` 样本充足性判断，不会改生产策略参数。
 - Candidate-impact 报告只能说明 observed run universe 内候选集合变化，不能自动生成最优参数，也不能修改 runtime config、交易状态或通知。
-- `strategy-lab update` 默认 dry-run；显式 `--build-dataset --write` 时只从 latest scanned run 构建本地 replay dataset，显式 `--write` 时只执行已有 Shadow Replay `collect_marks` / `settle` data-plan 和本地 receipt，不会执行 analyze、生成参数建议或修改生产状态。
+- `strategy-lab update` 默认 dry-run；显式 `--build-dataset --write` 时只从 latest scanned run 构建本地 replay dataset；增加 `--include-close-decisions` 时还会从 latest non-empty Close Advice run 构建 close facet。两者只写本地 research artifact；显式 `--write` 时只执行已有 Shadow Replay `collect_marks` / `settle` data-plan 和本地 receipt，不会执行 analyze、生成参数建议或修改生产状态。
 - 未显式传 `--dataset-id` 时，`strategy-lab update --latest --build-dataset --write` 默认使用 latest scanned run id 作为 dataset id；同名 dataset 已存在时返回 `dataset_build_reason=dataset_already_exists` 并跳过构建。
+- `--include-close-decisions` 必须和 `--build-dataset` 一起使用，且不能与显式 `--dataset-id` 组合。Close 与 candidate 属于独立选择；同 run 时只生成一个 close-aware dataset，不覆盖已有 dataset。
 - `strategy-lab readiness` 支持已有 dataset 输入，也支持通过 `--start-date` / `--end-date` / `--market` / `--account` 聚合 scanned-run window；显式 `--output` 只写本地 JSON artifact，不会采样 mark、settle outcome 或生成生产参数 patch。
 - `strategy-lab experiment` 支持已有 dataset 输入，也支持通过 `--start-date` / `--end-date` / `--market` / `--account` 聚合 scanned-run window；它生成的 scorecard 只用于人工复盘，不是生产参数建议；Combo Yield 结果位于 `group_experiments.combo_yield`。
 - `strategy-lab proposal` 接收 experiment JSON 文件或包含 `experiment.json` 的目录；显式 `--output` / `--markdown-output` 只写本地 artifact，不会应用 patch。`filter_only` / `path_only` 只返回 evidence gap；Combo Yield 结果通过 `group_advisory` 表达，不生成单腿 patch。

--- a/docs/gateflow/close-evidence-collection-plan-20260723.md
+++ b/docs/gateflow/close-evidence-collection-plan-20260723.md
@@ -1,0 +1,220 @@
+# Close Advice S5 Evidence Collection Bridge — Implementation Plan
+
+## 1. Goal
+
+在不改变生产 Close Advice 决策权威的前提下，把已经存在的 `close_advice.csv` 正式决策证据接入现有 Strategy Lab recorder，使 S5 能自动积累 episode、mark 和 outcome 数据，并可用现有 readiness / experiment 流程评估 P0/P1/P2/P3。
+
+本 work unit 只建立 evidence collection bridge。P0 继续是唯一生产策略；P1/P2/P3 继续 shadow-only。
+
+## 2. Current Facts
+
+- `research shadow-replay build --include-close-decisions` 已能严格构建 Close Advice facet，但只能手工调用。
+- Strategy Lab build timer 每 6 小时运行 `research strategy-lab update --build-dataset --write`，当前没有启用 Close Advice facet。
+- `run_strategy_lab_update()` 只选择“最新包含 candidate / trace / reject evidence 的 run”。生产 run 中 Close Advice 文件与最新 candidate run 不保证出现在同一个目录，因此直接把 close flag 传给现有 latest build 会周期性失败。
+- Close capture 已在 owner boundary 内 fail-closed：缺少 lot identity、audit timestamp、position context 或正式决策字段时抛错，不生成不完整数据集。
+- Dataset ID 默认使用 run ID；已存在的数据集不会被覆盖，从而保护已采集的 mark / outcome。
+
+## 3. Scope
+
+### In scope
+
+1. 给 Strategy Lab update 增加显式 opt-in `include_close_decisions` 契约。
+2. 在一次 build update 中，独立选择最新包含至少一条 Close Advice 行的 run，并先构建带 Close Advice facet 的 dataset。
+3. 保持现有 latest candidate dataset build 的选择和行为不变；Close build 完成后再执行 candidate build。
+4. 让 systemd / launchd Strategy Lab recorder build action 默认显式启用 Close Advice evidence collection，并在 service profile 中公开该能力。
+5. 补齐 CLI、application、service rendering、idempotency、empty / malformed evidence 和安全边界测试。
+6. 更新最小必要运维文档，明确采样频率、失败语义、写入边界和验证命令。
+7. 合并并发布后，执行一次生产 research canary，再启用更新后的既有 recorder unit；验证不触发通知、配置、交易或券商写入。
+
+### Out of scope
+
+- 不修改 `domain/domain/close_advice.py`、P0/P1/P2/P3 阈值或排序。
+- 不改变通知文案、通知路由或发送行为。
+- 不修改 `config.yaml`、生成配置、position ledger、trade events、Feishu mirror 或 broker-facing data。
+- 不新增 service / timer，不提高现有 6h build、2h mark、每日 settle 的频率。
+- 不回填历史 legacy run，不覆盖或原地升级已存在的 candidate-only dataset。
+- 不自动晋升 shadow policy，不改变 production recommendation authority。
+
+## 4. Architecture and Ownership
+
+### 4.1 Run selection owner
+
+在 `src/application/shadow_replay/capture.py` 增加窄 helper：
+
+```python
+latest_close_decision_run_dir(
+    *, repo_root: Path, runs_root: Path | None = None
+) -> tuple[Path | None, dict[str, Any]]
+```
+
+契约：
+
+- 按现有 `latest_shadow_replay_run_dir()` 相同的 runs-root / mtime 约定遍历 run。
+- 用现有 `ShadowReplaySourceSelection` 与 `close_advice_paths_from_selection()` 发现 account-scoped `close_advice.csv`。
+- 只有至少一个 CSV data row 的 run 才算可采集；header-only / empty 文件计入 skipped-empty，不阻止继续寻找更早的非空 run。
+- helper 只做可采集性选择，不复制 Close Advice schema/policy 校验。发现非空 run 后，由现有 `capture_close_decision_episodes()` 做完整 fail-closed 校验；不能因新 selector 而把 malformed evidence 静默跳过。
+- 返回稳定、可测试的 selection metadata：found、run ID/path、searched count、skipped-without-close count、skipped-empty count、close path count、close row count。
+
+这保持 evidence discovery 属于 Shadow Replay capture owner，Strategy Lab 只负责编排。
+
+### 4.2 Strategy Lab orchestration
+
+在 `src/application/strategy_lab/update.py`：
+
+- `run_strategy_lab_update()` 新增 `include_close_decisions: bool = False`。
+- `include_close_decisions=True` 必须与 `build_dataset=True` 一起使用；同时禁止显式 `dataset_id`，因为一次 update 最多涉及 close run 和 candidate run 两个独立 run ID，单一显式 ID 会产生冲突语义。
+- 新增窄的 `_build_latest_close_decision_dataset()`：
+  - 未启用时返回 `not_requested`；
+  - 找不到非空 Close Advice run 时返回 `latest_close_decision_run_not_found`，这是正常 empty state，不让 recorder unit 失败；
+  - dry-run 返回 `requires_write` 且不创建目录；
+  - target 已存在时不覆盖，并报告：若 manifest 已声明 close facet 则为正常 idempotent skip；若 target 是 candidate-only，则报告 `dataset_exists_without_close_decisions`，保留数据且不伪装为采集成功；
+  - write 时以选中的 `run_dir` 和 run ID 调用现有 `build_shadow_replay_dataset(..., include_close_decisions=True)`；所有正式 evidence 校验继续由 capture owner 执行。
+- 执行顺序固定为 close build -> candidate build -> data plan：
+  - 同一 run 同时有 close 和 candidate evidence 时，close build 先生成完整 dataset，candidate build 因 run ID 已存在而幂等跳过；
+  - 不同 run 时各生成一个 dataset，候选采样行为不变；
+  - data plan 在两个 build 后运行，立即看见新 dataset。
+- Close build 与 candidate build 是独立写入单元。若 close build 因非空 malformed evidence 抛出 `ValueError`，orchestrator 必须保存原异常、继续执行原 candidate build，再重新抛出同一错误；不得把 Close failure 转成 success，也不得让新 facet 阻断既有 candidate evidence accumulation。异常路径不继续 data plan。
+- 同 run malformed 时，异常后的 candidate build 可以安全落下 candidate-only dataset；这会让该 run 后续显示 `dataset_exists_without_close_decisions`，但不覆盖/迁移它。下一条合法 Close run 继续自然恢复自动采集。
+- 保留 `shadow_replay.dataset_build` 作为现有 candidate build 公共字段；新增 `shadow_replay.close_decision_dataset_build`，避免破坏既有消费者。
+- 现有 singular summary 字段 `dataset_build_requested`、`dataset_built`、`dataset_build_reason`、`built_dataset_id` 继续严格表示 candidate build，保持兼容；新增 `close_decision_dataset_build_requested`、`close_decision_dataset_built`、`close_decision_dataset_build_reason`、`built_close_decision_dataset_id`。
+- 顶层 `summary.status` 与 safety persistent write targets 对任一 build 聚合；`next_action` 的 dry-run 可以继续使用通用 rerun-with-write action，malformed evidence 仍通过异常暴露。
+
+### 4.3 Public CLI and service wiring
+
+在 `src/interfaces/cli/research.py`：
+
+- 给 `research strategy-lab update` 增加 `--include-close-decisions`。
+- 参数仅传入 application contract；不在 CLI 重做选择或校验。
+
+在 `src/application/service_deploy.py`：
+
+- 现有 systemd / launchd Strategy Lab build action 增加 `--include-close-decisions`。
+- `service.profile.json.strategy_lab_recorder` 增加 `include_close_decisions: true`，作为可观测部署事实。
+- 不新增 renderer 参数或 operator-authored runtime config knob：Strategy Lab recorder 本身已是显式 opt-in，启用 recorder 即采集其当前支持的正式 research evidence，避免第二层容易漂移的开关。
+
+## 5. State and Failure Semantics
+
+| State | Close build result | Candidate build | Unit result |
+|---|---|---|---|
+| 没有 Close Advice 文件或全部为空 | skip: `latest_close_decision_run_not_found` | 照常 | 成功 |
+| 最新非空 Close run 合法且 target 不存在 | build close facet | 照常；同 run 时幂等 skip | 成功 |
+| target 已含 close facet | idempotent skip | 照常 | 成功 |
+| target 已存在但无 close facet | safe skip + explicit reason | 照常 | 成功但 evidence gap 可见 |
+| 非空 Close run 缺必需正式字段/context/audit | capture 抛错，目标目录在严格校验前不应形成有效 close dataset | candidate build 仍执行，随后重新抛出原错误 | 失败，等待更新的合法 run；candidate evidence 不丢失 |
+| dry-run | 只返回选择和 `requires_write` | 现有 dry-run | 无写入 |
+
+不使用 suffix dataset ID 绕过冲突，因为同一 run 的 candidate snapshots 会在跨 dataset 分析中重复计数。也不原地增补 candidate-only dataset，因为那会引入对 manifest、marks、outcomes 的部分更新/恢复事务，本 work unit 没有必要承担该迁移风险。
+
+## 6. Implementation Slices
+
+### S1 — Close-aware Strategy Lab build contract
+
+Files:
+
+- `src/application/shadow_replay/capture.py`
+- `src/application/strategy_lab/update.py`
+- `src/interfaces/cli/research.py`
+- `tests/test_strategy_lab.py`
+- `tests/test_research.py`
+- `tests/test_close_advice_shadow_capture.py`（只有 selector owner 的测试确有必要时）
+
+Deliverables:
+
+- latest non-empty close-run selector and metadata;
+- opt-in application / CLI contract;
+- close-first / candidate-second orchestration;
+- explicit result, summary, safety and next-action semantics;
+- deterministic tests for different-run, same-run, empty, malformed, dry-run, collision and idempotency paths.
+- CLI parser-to-handler forwarding 及不合法参数组合测试。
+
+Acceptance:
+
+- 现有 Strategy Lab update tests 不改语义地通过；
+- 新 tests 证明最新 candidate run 无 close 文件时不会导致 close capture 错选或失败；
+- malformed non-empty close evidence 仍 fail-closed；
+- malformed close evidence 抛错前仍完成独立 candidate build；
+- build 不覆盖已有 marks/outcomes；
+- 既有 candidate summary 字段保持原语义，新增 close-specific summary 字段准确反映第二个 build；
+- CLI 拒绝 `--include-close-decisions` 缺少 `--build-dataset` 或同时携带 `--dataset-id`，并证明合法 flag 被传到 application；
+- safety 保持 `writes_runtime_config=false`、`writes_trade_state=false`、`sends_notifications=false`。
+
+### S2 — Existing recorder wiring and operator contract
+
+Files:
+
+- `src/application/service_deploy.py`
+- `tests/test_service_deploy.py`
+- `docs/TOOL_REFERENCE.md`
+- `docs/SHADOW_REPLAY_RUNBOOK.md`
+- `docs/DEPLOY_LINUX_MAC.md`（仅当现有 recorder 安装/验证段需要同步）
+
+Deliverables:
+
+- systemd / launchd build command 启用 close collection；
+- service profile 明确暴露该事实；
+- 文档说明 6h sampling、2h marks、daily settlement、fail-closed 和不改变生产策略的边界；
+- renderer / drift tests 更新。
+
+Acceptance:
+
+- systemd 与 launchd 生成命令均含 `--include-close-decisions`；
+- 未启用 Strategy Lab recorder 时仍不生成相关 unit；
+- service drift 仍通过；
+- 不新增 timer/service 或 operator-authored runtime config key；只新增上述 service profile observability field。
+
+## 7. Verification
+
+### Focused tests
+
+```bash
+python3.12 -m pytest -q \
+  tests/test_close_advice_shadow_capture.py \
+  tests/test_strategy_lab.py \
+  tests/test_service_deploy.py
+```
+
+### Broader checks
+
+```bash
+python3.12 -m pytest -q tests/test_shadow_replay_*.py tests/test_research.py
+python3.12 scripts/check_dependency_graph.py
+python3.12 scripts/release_check.py --check
+```
+
+最终发布前按仓库 release flow 运行完整 Python 3.12 suite、release smoke 和 dependency graph。
+
+## 8. Production Rollout and Canary
+
+Gateflow 完成 Draft PR 后停在 merge 授权边界。获 CEO 明确合并/发布授权后：
+
+1. 合并并走 VERSION-driven patch release；不手工修改生产配置。
+2. 远端升级前检查 release、磁盘 headroom、当前 service profile 和 Strategy Lab units。
+3. 安装/刷新同一组既有 recorder units，使 build command 带新 flag；不新增服务。
+4. 单次手工 research canary：运行与 build unit 等价的 `strategy-lab update --latest --build-dataset --include-close-decisions --write --max-datasets 0`。该操作只写本地 research dataset；不发送通知、不写交易/配置/券商数据。
+5. 验证：
+   - result 显示 close dataset built 或明确幂等/empty reason；
+   - 新 dataset manifest 有 `close_decision_facet` 且 episode count 与源文件可核对；
+   - P0 shadow evaluation 与生产 `recommendation_state` 一致；
+   - mark sampler / settle timer active，unit 最近一次状态成功；
+   - runtime health、核心 services/timers 保持正常。
+6. 若 canary 发现 malformed evidence，停止 rollout diagnosis，不弱化 capture 校验、不删除/覆盖 dataset、不提升策略。
+
+## 9. Success Criteria
+
+- 自动 recorder 能从最新非空 Close Advice run 生成严格、可审计的 close decision dataset。
+- candidate recorder 原有选择行为保持不变。
+- 同 run 不重复建 dataset，不覆盖已有 research state；collision 明确可见。
+- mark / outcome lifecycle 无需新服务即可继续处理 close facet。
+- 生产 P0 authority、通知、配置、交易状态和 broker-facing data 均未改变。
+- focused + relevant broader tests、dependency graph、release checks 和生产 canary 全部通过。
+
+## 10. Residual Risks and Deferred Work
+
+- 6 小时 recorder 是时间采样，不保证捕获每一次 tick 内部状态转换；它足以启动 S5 evidence accumulation，但 readiness 报告必须把采样密度视为 coverage，而不是完整事件日志。
+- 已存在的 candidate-only dataset 不在本次原地迁移；collision 会被显式报告，后续合法 Close run 会自然建立新 evidence。
+- 目录 mtime 与现有 selector 保持一致；活跃 run 的短暂部分写入可能令一次 unit fail-closed，下一次完整 run 会恢复。若生产观察到持续竞争，再单独设计 run-complete marker，不在本 work unit 推断新增状态。
+- 自动采集只解除“零数据”阻塞，不等于策略可晋升；P1/P2/P3 仍需达到既定样本量、mark/outcome、分层稳定性和 CEO 决策门槛。
+
+## 11. Open Questions
+
+- 无。实现不得重新解释以上范围；若发现必须覆盖现有 dataset 或改变 timer cadence 才能达成目标，停止并回到 CEO 决策。

--- a/docs/gateflow/close-evidence-collection/aggregate-validation.md
+++ b/docs/gateflow/close-evidence-collection/aggregate-validation.md
@@ -1,0 +1,61 @@
+# Gateflow Aggregate Validation — Close Evidence Collection
+
+- Gate: aggregate validation
+- Work unit: `close-evidence-collection`
+- Reviewed commits: `ad5912bd`, `3fe0f3cf`, `a08e2012`
+- Artifact path: `docs/gateflow/close-evidence-collection/aggregate-validation.md`
+- Completion status: validation and aggregate deepreview complete; ready for aggregate commit
+
+## Aggregate scope
+
+- Close run discovery and strict dataset capture orchestration.
+- CLI public contract and result/safety semantics.
+- systemd/launchd recorder wiring and service profile observability.
+- Operator documentation and generated dependency graph.
+- No strategy policy, notification, authored production config, trade, Feishu or broker-facing change.
+
+## Validation evidence
+
+Initial full suite found only the expected stale generated dependency graph after new test imports:
+
+```text
+1 failed, 3048 passed, 10 skipped, 6 warnings
+failure: docs/DEPENDENCY_GRAPH.md stale
+```
+
+The repository generator refreshed `docs/DEPENDENCY_GRAPH.md`; production import edges remained unchanged and architecture guards stayed clean:
+
+```text
+[OK] dependency graph generated; production_modules=481 cycles=0
+[OK] dependency graph current; production_modules=481 cycles=0
+```
+
+Release metadata remains valid for the current unreleased branch base:
+
+```text
+[OK] release metadata valid for 1.4.12
+```
+
+Final full Python 3.12 suite:
+
+```text
+3049 passed, 10 skipped, 6 warnings in 61.03s
+```
+
+Warnings are pre-existing Legacy Tick renderer deprecations outside this work unit.
+
+## Docs decision
+
+- Public flag and automatic recorder behavior are documented in the existing Tool Reference, Shadow Replay runbook and Linux/Mac deployment guide.
+- Generated dependency graph is refreshed because the repository guard requires it.
+
+## Residual risks and uncovered areas
+
+- Real production artifact cadence/shape: `covered by later approved rollout` canary after merge/release authorization.
+- 6h sampling completeness: `assigned to later work unit` S5 readiness evaluation.
+- Active-run partial-write/collision recovery: `requiring new issue or explicit user decision` only if canary/runtime evidence shows material recurrence.
+- Strategy promotion: `requiring explicit user decision`; explicitly outside this work unit.
+
+## Stop condition
+
+All local aggregate quality gates and deepreview pass; no accepted unresolved finding remains.

--- a/docs/gateflow/close-evidence-collection/final-closeout.md
+++ b/docs/gateflow/close-evidence-collection/final-closeout.md
@@ -1,0 +1,46 @@
+# Gateflow Closeout — Close Evidence Collection
+
+- Work unit: `close-evidence-collection`
+- Branch: `codex/close-evidence-collection`
+- Draft PR: https://github.com/liuxie066/options-monitor/pull/114
+- Artifact path: `docs/gateflow/close-evidence-collection/final-closeout.md`
+- Status: local and PR gates complete; waiting explicit merge authorization
+
+## Delivered outcome
+
+- Strategy Lab update can independently select and strictly build the latest non-empty Close Advice run.
+- Existing candidate collection is preserved across Close capture failures.
+- Same-run idempotency prevents duplicate datasets; existing/incomplete targets are never overwritten and are explicitly classified.
+- Existing systemd/launchd Strategy Lab recorder build action automatically enables Close evidence collection.
+- Service profile and operator docs expose the 6h build, 2h mark and daily settle lifecycle.
+- P0 remains the sole production authority; P1/P2/P3 remain shadow-only.
+
+## Gate results
+
+- Planreview: pass-with-risks after three accepted findings were fixed.
+- S1 deepreview: pass-with-risks after two accepted findings were fixed.
+- S2 deepreview: pass-with-risks, no findings.
+- Aggregate deepreview: pass-with-risks, no findings.
+- PR #114 deepreview: pass-with-risks, no findings.
+- Local full suite: 3049 passed, 10 skipped, 6 pre-existing warnings.
+- Dependency graph: 481 production modules, 0 cycles, guards pass.
+- GitHub checks after PR review artifact push: Analyze (actions), Analyze (python), CodeQL, agent-plugin and guardrails all pass.
+
+## Safety boundary verified
+
+- No Close Advice policy threshold or production recommendation authority change.
+- No notification content/routing/send change.
+- No operator-authored runtime config, ledger/trade, Feishu or broker-facing write path change.
+- New writes are limited to existing local research/replay artifact paths.
+
+## Residual risks and ownership
+
+- 6h sampling is not event-complete: `assigned to later work unit` S5 readiness coverage evaluation.
+- Active-run partial-write/collision recovery: `requiring new issue or explicit user decision` only if production canary/runtime evidence proves material recurrence.
+- Existing incomplete/candidate-only dataset repair: `assigned to later work unit` only if production evidence justifies migration.
+- Release, service reconcile and one production research canary: `covered by later approved rollout` after merge authorization.
+- Policy promotion: `requiring explicit user decision` after S5 evidence readiness.
+
+## Stop condition
+
+Do not mark the PR ready, merge, release, reconcile production services or run the production write canary without explicit CEO authorization. The current safe handoff is Draft PR #114 with all implementation/review gates complete.

--- a/docs/gateflow/close-evidence-collection/plan-review-fix.md
+++ b/docs/gateflow/close-evidence-collection/plan-review-fix.md
@@ -1,0 +1,36 @@
+# Gateflow Plan Review Fix — Close Evidence Collection
+
+- Gate: plan review fix
+- Work unit: `close-evidence-collection`
+- Plan: `docs/gateflow/close-evidence-collection-plan-20260723.md`
+- Review: `docs/reviews/plan-review-20260723-083540.md`
+- Artifact path: `docs/gateflow/close-evidence-collection/plan-review-fix.md`
+- Completion status: fixed; pending re-review
+
+## Finding decisions and fixes
+
+### PR-01 — accepted — 已修复
+
+Close capture 与 candidate capture 改为独立写入单元。正常路径仍 close-first，确保同 run 生成完整 dataset；若 strict Close capture 抛出 `ValueError`，orchestrator 必须保存异常、执行原 candidate build、再重新抛出，从而同时保持 Close fail-closed 与既有 candidate accumulation。
+
+验证要求新增 distinct-run 和 same-run malformed cases：调用必须失败，但 candidate dataset 已写入且不伪造 close facet。
+
+### PR-02 — accepted — 已修复
+
+计划已冻结双 build 的兼容输出：原 singular summary 字段只描述 candidate build；新增四个 close-specific summary 字段；顶层 status 与 safety 对任一 persistent build 聚合。S1 明确加入 `tests/test_research.py`，覆盖 CLI forwarding 和两个非法参数组合。
+
+### PR-03 — accepted — 已修复
+
+计划已区分 operator-authored runtime config 与 service profile observability field。S2 不新增前者，仅增加既定部署事实字段。
+
+## Validation
+
+- 修订后 plan 逐项回应三个 accepted findings。
+- Scope、non-goals、service/timer cadence 和生产 authority 均未扩大。
+- 待独立 re-review 验证 finding 状态。
+
+## Residual risks
+
+- 6h sampling coverage：assigned to later S5 readiness evaluation；不在本 work unit 提升 cadence。
+- Existing candidate-only dataset collision：assigned to later work unit only if production evidence shows material loss；本 work unit fail-safe skip。
+- Active-run partial write race：requiring new issue or explicit user decision only if production canary/runtime evidence shows recurrence；当前不新增 run-complete state。

--- a/docs/gateflow/close-evidence-collection/s1-implementation.md
+++ b/docs/gateflow/close-evidence-collection/s1-implementation.md
@@ -1,0 +1,67 @@
+# Gateflow Implementation Artifact — S1 Close-aware Strategy Lab Build
+
+- Gate: implementation slice
+- Work unit: `close-evidence-collection`
+- Slice: S1 — Close-aware Strategy Lab build contract
+- Plan: `docs/gateflow/close-evidence-collection-plan-20260723.md`
+- Artifact path: `docs/gateflow/close-evidence-collection/s1-implementation.md`
+- Completion status: implementation and re-review complete; ready for accepted slice commit
+
+## Scope implemented
+
+- Added independent latest non-empty Close Advice run discovery in the Shadow Replay capture owner.
+- Added opt-in `include_close_decisions` to Strategy Lab update and the public CLI.
+- Added close-first dataset build while preserving the existing candidate build contract.
+- Isolated strict Close failure from candidate evidence accumulation: candidate build still runs, then the original Close error is re-raised.
+- Added explicit close-specific build result and summary fields while keeping existing singular summary fields candidate-only.
+- Aggregated safety/status across either local dataset write.
+- Added CLI validation for ambiguous/ineffective argument combinations.
+
+## Changed files
+
+- `src/application/shadow_replay/capture.py`
+- `src/application/strategy_lab/update.py`
+- `src/interfaces/cli/research.py`
+- `tests/test_strategy_lab.py`
+- `tests/test_research.py`
+
+## State and error handling evidence
+
+- Empty/header-only Close files are skipped by discovery and do not fail the recorder.
+- Non-empty malformed evidence still fails in `capture_close_decision_episodes()` before a valid close dataset is written.
+- Valid same-run close/candidate evidence creates one close-aware dataset; the candidate builder then idempotently skips the same run ID.
+- Distinct close/candidate runs create two independent datasets.
+- An existing candidate-only target is never overwritten and returns `dataset_exists_without_close_decisions`.
+- Dry-run selects both sources but creates no dataset directory.
+- Existing `dataset_built` / `built_dataset_id` remain candidate-only; new close-specific fields report close build state.
+
+## Validation
+
+```text
+PYTHONDONTWRITEBYTECODE=1 python3.12 -m pytest -q -p no:cacheprovider \
+  tests/test_close_advice_shadow_capture.py tests/test_strategy_lab.py tests/test_research.py
+75 passed in 2.35s
+
+python3.12 -m ruff check \
+  src/application/shadow_replay/capture.py src/application/strategy_lab/update.py \
+  src/interfaces/cli/research.py tests/test_research.py tests/test_strategy_lab.py
+All checks passed!
+
+git diff --check
+passed
+```
+
+## Docs decision
+
+Public/operator docs are intentionally deferred to approved S2, where the recorder service command and profile contract are wired.
+
+## Residual risks and uncovered areas
+
+- 6h sampling density: `covered by later approved slice` for documentation in S2, then `assigned to later work unit` for S5 readiness coverage evaluation.
+- Existing candidate-only close collision: `assigned to later work unit` only if production evidence shows material loss; current slice reports and preserves it.
+- Active-run partial write race: `requiring new issue or explicit user decision` only if production canary/runtime evidence proves recurrence.
+- Systemd/launchd automatic enablement: `covered by later approved slice` S2.
+
+## Stop condition
+
+S1 code, focused validation and deepreview loop are complete; no accepted unresolved finding remains.

--- a/docs/gateflow/close-evidence-collection/s1-review-fix.md
+++ b/docs/gateflow/close-evidence-collection/s1-review-fix.md
@@ -1,0 +1,42 @@
+# Gateflow Review Fix Artifact — S1 Close-aware Strategy Lab Build
+
+- Gate: code review fix
+- Work unit: `close-evidence-collection`
+- Slice: S1
+- Review: `docs/reviews/code-review-20260723-084455.md`
+- Implementation artifact: `docs/gateflow/close-evidence-collection/s1-implementation.md`
+- Artifact path: `docs/gateflow/close-evidence-collection/s1-review-fix.md`
+- Completion status: fixes complete; pending re-review
+
+## Finding decisions and fixes
+
+### S1-DR-01 — accepted — 已修复
+
+- Close build wrapper now catches `Exception`, not only `ValueError`.
+- Every Close build failure still triggers the independent candidate build attempt and then re-raises the original Close error.
+- Added regression coverage with an injected `OSError`; the call fails with that error while the valid candidate manifest is persisted.
+
+### S1-DR-02 — accepted — 已修复
+
+- Replaced manifest-only detection with an explicit facet status check.
+- `complete` requires both a manifest `close_decision_facet` and all three `OPTIONAL_CLOSE_DATASET_FILES` as regular files.
+- Incomplete persisted state returns `dataset_exists_without_complete_close_decisions`; candidate-only state retains `dataset_exists_without_close_decisions`.
+- Added complete-idempotency coverage that preserves existing close marks and incomplete-facet coverage that does not overwrite the target.
+
+## Validation
+
+```text
+75 passed in 2.35s
+ruff: all checks passed
+git diff --check: passed
+```
+
+## Docs decision
+
+No S1 docs change. New operator behavior remains owned by S2 service/docs wiring.
+
+## Residual risks
+
+- 6h sampling coverage: `covered by later approved slice` S2 for docs and `assigned to later work unit` S5 for readiness evaluation.
+- No automatic repair of incomplete existing datasets: `assigned to later work unit` only with production evidence; current behavior is explicit and non-destructive.
+- Service enablement: `covered by later approved slice` S2.

--- a/docs/gateflow/close-evidence-collection/s2-implementation.md
+++ b/docs/gateflow/close-evidence-collection/s2-implementation.md
@@ -1,0 +1,62 @@
+# Gateflow Implementation Artifact — S2 Recorder Wiring and Operator Contract
+
+- Gate: implementation slice
+- Work unit: `close-evidence-collection`
+- Slice: S2 — Existing recorder wiring and operator contract
+- Plan: `docs/gateflow/close-evidence-collection-plan-20260723.md`
+- Artifact path: `docs/gateflow/close-evidence-collection/s2-implementation.md`
+- Completion status: implementation and code review complete; ready for accepted slice commit
+
+## Scope implemented
+
+- Added `--include-close-decisions` to the existing Strategy Lab build action for both systemd and launchd bundles.
+- Added `strategy_lab_recorder.include_close_decisions=true` to the generated service profile as an observable deployment fact.
+- Kept the existing three-service/timer lifecycle and all cadences unchanged.
+- Updated operator docs for independent candidate/Close run selection, same-run idempotency, strict failure isolation, 6h sampling coverage, 2h marks and daily settlement.
+- Preserved the safety boundary: local research/replay writes only; no production strategy, notification, runtime config, trade, Feishu or broker-facing mutation.
+
+## Changed files
+
+- `src/application/service_deploy.py`
+- `tests/test_service_deploy.py`
+- `docs/TOOL_REFERENCE.md`
+- `docs/SHADOW_REPLAY_RUNBOOK.md`
+- `docs/DEPLOY_LINUX_MAC.md`
+
+## Contract evidence
+
+- systemd build command contains `--build-dataset --include-close-decisions --write`.
+- launchd build `ProgramArguments` contains `--include-close-decisions`.
+- service profile records `include_close_decisions: true` only when the existing recorder opt-in is enabled.
+- Default render without recorder remains unchanged and emits no Strategy Lab units.
+- Service drift reconciliation continues to use the same profile and unit set.
+
+## Validation
+
+```text
+PYTHONDONTWRITEBYTECODE=1 python3.12 -m pytest -q -p no:cacheprovider \
+  tests/test_service_deploy.py tests/test_strategy_lab.py tests/test_research.py \
+  tests/test_close_advice_shadow_capture.py
+175 passed in 2.81s
+
+python3.12 -m ruff check src/application/service_deploy.py tests/test_service_deploy.py
+All checks passed!
+
+git diff --check
+passed
+```
+
+## Docs decision
+
+Updated only existing public/operator sections that describe Strategy Lab update and recorder lifecycle. No additional design document or duplicate runbook was added.
+
+## Residual risks and uncovered areas
+
+- 6h sampling is not event-complete: `assigned to later work unit` S5 readiness coverage evaluation; documented here.
+- Existing candidate-only/incomplete datasets are not repaired: `assigned to later work unit` only with production evidence.
+- Service installation, remote upgrade and canary: `covered by later approved rollout` after merge/release authorization.
+- Production strategy promotion: `requiring explicit user decision`; not authorized by this work unit.
+
+## Stop condition
+
+S2 code/docs, focused validation and deepreview are complete; no accepted unresolved finding remains.

--- a/docs/reviews/code-review-20260723-084455.md
+++ b/docs/reviews/code-review-20260723-084455.md
@@ -1,0 +1,49 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `codex/close-evidence-collection`
+- Base: accepted plan commit `ad5912bd`
+- Output file: `docs/reviews/code-review-20260723-084455.md`
+- Included scope: S1 implementation in Close run discovery, Strategy Lab dual-build orchestration, CLI forwarding/validation, summary/safety contract and focused tests.
+- Excluded scope: S2 service renderer/docs; release/deployment; strategy policy; notifications; production config/trade/broker state.
+- Parallel review coverage: 无；scope is one bounded orchestration/capture chain and was reviewed end to end.
+
+## Findings
+
+### S1-DR-01-未修复-中-只有 ValueError 能触发 candidate 保底，Close I/O 失败仍会回归原 recorder
+- **入口/函数**: `research strategy-lab update --build-dataset --include-close-decisions` -> `run_strategy_lab_update()` -> `_build_latest_close_decision_dataset()`
+- **文件(行号)**: `src/application/strategy_lab/update.py:52-81`; `src/application/shadow_replay/capture.py:1633`
+- **输入场景**: Close selector 找到非空文件，但读取 CSV、读取 context/audit、解析已存在 manifest 或写入 close dataset 时发生 `PermissionError`、`FileNotFoundError` 之外的 `OSError`、短暂 I/O error 等非 `ValueError`；candidate run 本身合法且可写。
+- **实际分支**: Close build 的 wrapper 只 `except ValueError`。非 `ValueError` 直接从第 53-60 行传播，69-81 行的 independent candidate build never runs。
+- **预期行为**: 按 accepted plan，Close 与 candidate 是独立写入单元；任何 Close build failure 都应保留原错误、仍尝试原 candidate build，再重新抛出 Close failure。Fail-closed 应保护 Close evidence，不应把 optional S5 facet 变成现有 candidate recorder 的可用性依赖。
+- **实际行为**: Close I/O failure 提前终止整个 update，原 candidate dataset 没有生成；该错误可在 6h recorder 重试时重复。
+- **直接证据**: `run_strategy_lab_update()` 第 61 行的捕获类型固定为 `ValueError`；candidate fallback 只位于 `close_build_error is not None` 分支。`read_csv_rows()` 和 dataset/file reads are synchronous filesystem operations and can raise `OSError` subclasses.
+- **影响**: 新 Close bridge 仍可回归既有 candidate evidence accumulation；错误类型而非 ownership boundary 决定是否隔离，行为不稳定。
+- **建议改法和验证点**: 将 Close build wrapper 收束为捕获 `Exception`（不捕获 `BaseException`），对所有 Close build failures 复用同一 candidate-attempt/re-raise path；reason 可保留内部 fallback 值，因为异常不会作为成功 result 返回。增加 monkeypatch/regression test：Close builder raises `OSError`, public call still raises that error, valid candidate dataset exists.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### S1-DR-02-未修复-中-只信 manifest 声明会把缺失 Close 文件的损坏 dataset 当成幂等成功
+- **入口/函数**: `run_strategy_lab_update()` -> `_build_latest_close_decision_dataset()` -> `_dataset_has_close_decision_facet()`
+- **文件(行号)**: `src/application/strategy_lab/update.py:292-309,345-353`
+- **输入场景**: run-ID target 已存在；`manifest.json` 仍含 `close_decision_facet`，但 `close_decision_episodes.jsonl`、marks 或 outcomes 至少一个缺失（例如部分文件清理、磁盘/同步损坏或人工恢复不完整）。
+- **实际分支**: `_dataset_has_close_decision_facet()` 只检查 manifest 中 value 是 dict，返回 true；caller 报告 `dataset_already_has_close_decisions` 并成功跳过。
+- **预期行为**: “already has close decisions” 必须由完整 Close dataset contract 证明。因本 slice 禁止覆盖/修复 existing target，至少应返回显式 collision/gap reason，不能把缺失 evidence 报成幂等完成。
+- **实际行为**: recorder 静默认为 Close facet 已存在；后续 status/readiness 可看不到 episodes，S5 仍缺数据但 build result 表示成功 idempotent skip。
+- **直接证据**: 第 345-353 行不检查 `OPTIONAL_CLOSE_DATASET_FILES`；capture builder 会为合法 facet 写出三个 optional files，且 manifest `files` 也声明它们。当前 tests 只覆盖 candidate-only collision，没有覆盖完整 close idempotency或 manifest/file mismatch。
+- **影响**: evidence loss 被隐藏，自动恢复/诊断受阻，生产 canary 可能误判 collection bridge 已正常工作。
+- **建议改法和验证点**: 让 completeness check 同时要求 manifest close facet 和 `OPTIONAL_CLOSE_DATASET_FILES` 三个文件都是 regular files；不完整时返回明确 `dataset_exists_without_complete_close_decisions`（与 candidate-only reason 区分）。增加两类测试：完整 Close dataset 二次运行返回 idempotent skip 且已有 close marks 保持不变；删掉任一 required close file 后返回 incomplete reason、不得报 already-has 或覆盖 target。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 6h sampling density remains deferred to S5 readiness coverage evaluation.
+- Existing candidate-only target is intentionally not migrated or overwritten; the explicit gap remains data-safe.
+- S2 service command/profile and docs are not in this slice and remain covered by the approved later slice.

--- a/docs/reviews/code-review-20260723-084634.md
+++ b/docs/reviews/code-review-20260723-084634.md
@@ -1,0 +1,41 @@
+# Code Re-review
+
+## Scope
+
+- Mode: current changes re-review
+- Branch or PR: `codex/close-evidence-collection`
+- Base: accepted plan commit `ad5912bd`
+- Original review: `docs/reviews/code-review-20260723-084455.md`
+- Fix artifact: `docs/gateflow/close-evidence-collection/s1-review-fix.md`
+- Output file: `docs/reviews/code-review-20260723-084634.md`
+- Included scope: S1 accepted findings, affected error/idempotency branches and regression tests.
+- Excluded scope: S2 service/docs; deployment; strategy/notification/config/trade/broker behavior.
+- Parallel review coverage: 无。
+
+## Findings
+
+### S1-DR-01 — 已修复
+
+`run_strategy_lab_update()` now catches every Close-build `Exception`, attempts the candidate build, and re-raises the original Close error. It does not catch `BaseException`. The added `OSError` regression proves the public call remains failed while candidate evidence persists.
+
+### S1-DR-02 — 已修复
+
+Existing target classification now requires the manifest facet plus all three close dataset files for `dataset_already_has_close_decisions`. Missing files return the explicit incomplete reason without overwrite. Tests cover both complete idempotency with preserved marks and incomplete state.
+
+No new material finding was found in the fix diff.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 6h sampling density remains `assigned to later work unit` S5 readiness evaluation.
+- Incomplete existing datasets are reported but not repaired; this is `assigned to later work unit` only if production evidence justifies a recovery/migration contract.
+- S2 automatic service wiring and docs remain `covered by later approved slice`.
+
+## Conclusion
+
+`pass-with-risks`
+
+Both accepted S1 findings are fixed, focused tests pass, and no blocking open question remains.

--- a/docs/reviews/code-review-20260723-084916.md
+++ b/docs/reviews/code-review-20260723-084916.md
@@ -1,0 +1,40 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `codex/close-evidence-collection`
+- Base: accepted S1 commit `3fe0f3cf`
+- Output file: `docs/reviews/code-review-20260723-084916.md`
+- Included scope: S2 systemd/launchd Strategy Lab recorder command generation, service profile observability, service-deploy tests and operator documentation.
+- Excluded scope: S1 internals already accepted; production installation/release/canary; Close Advice policy/notification/config/trade/broker state.
+- Parallel review coverage: 无；the bounded renderer/profile/docs diff was reviewed through both target branches and drift expectations.
+
+## Findings
+
+未发现实质性问题。
+
+Direct review evidence:
+
+- Both systemd and launchd build commands pass the new public flag at the same existing `strategy-lab update` entry point.
+- Sample and settle actions remain separate and their cadence/limits are unchanged.
+- The service profile field is emitted only under the existing `include_strategy_lab_recorder` opt-in.
+- Default rendering still omits all recorder units; service drift tests continue to pass.
+- Docs accurately distinguish research sampling from event-complete logging and production strategy authority.
+- The 175-test focused chain covers renderer, drift, Strategy Lab/CLI and Close capture regressions.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Actual systemd/launchd installation is not exercised locally: `covered by later approved rollout` after merge/release authorization.
+- 6h sampling is not event-complete: `assigned to later work unit` S5 readiness coverage evaluation and explicitly documented.
+- Production strategy promotion remains `requiring explicit user decision`; no production authority changed here.
+
+## Conclusion
+
+`pass-with-risks`
+
+No accepted finding or blocking open question remains; S2 may be committed.

--- a/docs/reviews/code-review-20260723-085352.md
+++ b/docs/reviews/code-review-20260723-085352.md
@@ -1,0 +1,45 @@
+# Code Review
+
+## Scope
+
+- Mode: current branch aggregate changes
+- Branch or PR: `codex/close-evidence-collection`
+- Base: `origin/main@df908e41`
+- Output file: `docs/reviews/code-review-20260723-085352.md`
+- Included scope: accepted plan plus S1/S2 production code, public CLI, dataset lifecycle, systemd/launchd recorder wiring, service profile, tests, docs and generated dependency graph.
+- Excluded scope: release metadata bump/publication; remote installation/canary; production policy promotion; notification/config/trade/Feishu/broker mutations.
+- Parallel review coverage: 无；the aggregate change is one bounded research evidence state machine and was reviewed across its complete local call chain.
+
+## Findings
+
+未发现实质性问题。
+
+Aggregate evidence checked:
+
+- Public flag source -> CLI forwarding -> application validation -> close selector -> strict capture -> dataset manifest/files.
+- Independent candidate fallback for every Close build `Exception`, including the persisted partial-success/error path.
+- Same-run idempotency, distinct-run dual build, empty state, malformed state, I/O failure, candidate-only collision and incomplete close-facet classification.
+- Summary backward compatibility and aggregate persistent-write safety reporting.
+- Existing mark/settle lifecycle discovery of optional close files; no new state owner or service was introduced.
+- systemd and launchd build commands use the same public application contract; sample/settle actions and cadence remain unchanged.
+- Profile/drift ownership remains under the existing explicit recorder opt-in.
+- Repository boundaries remain clean: dependency graph reports 481 production modules, 1929 production/script edges, zero cycles and passing guards.
+- Full Python 3.12 suite passes: 3049 passed, 10 skipped, 6 pre-existing deprecation warnings.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- A 6h recorder is sampling, not an event-complete Close Advice journal: `assigned to later work unit` S5 readiness coverage evaluation; docs state this explicitly.
+- A timer overlapping a partially written active run can produce a fail-closed attempt and candidate-only collision: `requiring new issue or explicit user decision` only if production canary/runtime evidence shows material recurrence. The current implementation does not invent a run-complete state.
+- Existing incomplete/candidate-only datasets are reported but never overwritten: `assigned to later work unit` only if recovery is justified by production evidence.
+- Remote service reconciliation and OpenD-backed mark sampling remain `covered by later approved rollout` after merge/release authorization.
+- P1/P2/P3 promotion remains `requiring explicit user decision`; this change does not grant production authority.
+
+## Conclusion
+
+`pass-with-risks`
+
+The aggregate implementation is merge-ready from the local code-quality perspective; no accepted unresolved finding or blocking open question remains.

--- a/docs/reviews/plan-review-20260723-083540.md
+++ b/docs/reviews/plan-review-20260723-083540.md
@@ -1,0 +1,79 @@
+# Plan Review
+
+## Reviewed target and scope
+
+- Target: `docs/gateflow/close-evidence-collection-plan-20260723.md`
+- Scope: Close Advice S5 automatic evidence collection bridge through the existing Strategy Lab recorder.
+- Review posture: adversarial review of architecture boundaries, failure isolation, idempotency, public result contracts, implementation slicing, testability, overengineering and rollout safety.
+- Source facts checked:
+  - `src/application/strategy_lab/update.py`
+  - `src/application/shadow_replay/capture.py`
+  - `src/interfaces/cli/research.py`
+  - `src/application/service_deploy.py`
+  - `tests/test_strategy_lab.py`
+  - `tests/test_service_deploy.py`
+
+## Assumptions tested
+
+1. Close evidence selection can be independent of latest candidate-run selection without duplicating policy validation.
+2. A close-first build preserves the existing candidate recorder behavior.
+3. Run-ID idempotency prevents duplicate datasets and protects existing marks/outcomes.
+4. One Strategy Lab update result can describe up to two builds without ambiguous success/safety semantics.
+5. Enabling close collection in the existing recorder does not broaden production recommendation, notification, config, trade or broker write authority.
+6. Empty Close Advice output is a normal state, while non-empty malformed formal evidence must remain fail-closed.
+
+## Findings
+
+### PR-01-未修复-高-Close capture 失败会在 candidate build 前终止，违反“候选采样行为不变”
+- **位置**: `4.2 Strategy Lab orchestration` 的固定执行顺序与 `5. State and Failure Semantics` 的 malformed row；S1 acceptance。
+- **问题类型**: 过度耦合 / 状态机漏洞 / 最佳实践偏离
+- **当前写法**: plan 固定执行 `close build -> candidate build -> data plan`，并规定非空 Close run 校验失败时“不继续掩盖错误”。表格中的 candidate build 对应为“不继续”。
+- **反例/失败场景**: recorder 已稳定采集 candidate evidence；部署新版本后，最新 Close Advice run 因缺 audit timestamp、position context 或正式字段而 fail-closed。`_build_latest_close_decision_dataset()` 抛出 `ValueError`，`_build_latest_dataset()` 未执行，原有 candidate dataset 也不再生成。由于 build timer 每次优先命中该非空 Close run，故障可重复发生，直到出现更新的可选 run。
+- **为什么有问题**: Close evidence 是新接入的可选 S5 facet，不应成为既有 candidate recorder 的前置可用性依赖。plan 同时声明“保持现有 latest candidate dataset build 的选择和行为不变”，但当前 sequencing 直接违反该承诺。Fail-closed 应保护 Close evidence 的正确性，不等于禁止独立 candidate research write。
+- **直接证据**: 当前 `run_strategy_lab_update()` 在 `_build_latest_dataset()` 返回后才调用 data plan；plan 要在该位置前插入可抛错的 close build。现有 `capture_close_decision_episodes()` 对多种缺失证据直接抛 `ValueError`。服务 build command 会默认启用新 flag，因此该错误会进入所有 opt-in recorder 部署。
+- **影响**: 新功能可回归既有自动 candidate evidence accumulation；unit 会持续失败；S5 故障面被不必要地扩大到其它研究数据。
+- **建议改法和验证点**: 保留正常路径的 close-first 顺序以解决同-run collision，但把两个 build 作为独立写入单元：捕获 close build 的 `ValueError`，仍执行原 candidate build，然后重新抛出原错误，使 unit 保持 fail-closed 且 candidate collection 不丢失。若两者是同一 run，异常后允许 candidate-only dataset 落地并明确这是不可自动修复的 collision；不得伪造 close success。新增测试：malformed close run + distinct valid candidate run 时，调用抛错但 candidate dataset 已生成；same-run malformed 时同样保留 candidate evidence、没有 close facet；下一次合法新 close run 可恢复。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-02-未修复-中-双 build 的 summary 和 CLI 验证契约欠规格，implementation 仍需自行设计
+- **位置**: `4.2 Strategy Lab orchestration` 的 result/summary 说明；S1 files、deliverables 和 acceptance。
+- **问题类型**: 契约缺失 / 不可直接实施 / 测试缺口
+- **当前写法**: plan 只说 summary / next action / safety “同时计入两种 build”，保留 `shadow_replay.dataset_build` 并新增 `close_decision_dataset_build`；没有定义现有 singular 字段 `dataset_built`、`dataset_build_reason`、`built_dataset_id` 如何表达两个 build。S1 又修改 public CLI parser/handler，但测试文件清单没有 CLI handler contract test。
+- **反例/失败场景**: close build 成功、candidate build 因同 run 已存在而 skip。若 implementation 继续从 candidate build 派生 singular summary，则 `dataset_built=false`，与实际 persistent write 和 safety 冲突；若改为聚合 true，`built_dataset_id` 又无法说明是哪个 build。另一个实现可能覆盖旧字段含义，破坏现有消费者。CLI flag 若未正确传入 application，纯 application tests 和 service string assertions仍可通过。
+- **为什么有问题**: 这是 public JSON contract 和 operator CLI 变更。未给出向后兼容字段语义会让代码生成 Agent 再做产品/架构决策，review 无法基于确定 contract 验收。
+- **直接证据**: 当前 `_summary()` 只有 candidate `dataset_build` 参数，产生 singular `dataset_built` / `dataset_build_reason` / `built_dataset_id`；`_safety()` 也只接收一个 build。当前测试仅直接调用 `run_strategy_lab_update()`，没有覆盖 `research strategy-lab update` parser 到 handler 的 flag forwarding。
+- **影响**: 运行结果可能自相矛盾，自动化与 canary 无法准确判断 Close dataset 是否写入；CLI 接线回归可能漏测；后续兼容修复返工。
+- **建议改法和验证点**: 明确保持所有既有 singular summary 字段严格表示 candidate build，不改变旧语义；新增独立 `close_decision_dataset_build_requested`、`close_decision_dataset_built`、`close_decision_dataset_build_reason`、`built_close_decision_dataset_id`。顶层 `status` 与 safety write targets 对任一 build 聚合。`next_action` 在 dry-run 时可使用现有通用 rerun action，但 malformed evidence 继续异常。S1 加入 `tests/test_research.py` 或现有 CLI contract test，证明 flag forwarding 以及 `--include-close-decisions` 与缺少 `--build-dataset` / 携带 `--dataset-id` 的拒绝语义。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### PR-03-未修复-低-“不新增 config key”与新增 service profile 字段文字冲突
+- **位置**: `4.3 Public CLI and service wiring` 与 S2 acceptance。
+- **问题类型**: 契约缺失
+- **当前写法**: plan 要新增 `service.profile.json.strategy_lab_recorder.include_close_decisions`，同时 acceptance 写“没有新增 timer/service/config key”。
+- **反例/失败场景**: 实现或 review Agent 可能把 profile observability field 当成被禁止的新 key 而删除它，或反过来误以为可以新增 operator-authored runtime config。
+- **为什么有问题**: service profile 是部署事实而非 `config.yaml` authoring contract，但 plan 没有把两者区分清楚。
+- **直接证据**: 同一 plan 的两个章节对 key addition 给出相反字面要求。
+- **影响**: S2 验收歧义，文档/测试与实现可能漂移。
+- **建议改法和验证点**: 把 acceptance 改为“不新增 timer/service 或 operator-authored runtime config key；只新增既定的 service profile observability field”。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 低
+
+## Open Questions
+
+- 无。三个 findings 都能在不扩大目标和不改变生产策略的情况下收敛。
+
+## Residual Risks
+
+- 6h sampling 不是每次 tick 的完整事件日志；plan 已正确把它列为 coverage residual risk。
+- 已存在 candidate-only dataset 的不覆盖策略会放弃该 run 的 close facet；plan 已选择数据安全优先，并要求显式 collision reason。
+- runs-root mtime 与活跃写入竞争仍可能造成一次 fail-closed；保持现有 selector 约定是本 work unit 的合理最小选择。
+
+建议将这些 residual risks 继续保留在修订后的 Gateflow plan，并在生产 canary / 后续 readiness 报告中核验，而不是在本 work unit 新增 run-complete state 或迁移流程。
+
+## Conclusion
+
+`fail`
+
+当前方向总体合理且边界克制，但 PR-01 会让新 Close facet 破坏现有 candidate recorder，PR-02 令 public result contract 仍不可直接实施。修订并重新 review 后再进入实现。

--- a/docs/reviews/plan-review-20260723-083722.md
+++ b/docs/reviews/plan-review-20260723-083722.md
@@ -1,0 +1,55 @@
+# Plan Re-review
+
+## Reviewed target and scope
+
+- Target: `docs/gateflow/close-evidence-collection-plan-20260723.md`
+- Original review: `docs/reviews/plan-review-20260723-083540.md`
+- Fix artifact: `docs/gateflow/close-evidence-collection/plan-review-fix.md`
+- Scope: accepted findings PR-01 through PR-03 plus regression check of architecture, scope and rollout boundaries after revision.
+
+## Assumptions retested
+
+1. Strict Close validation can fail without suppressing the existing candidate dataset write.
+2. Valid same-run close/candidate evidence still produces one full dataset rather than duplicates.
+3. Existing public candidate summary fields remain backward compatible while close-specific results are observable.
+4. CLI argument validation and forwarding are now directly testable.
+5. Service profile observability does not create a new operator-authored production config surface.
+
+## Finding status
+
+### PR-01 — 已修复
+
+The plan now makes close and candidate builds independent write units. A Close `ValueError` is preserved, candidate build still runs, and the original Close failure is re-raised before data-plan execution. Normal close-first ordering remains, so valid same-run evidence creates one full dataset. The required distinct-run and same-run malformed tests make both fail-closed and regression behavior reviewable.
+
+### PR-02 — 已修复
+
+The plan freezes compatibility semantics: existing singular fields remain candidate-only; four named close-specific summary fields describe the second build; aggregate status and safety account for either write. `tests/test_research.py` is now in S1 with explicit parser-to-handler forwarding and invalid-combination cases.
+
+### PR-03 — 已修复
+
+The revised text distinguishes the allowed service profile observability field from prohibited new operator-authored runtime configuration. S2 acceptance is no longer contradictory.
+
+## Open questions
+
+- 无。
+
+## Residual risks and classification
+
+- 6h sampling is not an event-complete log: `assigned to later work unit` — S5 readiness evaluation must report coverage before any policy promotion.
+- Existing candidate-only dataset collision is not migrated: `assigned to later work unit` only if production evidence shows material loss; current behavior is explicit, non-destructive skip.
+- Active-run partial write race can cause a transient strict failure: `requiring new issue or explicit user decision` only if production canary/runtime history proves recurrence; no speculative run-complete state is added here.
+- Candidate build could independently fail while a Close error is pending: `fixed in current slice` through deterministic tests and implementation artifact evidence for the intended valid-candidate scenario; unrelated candidate-source failures retain existing exception behavior and are not hidden.
+
+## Architecture, best-practice, optimality, overengineering and overcoupling conclusion
+
+- Ownership remains correct: discovery/capture in Shadow Replay, lifecycle orchestration in Strategy Lab, deployment command generation in service deploy.
+- The plan reuses the existing dataset, mark and settlement lifecycle; it adds no new service, timer, storage schema or production strategy authority.
+- Independent run selection is necessary because production candidate and Close artifacts are not co-located in every latest run.
+- The close-first plus candidate-on-error rule is the smallest design that handles same-run idempotency without coupling optional Close availability to existing candidate collection.
+- No material overengineering or blocking overcoupling remains.
+
+## Conclusion
+
+`pass-with-risks`
+
+All accepted findings are fixed and classified residual risks are explicitly outside this work unit or conditioned on production evidence. The plan is code-generation-ready and may enter implementation.

--- a/docs/reviews/pr-114-review-20260723-085653.md
+++ b/docs/reviews/pr-114-review-20260723-085653.md
@@ -1,0 +1,45 @@
+# Pull Request Review
+
+## Scope
+
+- Mode: PR
+- PR: #114 — `feat: automate Close Advice evidence collection`
+- URL: https://github.com/liuxie066/options-monitor/pull/114
+- Author: `liuxie066`
+- Head: `codex/close-evidence-collection@016274fb0326dbd648940060c954f3ae9413d88f`
+- Base: `main`
+- Output file: `docs/reviews/pr-114-review-20260723-085653.md`
+- Included scope: complete remote PR diff, metadata, commits, changed files, public/production boundaries, local aggregate validation and GitHub checks.
+- Excluded scope: post-merge release/deployment/canary and any strategy promotion decision.
+- Parallel review coverage: 无；the remote PR matches the locally reviewed aggregate commit.
+
+## Findings
+
+未发现实质性问题。
+
+PR facts and evidence:
+
+- Draft PR, mergeable state reported `MERGEABLE`; base/head are correct.
+- Remote diff contains the four accepted Gateflow commits and the expected 23 files only.
+- Production code changes remain limited to Shadow Replay capture, Strategy Lab orchestration, CLI forwarding and service command/profile rendering.
+- No Close Advice policy, notification renderer/router, authored runtime config, ledger/trade, Feishu or broker-facing module changed.
+- Local final validation: 3049 passed, 10 skipped, 6 pre-existing warnings; dependency graph 481 production modules and zero cycles; release metadata valid for current base.
+- GitHub checks all passed: Analyze (actions), Analyze (python), CodeQL, agent-plugin and guardrails.
+- Prior accepted S1 findings are fixed and present in the remote diff: all Close build exceptions preserve candidate attempt; close idempotency requires manifest plus all optional close files.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 6h sampling is not event-complete: `assigned to later work unit` S5 readiness coverage evaluation.
+- Active-run partial-write/collision recovery is not automated: `requiring new issue or explicit user decision` only if production evidence shows material recurrence.
+- Release publication, service reconcile and research canary are `covered by later approved rollout` after merge authorization.
+- P1/P2/P3 promotion remains `requiring explicit user decision`; PR #114 does not alter production authority.
+
+## Conclusion
+
+`pass-with-risks`
+
+PR #114 satisfies the Gateflow PR review gate. It remains Draft and has not been approved, marked ready or merged.

--- a/src/application/service_deploy.py
+++ b/src/application/service_deploy.py
@@ -985,6 +985,7 @@ def render_service_bundle(
                 "--profile-path",
                 profile_path,
                 "--build-dataset",
+                "--include-close-decisions",
                 "--write",
                 "--source",
                 "local",
@@ -1418,6 +1419,7 @@ def render_service_bundle(
                 "--profile-path",
                 profile_path,
                 "--build-dataset",
+                "--include-close-decisions",
                 "--write",
                 "--source",
                 "local",
@@ -1659,6 +1661,7 @@ def render_service_bundle(
         } if include_wechat_clawbot else None,
         strategy_lab_recorder={
             "enabled": True,
+            "include_close_decisions": True,
             "source": recorder_source,
             "max_datasets": recorder_max_datasets,
             "mark_stale_hours": recorder_mark_stale_hours,

--- a/src/application/shadow_replay/capture.py
+++ b/src/application/shadow_replay/capture.py
@@ -1595,6 +1595,71 @@ def latest_shadow_replay_run_dir(*, repo_root: Path, runs_root: Path | None = No
     }
 
 
+def latest_close_decision_run_dir(
+    *,
+    repo_root: Path,
+    runs_root: Path | None = None,
+) -> tuple[Path | None, dict[str, Any]]:
+    """Return the latest run containing at least one Close Advice data row."""
+
+    root = (runs_root or (repo_root / "output_runs")).resolve()
+    searched_count = 0
+    skipped_without_close_count = 0
+    skipped_empty_count = 0
+    if not root.exists() or not root.is_dir():
+        return None, {
+            "requested": True,
+            "found": False,
+            "source": "runs_root_mtime",
+            "runs_root": safe_rel(root, base=repo_root),
+            "path": None,
+            "run_id": None,
+            "searched_count": 0,
+            "skipped_without_close_count": 0,
+            "skipped_empty_count": 0,
+        }
+    run_dirs = sorted(
+        [item.resolve() for item in root.iterdir() if item.is_dir()],
+        key=lambda item: (item.stat().st_mtime, item.name),
+        reverse=True,
+    )
+    for run_dir in run_dirs:
+        searched_count += 1
+        probe = ShadowReplaySourceSelection(repo_root=repo_root, run_dir=run_dir, runs_root=root)
+        close_paths = close_advice_paths_from_selection(probe)
+        if not close_paths:
+            skipped_without_close_count += 1
+            continue
+        close_row_count = sum(len(read_csv_rows(path)) for path in close_paths)
+        if close_row_count <= 0:
+            skipped_empty_count += 1
+            continue
+        return run_dir, {
+            "requested": True,
+            "found": True,
+            "source": "runs_root_mtime",
+            "runs_root": safe_rel(root, base=repo_root),
+            "path": safe_rel(run_dir, base=repo_root),
+            "run_id": run_dir.name,
+            "searched_count": searched_count,
+            "skipped_without_close_count": skipped_without_close_count,
+            "skipped_empty_count": skipped_empty_count,
+            "close_path_count": len(close_paths),
+            "close_row_count": close_row_count,
+        }
+    return None, {
+        "requested": True,
+        "found": False,
+        "source": "runs_root_mtime",
+        "runs_root": safe_rel(root, base=repo_root),
+        "path": None,
+        "run_id": None,
+        "searched_count": searched_count,
+        "skipped_without_close_count": skipped_without_close_count,
+        "skipped_empty_count": skipped_empty_count,
+    }
+
+
 def dedupe_snapshots(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     seen: set[tuple[Any, ...]] = set()

--- a/src/application/strategy_lab/update.py
+++ b/src/application/strategy_lab/update.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Iterable
 
 from src.application.shadow_replay import build_shadow_replay_dataset, run_shadow_replay_data_plan
-from src.application.shadow_replay.capture import latest_shadow_replay_run_dir
-from src.application.shadow_replay.common import dataset_output_dir, resolve_optional, resolve_output_path, text, utc_now, write_json
+from src.application.shadow_replay.capture import (
+    latest_close_decision_run_dir,
+    latest_shadow_replay_run_dir,
+)
+from src.application.shadow_replay.common import (
+    OPTIONAL_CLOSE_DATASET_FILES,
+    dataset_output_dir,
+    resolve_optional,
+    resolve_output_path,
+    text,
+    utc_now,
+    write_json,
+)
 
 
 UPDATE_SCHEMA_VERSION = "strategy_lab_update.v1"
@@ -24,6 +36,7 @@ def run_strategy_lab_update(
     latest: bool = False,
     max_datasets: int | None = None,
     build_dataset: bool = False,
+    include_close_decisions: bool = False,
     runs_root: str | Path | None = None,
     dataset_id: str | None = None,
     write: bool = False,
@@ -39,7 +52,41 @@ def run_strategy_lab_update(
     include_realized_volatility: bool = False,
     max_symbols: int | None = None,
 ) -> dict[str, Any]:
+    if include_close_decisions and not build_dataset:
+        raise ValueError("include_close_decisions requires build_dataset")
+    if include_close_decisions and text(dataset_id):
+        raise ValueError("include_close_decisions cannot be combined with dataset_id")
     effective_max = _effective_max_datasets(latest=latest, max_datasets=max_datasets)
+    close_build_error: Exception | None = None
+    try:
+        close_dataset_build = _build_latest_close_decision_dataset(
+            repo_root=repo_root,
+            dataset_root=dataset_root,
+            runs_root=runs_root,
+            requested=bool(build_dataset and include_close_decisions),
+            write=bool(write),
+        )
+    except Exception as exc:
+        close_build_error = exc
+        close_dataset_build = {
+            "requested": True,
+            "executed": False,
+            "reason": "close_decision_dataset_build_failed",
+            "source": "latest_close_decision_run",
+        }
+    if close_build_error is not None:
+        try:
+            _build_latest_dataset(
+                repo_root=repo_root,
+                dataset_root=dataset_root,
+                runs_root=runs_root,
+                dataset_id=dataset_id,
+                requested=bool(build_dataset),
+                write=bool(write),
+            )
+        except Exception as candidate_build_error:
+            raise close_build_error from candidate_build_error
+        raise close_build_error
     dataset_build = _build_latest_dataset(
         repo_root=repo_root,
         dataset_root=dataset_root,
@@ -77,6 +124,7 @@ def run_strategy_lab_update(
         "summary": _summary(
             data_plan=data_plan,
             dataset_build=dataset_build,
+            close_dataset_build=close_dataset_build,
             status=status,
             write=bool(write),
             latest=bool(latest),
@@ -87,6 +135,8 @@ def run_strategy_lab_update(
             "selection_mode": "highest_priority_due_dataset" if latest else "all_due_datasets",
             "build_dataset": bool(build_dataset),
             "build_source": "latest_scanned_run" if build_dataset else None,
+            "include_close_decisions": bool(include_close_decisions),
+            "close_build_source": "latest_close_decision_run" if include_close_decisions else None,
             "runs_root": str(runs_root) if runs_root is not None and text(runs_root) else None,
             "dataset_id": text(dataset_id) or None,
         },
@@ -102,10 +152,16 @@ def run_strategy_lab_update(
         },
         "shadow_replay": {
             "dataset_build": dataset_build,
+            "close_decision_dataset_build": close_dataset_build,
             "status": status,
             "data_plan_run": data_plan,
         },
-        "safety": _safety(data_plan=data_plan, dataset_build=dataset_build, output=output),
+        "safety": _safety(
+            data_plan=data_plan,
+            dataset_build=dataset_build,
+            close_dataset_build=close_dataset_build,
+            output=output,
+        ),
     }
     if output:
         write_json(resolve_output_path(output), result)
@@ -207,6 +263,112 @@ def _build_latest_dataset(
     }
 
 
+def _build_latest_close_decision_dataset(
+    *,
+    repo_root: str | Path,
+    dataset_root: str | Path | None,
+    runs_root: str | Path | None,
+    requested: bool,
+    write: bool,
+) -> dict[str, Any]:
+    if not requested:
+        return {
+            "requested": False,
+            "executed": False,
+            "reason": "not_requested",
+            "source": "latest_close_decision_run",
+        }
+    base = Path(repo_root).expanduser().resolve()
+    run_dir, latest_selection = latest_close_decision_run_dir(
+        repo_root=base,
+        runs_root=resolve_optional(runs_root, base=base),
+    )
+    if run_dir is None:
+        return {
+            "requested": True,
+            "executed": False,
+            "reason": "latest_close_decision_run_not_found",
+            "source": "latest_close_decision_run",
+            "source_selection": latest_selection,
+            "dataset_id": None,
+            "dataset_id_source": "latest_close_run_id",
+            "dataset_root": str(dataset_root) if dataset_root is not None and text(dataset_root) else None,
+            "runs_root": str(runs_root) if runs_root is not None and text(runs_root) else None,
+        }
+    selected_dataset_id = run_dir.name
+    target = _dataset_target_dir(repo_root=base, dataset_root=dataset_root, dataset_id=selected_dataset_id)
+    if target.exists():
+        close_facet_status = _close_decision_facet_status(target)
+        return {
+            "requested": True,
+            "executed": False,
+            "reason": (
+                "dataset_already_has_close_decisions"
+                if close_facet_status == "complete"
+                else (
+                    "dataset_exists_without_complete_close_decisions"
+                    if close_facet_status == "incomplete"
+                    else "dataset_exists_without_close_decisions"
+                )
+            ),
+            "source": "latest_close_decision_run",
+            "dataset_id": selected_dataset_id,
+            "dataset_id_source": "latest_close_run_id",
+            "dataset_dir": str(target),
+            "source_selection": latest_selection,
+            "dataset_root": str(dataset_root) if dataset_root is not None and text(dataset_root) else None,
+            "runs_root": str(runs_root) if runs_root is not None and text(runs_root) else None,
+        }
+    if not write:
+        return {
+            "requested": True,
+            "executed": False,
+            "reason": "requires_write",
+            "source": "latest_close_decision_run",
+            "dataset_id": selected_dataset_id,
+            "dataset_id_source": "latest_close_run_id",
+            "source_selection": latest_selection,
+            "dataset_root": str(dataset_root) if dataset_root is not None and text(dataset_root) else None,
+            "runs_root": str(runs_root) if runs_root is not None and text(runs_root) else None,
+        }
+    manifest = build_shadow_replay_dataset(
+        repo_root=base,
+        run_id=selected_dataset_id,
+        runs_root=runs_root,
+        run_dir=run_dir,
+        dataset_root=dataset_root,
+        dataset_id=selected_dataset_id,
+        include_close_decisions=True,
+    )
+    return {
+        "requested": True,
+        "executed": True,
+        "reason": "built_latest_close_decision_run",
+        "source": "latest_close_decision_run",
+        "dataset_id": manifest.get("dataset_id"),
+        "dataset_id_source": "latest_close_run_id",
+        "dataset_dir": manifest.get("dataset_dir"),
+        "source_selection": latest_selection,
+        "manifest_summary": manifest.get("summary") or {},
+        "manifest_safety": manifest.get("safety") or {},
+    }
+
+
+def _close_decision_facet_status(dataset_dir: Path) -> str:
+    manifest_path = dataset_dir / "manifest.json"
+    if not manifest_path.is_file():
+        return "absent"
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "absent"
+    if not isinstance(payload, dict) or not isinstance(payload.get("close_decision_facet"), dict):
+        return "absent"
+    if all((dataset_dir / name).is_file() for name in OPTIONAL_CLOSE_DATASET_FILES):
+        return "complete"
+    return "incomplete"
+
+
 def _dataset_target_dir(*, repo_root: Path, dataset_root: str | Path | None, dataset_id: str) -> Path:
     root = resolve_optional(dataset_root, base=repo_root)
     if root is not None:
@@ -218,6 +380,7 @@ def _summary(
     *,
     data_plan: dict[str, Any],
     dataset_build: dict[str, Any],
+    close_dataset_build: dict[str, Any],
     status: dict[str, Any] | None,
     write: bool,
     latest: bool,
@@ -229,14 +392,30 @@ def _summary(
     planned_count = int(plan_summary.get("planned_count") or 0)
     build_requested = bool(dataset_build.get("requested"))
     build_executed = bool(dataset_build.get("executed"))
+    close_build_requested = bool(close_dataset_build.get("requested"))
+    close_build_executed = bool(close_dataset_build.get("executed"))
     return {
-        "status": "error" if error_count else ("updated" if write and (executed_count or build_executed) else "planned"),
+        "status": (
+            "error"
+            if error_count
+            else (
+                "updated"
+                if write and (executed_count or build_executed or close_build_executed)
+                else "planned"
+            )
+        ),
         "write": bool(write),
         "latest": bool(latest),
         "dataset_build_requested": build_requested,
         "dataset_built": build_executed,
         "dataset_build_reason": dataset_build.get("reason"),
         "built_dataset_id": dataset_build.get("dataset_id") if build_executed else None,
+        "close_decision_dataset_build_requested": close_build_requested,
+        "close_decision_dataset_built": close_build_executed,
+        "close_decision_dataset_build_reason": close_dataset_build.get("reason"),
+        "built_close_decision_dataset_id": (
+            close_dataset_build.get("dataset_id") if close_build_executed else None
+        ),
         "dataset_count": status_summary.get("dataset_count"),
         "data_plan_action_count": plan_summary.get("plan_action_count"),
         "planned_count": planned_count,
@@ -287,10 +466,16 @@ def _next_action(
     return "wait_for_more_replay_evidence"
 
 
-def _safety(*, data_plan: dict[str, Any], dataset_build: dict[str, Any], output: str | Path | None) -> dict[str, Any]:
+def _safety(
+    *,
+    data_plan: dict[str, Any],
+    dataset_build: dict[str, Any],
+    close_dataset_build: dict[str, Any],
+    output: str | Path | None,
+) -> dict[str, Any]:
     safety = dict(data_plan.get("safety") or {})
     targets = list(safety.get("persistent_write_targets") or [])
-    if bool(dataset_build.get("executed")):
+    if bool(dataset_build.get("executed")) or bool(close_dataset_build.get("executed")):
         targets.append("shadow_replay_dataset")
     if output:
         targets.append("strategy_lab_update_artifact")
@@ -300,7 +485,9 @@ def _safety(*, data_plan: dict[str, Any], dataset_build: dict[str, Any], output:
             "runtime_config_write_allowed": False,
             "production_recommendation_allowed": False,
             "online_ai_called": False,
-            "writes_shadow_replay_dataset_build": bool(dataset_build.get("executed")),
+            "writes_shadow_replay_dataset_build": bool(
+                dataset_build.get("executed") or close_dataset_build.get("executed")
+            ),
             "writes_strategy_lab_update_artifact": bool(output),
             "persistent_write_targets": deduped_targets,
             "writes_persistent_outputs": bool(deduped_targets),

--- a/src/interfaces/cli/research.py
+++ b/src/interfaces/cli/research.py
@@ -171,6 +171,11 @@ def add_research_commands(subparsers: Any) -> argparse.ArgumentParser:
         help="build a local replay dataset from the latest scanned run before running the data plan; writes only with --write",
     )
     strategy_lab_update.add_argument(
+        "--include-close-decisions",
+        action="store_true",
+        help="also build a dataset from the latest non-empty Close Advice run; requires --build-dataset and --write to persist",
+    )
+    strategy_lab_update.add_argument(
         "--runs-root",
         default=None,
         help="runs root for --build-dataset; defaults to profile/runtime output_runs",
@@ -850,6 +855,7 @@ def handle_research_command(
                     latest=bool(args.latest),
                     max_datasets=args.max_datasets,
                     build_dataset=bool(args.build_dataset),
+                    include_close_decisions=bool(args.include_close_decisions),
                     runs_root=runs_root,
                     dataset_id=args.dataset_id,
                     write=bool(args.write),

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -6,12 +6,70 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, TypedDict
 
+import pytest
+
 
 class _ToolKwargs(TypedDict):
     load_runtime_config: Callable[..., tuple[Path, dict[str, Any]]]
     repo_base: Callable[[], Path]
     mask_path: Callable[[Any], str | None]
     now_fn: Callable[[], datetime]
+
+
+def test_strategy_lab_update_cli_forwards_close_decision_build_flag(monkeypatch, tmp_path: Path) -> None:
+    import src.application.strategy_lab as strategy_lab
+    from src.interfaces.cli.main import parse_args
+    from src.interfaces.cli.research import handle_research_command
+
+    calls: list[dict[str, Any]] = []
+
+    def _run_strategy_lab_update(**kwargs):
+        calls.append(kwargs)
+        return {"schema_version": "strategy_lab_update.v1", "summary": {}, "safety": {}}
+
+    monkeypatch.setattr(strategy_lab, "run_strategy_lab_update", _run_strategy_lab_update)
+    args = parse_args(
+        [
+            "research",
+            "strategy-lab",
+            "update",
+            "--build-dataset",
+            "--include-close-decisions",
+            "--write",
+        ]
+    )
+
+    response = handle_research_command(args, repo_base_fn=lambda: tmp_path)
+
+    assert response["ok"] is True
+    assert calls[0]["build_dataset"] is True
+    assert calls[0]["include_close_decisions"] is True
+    assert calls[0]["write"] is True
+
+
+@pytest.mark.parametrize(
+    "extra_args, expected_message",
+    [
+        (["--include-close-decisions"], "requires build_dataset"),
+        (
+            ["--build-dataset", "--include-close-decisions", "--dataset-id", "explicit"],
+            "cannot be combined with dataset_id",
+        ),
+    ],
+)
+def test_strategy_lab_update_cli_rejects_invalid_close_build_combinations(
+    tmp_path: Path,
+    extra_args: list[str],
+    expected_message: str,
+) -> None:
+    from src.application.agent_tool_contracts import AgentToolError
+    from src.interfaces.cli.main import parse_args
+    from src.interfaces.cli.research import handle_research_command
+
+    args = parse_args(["research", "strategy-lab", "update", *extra_args])
+
+    with pytest.raises(AgentToolError, match=expected_message):
+        handle_research_command(args, repo_base_fn=lambda: tmp_path)
 
 
 def _runtime_status_data(*, tick_metrics: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/tests/test_service_deploy.py
+++ b/tests/test_service_deploy.py
@@ -823,7 +823,8 @@ def test_render_systemd_bundle_can_include_strategy_lab_recorder_timers(tmp_path
 
     assert str(repo / "om") + " research strategy-lab update --latest" in build_service
     assert "--profile-path " + str(runtime / "service.profile.json") in build_service
-    assert "--build-dataset --write --source local" in build_service
+    assert "--include-close-decisions" in build_service
+    assert "--build-dataset --include-close-decisions --write --source local" in build_service
     assert "--max-datasets 0" in build_service
     assert "--settle-after-collect" not in build_service
     assert "OnUnitActiveSec=6h" in build_timer
@@ -840,6 +841,7 @@ def test_render_systemd_bundle_can_include_strategy_lab_recorder_timers(tmp_path
     assert {"name": "options-monitor-strategy-lab-settle.timer"} in profile["services"]
     assert profile["strategy_lab_recorder"] == {
         "enabled": True,
+        "include_close_decisions": True,
         "source": "opend",
         "max_datasets": 3,
         "mark_stale_hours": 2,
@@ -878,6 +880,7 @@ def test_render_launchd_strategy_lab_recorder_separates_actions(tmp_path: Path) 
     build_payload = plistlib.loads(build_plist.encode("utf-8"))
 
     assert build_args[build_args.index("--max-datasets") + 1] == "0"
+    assert "--include-close-decisions" in build_args
     assert "--settle-after-collect" not in build_args
     assert build_payload["StartInterval"] == 21600
     assert sample_args[sample_args.index("--action") + 1] == "collect_marks"

--- a/tests/test_strategy_lab.py
+++ b/tests/test_strategy_lab.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import csv
 import json
 from pathlib import Path
+
+import pytest
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> None:
@@ -163,7 +166,12 @@ def _write_update_dataset(dataset: Path) -> None:
 
 
 def _write_latest_scanned_run(runs_root: Path) -> Path:
-    run_account = runs_root / "run-evidence" / "accounts" / "lx"
+    _write_candidate_run(runs_root, "run-evidence")
+    return runs_root
+
+
+def _write_candidate_run(runs_root: Path, run_id: str) -> Path:
+    run_account = runs_root / run_id / "accounts" / "lx"
     run_account.mkdir(parents=True, exist_ok=True)
     (run_account / "sell_put_candidates.csv").write_text(
         (
@@ -187,7 +195,100 @@ def _write_latest_scanned_run(runs_root: Path) -> Path:
         + "\n",
         encoding="utf-8",
     )
-    return runs_root
+    return run_account.parent.parent
+
+
+def _write_close_run(
+    runs_root: Path,
+    run_id: str,
+    *,
+    include_audit: bool = True,
+    include_candidate: bool = False,
+) -> Path:
+    account_dir = runs_root / run_id / "accounts" / "lx"
+    close_path = account_dir / "close_advice.csv"
+    row = {
+        "account": "lx",
+        "position_lot_id": "lot-1",
+        "symbol": "NVDA",
+        "option_type": "put",
+        "expiration": "2026-08-21",
+        "strike": 100,
+        "position_side": "short",
+        "strategy_family": "sell_put",
+        "strategy_profile": "insurance_underwriting",
+        "tier": "medium",
+        "exit_state": "profit_capture",
+        "evaluation_status": "priced",
+        "fee_calc_status": "schedule_estimate",
+        "estimated_pnl_if_close_net": 80,
+        "short_vol_thesis_status": "valid",
+        "continued_willingness": "true",
+        "close_calibration_status": "complete",
+        "capture_ratio": 0.85,
+        "remaining_annualized_return": 0.07,
+        "dte": 29,
+        "close_mid": 0.2,
+        "bid": 0.19,
+        "ask": 0.21,
+        "remaining_premium": 20,
+        "estimated_close_fee": 1.5,
+        "fee_calc_basis": "futu_us_fixed_package_2026-07-22",
+        "contracts_open": 1,
+        "multiplier": 100,
+        "currency": "USD",
+        "policy_version": "p0_current.v1",
+        "recommendation_state": "close",
+        "decision_basis": "profit_capture_medium",
+        "decision_evidence_status": "complete",
+    }
+    close_path.parent.mkdir(parents=True, exist_ok=True)
+    with close_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(row))
+        writer.writeheader()
+        writer.writerow(row)
+    context_path = account_dir / "state" / "option_positions_context.json"
+    context_path.parent.mkdir(parents=True, exist_ok=True)
+    context_path.write_text(
+        json.dumps(
+            {
+                "as_of_utc": "2026-07-23T01:00:30Z",
+                "open_positions_min": [
+                    {
+                        "record_id": "lot-1",
+                        "account": "lx",
+                        "symbol": "NVDA",
+                        "option_type": "put",
+                        "side": "short",
+                        "expiration": "2026-08-21",
+                        "strike": 100,
+                        "contracts": 1,
+                        "contracts_open": 1,
+                        "multiplier": 100,
+                        "currency": "USD",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    if include_audit:
+        audit_path = runs_root / run_id / "state" / "audit_events.jsonl"
+        _write_jsonl(
+            audit_path,
+            [
+                {
+                    "run_id": run_id,
+                    "account": "lx",
+                    "action": "close_advice",
+                    "status": "ok",
+                    "event_at_utc": "2026-07-23T01:01:00Z",
+                }
+            ],
+        )
+    if include_candidate:
+        _write_candidate_run(runs_root, run_id)
+    return runs_root / run_id
 
 
 def _write_strategy_lab_window_run(root: Path) -> Path:
@@ -1383,6 +1484,308 @@ def test_strategy_lab_update_latest_build_is_idempotent_by_run_id(tmp_path: Path
     assert second["shadow_replay"]["dataset_build"]["dataset_id"] == "run-evidence"
     assert second["shadow_replay"]["dataset_build"]["executed"] is False
     assert json.loads(mark_path.read_text(encoding="utf-8"))["option_mid"] == 1.1
+
+
+def test_strategy_lab_update_builds_close_and_candidate_from_independent_runs(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    _write_close_run(runs_root, "20260723T010000Z-close")
+    _write_candidate_run(runs_root, "20260723T020000Z-candidate")
+    dataset_root = tmp_path / "datasets"
+
+    result = run_strategy_lab_update(
+        repo_root=tmp_path,
+        dataset_root=dataset_root,
+        runs_root=runs_root,
+        build_dataset=True,
+        include_close_decisions=True,
+        latest=True,
+        write=True,
+        max_datasets=0,
+        min_sample=1,
+    )
+
+    close_build = result["shadow_replay"]["close_decision_dataset_build"]
+    candidate_build = result["shadow_replay"]["dataset_build"]
+    assert close_build["executed"] is True
+    assert close_build["dataset_id"] == "20260723T010000Z-close"
+    assert close_build["source_selection"]["close_row_count"] == 1
+    assert candidate_build["executed"] is True
+    assert candidate_build["dataset_id"] == "20260723T020000Z-candidate"
+    assert result["summary"]["dataset_built"] is True
+    assert result["summary"]["built_dataset_id"] == "20260723T020000Z-candidate"
+    assert result["summary"]["close_decision_dataset_built"] is True
+    assert result["summary"]["built_close_decision_dataset_id"] == "20260723T010000Z-close"
+    assert result["safety"]["writes_shadow_replay_dataset_build"] is True
+    close_manifest = json.loads(
+        (dataset_root / "20260723T010000Z-close" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert close_manifest["close_decision_facet"]["episode_count"] == 1
+
+
+def test_strategy_lab_update_same_run_builds_one_close_aware_dataset(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    run_id = "20260723T010000Z-combined"
+    _write_close_run(runs_root, run_id, include_candidate=True)
+    dataset_root = tmp_path / "datasets"
+
+    result = run_strategy_lab_update(
+        repo_root=tmp_path,
+        dataset_root=dataset_root,
+        runs_root=runs_root,
+        build_dataset=True,
+        include_close_decisions=True,
+        write=True,
+        max_datasets=0,
+        min_sample=1,
+    )
+
+    assert result["summary"]["close_decision_dataset_built"] is True
+    assert result["summary"]["dataset_built"] is False
+    assert result["summary"]["dataset_build_reason"] == "dataset_already_exists"
+    assert (dataset_root / run_id / "close_decision_episodes.jsonl").is_file()
+    assert len(list(dataset_root.iterdir())) == 1
+
+
+def test_strategy_lab_update_skips_empty_close_run_and_keeps_candidate_build(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    empty_close = runs_root / "20260723T020000Z-empty" / "accounts" / "lx" / "close_advice.csv"
+    empty_close.parent.mkdir(parents=True, exist_ok=True)
+    empty_close.write_text("account,position_lot_id\n", encoding="utf-8")
+    _write_candidate_run(runs_root, "20260723T030000Z-candidate")
+    dataset_root = tmp_path / "datasets"
+
+    result = run_strategy_lab_update(
+        repo_root=tmp_path,
+        dataset_root=dataset_root,
+        runs_root=runs_root,
+        build_dataset=True,
+        include_close_decisions=True,
+        write=True,
+        max_datasets=0,
+        min_sample=1,
+    )
+
+    close_build = result["shadow_replay"]["close_decision_dataset_build"]
+    assert close_build["reason"] == "latest_close_decision_run_not_found"
+    assert close_build["source_selection"]["skipped_empty_count"] == 1
+    assert result["summary"]["dataset_built"] is True
+
+
+def test_strategy_lab_update_malformed_close_fails_after_independent_candidate_build(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    close_run_id = "20260723T010000Z-close"
+    candidate_run_id = "20260723T020000Z-candidate"
+    _write_close_run(runs_root, close_run_id, include_audit=False)
+    _write_candidate_run(runs_root, candidate_run_id)
+    dataset_root = tmp_path / "datasets"
+
+    with pytest.raises(ValueError, match="audit timestamp missing"):
+        run_strategy_lab_update(
+            repo_root=tmp_path,
+            dataset_root=dataset_root,
+            runs_root=runs_root,
+            build_dataset=True,
+            include_close_decisions=True,
+            write=True,
+            max_datasets=0,
+            min_sample=1,
+        )
+
+    assert (dataset_root / candidate_run_id / "manifest.json").is_file()
+    assert not (dataset_root / close_run_id).exists()
+
+
+def test_strategy_lab_update_same_run_malformed_close_preserves_candidate_evidence(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    run_id = "20260723T010000Z-combined"
+    _write_close_run(runs_root, run_id, include_audit=False, include_candidate=True)
+    dataset_root = tmp_path / "datasets"
+
+    with pytest.raises(ValueError, match="audit timestamp missing"):
+        run_strategy_lab_update(
+            repo_root=tmp_path,
+            dataset_root=dataset_root,
+            runs_root=runs_root,
+            build_dataset=True,
+            include_close_decisions=True,
+            write=True,
+            max_datasets=0,
+            min_sample=1,
+        )
+
+    assert (dataset_root / run_id / "manifest.json").is_file()
+    assert not (dataset_root / run_id / "close_decision_episodes.jsonl").exists()
+
+
+def test_strategy_lab_update_close_io_failure_preserves_candidate_evidence(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.strategy_lab.update as update_module
+
+    runs_root = tmp_path / "output_runs"
+    candidate_run_id = "20260723T020000Z-candidate"
+    _write_candidate_run(runs_root, candidate_run_id)
+    dataset_root = tmp_path / "datasets"
+
+    def _raise_close_io_error(**_kwargs):
+        raise OSError("close source temporarily unreadable")
+
+    monkeypatch.setattr(update_module, "_build_latest_close_decision_dataset", _raise_close_io_error)
+
+    with pytest.raises(OSError, match="temporarily unreadable"):
+        update_module.run_strategy_lab_update(
+            repo_root=tmp_path,
+            dataset_root=dataset_root,
+            runs_root=runs_root,
+            build_dataset=True,
+            include_close_decisions=True,
+            write=True,
+            max_datasets=0,
+            min_sample=1,
+        )
+
+    assert (dataset_root / candidate_run_id / "manifest.json").is_file()
+
+
+def test_strategy_lab_update_reports_candidate_only_close_collision_without_overwrite(tmp_path: Path) -> None:
+    from src.application.shadow_replay import build_shadow_replay_dataset
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    run_id = "20260723T010000Z-combined"
+    _write_close_run(runs_root, run_id, include_candidate=True)
+    dataset_root = tmp_path / "datasets"
+    build_shadow_replay_dataset(
+        repo_root=tmp_path,
+        run_id=run_id,
+        runs_root=runs_root,
+        dataset_root=dataset_root,
+        dataset_id=run_id,
+    )
+    mark_path = dataset_root / run_id / "mark_path_snapshots.jsonl"
+    mark_path.write_text('{"preserved": true}\n', encoding="utf-8")
+
+    result = run_strategy_lab_update(
+        repo_root=tmp_path,
+        dataset_root=dataset_root,
+        runs_root=runs_root,
+        build_dataset=True,
+        include_close_decisions=True,
+        write=True,
+        max_datasets=0,
+        min_sample=1,
+    )
+
+    close_build = result["shadow_replay"]["close_decision_dataset_build"]
+    assert close_build["reason"] == "dataset_exists_without_close_decisions"
+    assert result["summary"]["close_decision_dataset_built"] is False
+    assert json.loads(mark_path.read_text(encoding="utf-8"))["preserved"] is True
+    assert not (dataset_root / run_id / "close_decision_episodes.jsonl").exists()
+
+
+def test_strategy_lab_update_complete_close_dataset_is_idempotent(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    run_id = "20260723T010000Z-combined"
+    _write_close_run(runs_root, run_id, include_candidate=True)
+    dataset_root = tmp_path / "datasets"
+    kwargs = {
+        "repo_root": tmp_path,
+        "dataset_root": dataset_root,
+        "runs_root": runs_root,
+        "build_dataset": True,
+        "include_close_decisions": True,
+        "write": True,
+        "max_datasets": 0,
+        "min_sample": 1,
+    }
+    run_strategy_lab_update(**kwargs)
+    close_marks = dataset_root / run_id / "close_decision_marks.jsonl"
+    close_marks.write_text('{"preserved": true}\n', encoding="utf-8")
+
+    second = run_strategy_lab_update(**kwargs)
+
+    close_build = second["shadow_replay"]["close_decision_dataset_build"]
+    assert close_build["reason"] == "dataset_already_has_close_decisions"
+    assert json.loads(close_marks.read_text(encoding="utf-8"))["preserved"] is True
+
+
+def test_strategy_lab_update_reports_incomplete_close_dataset_without_overwrite(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    run_id = "20260723T010000Z-combined"
+    _write_close_run(runs_root, run_id, include_candidate=True)
+    dataset_root = tmp_path / "datasets"
+    kwargs = {
+        "repo_root": tmp_path,
+        "dataset_root": dataset_root,
+        "runs_root": runs_root,
+        "build_dataset": True,
+        "include_close_decisions": True,
+        "write": True,
+        "max_datasets": 0,
+        "min_sample": 1,
+    }
+    run_strategy_lab_update(**kwargs)
+    missing_path = dataset_root / run_id / "close_decision_marks.jsonl"
+    missing_path.unlink()
+
+    second = run_strategy_lab_update(**kwargs)
+
+    close_build = second["shadow_replay"]["close_decision_dataset_build"]
+    assert close_build["reason"] == "dataset_exists_without_complete_close_decisions"
+    assert not missing_path.exists()
+
+
+def test_strategy_lab_update_close_build_dry_run_does_not_write(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    runs_root = tmp_path / "output_runs"
+    _write_close_run(runs_root, "20260723T010000Z-close")
+    _write_candidate_run(runs_root, "20260723T020000Z-candidate")
+    dataset_root = tmp_path / "datasets"
+
+    result = run_strategy_lab_update(
+        repo_root=tmp_path,
+        dataset_root=dataset_root,
+        runs_root=runs_root,
+        build_dataset=True,
+        include_close_decisions=True,
+        max_datasets=0,
+        min_sample=1,
+    )
+
+    assert result["summary"]["close_decision_dataset_build_reason"] == "requires_write"
+    assert result["shadow_replay"]["dataset_build"]["reason"] == "requires_write"
+    assert result["safety"]["writes_shadow_replay_dataset_build"] is False
+    assert not dataset_root.exists()
+
+
+def test_strategy_lab_update_rejects_ambiguous_close_build_arguments(tmp_path: Path) -> None:
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    with pytest.raises(ValueError, match="requires build_dataset"):
+        run_strategy_lab_update(repo_root=tmp_path, include_close_decisions=True)
+    with pytest.raises(ValueError, match="cannot be combined with dataset_id"):
+        run_strategy_lab_update(
+            repo_root=tmp_path,
+            build_dataset=True,
+            include_close_decisions=True,
+            dataset_id="explicit",
+        )
 
 
 def test_strategy_lab_experiment_supports_run_window_scope(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add independent latest non-empty Close Advice run selection to Strategy Lab update
- preserve candidate recorder behavior while strict Close capture fails closed
- wire the existing systemd and launchd recorder build action to collect close episodes automatically
- document sampling, safety and idempotency boundaries

## Validation
- Python 3.12 full suite: 3049 passed, 10 skipped, 6 pre-existing warnings
- dependency graph: 481 production modules, 0 cycles
- release metadata check: valid for current 1.4.12 base
- planreview, S1/S2 deepreview and aggregate deepreview passed

## Safety
- P0 remains the only production Close Advice authority
- P1/P2/P3 remain shadow-only
- no notification, production config, trade, Feishu or broker-facing state changes
- recorder writes local research/replay artifacts only

## Residual risk
- 6h collection is sampling, not an event-complete journal
- policy promotion remains a separate CEO decision after S5 evidence readiness