### PR TITLE
fix: normalize hosted all-account MTD scope

### DIFF
--- a/docs/gateflow/copilot-mtd-hosted-scope/accepted-plan.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/accepted-plan.md
@@ -1,0 +1,11 @@
+# Gateflow Accepted Plan
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Gate: `plan review -> re-review -> accepted plan`
+- Status: pass
+- Plan: `docs/gateflow/copilot-mtd-hosted-scope/plan.md`
+- PlanReview: `docs/reviews/plan-review-20260723-184055.md`
+- Findings: none
+- Residual risks: hosted wording remains guarded by the mandatory production P1 validation
+- Next entry point: `implementation`
+

--- a/docs/gateflow/copilot-mtd-hosted-scope/accepted-plan.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/accepted-plan.md
@@ -8,4 +8,3 @@
 - Findings: none
 - Residual risks: hosted wording remains guarded by the mandatory production P1 validation
 - Next entry point: `implementation`
-

--- a/docs/gateflow/copilot-mtd-hosted-scope/aggregate-code-review.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/aggregate-code-review.md
@@ -1,0 +1,13 @@
+# Gateflow Aggregate DeepReview
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Gate: `aggregate deepreview -> fix -> re-review`
+- Review artifact: `docs/reviews/code-review-20260723-184356.md`
+- Findings: none after mechanical EOF-whitespace correction
+- Ruff: pass
+- Compileall: pass
+- Focused tests: 92 pass
+- Agent/plugin contract tests: 102 pass
+- Residual risk: hosted answer quality remains assigned to production P1 validation
+- Status: pass
+- Next entry point: `accepted deepreview commit`

--- a/docs/gateflow/copilot-mtd-hosted-scope/final-closeout.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/final-closeout.md
@@ -1,0 +1,61 @@
+# Gateflow Final Closeout
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Gate: `final closeout`
+- Completion status: `final closeout pass`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/117`
+- PR review artifact: `docs/reviews/pr-117-review-20260723-184603.md`
+
+## What Changed
+
+- The option-performance Copilot adapter now treats the production-observed `all`, `:all`, and
+  `__omit__` values as omitted optional account/broker scope.
+- Empty scope remains rejected and real account/broker values remain effective.
+- Model-visible schema guidance now explicitly describes all-scope behavior.
+- Regression coverage exercises the same payload-builder boundary used by the production Host.
+
+## Verification
+
+- Focused Copilot/MTD/option-performance tests: 92 passed.
+- Agent/plugin contract tests: 102 passed with one existing deprecation warning.
+- Ruff and compileall: passed.
+- Slice DeepReview: passed with no findings.
+- Aggregate DeepReview: passed with no findings after mechanical EOF whitespace cleanup.
+- PR #117 DeepReview: passed with no findings.
+- GitHub checks: Analyze actions, Analyze python, CodeQL, agent-plugin, and guardrails passed.
+
+## Finding Status
+
+- PlanReview findings: none.
+- Slice findings: none.
+- Aggregate findings: no code findings; pre-review Markdown EOF whitespace corrected.
+- PR findings: none.
+- Unclassified findings: none.
+
+## Docs Decision
+
+Only Gateflow and review evidence was added. No public command, payload, accounting, or operator
+documentation changed.
+
+## Remaining Risks and Owners
+
+- The configured hosted model may still drift after receiving correct facts. Owner: mandatory
+  production P1 validation after patch deployment.
+- The allowlist intentionally excludes unobserved aliases. Owner: future production-trace-driven
+  maintenance.
+
+## Issue Link Status
+
+This conversation-initiated work unit has no GitHub issue, so no issue link or closeout comment is
+required.
+
+## Safety Boundary
+
+- No production config, financial data, ledger state, notification, or Feishu message was changed.
+- The original dirty workspace was not modified.
+- PR #117 remains Draft; it was not merged or marked ready.
+
+## Next Entry Point
+
+After explicit merge authorization: merge PR #117, publish patch version v1.4.16, upgrade
+`liuxie-incus`, and rerun direct MTD plus production P1 validation without outbound Feishu delivery.

--- a/docs/gateflow/copilot-mtd-hosted-scope/goal-confirmation.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/goal-confirmation.md
@@ -58,4 +58,3 @@ None. The production trace identifies the exact values and owning boundary.
 
 - Hosted wording may still drift after correct data reaches the model. This remains covered by the
   existing deterministic P1 evaluator and must be re-run against production after deployment.
-

--- a/docs/gateflow/copilot-mtd-hosted-scope/goal-confirmation.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/goal-confirmation.md
@@ -1,0 +1,61 @@
+# Gateflow Goal Confirmation
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Gate: `goal confirmation`
+- Status: confirmed
+- Base: `origin/main@119a4271`
+- Branch: `fix/copilot-mtd-hosted-scope`
+
+## Confirmed Goal
+
+Make the production Copilot treat the hosted model's explicit all-scope markers as omission for
+`option_performance_report.account` and `.broker`, so the exact question
+`7月 mtd 的期权收益` reads the real all-account MTD report instead of an empty synthetic account.
+
+The user's prior Gateflow confirmation covers this same MTD answer-quality goal. The separately
+authorized release/deployment verification exposed the concrete hosted-model failure, so no new
+product or accounting decision is required.
+
+## Motivation and Direct Evidence
+
+The v1.4.15 production P1 report showed:
+
+- the first malformed empty-account call failed closed as designed;
+- subsequent calls used `__omit__`, `:all`, and `all` for both account and broker;
+- those literal values reached the option-performance engine and produced empty scopes such as
+  `accounts=["__omit__"]`;
+- the model then answered that no concrete financial result was available even though a direct
+  all-account `period=mtd` tool call returned the real `lx` and `sy` facts.
+
+The owning boundary is
+`src/application/agent_tools/positions.py::_normalize_option_performance_copilot_input()`.
+`src/application/copilot/tools.py::build_tool_payload()` already delegates Copilot-specific input
+normalization there before applying safe defaults.
+
+## Success Signals
+
+- Copilot-only values `all`, `:all`, and `__omit__` are removed from optional `account` and
+  `broker` fields before execution.
+- The normalized payload still contains `period=mtd`, the channel-fixed `config_key`, and existing
+  safe defaults.
+- Real account/broker filters remain unchanged.
+- Empty strings and invalid period combinations remain fail closed.
+- Focused regression, full release checks, and the production P1 MTD case pass after deployment.
+
+## Scope Boundary and Non-goals
+
+- No ledger, PnL, cash, assignment, FX, or fee semantics change.
+- No generic sentinel framework and no normalization changes for unrelated tools.
+- No production configuration, model selection, Feishu transport, or notification behavior change.
+- No acceptance of empty strings, nulls, arbitrary unknown account names, or arbitrary aliases.
+- No live Feishu message is sent during validation.
+
+## Open Questions
+
+None. The production trace identifies the exact values and owning boundary.
+
+## Residual Risk Classification
+
+- Hosted wording may still drift after correct data reaches the model. This remains covered by the
+  existing deterministic P1 evaluator and must be re-run against production after deployment.
+

--- a/docs/gateflow/copilot-mtd-hosted-scope/plan.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/plan.md
@@ -110,4 +110,3 @@ entity, workflow, config key, persistence, or accounting branch.
 
 Report the normalized contract, tests/reviews, patch release/commit, remote active version,
 service health, direct MTD scope, production P1 result, and any remaining model-quality risk.
-

--- a/docs/gateflow/copilot-mtd-hosted-scope/plan.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/plan.md
@@ -1,0 +1,113 @@
+# Gateflow Plan — Hosted MTD All-scope Normalization
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Gate: `plan`
+- Status: proposed
+- Base: `origin/main@119a4271`
+
+## Goal and Success Signal
+
+Normalize the three all-scope markers observed in the v1.4.15 production Copilot trace so the
+first successful `option_performance_report(period=mtd)` call omits account and broker and reads
+the actual aggregate report. Preserve every existing fail-closed and accounting contract.
+
+Completion requires focused and broad tests plus a post-deployment production P1 run where:
+
+- the first recorded successful tool input contains `period=mtd` and no `account`/`broker`;
+- its result scope contains the real configured accounts rather than a marker;
+- the MTD response names all-account scope, realized PnL, cash, and assignment;
+- no Feishu message or financial write occurs.
+
+## First-principles Judgment
+
+The model's marker choice is external protocol variability, but interpreting optional scope belongs
+at the existing Copilot-specific normalizer, before tool execution. Fixing the report engine would
+pollute accounting semantics; adding prompt templates alone would leave the observed values
+unhandled; adding a global sentinel layer would broaden behavior without evidence.
+
+## Affected Files
+
+- `src/application/agent_tools/positions.py`
+- `tests/test_copilot_phase1.py`
+- Gateflow/review artifacts for this work unit
+
+No public CLI, external agent-tool schema, storage schema, config, or docs contract changes.
+
+## Contract Decisions
+
+- Define a private, option-performance-Copilot-only set containing exactly `all`, `:all`, and
+  `__omit__`.
+- Compare markers after existing string trimming and case normalization.
+- Remove matching optional `account`/`broker` keys; do not replace them with null.
+- Keep empty strings invalid.
+- Keep non-marker values byte-for-byte except for the existing outer trim.
+- Add Copilot schema descriptions making omission/all-scope behavior explicit; this affects model
+  guidance only and does not change the public tool schema.
+
+## Implementation Slice S1
+
+### Objective
+
+Make hosted all-scope arguments reach the canonical report as omitted scope.
+
+### Allowed Changes
+
+- Add the private marker constant and narrow normalization branch in
+  `_normalize_option_performance_copilot_input()`.
+- Improve only the Copilot `account`/`broker` property descriptions.
+- Add parameterized regression coverage through `copilot_tools.build_tool_payload()`.
+
+### Invariants and Error Handling
+
+- Empty optional scope remains `ValueError`.
+- A real `lx`, `sy`, or broker value remains present.
+- Period-field cleanup runs after scope normalization exactly as today.
+- Channel-fixed `config_key` continues to override model input through the existing payload builder.
+
+### Tests
+
+Run:
+
+```text
+./.venv/bin/python -m pytest tests/test_copilot_phase1.py tests/test_copilot_p1_eval.py tests/test_option_performance_agent_tool.py
+./.venv/bin/python -m pytest tests/test_agent_plugin_contract.py tests/test_agent_plugin_smoke.py
+```
+
+Assertions:
+
+- each observed marker disappears for both optional fields;
+- real scope values survive;
+- empty scope remains rejected;
+- the existing MTD/period and plugin contracts pass.
+
+### Stop Condition
+
+Stop if a marker is also a valid configured account or broker in current production facts, or if
+normalization would need to move into the accounting/report engine.
+
+## Review and Release Validation
+
+- Run DeepReview on the slice and aggregate diff.
+- Run full release checks because the fix changes the production Agent tool boundary.
+- Publish a patch version only after all local gates pass.
+- Upgrade `liuxie-incus`, run `om update verify --no-check-latest`, service checks, the direct MTD
+  read, and the production P1 evaluator.
+- If the hosted MTD case still fails, report the new trace as a blocking validation failure rather
+  than broadening normalization speculatively.
+
+## Risks
+
+- Over-accepting aliases could hide a typo. Mitigation: exact three-value allowlist, Copilot-only.
+- Model wording can still drift after correct facts arrive. Mitigation: production P1 gate remains
+  mandatory.
+
+## Why This Is Not Overengineered
+
+The plan changes one existing normalizer and one focused test area. It adds no new layer, public
+entity, workflow, config key, persistence, or accounting branch.
+
+## Completion Report
+
+Report the normalized contract, tests/reviews, patch release/commit, remote active version,
+service health, direct MTD scope, production P1 result, and any remaining model-quality risk.
+

--- a/docs/gateflow/copilot-mtd-hosted-scope/pr-code-review.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/pr-code-review.md
@@ -1,0 +1,13 @@
+# Gateflow PR Review
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Gate: `PR review -> fix -> re-review`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/117`
+- Review artifact: `docs/reviews/pr-117-review-20260723-184603.md`
+- Findings: none
+- CI at review time: pending
+- Residual risks:
+  - GitHub checks must pass before merge/release
+  - production hosted-model P1 validation remains mandatory after deployment
+- Status: pass
+- Next entry point: `accepted PR review commit`

--- a/docs/gateflow/copilot-mtd-hosted-scope/s1-code-review.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/s1-code-review.md
@@ -1,0 +1,11 @@
+# Gateflow S1 Code Review
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Gate: `code review -> re-review`
+- Review artifact: `docs/reviews/code-review-20260723-184313.md`
+- Finding status: no findings
+- Validation: 92 focused tests and 102 Agent/plugin contract tests passed
+- Residual risk: production hosted-model wording remains assigned to the mandatory live P1 gate
+- Status: pass
+- Next entry point: `accepted slice commit`
+

--- a/docs/gateflow/copilot-mtd-hosted-scope/s1-code-review.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/s1-code-review.md
@@ -8,4 +8,3 @@
 - Residual risk: production hosted-model wording remains assigned to the mandatory live P1 gate
 - Status: pass
 - Next entry point: `accepted slice commit`
-

--- a/docs/gateflow/copilot-mtd-hosted-scope/s1-implementation.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/s1-implementation.md
@@ -55,4 +55,3 @@ used for both passing commands.
 ## Next Entry Point
 
 `code review`
-

--- a/docs/gateflow/copilot-mtd-hosted-scope/s1-implementation.md
+++ b/docs/gateflow/copilot-mtd-hosted-scope/s1-implementation.md
@@ -1,0 +1,58 @@
+# Gateflow S1 Implementation
+
+- Work unit: `copilot-mtd-hosted-scope`
+- Slice: S1 — hosted all-scope normalization
+- Gate: `implementation`
+- Status: complete
+
+## Changes
+
+- Added an option-performance-Copilot-only allowlist for the production-observed markers `all`,
+  `:all`, and `__omit__`.
+- `_normalize_option_performance_copilot_input()` now removes those values from optional account
+  and broker scope before safe defaults and channel-fixed input are applied.
+- Empty strings still raise `ValueError`; real account/broker values remain present.
+- Copilot schema descriptions now tell the model to omit the field or use `all` for aggregate
+  scope.
+- Added parameterized regression coverage for every observed marker, uppercase/whitespace
+  handling, fixed market scope, real scope passthrough, and the existing invalid-empty path.
+
+## Changed Files
+
+- `src/application/agent_tools/positions.py`
+- `tests/test_copilot_phase1.py`
+
+## Validation
+
+```text
+92 passed:
+tests/test_copilot_phase1.py
+tests/test_copilot_p1_eval.py
+tests/test_option_performance_agent_tool.py
+
+102 passed, 1 existing deprecation warning:
+tests/test_agent_plugin_contract.py
+tests/test_agent_plugin_smoke.py
+```
+
+The first attempted test command used the original checkout's lightweight `.venv`, which has no
+pytest and therefore collected no tests. The supported pyenv Python 3.12.13 environment was then
+used for both passing commands.
+
+## Scope and Safety
+
+- No report engine, accounting, ledger, storage, config, transport, or sending code changed.
+- No production state or Feishu message was written.
+- The original dirty workspace remains untouched.
+
+## Residual Risks
+
+- Hosted-model wording after receiving correct facts still requires production P1 validation.
+  Classification: mandatory post-release validation for this work unit.
+- Unknown future scope aliases are intentionally unsupported until production evidence exists.
+  Classification: future model-evaluation maintenance, not current scope.
+
+## Next Entry Point
+
+`code review`
+

--- a/docs/reviews/code-review-20260723-184313.md
+++ b/docs/reviews/code-review-20260723-184313.md
@@ -35,4 +35,3 @@ calling only the private helper.
 - Hosted-model response wording is not proven by deterministic tests and remains a mandatory
   production P1 post-deployment gate.
 - The allowlist intentionally does not cover unobserved aliases.
-

--- a/docs/reviews/code-review-20260723-184313.md
+++ b/docs/reviews/code-review-20260723-184313.md
@@ -1,0 +1,38 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `fix/copilot-mtd-hosted-scope`
+- Base: accepted-plan commit `6a22a3a1`
+- Output file: `docs/reviews/code-review-20260723-184313.md`
+- Included scope: option-performance Copilot input normalization, model-visible schema
+  descriptions, focused regressions, implementation artifact
+- Excluded scope: accounting/report engine, generic Copilot Host, Feishu transport, production
+  model behavior not reproducible without deployment
+- Parallel review coverage: 无；the slice is one narrow input path
+
+## Findings
+
+未发现实质性问题。
+
+The reviewed path is:
+
+`Copilot model arguments -> build_tool_payload() -> tool-local copilot_input_normalizer ->
+safe defaults -> channel-fixed input -> option_performance_report`
+
+The exact observed markers are removed only inside the option-performance Copilot adapter. Empty
+strings still raise, real filters survive, fixed market scope remains authoritative, and the
+domain/report engine is unchanged. Tests exercise the production payload builder rather than
+calling only the private helper.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Hosted-model response wording is not proven by deterministic tests and remains a mandatory
+  production P1 post-deployment gate.
+- The allowlist intentionally does not cover unobserved aliases.
+

--- a/docs/reviews/code-review-20260723-184356.md
+++ b/docs/reviews/code-review-20260723-184356.md
@@ -1,0 +1,41 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `fix/copilot-mtd-hosted-scope`
+- Base: `origin/main@119a4271`
+- Output file: `docs/reviews/code-review-20260723-184356.md`
+- Included scope: complete Gateflow work unit, plan/review artifacts, option-performance Copilot
+  scope normalization, schema guidance, regression tests
+- Excluded scope: unchanged accounting/report engine, transports, production config, unrelated
+  original-workspace changes
+- Parallel review coverage: 无；single narrow adapter path reviewed end to end
+
+## Findings
+
+未发现实质性问题。
+
+Adversarial checks confirmed:
+
+- exact marker recognition is confined to the option-performance Copilot normalizer;
+- empty, null, and non-marker invalid values are not converted into aggregate scope;
+- real filters remain effective;
+- safe defaults and channel-fixed config retain their existing precedence;
+- normalization does not cross into the public tool schema or report engine;
+- regression assertions exercise the production payload builder;
+- no storage, state machine, write, notification, or external side effect is added.
+
+The aggregate preflight initially found one extra blank line at EOF in each new Markdown artifact.
+Those mechanical whitespace errors were removed before this review concluded.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- A correct tool result does not guarantee a hosted model will produce the required wording. The
+  work unit correctly treats the production P1 evaluator as a blocking deployment gate.
+- No live Feishu send is included; equivalent channel-facade/model/tool behavior will be validated
+  without outbound delivery.

--- a/docs/reviews/plan-review-20260723-184055.md
+++ b/docs/reviews/plan-review-20260723-184055.md
@@ -54,4 +54,3 @@ None.
 
 The plan is code-generation-ready and is the smallest credible root-boundary fix. Proceed with S1
 without expanding accepted markers or changing the report engine.
-

--- a/docs/reviews/plan-review-20260723-184055.md
+++ b/docs/reviews/plan-review-20260723-184055.md
@@ -1,0 +1,57 @@
+# Plan Review — Hosted MTD All-scope Normalization
+
+- Reviewed target:
+  `docs/gateflow/copilot-mtd-hosted-scope/plan.md`
+- Work unit: `copilot-mtd-hosted-scope`
+- Scope: production-trace-driven Copilot normalization for optional
+  `option_performance_report.account` and `.broker`
+- Conclusion: `pass-with-risks`
+
+## Assumptions Tested
+
+1. **The failure is at the Copilot input boundary.** Confirmed. The production trace records
+   successful tool inputs containing `__omit__`, `:all`, and `all`, followed by empty synthetic
+   account scopes. A direct omitted-scope call returns real `lx` and `sy` facts.
+2. **The existing owner is narrow enough.** Confirmed.
+   `build_tool_payload()` already delegates to the tool definition's
+   `copilot_input_normalizer` before defaults and fixed channel scope are applied.
+3. **Removing these keys preserves accounting semantics.** Confirmed. Omission is already the
+   canonical all-account/all-broker contract of `option_performance_report`; the report engine
+   requires no change.
+4. **Fail-closed behavior remains testable.** Confirmed. The plan explicitly retains the existing
+   empty-string rejection and real-scope passthrough tests.
+5. **The values are not current production identities.** Confirmed by the production MTD report,
+   whose accounts are `lx` and `sy` and whose broker is `富途`.
+
+## Special Lenses
+
+- **Architecture boundary:** pass. The change stays in the existing tool-local Copilot adapter and
+  does not enter domain, ledger, report, Feishu transport, or generic Host code.
+- **Best practice:** pass. Exact evidence-derived normalization, negative tests, and live
+  post-deployment validation are proportionate to an external model protocol variation.
+- **Optimal solution:** pass. Prompt-only guidance already failed; report-engine normalization is
+  the wrong owner; a global sentinel abstraction has no supporting cross-tool evidence.
+- **Overengineering:** pass. One private allowlist and one branch in an existing normalizer.
+- **Overcoupling:** pass. No shared state, schema migration, new protocol, or cross-module runtime
+  dependency is introduced.
+
+## Findings
+
+No material findings.
+
+## Open Questions
+
+None.
+
+## Residual Risks
+
+- Correct scope normalization does not mathematically guarantee hosted-model wording. The plan
+  correctly keeps the production P1 evaluator as a blocking post-deployment gate.
+- Future model providers may emit other aliases. They must be added only with production evidence,
+  not generalized in this work unit.
+
+## Review Decision
+
+The plan is code-generation-ready and is the smallest credible root-boundary fix. Proceed with S1
+without expanding accepted markers or changing the report engine.
+

--- a/docs/reviews/pr-117-review-20260723-184603.md
+++ b/docs/reviews/pr-117-review-20260723-184603.md
@@ -1,0 +1,36 @@
+# Code Review
+
+## Scope
+
+- Mode: PR
+- PR: `#117` — `fix: normalize hosted all-account MTD scope`
+- URL: `https://github.com/liuxie066/options-monitor/pull/117`
+- Author: `liuxie066`
+- Head: `fix/copilot-mtd-hosted-scope@558444a2`
+- Base: `main@119a4271`
+- Output file: `docs/reviews/pr-117-review-20260723-184603.md`
+- Included scope: complete PR diff, production trace alignment, tool input precedence, negative
+  scope handling, focused tests, Gateflow artifacts
+- Excluded scope: unchanged accounting/report implementation and transports; hosted behavior before
+  merge/release
+- CI at review time: Analyze actions/python, agent-plugin, and guardrails pending
+- Parallel review coverage: 无；single narrow adapter change
+
+## Findings
+
+未发现实质性问题。
+
+The PR matches its stated contract and production evidence. The three accepted markers are removed
+before defaults and fixed market input; real scope and invalid-empty behavior remain covered.
+There is no generic parser expansion, storage mutation, reporting-policy change, or transport
+side effect. The tests would fail if a marker remained literal or a real filter were removed.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- GitHub checks were pending when reviewed and must complete before merge/release.
+- The hosted-model answer remains an explicit post-deployment P1 gate; deterministic review cannot
+  substitute for it.

--- a/src/application/agent_tools/positions.py
+++ b/src/application/agent_tools/positions.py
@@ -235,14 +235,20 @@ _OPTION_PERFORMANCE_PERIOD_FIELDS_BY_KIND = {
     "year": frozenset({"year"}),
     "range": frozenset({"start_date", "end_date"}),
 }
+_OPTION_PERFORMANCE_COPILOT_ALL_SCOPE_MARKERS = frozenset({"all", ":all", "__omit__"})
 
 
 def _normalize_option_performance_copilot_input(payload: Mapping[str, Any]) -> dict[str, Any]:
     normalized = dict(payload)
     for name in ("account", "broker"):
         value = normalized.get(name)
-        if name in normalized and isinstance(value, str) and not value.strip():
+        if name not in normalized or not isinstance(value, str):
+            continue
+        stripped = value.strip()
+        if not stripped:
             raise ValueError(f"{name} must be non-empty when provided")
+        if stripped.lower() in _OPTION_PERFORMANCE_COPILOT_ALL_SCOPE_MARKERS:
+            normalized.pop(name)
     period_value = normalized.get("period")
     if not isinstance(period_value, str) or period_value not in _OPTION_PERFORMANCE_PERIOD_FIELDS_BY_KIND:
         return normalized
@@ -314,8 +320,14 @@ OPTION_PERFORMANCE_REPORT_TOOL = build_agent_tool(
         "type": "object",
         "properties": {
             "config_key": {"type": "string", "enum": ["us", "hk"]},
-            "account": {"type": "string"},
-            "broker": {"type": "string"},
+            "account": {
+                "type": "string",
+                "description": "Optional account filter. Omit or use all for all accounts.",
+            },
+            "broker": {
+                "type": "string",
+                "description": "Optional broker filter. Omit or use all for all brokers.",
+            },
             "period": {"type": "string", "enum": ["mtd", "ytd", "month", "year", "range"]},
             "as_of_date": {"type": "string", "format": "date"},
             "month": {"type": "string", "pattern": r"^\d{4}-(0[1-9]|1[0-2])$"},

--- a/tests/test_copilot_phase1.py
+++ b/tests/test_copilot_phase1.py
@@ -290,6 +290,42 @@ def test_option_performance_payload_does_not_infer_period_or_hide_invalid_scope(
         definition.validate_input(explicit_null)
 
 
+@pytest.mark.parametrize("marker", ["all", " ALL ", ":all", "__omit__"])
+def test_option_performance_payload_omits_hosted_all_scope_markers(marker: str) -> None:
+    payload, error = copilot_tools.build_tool_payload(
+        "option_performance_report",
+        {
+            "period": "mtd",
+            "account": marker,
+            "broker": marker,
+        },
+        fixed_input={"config_key": "us"},
+    )
+
+    assert error is None
+    assert payload is not None
+    assert payload["config_key"] == "us"
+    assert payload["period"] == "mtd"
+    assert "account" not in payload
+    assert "broker" not in payload
+
+
+def test_option_performance_payload_preserves_real_scope_filters() -> None:
+    payload, error = copilot_tools.build_tool_payload(
+        "option_performance_report",
+        {
+            "period": "mtd",
+            "account": " lx ",
+            "broker": " 富途 ",
+        },
+    )
+
+    assert error is None
+    assert payload is not None
+    assert payload["account"] == "lx"
+    assert payload["broker"] == "富途"
+
+
 def test_option_performance_payload_preserves_fixed_month_scope() -> None:
     conflicting, error = copilot_tools.build_tool_payload(
         "option_performance_report",


### PR DESCRIPTION
## Summary
- normalize production-observed all-scope markers in the option-performance Copilot adapter
- preserve empty-scope rejection and real account/broker filters
- add regression coverage for the hosted model failure trace

## Evidence
- v1.4.15 production P1 trace passed __omit__, :all, and all as literal account/broker values
- 92 focused tests passed
- 102 Agent/plugin contract tests passed
- slice and aggregate DeepReview passed

## Safety
- read-only tool boundary only
- no accounting, ledger, config, transport, notification, or production-state change
- production P1 rerun remains the post-deployment gate