### PR TITLE
fix: preserve PM data freshness evidence

### DIFF
--- a/contracts/portfolio-management/README.md
+++ b/contracts/portfolio-management/README.md
@@ -3,8 +3,11 @@
 This directory pins the OM-facing `portfolio.api.v1` OpenAPI contract owned by
 `portfolio-management`.
 
-Do not edit the OpenAPI snapshot locally. Refresh it from an immutable
-`pm-api-v*` contract release, update `vendor-manifest.json`, and run
+Do not edit the OpenAPI snapshot locally. The current copy is pinned to an
+explicit unpublished PM commit and SHA-256; `pm-api-v1.0.0` is only a planned
+tag. Refresh it from a reviewed commit or, after a separately authorized
+publication, an immutable `pm-api-v*` contract release; update
+`vendor-manifest.json`, and run
 `tests/test_portfolio_management_contract_vendor.py`.
 
 OM runtime code does not import PM source modules. The vendored document is a

--- a/contracts/portfolio-management/v1.openapi.json
+++ b/contracts/portfolio-management/v1.openapi.json
@@ -1,6 +1,110 @@
 {
   "components": {
     "schemas": {
+      "AccountsOverviewResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "account_count": {
+            "title": "Account Count",
+            "type": "integer"
+          },
+          "accounts": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Accounts",
+            "type": "array"
+          },
+          "failed_count": {
+            "title": "Failed Count",
+            "type": "integer"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
+          "items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          },
+          "successful_count": {
+            "title": "Successful Count",
+            "type": "integer"
+          },
+          "summary": {
+            "additionalProperties": true,
+            "title": "Summary",
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "freshness",
+          "retrieved_at_utc",
+          "status",
+          "accounts",
+          "account_count",
+          "successful_count",
+          "failed_count",
+          "summary",
+          "items"
+        ],
+        "title": "AccountsOverviewResponse",
+        "type": "object"
+      },
+      "AccountsResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "accounts": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Accounts",
+            "type": "array"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "freshness",
+          "retrieved_at_utc",
+          "accounts",
+          "count"
+        ],
+        "title": "AccountsResponse",
+        "type": "object"
+      },
       "CapitalFactsResponse": {
         "additionalProperties": true,
         "properties": {
@@ -20,10 +124,17 @@
             ],
             "title": "Amounts"
           },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
           "period": {
             "additionalProperties": true,
             "title": "Period",
             "type": "object"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
           },
           "schema_version": {
             "title": "Schema Version",
@@ -34,18 +145,279 @@
             "type": "string"
           },
           "success": {
+            "const": true,
             "title": "Success",
             "type": "boolean"
           }
         },
         "required": [
           "success",
+          "freshness",
+          "retrieved_at_utc",
           "schema_version",
           "status",
           "account",
           "period"
         ],
         "title": "CapitalFactsResponse",
+        "type": "object"
+      },
+      "CashResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "by_currency": {
+            "additionalProperties": true,
+            "title": "By Currency",
+            "type": "object"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
+          "items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "freshness",
+          "retrieved_at_utc",
+          "by_currency",
+          "items",
+          "count"
+        ],
+        "title": "CashResponse",
+        "type": "object"
+      },
+      "DistributionResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "accounts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accounts"
+          },
+          "by_asset": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "By Asset"
+          },
+          "by_type": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "By Type"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          },
+          "total_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Quantity"
+          },
+          "total_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Value"
+          }
+        },
+        "required": [
+          "success",
+          "freshness",
+          "retrieved_at_utc"
+        ],
+        "title": "DistributionResponse",
+        "type": "object"
+      },
+      "FreshnessEvidence": {
+        "properties": {
+          "dataset_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Dataset Ids",
+            "type": "array"
+          },
+          "observed_at_utc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observed At Utc"
+          },
+          "reason_codes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Reason Codes",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "fresh",
+              "stale",
+              "unknown",
+              "unavailable"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "trust_status": {
+            "enum": [
+              "trusted",
+              "partial",
+              "untrusted",
+              "unavailable"
+            ],
+            "title": "Trust Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "trust_status",
+          "dataset_ids"
+        ],
+        "title": "FreshnessEvidence",
+        "type": "object"
+      },
+      "FullReportResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "distribution": {
+            "additionalProperties": true,
+            "title": "Distribution",
+            "type": "object"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          },
+          "nav": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nav"
+          },
+          "overview": {
+            "additionalProperties": true,
+            "title": "Overview",
+            "type": "object"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
+          },
+          "returns": {
+            "additionalProperties": true,
+            "title": "Returns",
+            "type": "object"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          },
+          "top_holdings": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Top Holdings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "success",
+          "freshness",
+          "retrieved_at_utc",
+          "generated_at",
+          "overview",
+          "returns",
+          "top_holdings",
+          "distribution"
+        ],
+        "title": "FullReportResponse",
         "type": "object"
       },
       "FutuHoldingsSyncRequest": {
@@ -80,6 +452,167 @@
         "title": "FutuHoldingsSyncRequest",
         "type": "object"
       },
+      "FutuHoldingsSyncResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "account": {
+            "title": "Account",
+            "type": "string"
+          },
+          "broker": {
+            "title": "Broker",
+            "type": "string"
+          },
+          "dry_run": {
+            "title": "Dry Run",
+            "type": "boolean"
+          },
+          "positions": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Positions",
+            "type": "array"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "source_snapshot_id": {
+            "title": "Source Snapshot Id",
+            "type": "string"
+          },
+          "stages": {
+            "additionalProperties": true,
+            "title": "Stages",
+            "type": "object"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          },
+          "sync_run_id": {
+            "title": "Sync Run Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "account",
+          "broker",
+          "dry_run",
+          "source",
+          "source_snapshot_id",
+          "sync_run_id",
+          "stages",
+          "positions"
+        ],
+        "title": "FutuHoldingsSyncResponse",
+        "type": "object"
+      },
+      "HoldingsResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "by_market": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "By Market"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
+          "holdings": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Holdings"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "freshness",
+          "retrieved_at_utc",
+          "count"
+        ],
+        "title": "HoldingsResponse",
+        "type": "object"
+      },
+      "NavResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
+          "history": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "latest": {
+            "additionalProperties": true,
+            "title": "Latest",
+            "type": "object"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
+          },
+          "success": {
+            "const": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "freshness",
+          "retrieved_at_utc",
+          "latest",
+          "history"
+        ],
+        "title": "NavResponse",
+        "type": "object"
+      },
       "PublicErrorResponse": {
         "properties": {
           "details": {
@@ -112,20 +645,6 @@
           "request_id"
         ],
         "title": "PublicErrorResponse",
-        "type": "object"
-      },
-      "PublicResponse": {
-        "additionalProperties": true,
-        "properties": {
-          "success": {
-            "title": "Success",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "success"
-        ],
-        "title": "PublicResponse",
         "type": "object"
       },
       "ValuationEvidenceRequest": {
@@ -172,6 +691,9 @@
             "title": "Account Status",
             "type": "array"
           },
+          "freshness": {
+            "$ref": "#/components/schemas/FreshnessEvidence"
+          },
           "holdings": {
             "items": {
               "additionalProperties": true,
@@ -187,6 +709,10 @@
             },
             "title": "Quotes",
             "type": "array"
+          },
+          "retrieved_at_utc": {
+            "title": "Retrieved At Utc",
+            "type": "string"
           },
           "schema_version": {
             "title": "Schema Version",
@@ -207,6 +733,7 @@
             "type": "string"
           },
           "success": {
+            "const": true,
             "title": "Success",
             "type": "boolean"
           },
@@ -220,6 +747,8 @@
         },
         "required": [
           "success",
+          "freshness",
+          "retrieved_at_utc",
           "schema_version",
           "status",
           "scope",
@@ -263,7 +792,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/AccountsResponse"
                 }
               }
             },
@@ -365,7 +894,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/AccountsOverviewResponse"
                 }
               }
             },
@@ -600,7 +1129,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/CashResponse"
                 }
               }
             },
@@ -732,7 +1261,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/DistributionResponse"
                 }
               }
             },
@@ -802,7 +1331,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/FutuHoldingsSyncResponse"
                 }
               }
             },
@@ -903,7 +1432,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/HoldingsResponse"
                 }
               }
             },
@@ -986,7 +1515,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/NavResponse"
                 }
               }
             },
@@ -1069,7 +1598,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicResponse"
+                  "$ref": "#/components/schemas/FullReportResponse"
                 }
               }
             },

--- a/contracts/portfolio-management/vendor-manifest.json
+++ b/contracts/portfolio-management/vendor-manifest.json
@@ -1,8 +1,9 @@
 {
   "api_version": "portfolio.api.v1",
   "upstream_repository": "portfolio-management",
-  "upstream_contract_release": "pm-api-v1.0.0",
-  "upstream_commit": "f80917f8df0add8c7fc5e5eefb63c08c5e1ae599",
+  "upstream_release_state": "unpublished",
+  "planned_upstream_contract_release": "pm-api-v1.0.0",
+  "upstream_commit": "7c406e5f70e7b10e17d74b1f1ed242b4262e8ca3",
   "contract_path": "contracts/portfolio-management/v1.openapi.json",
-  "sha256": "f66cb571b54e9a5e63b756facd1bbf1dd8df6efd1e6e87280417d89d6be7a650"
+  "sha256": "c9fe8b95d4fce0dc1632a5cb903e87fa1170895453be95af047fdef53513f871"
 }

--- a/contracts/quality-monitoring/README.md
+++ b/contracts/quality-monitoring/README.md
@@ -5,7 +5,8 @@ by Options Monitor tests and its future quality producer.
 
 The canonical contract belongs to the independent `investment-quality`
 repository. Do not edit the Schema locally. Refresh it from the upstream
-contract release, update `vendor-manifest.json`, and run
+commit pin while the manifest is `unpublished`, or from the upstream contract
+release after its tag exists; update `vendor-manifest.json`, and run
 `tests/test_quality_status_contract_vendor.py`.
 
 Producer-specific fields must use the public `extensions` object. OM runtime

--- a/contracts/quality-monitoring/vendor-manifest.json
+++ b/contracts/quality-monitoring/vendor-manifest.json
@@ -2,7 +2,8 @@
   "schema_version": "investment.quality_status.v1",
   "schema_id": "urn:investment:quality-status:v1",
   "upstream_repository": "investment-quality",
-  "upstream_contract_release": "contract-v1",
+  "upstream_release_state": "unpublished",
+  "planned_upstream_contract_release": "contract-v1",
   "upstream_commit": "36c9910bc67c941c04f0768f201aadab32f8749a",
   "schema_path": "contracts/quality-monitoring/quality_status.v1.schema.json",
   "sha256": "8635a4b5b134fc911b4b5f68beb36cbe87f43e0ef4d6ca31c44e98c9bfd43338"

--- a/docs/reviews/code-review-20260726-225125.md
+++ b/docs/reviews/code-review-20260726-225125.md
@@ -1,0 +1,79 @@
+# Code Review
+
+## Scope
+
+- Mode: aggregate PR review
+- Branch or PR: `investment-quality#1`, `portfolio-management#35`, `options-monitor#121`
+- Base: each PR's `main` base (`b7f2ca9`, `41d4923`, `c7570b79`)
+- Output file: `docs/reviews/code-review-20260726-225125.md`
+- Included scope: cross-system document ownership and Phase 5 runbook; quality-contract and PM OpenAPI release/vendor flows; PM `/api/v1` HTTP surface; OM consolidated PM client, Agent tool adapter, holdings-sync facade, valuation/assignment callers; changed tests and completed GitHub checks
+- Excluded scope: full re-review of pre-existing Phase 0–4 producer state machines, SQLite migrations, Feishu delivery internals, generated OpenAPI content beyond the public response surface, and production runtime evidence because no release or deployment occurred
+- Parallel review coverage: 无；主 reviewer 沿三个 PR 的真实契约发布链和 `OM -> PM /api/v1` 调用链聚合审查
+
+## Findings
+
+### DR-01-未修复-高-OM 把 HTTP 获取时间冒充底层投资数据的新鲜度
+
+- **入口/函数**: OM Agent `portfolio_query` -> `_portfolio_query()` -> `PortfolioManagementClient.read_view()`
+- **文件(行号)**: `options-monitor/src/application/agent_tools/portfolio.py:112-134`; `portfolio-management/src/app/portfolio_read_service.py:254-323`; `portfolio-management/src/app/cash_service.py:133-159`
+- **输入场景**: PM 从本地/Feishu 存储返回一份历史 holdings、cash、NAV 或 report payload；数据本身没有 source snapshot time，或者上游 payload 已明确带有 stale/partial freshness。
+- **实际分支**: `_portfolio_query()` 收到任何成功 HTTP object 后，无条件覆盖 `source`、`scope` 和 `freshness`，把 `freshness.status` 写成 `live`，并把 `observed_at` 写成 OM 当前请求时间。
+- **预期行为**: 数据新鲜度必须由 PM 数据 owner 根据 snapshot/receipt/source time 产生；OM 只能保留该证据。若 PM 未提供数据时间，应返回 unknown/unavailable，而不是用传输完成时间推断数据新鲜。
+- **实际行为**: 陈旧的 PM replica 只要能够成功响应 HTTP，就会在 Agent 对外结果中显示为 `live`；如果 PM 后续新增真实 freshness 字段，也会被 OM 覆盖。
+- **直接证据**: `portfolio.py:124-133` 对所有 view 无条件执行 `data["freshness"]={"status":"live","observed_at":now}`；PM 的普通 holdings/cash read path 只是读取存储并返回业务行，`portfolio_read_service.py:293-323` 和 `cash_service.py:133-159` 没有证明 source snapshot 当前；回归测试 `tests/test_portfolio_agent_tool.py:93-113` 反而固化了任意成功 payload 都必须变成 `live`。
+- **影响**: 直接产生错误可信度结论。Agent、人工诊断或后续消费者可能把历史正股/现金/MMF/NAV 当成实时事实，违背模块要求的 `partial/stale/unavailable` 证据传播。
+- **建议改法和验证点**: PM 为每个 V1 read model 提供 owner-controlled `freshness`（至少 status、source observed time、retrieved time 分离）；OM 原样保留并验证，不存在时 fail closed。新增回归：PM 返回 stale、partial、无 freshness 三种 payload，OM 分别保留 stale/partial、将缺失映射为 unavailable，且单独记录 transport retrieval time。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-02-未修复-高-多数 PM V1 响应契约只约束 success，无法防止真实字段破坏
+
+- **入口/函数**: PM `create_app()` 的 `/api/v1/accounts|overview|holdings|cash|nav|distribution|report/full|futu/holdings/sync` -> OpenAPI snapshot -> OM vendor contract test
+- **文件(行号)**: `portfolio-management/src/service/http.py:92-102,284-352,400-428`; `portfolio-management/contracts/om-api/v1.openapi.json:117-129`; `options-monitor/tests/test_portfolio_management_contract_vendor.py:14-43`; `options-monitor/src/infrastructure/portfolio_management_client.py:193-257`
+- **输入场景**: PM 在保持 `success: true`、路径和版本 header 不变的情况下，删除或重命名 `holdings`、`items`、`latest`、`history`、`accounts`、金额或状态字段。
+- **实际分支**: 这些端点统一声明 `response_model=PublicResponse`；该 model 允许任意额外字段且只要求一个 boolean `success`。OM 的 contract test 只比较 operation 集合、版本 header 和错误 schema；运行时 client 只验证 JSON object、版本 header 和 `success is not false`。
+- **预期行为**: 标为稳定 `portfolio.api.v1` 且 vendored 给 OM 的契约应为每个被消费的成功响应声明必要字段、类型、状态枚举和 freshness/provenance 边界；破坏字段必须使 producer 或 consumer contract test 失败。
+- **实际行为**: OpenAPI 对核心成功 payload 的有效承诺等价于 `{"success": boolean, ...anything}`。字段级 breaking change 会通过 PM snapshot test、OM vendor test和 client protocol check，直到真实业务调用出现 KeyError、空数据或错误解释。
+- **直接证据**: `PublicResponse` 使用 `ConfigDict(extra="allow")` 且仅定义 `success`；生成 schema 在 `v1.openapi.json:117-129` 明确为 `additionalProperties: true`、required 只有 `success`；`test_portfolio_management_contract_vendor.py:23-43` 未验证各 operation 的成功字段；client 在 `portfolio_management_client.py:245-257` 仅检查 header、JSON object 和失败标志。
+- **影响**: “版本化契约”主要保护路径而不保护数据语义，无法实现本次多仓治理的核心目标；PM 与 OM 会在字段演进时重新形成隐性字符串/字典耦合。
+- **建议改法和验证点**: 为每个 OM 实际消费的 view 建立 owner-owned response model，必要字段 `extra="forbid"` 或明确兼容策略；OpenAPI contract test 对 required 字段、类型、枚举和 provenance 做断言；OM 加 schema validation 或生成/手写 typed adapter contract。同步增加 breaking fixture，证明删改字段时 PM 和 OM CI 都会失败。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-03-未修复-高-Phase 5 Runbook 仍允许发布不包含 PM V1 契约的旧目标
+
+- **入口/函数**: `phase5-runbook.md` Step 1 发布 PM，然后发布/部署使用 V1-only client 的 OM
+- **文件(行号)**: `investment-quality/docs/quality-monitoring/phase5-runbook.md:26-34,81-115`; `options-monitor/src/infrastructure/portfolio_management_client.py:20-40,245-248`
+- **输入场景**: 操作者按 Runbook 对 PM 选择满足文档条件的 `main@c66422a`，发布 `v0.1.27`，随后从当前 OM main 发布并升级。
+- **实际分支**: Runbook 的 PM exit condition 只要求目标包含 `c66422a`，Step 5.2 也只复核该旧提交；`c66422a:src/service/http.py` 中没有任何 `/api/v1` 或 `PM_API_VERSION`。当前 OM 已只调用 `/api/v1/*` 并强制要求 `X-PM-API-Version=portfolio.api.v1`。
+- **预期行为**: 跨仓发布顺序必须把 producer contract commit 作为 OM consumer 的硬前置，PM release tag 至少包含本 PR 的 V1 contract/manual-distribution head，然后才能发布 OM consumer。
+- **实际行为**: 文档允许一个自身 exit gate 全部通过、但 PM 对 OM 返回 404/缺少版本 header 的组合；运行时会被 OM 判为 HTTP 或 protocol error。
+- **直接证据**: Runbook `:31` 写 `main@c66422a 或其后继`，`:102-105` 只要求 tag 包含 `c66422a`；只读检查 `git show c66422a:src/service/http.py` 未发现 `/api/v1`；OM client 的路径表在 `portfolio_management_client.py:20-40` 全部使用 V1，`:245-248` 对缺失 header fail closed。
+- **影响**: 按权威上线文档操作仍可得到确定性不兼容部署，导致 OM 的 PM holdings/cash/NAV/assignment/同步能力整体不可用。
+- **建议改法和验证点**: 更新 Runbook 的 PM 最低锚点为包含 V1 契约及人工同步修正的已合并 head（至少 `9e7863d`，最好记录 PR #35 merge commit `2a1122a`）；Hub 锚点同步更新为 PR #1 merge commit。Phase 5 preflight 增加从拟发布 PM artifact 调用所有 `CONTRACT_OPERATIONS` 并验证 header/schema，再允许发布 OM。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-04-未修复-中-权威状态和 vendor manifest 把尚不存在的 tag 记录为已发布契约
+
+- **入口/函数**: Hub `implementation-status.md` / contract manifest -> PM、OM vendor manifests -> release validators
+- **文件(行号)**: `investment-quality/docs/quality-monitoring/implementation-status.md:18-34`; `investment-quality/docs/quality-monitoring/contract-release.md:14-22`; `investment-quality/contracts/contract-manifest.json:1-6`; `options-monitor/contracts/quality-monitoring/vendor-manifest.json:1-8`; `options-monitor/contracts/portfolio-management/vendor-manifest.json:1-7`; `portfolio-management/contracts/om-api/manifest.json:1-9`
+- **输入场景**: 审计者或 operator 读取当前 main，判断 `contract-v1` 和 `pm-api-v1.0.0` 是否已经是不可变、可追溯的 release。
+- **实际分支**: `implementation-status.md` 把 `contract-v1` 列为 Phase 0 完成证据；两类 consumer manifest 都填写 `upstream_contract_release`。但 `contract-release.md` 又说明 tag 需要后续独立授权创建；2026-07-26 对两个远端执行精确 tag 查询均返回空。
+- **预期行为**: 在 tag 实际存在并通过 annotated-tag/commit/hash 验证前，权威状态应明确为 unpublished/planned；consumer provenance 不应把计划名称呈现为已经存在的 upstream release。
+- **实际行为**: 当前文件同时表达“release 已固定”和“release 尚待创建”，CI 也只校验 manifest 字符串/hash，无法证明远端 immutable tag 存在。
+- **直接证据**: `implementation-status.md:25,30` 将 release 和 pinned upstream release 作为完成证据；`contract-release.md:16-19` 明确 tag 尚待授权创建；Hub/PM validator 都只有在显式传入 tag 时才会 `git cat-file -t` 验证，普通 PR CI 不验证远端 tag；`git ls-remote --tags` 对 `contract-v1`、`pm-api-v1.0.0` 无匹配。
+- **影响**: 数据质量模块自己的 provenance 不可信，审计和后续人工同步可能误以为 consumer 已基于不可变 release，而实际上只能追溯到普通 commit。
+- **建议改法和验证点**: 在不授权发布的当前阶段，把 implementation status 和 vendor provenance 明确标为 `unpublished commit pin`；独立发布授权创建 tag 后，再由人工 vendor 流更新为 released provenance。增加只在 release/tag workflow 中运行的 remote/tag-object/commit/hash 一致性检查，并避免普通 PR 测试把 planned tag 当作 release 成功证据。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+- `portfolio_query.freshness` 是否曾被有意定义为“HTTP retrieval freshness”而非“底层数据 freshness”？当前字段名、Agent output contract 和质量监控目标都指向后者；若确实需要前者，应改名为 transport/retrieval metadata，不能继续使用 `freshness.status=live`。
+
+## Residual Risk
+
+- 三个 PR 的 GitHub checks 均通过，但现有 checks 主要证明 snapshot/hash/路径一致和单元行为，没有覆盖上述跨仓语义。
+- 本次未重新审计 PR 之前已经存在的全部 Phase 0–4 producer、incident/outbox、retention 和 gate 状态机；这些区域仍以既有测试与文档证据为准。
+- 没有生产 release 或部署，因此没有真实 PM V1 compatibility、OpenD baseline、飞书 incident/recovery 或 rollback 证据。

--- a/src/application/agent_tools/portfolio.py
+++ b/src/application/agent_tools/portfolio.py
@@ -31,6 +31,8 @@ from src.infrastructure.portfolio_management_client import (
 
 _ACCOUNT_REQUIRED_VIEWS = frozenset({"holdings", "cash", "nav", "full_report"})
 _FORBIDDEN_ENDPOINT_FIELDS = frozenset({"base_url", "endpoint", "service_url", "url"})
+_PM_FRESHNESS_STATUSES = frozenset({"fresh", "stale", "unknown", "unavailable"})
+_PM_TRUST_STATUSES = frozenset({"trusted", "partial", "untrusted", "unavailable"})
 
 
 def _portfolio_client() -> PortfolioManagementClient:
@@ -127,11 +129,47 @@ def _portfolio_query(payload: dict[str, Any]):
         "transport": "loopback_http",
     }
     data["scope"] = scope
-    data["freshness"] = {
-        "status": "live",
-        "observed_at": datetime.now(timezone.utc).isoformat(),
+    if view == "health":
+        data["freshness"] = {
+            "status": "fresh",
+            "trust_status": "trusted",
+            "observed_at_utc": datetime.now(timezone.utc).isoformat(),
+            "dataset_ids": ["pm.runtime"],
+            "reason_codes": [],
+        }
+        return data, [], {}
+
+    freshness, warning = _validate_pm_freshness(response.get("freshness"))
+    data["freshness"] = freshness
+    return data, ([warning] if warning else []), {}
+
+
+def _validate_pm_freshness(value: Any) -> tuple[dict[str, Any], str | None]:
+    if not isinstance(value, dict):
+        return _unavailable_pm_freshness(), "PM freshness evidence is missing; data is unavailable"
+    status = str(value.get("status") or "")
+    trust_status = str(value.get("trust_status") or "")
+    dataset_ids = value.get("dataset_ids")
+    reason_codes = value.get("reason_codes")
+    if (
+        status not in _PM_FRESHNESS_STATUSES
+        or trust_status not in _PM_TRUST_STATUSES
+        or not isinstance(dataset_ids, list)
+        or not dataset_ids
+        or not isinstance(reason_codes, list)
+    ):
+        return _unavailable_pm_freshness(), "PM freshness evidence is invalid; data is unavailable"
+    return dict(value), None
+
+
+def _unavailable_pm_freshness() -> dict[str, Any]:
+    return {
+        "status": "unavailable",
+        "trust_status": "unavailable",
+        "observed_at_utc": None,
+        "dataset_ids": [],
+        "reason_codes": ["PM_FRESHNESS_EVIDENCE_MISSING"],
     }
-    return data, [], {}
 
 
 def _read_capital_facts(*, account: str, period: str, as_of_month: str) -> dict[str, Any]:
@@ -368,7 +406,13 @@ PORTFOLIO_QUERY_TOOL = build_agent_tool(
     ),
     output_contract={
         "fact_fields": ["success", "source", "scope", "freshness"],
-        "freshness_fields": ["freshness.status", "freshness.observed_at"],
+        "freshness_fields": [
+            "freshness.status",
+            "freshness.trust_status",
+            "freshness.observed_at_utc",
+            "freshness.dataset_ids",
+            "freshness.reason_codes",
+        ],
         "notes": ["Portfolio payload fields vary by selected view and are preserved at the top level."],
     },
     copilot_input_fields=(

--- a/tests/test_agent_plugin_contract.py
+++ b/tests/test_agent_plugin_contract.py
@@ -237,7 +237,10 @@ def test_agent_tool_output_contracts_advertise_model_visible_data_shape() -> Non
     assert "investigation_recipes[].name" not in tools["analysis_catalog"]["output_contract"]["fact_fields"]
     assert tools["portfolio_query"]["output_contract"]["freshness_fields"] == [
         "freshness.status",
-        "freshness.observed_at",
+        "freshness.trust_status",
+        "freshness.observed_at_utc",
+        "freshness.dataset_ids",
+        "freshness.reason_codes",
     ]
     assert tools["preview_notification"]["input_schema"]["render_style"]["enum"] == ["compact", "legacy"]
     assert "renderer" in tools["preview_notification"]["output_contract"]["fact_fields"]

--- a/tests/test_portfolio_agent_tool.py
+++ b/tests/test_portfolio_agent_tool.py
@@ -92,11 +92,24 @@ def test_assignment_scenario_tool_has_accounts_only_contract(monkeypatch) -> Non
 
 def test_portfolio_query_preserves_payload_and_adds_evidence_metadata(monkeypatch) -> None:
     monkeypatch.delenv(portfolio.SERVICE_URL_ENV, raising=False)
+    pm_freshness = {
+        "status": "stale",
+        "trust_status": "partial",
+        "observed_at_utc": "2026-07-25T21:00:00Z",
+        "dataset_ids": ["pm.holdings_quantity", "pm.prices"],
+        "reason_codes": ["SOURCE_STALE"],
+    }
 
     data, warnings, meta, seen = _call(
         {"view": "overview", "accounts": ["lx", "sy"], "include_details": True},
         monkeypatch,
-        {"success": True, "accounts": ["lx", "sy"], "total_value": 123.45},
+        {
+            "success": True,
+            "accounts": ["lx", "sy"],
+            "total_value": 123.45,
+            "freshness": pm_freshness,
+            "retrieved_at_utc": "2026-07-26T01:00:00Z",
+        },
     )
 
     parsed = urlsplit(seen["request"].full_url)
@@ -109,10 +122,23 @@ def test_portfolio_query_preserves_payload_and_adds_evidence_metadata(monkeypatc
     assert data["total_value"] == 123.45
     assert data["source"] == {"service": "portfolio-management", "transport": "loopback_http"}
     assert data["scope"] == {"view": "overview", "accounts": ["lx", "sy"]}
-    assert data["freshness"]["status"] == "live"
-    assert data["freshness"]["observed_at"].endswith("+00:00")
+    assert data["freshness"] == pm_freshness
+    assert data["retrieved_at_utc"] == "2026-07-26T01:00:00Z"
     assert warnings == []
     assert meta == {}
+
+
+def test_portfolio_query_marks_business_data_unavailable_without_pm_freshness(monkeypatch) -> None:
+    data, warnings, _, _ = _call(
+        {"view": "cash", "account": "lx"},
+        monkeypatch,
+        {"success": True, "items": []},
+    )
+
+    assert data["freshness"]["status"] == "unavailable"
+    assert data["freshness"]["trust_status"] == "unavailable"
+    assert data["freshness"]["reason_codes"] == ["PM_FRESHNESS_EVIDENCE_MISSING"]
+    assert warnings == ["PM freshness evidence is missing; data is unavailable"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_portfolio_management_contract_vendor.py
+++ b/tests/test_portfolio_management_contract_vendor.py
@@ -43,3 +43,22 @@ def test_vendored_pm_openapi_declares_version_and_error_contracts() -> None:
             == "portfolio.api.v1"
         )
         assert operation["responses"]["503"]["content"]["application/json"]["schema"]
+
+
+def test_vendored_pm_openapi_requires_core_success_and_freshness_fields() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    document = json.loads((ROOT / manifest["contract_path"]).read_text(encoding="utf-8"))
+    schemas = document["components"]["schemas"]
+    assert {
+        "success",
+        "accounts",
+        "count",
+        "freshness",
+        "retrieved_at_utc",
+    } <= set(schemas["AccountsResponse"]["required"])
+    assert {
+        "success",
+        "count",
+        "freshness",
+        "retrieved_at_utc",
+    } <= set(schemas["HoldingsResponse"]["required"])

--- a/tests/test_portfolio_management_contract_vendor.py
+++ b/tests/test_portfolio_management_contract_vendor.py
@@ -15,7 +15,9 @@ def test_vendored_pm_openapi_matches_manifest_and_client_operations() -> None:
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     contract_path = ROOT / manifest["contract_path"]
     assert manifest["api_version"] == "portfolio.api.v1"
-    assert manifest["upstream_contract_release"] == "pm-api-v1.0.0"
+    assert manifest["upstream_release_state"] == "unpublished"
+    assert manifest["planned_upstream_contract_release"] == "pm-api-v1.0.0"
+    assert manifest["upstream_commit"] == "7c406e5f70e7b10e17d74b1f1ed242b4262e8ca3"
     assert len(manifest["upstream_commit"]) == 40
     assert all(character in "0123456789abcdef" for character in manifest["upstream_commit"])
     assert hashlib.sha256(contract_path.read_bytes()).hexdigest() == manifest["sha256"]

--- a/tests/test_quality_status_contract_vendor.py
+++ b/tests/test_quality_status_contract_vendor.py
@@ -17,7 +17,8 @@ def test_vendored_quality_status_schema_matches_manifest() -> None:
     schema_bytes = schema_path.read_bytes()
 
     assert hashlib.sha256(schema_bytes).hexdigest() == manifest["sha256"]
-    assert str(manifest["upstream_contract_release"]).startswith("contract-v")
+    assert manifest["upstream_release_state"] == "unpublished"
+    assert str(manifest["planned_upstream_contract_release"]).startswith("contract-v")
     assert len(manifest["upstream_commit"]) == 40
 
     schema = json.loads(schema_bytes)


### PR DESCRIPTION
Summary:
- preserve and validate PM-owned freshness evidence in portfolio_query
- mark missing or invalid business freshness evidence unavailable
- vendor the typed PM V1 OpenAPI contract by unpublished commit pin
- record the original code-review findings

Validation:
- 3247 passed, 10 skipped
- focused contract and portfolio tool tests passed
- Ruff passed

Scope: review only; no release or deployment.