### PR TITLE
fix sy daily brief failure authority

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 874 (`src`: 477, `domain`: 73, `scripts`: 8, `tests`: 316)
-- Internal import edges: 5256 total, 2347 production/script edges excluding tests
+- Python files scanned: 876 (`src`: 478, `domain`: 73, `scripts`: 8, `tests`: 317)
+- Internal import edges: 5288 total, 2352 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,9 +31,9 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|394| domain
+  application -->|395| domain
   application -->|3| domain_services
-  application -->|134| infrastructure
+  application -->|133| infrastructure
   application -->|43| storage
   domain_services -->|5| domain
   domain_services -->|2| storage
@@ -44,8 +44,8 @@ flowchart LR
   scripts -->|12| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2063| application
-  tests -->|458| domain
+  tests -->|2088| application
+  tests -->|460| domain
   tests -->|2| domain_services
   tests -->|131| infrastructure
   tests -->|197| interfaces
@@ -57,8 +57,8 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 394 |
-| application | infrastructure | 134 |
+| application | domain | 395 |
+| application | infrastructure | 133 |
 | interfaces | application | 133 |
 | application | storage | 43 |
 | scripts | application | 12 |
@@ -75,8 +75,8 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2063 |
-| tests | domain | 458 |
+| tests | application | 2088 |
+| tests | domain | 460 |
 | tests | interfaces | 197 |
 | tests | infrastructure | 131 |
 | tests | storage | 16 |
@@ -89,9 +89,9 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 
 | from | to | imports |
 |---|---|---|
-| src.application | domain.domain | 239 |
+| src.application | domain.domain | 240 |
 | src.interfaces | src.application | 111 |
-| src.application | src.infrastructure | 101 |
+| src.application | src.infrastructure | 100 |
 | src.application.ledger | domain.domain | 37 |
 | src.application | domain.storage | 34 |
 | src.application.ledger | domain.domain.ledger | 30 |
@@ -188,7 +188,7 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | domain.domain.engine | 24 |
 | src.application.settings | 24 |
 | src.application.agent_tools.runtime_helpers | 23 |
-| domain.domain.decision_state_fingerprint | 22 |
+| domain.domain.decision_state_fingerprint | 23 |
 | src.application.config_sections | 20 |
 
 ### Highest Fan-Out Production Modules

--- a/docs/POSITION_ADVICE_V2_CONTRACT.md
+++ b/docs/POSITION_ADVICE_V2_CONTRACT.md
@@ -227,6 +227,42 @@ from final resolution through bounded provider completion. The dedupe key is:
 portfolio_scope_id + authority_generation + account_run_id + channel
 ```
 
+Normal `fixed_report` and `candidate_alert` delivery continues to use
+`position_advice_notification_authority_token.v1`. It requires the successful
+current-run `position_advice_sources.v2.json`; a portfolio receipt by itself
+does not prove candidate, lifecycle, cash-capacity, or share-coverage
+completeness and cannot authorize a normal report.
+
+Scheduled failure delivery uses the separate
+`position_advice_notification_authority_token.v2`. That token has the exact
+purpose binding `authorized_delivery_kinds=["fixed_failure"]`. It may be built
+from the current Account Run's unique fresh immutable portfolio receipt after
+the account, market, run, payload, and recomputed portfolio identity all match
+and authority resolves without conflict. At the final send boundary the
+executor reopens the exact persisted Daily Brief envelope under its repository
+lock and requires the caller kind, persisted kind, and token purpose all to be
+`fixed_failure`, with the envelope still `pending`. The persisted
+`render_context.notification_authority_token` must also exist, validate, and
+match the supplied token's complete canonical payload and hash. Any mismatch is
+`AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED` with zero provider attempts.
+The failure envelope remains plain text, references only the current run's
+`scan_failure` artifact, and carries no candidate identities or normal-report
+claims.
+
+An already prepared envelope retains its original token in `render_context`;
+delivery-only retry reuses the exact message, delivery key, source digest,
+message hash, transport idempotency key, and token. Legacy normal v1 envelopes
+therefore keep their existing retry semantics.
+
+When a later reliable run produces `fixed_report` for the same scheduled target,
+a pending `fixed_failure` may be replaced only after notification authority
+reports no accepted, unresolved unknown, or in-flight provider evidence for the
+frozen failure token and channel. Never-attempted failures and definitely failed
+attempts are replaceable; accepted-but-unconfirmed, ambiguous, and in-flight
+failures retain the exact frozen envelope. This authority state, rather than the
+Daily Brief repository's `pending` status alone, closes the provider-accepted /
+repository-confirm crash window.
+
 Accepted delivery is strongly deduplicated. A definite failed attempt can be
 retried under the same reservation with a new append-only attempt receipt.
 Timeout or ambiguous delivery becomes durable `unknown`; it cannot be resent or

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,7 +1,7 @@
 flowchart LR
-  src_application["src.application"] -->|239| domain_domain["domain.domain"]
+  src_application["src.application"] -->|240| domain_domain["domain.domain"]
   src_interfaces["src.interfaces"] -->|111| src_application["src.application"]
-  src_application["src.application"] -->|101| src_infrastructure["src.infrastructure"]
+  src_application["src.application"] -->|100| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|37| domain_domain["domain.domain"]
   src_application["src.application"] -->|34| domain_storage["domain.storage"]
   src_application_ledger["src.application.ledger"] -->|30| domain_domain_ledger["domain.domain.ledger"]

--- a/docs/plans/sy-daily-brief-fixed-failure-authority-fix-plan-20260730.md
+++ b/docs/plans/sy-daily-brief-fixed-failure-authority-fix-plan-20260730.md
@@ -1,0 +1,605 @@
+# sy Daily Brief Fixed Failure Authority 修复计划
+
+> 2026-07-30 revision：根据 `docs/reviews/plan-review-20260730-115457.md` 收敛方案。当前 work unit 只恢复受限、不可行动的 `fixed_failure` 投递；不把 portfolio identity receipt 当成正常 v1 报告完整性的证明，不在本 work unit 开放正常 v1 degraded fallback。
+
+## 1. 目标
+
+修复 scheduled fixed run 中以下用户可见故障：
+
+```text
+当前 Account Run 缺少成功的 position_advice_sources.v2.json
+  -> Daily Brief normal authority 不可用
+  -> domain 已选择 fixed_failure
+  -> application 用 notification_allowed=false 覆盖为 none
+  -> delivery_key=null、无 provider attempt、账户完全无消息
+```
+
+完成后必须满足：
+
+1. 当前 run 存在唯一、fresh、immutable、账户/市场/run 一致的 portfolio source receipt，且 Position Advice authority 可解析时，即使正常 Daily Brief 不可靠，scheduled fixed run 仍可准备并投递一条不可行动的 `fixed_failure`；
+2. 缺少成功 PA summary 时绝不生成 normal `fixed_report` 或 `candidate_alert`，不声称 lifecycle human-review、候选、现金容量或备兑能力完整；
+3. receipt 缺失、重复、stale、path 越界、schema/hash/payload/run/account/market/identity 不一致，或 authority conflict 时保持 no-send；
+4. 已有成功 summary 的正常 v1、v2_shadow、v2 报告路径保持原语义；
+5. fixed failure 继续使用现有 plain-text renderer、scan-failure source、delivery repository、exact retry 和 notification authority 执行边界；
+6. `lx` 与 `sy` 独立解析和投递，任一账户失败不改变另一账户的 token、delivery key 或 provider attempt；
+7. 不发送真实通知，不修改生产 config，不自动补发历史消息。
+
+本计划的成功定义是“sy 不再无声失败，而是收到明确的本轮失败消息”，不是“本轮恢复正常策略报告”。
+
+## 2. 已确认事实与根因边界
+
+### 2.1 直接事实链
+
+- `publish_account_run_sources()` 在 candidate capture、FX、option-position fingerprint、cash capacity 和 share coverage 校验前，先发布 immutable portfolio source receipt；
+- 任一后续 source graph 失败都会使成功态 `position_advice_sources.v2.json` 缺失；
+- `_daily_brief_advice_authority()` 当前把该缺失映射为 normal notification authority 不可用；
+- `decide_daily_brief_notification()` 已在 unreliable + fixed due 时返回 `fixed_failure`；
+- `tick_notification_flow.py` 随后用 `notification_allowed=false` 把该决定覆盖为 `none`；
+- fixed-failure repository 已约束其 source 必须是 `scan_failure`、消息必须是 plain text、candidate identities 必须为空；
+- notification executor 会在发送锁内重新解析 authority，并把 delivery key、source digest、message hash 与 transport idempotency key 记录到 authority receipt。
+
+### 2.2 本次不再采用的假设
+
+以下推理被明确禁止：
+
+```text
+portfolio identity receipt valid
+  != PA source graph complete
+  != normal v1 report reliable
+  != lifecycle human-review complete
+```
+
+因此，不论缺失 summary 的具体后续原因是 ordinary candidate coverage gap，还是 FX、账本、指纹、容量、receipt integrity 或未知异常，本 work unit 都只允许 fixed failure。typed source outcome 与 normal v1 degraded allowlist 留给独立后续 work unit。
+
+## 3. 范围与非目标
+
+### 3.1 本 work unit 包含
+
+- 当前 Account Run portfolio identity evidence 的只读、安全解析；
+- 正常投递授权与 fixed-failure 投递授权分离；
+- purpose-restricted fixed-failure token v2 与现有 normal token v1 / 旧 envelope exact-retry 兼容；
+- Daily Brief domain decision 接收两个通用 permission 输入；
+- 删除 application 层对 domain `fixed_failure` 的无条件覆盖；
+- fixed-failure token 的 action-specific 选择与 exact envelope 绑定；
+- pending/confirmed/ambiguous、exact retry、账户隔离和 mixed old/new envelope 回归测试；
+- 结构化审计字段和 blocker/reason code。
+
+### 3.2 本 work unit 不包含
+
+- 不改变 candidate capture completeness；
+- 不增加 PA source graph 的降级成功态；
+- 不修改成功态 `position_advice_sources.v2.json` schema；
+- 不新建 typed PA source outcome artifact；
+- 不复用历史 run 的 PA summary、portfolio receipt 或 lifecycle rows；
+- 不从 ledger 平行推导 lifecycle human-review；
+- 不修改 fixed-failure 用户文案、通知渠道、scheduler 或 provider retry；
+- 不改变 authority policy、generation、promotion 或 first-use bootstrap；
+- 不处理 OpenD `EMPTY_CHAIN` 的上游数据质量；
+- 不 commit、release、upgrade、重启服务或发送真实通知。
+
+## 4. 核心设计
+
+### 4.1 身份 evidence 使用窄只读边界
+
+新增：
+
+```text
+src/application/position_advice_account_identity_reader.py
+```
+
+唯一公开函数：
+
+```python
+read_current_run_portfolio_identity(
+    *,
+    account_state_dir: Path,
+    account_run_id: str,
+    expected_account: str,
+    expected_market: str,
+    now: datetime,
+) -> dict[str, Any]
+```
+
+该 reader：
+
+1. 只在当前 `account_state_dir` 下定位：
+
+   ```text
+   position_advice_producers/portfolio/
+     <sha256({"producer_run_id": account_run_id})>/
+     <payload_hash>/receipt.json
+   ```
+
+2. 要求该 run-key 目录下恰好一个 regular-file receipt；0 个、多个、symlink 或非 regular file 都失败；
+3. receipt bytes 前后各读一次，变化则失败；
+4. 使用 `validate_source_receipt()` 校验：
+   - `source_kind=portfolio`
+   - expected account
+   - expected producer account run id
+   - freshness
+   - payload path containment
+   - receipt schema、snapshot id、payload hash；
+5. 要求 receipt 路径与 `payload_relpath` 都位于同一个 expected run-key / content-hash 目录，文件名分别固定为 `receipt.json` 与 `payload.json`；
+6. payload bytes 前后各读一次，并重新校验 raw SHA-256；变化或与 `validate_source_receipt()` 返回的 hash 不同则失败；
+7. 解析这组已稳定验证的 payload bytes，要求 `schema_version=position_advice_portfolio_source.v1`，并要求目录 content hash 等于 payload canonical SHA-256；
+8. 从 payload 的 `normalized_portfolio_source` 与非空 list `portfolio_context.source_account_identifiers` 重新计算 `portfolio_account_identity_hash()`；
+9. 重算值必须等于 receipt 中的 identity hash；
+10. receipt `included_markets` 必须包含 expected market；
+11. 返回 JSON-safe typed evidence：
+
+   ```json
+   {
+     "status": "available",
+     "normalized_account": "sy",
+     "normalized_portfolio_source": "futu",
+     "portfolio_account_identity_hash": "<sha256>",
+     "producer_account_run_id": "<run_id>",
+     "included_markets": ["HK"],
+     "snapshot_id": "<sha256>",
+     "receipt_hash": "<sha256>",
+     "payload_sha256": "<sha256>",
+     "source_observed_at": "<utc>",
+     "expires_at": "<utc>"
+   }
+   ```
+
+reader 不得：
+
+- 导入或调用 `position_advice_account_sources.py` publisher；
+- 打开 ledger；
+- 扫描其他 run；
+- 选择“最新”receipt；
+- 修复字段或忽略额外 receipt；
+- 写任何 artifact。
+
+通用 receipt/path/hash 校验继续归 `position_advice_source_receipts.py`；新 reader 只负责 current-run portfolio identity 的组合约束。
+
+### 4.2 Normal advice authority 保持 fail-closed
+
+`_daily_brief_advice_authority()` 的 missing-summary 分支改为确定性结果：
+
+```json
+{
+  "mode": "authority_conflict",
+  "available": false,
+  "blocker": "position_advice_source_summary_missing",
+  "rows": [],
+  "human_review_rows": [],
+  "preview": {}
+}
+```
+
+删除“没有历史目录时默认 v1 normal available”的捷径，也不再用历史目录是否非空判断当前 run 身份。
+
+这保证：
+
+- 正常 actions/positions 不会因 identity receipt fallback 被恢复；
+- lifecycle human-review completeness 不会被默认为 true；
+- `status/actionability` 继续 blocked；
+- normal fixed report 与 candidate alert 均不可授权。
+
+### 4.3 独立构造 fixed-failure authority
+
+`_daily_brief_notification_authority()` 接收两类证据：
+
+```python
+_daily_brief_notification_authority(
+    advice_authority,
+    *,
+    current_run_identity_evidence,
+    account,
+    account_run_id,
+)
+```
+
+返回契约：
+
+```json
+{
+  "selected_advice_contract": null,
+  "resolved_mode": "v1",
+  "authority_generation": 3,
+  "authority_policy_hash": "<sha256>",
+  "normal_delivery_allowed": false,
+  "fixed_failure_delivery_allowed": true,
+  "notification_allowed": false,
+  "blocker": "position_advice_source_summary_missing",
+  "normal_delivery_token": null,
+  "fixed_failure_delivery_token": {
+    "schema_version": "position_advice_notification_authority_token.v2",
+    "authorized_delivery_kinds": ["fixed_failure"]
+  },
+  "token": null,
+  "identity_evidence": {
+    "status": "available",
+    "snapshot_id": "<sha256>",
+    "receipt_hash": "<sha256>"
+  }
+}
+```
+
+兼容规则：
+
+- `notification_allowed` 保留为 `normal_delivery_allowed` 的 legacy alias；
+- `token` 保留为 `normal_delivery_token` 的 legacy alias；
+- fixed failure 使用独立字段 `fixed_failure_delivery_token`，不改变旧调用方对 `notification_allowed=false -> token=null` 的理解；
+- brief 只保存 receipt/snapshot hash 等审计摘要，不复制 portfolio payload 或账户标识明文。
+
+fixed-failure authority 的构造步骤：
+
+1. 读取 current-run identity evidence；
+2. 用 evidence 中的 source + identity 调用 `read_authority_resolution()`；
+3. 仅 `resolution.notifications_allowed=true` 时继续；
+4. authority mode 到 formal advice contract 的映射固定为：
+   - `v1 -> v1`
+   - `v2_shadow -> v1`
+   - `v2 -> v2`
+5. 使用新增的 `build_fixed_failure_notification_authority_token()` 构造 purpose-restricted v2 token；token 代表“该账户/run 当前 formal authority 已解析，并且只允许 fixed failure”，不代表正常报告数据完整；
+6. conflict、异常、identity evidence unavailable 时 `fixed_failure_delivery_allowed=false` 且 token 为空。
+
+新的 failure-only token 契约：
+
+```json
+{
+  "schema_version": "position_advice_notification_authority_token.v2",
+  "normalized_account": "sy",
+  "portfolio_scope_id": "<sha256>",
+  "normalized_portfolio_source": "futu",
+  "portfolio_account_identity_hash": "<sha256>",
+  "selected_advice_contract": "v1",
+  "resolved_mode": "v1",
+  "authority_generation": 3,
+  "authority_policy_hash": "<sha256>",
+  "account_run_id": "<run_id>",
+  "authorized_delivery_kinds": ["fixed_failure"],
+  "token_hash": "<sha256>"
+}
+```
+
+约束：
+
+- 现有 `build_notification_authority_token()` 与 `position_advice_notification_authority_token.v1` 保持不变，继续只服务 normal `fixed_report` / `candidate_alert`；
+- 新增 `NOTIFICATION_AUTHORITY_FAILURE_TOKEN_SCHEMA_V2` 与窄 builder，只生成 `authorized_delivery_kinds=["fixed_failure"]`；
+- v2 的 `authorized_delivery_kinds` 必须精确等于 canonical `["fixed_failure"]`；
+- token hash 必须包含完整 `authorized_delivery_kinds`；
+- 不允许调用方传入任意 kind、空 list、normal kind 或混合 kind；
+- 成功 PA summary 路径按现有 advice availability 继续构造 normal v1 token；
+- identity 与 authority 已解析时可以同时构造 normal v1 token 与 fixed-failure v2 token；
+- domain 在 normal report 可靠时优先选择 normal action。
+
+### 4.4 Domain 拥有最终 action matrix
+
+扩展：
+
+```python
+decide_daily_brief_notification(
+    *,
+    ran_scan: bool,
+    pipeline_reliable: bool,
+    fixed_due: bool,
+    pending_candidate_identities: Sequence[str],
+    normal_delivery_allowed: bool,
+    fixed_failure_delivery_allowed: bool,
+    retryable_envelope_kind: str | None = None,
+) -> dict[str, Any]
+```
+
+两个 permission 都是必传参数，不提供 permissive default；所有生产调用点和 domain tests 必须显式给值。
+
+状态矩阵：
+
+| 条件 | 结果 |
+|---|---|
+| `ran_scan=false` 且有 retryable envelope | `retry_exact`，继续使用 envelope 内原 token |
+| `ran_scan=false` 且无 retry | `none` |
+| `fixed_due=true`、pipeline reliable、normal allowed | `fixed_report` |
+| `fixed_due=true`、pipeline unreliable、failure allowed | `fixed_failure` |
+| `fixed_due=true`、pipeline reliable、normal denied、failure allowed | `fixed_failure` |
+| `fixed_due=true` 且 failure denied、normal 不可用 | `none` |
+| 非 fixed、pipeline reliable、normal allowed、有 pending candidates | `candidate_alert` |
+| 非 fixed 且 pipeline/normal 任一不可用 | `none` |
+
+reason code 分别使用：
+
+```text
+fixed_report_due
+fixed_scan_failed
+fixed_normal_authority_unavailable
+fixed_failure_authority_unavailable
+pending_candidates
+normal_authority_unavailable
+retryable_envelope
+```
+
+`tick_notification_flow.py` 删除当前 `if not authority_allows_notification: decision=none` 的事后覆盖。application 只把事实布尔值传给 domain，不再二次改写 action。
+
+application 的准备顺序固定为：
+
+1. `pipeline_reliable` 只表示 scan/brief 数据链本身可靠，不包含 notification authority；
+2. 计算 `normal_report_reliable = pipeline_reliable and normal_delivery_allowed`；
+3. `normal_report_reliable=true` 时才持久化 successful brief 并计算 pending candidates；
+4. `normal_report_reliable=false` 时写当前 run 的 failure artifact，供可能的 `fixed_failure` envelope 绑定；
+5. 将原始 `pipeline_reliable`、两个 permission 和 pending candidates 交给 domain；
+6. domain 返回 normal action 时必须已有 successful brief；返回 `fixed_failure` 时必须已有 failure artifact；断言不成立则 fail closed，不临时拼 source。
+
+### 4.5 Action-specific token 选择
+
+application 按 domain action 选择 token：
+
+| action | 必须使用 |
+|---|---|
+| `fixed_report` / `candidate_alert` | `normal_delivery_token` |
+| `fixed_failure` | `fixed_failure_delivery_token` |
+| `retry_exact` | 已持久化 envelope 的 `notification_authority_token` |
+| `none` | 不准备 envelope |
+
+若 action 对应的 token 缺失，必须在 prepare 前 fail closed 为 `none` 并记录 `daily_brief_authority_token_missing`；不得换用另一类 token。
+
+选中的 token 继续写入 persisted envelope：
+
+```text
+render_context.notification_authority_token
+```
+
+provider send 前，executor 继续从同一 envelope 取：
+
+- token；
+- `delivery_kind`；
+- `delivery_key`；
+- `source_digest`；
+- `message_sha256`；
+- transport idempotency key。
+
+`delivery_kind` 不能只信任 caller mapping。新增 repository read-only validator：
+
+```python
+validate_daily_decision_brief_delivery_identity(
+    *,
+    base: Path,
+    account: str,
+    market: str,
+    market_trading_date: str,
+    delivery_key: str,
+    source_digest: str,
+    message_sha256: str,
+    transport_idempotency_key: str,
+) -> dict[str, Any]
+```
+
+它在现有 delivery lock 下定位 persisted envelope，复用 account/date/key/source/message/transport 全量校验，并返回真实 `delivery_kind` 与 status。executor 不从 caller 自报 kind 做授权结论。
+
+这组已验证的 `delivery_identity` 由 notification authority receipt 固化。对 failure token v2，executor 必须在 provider call 前验证：
+
+```text
+persisted_envelope.delivery_kind == caller.delivery_kind
+persisted_envelope.delivery_kind in token.authorized_delivery_kinds
+persisted_envelope.status == pending
+```
+
+不匹配返回 `AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED`，attempt count 为 0。fixed failure 仍由 repository 强制：
+
+- `delivery_kind=fixed_failure`
+- `source_kind=scan_failure`
+- plain-text only
+- `candidate_identities=[]`
+- exact source reference + digest。
+
+failure-token `delivery_identity` 增加 `delivery_kind`：
+
+- 对 failure v2 token 必填并参与 authority receipt；
+- 对旧 v1 token 可缺失，以支持已持久化 envelope 的 exact retry；
+- reconciliation 必须保留该字段，但不改变既有 source/message/delivery-key 比对；
+- receipt schema 暂不升级，因为其 `delivery_identity` 本来就是 mapping；validator 必须同时接受 legacy mapping 和带 kind 的新 mapping。
+
+锁顺序固定为 notification authority global shared -> scope shared -> send lock -> 短暂 delivery lock；不得先持有 delivery lock 再等待 authority lock。persisted-envelope validation 完成并释放 delivery lock后才调用 provider。
+
+限制 fixed-failure capability 的边界是 failure token v2 的 authorized kind、action-specific token 字段、domain action、repository envelope contract、exact delivery identity 和 send-time authority re-resolution 的组合，而不是把 normal report completeness 写进 token。
+
+## 5. Delivery 状态与兼容性
+
+### 5.1 同 run fixed delivery
+
+沿用现有 fixed delivery key：
+
+```text
+market + market_trading_date + account + scheduled_target_market
+```
+
+状态规则：
+
+- `pending fixed_failure`：允许现有 repository 原子升级为 `fixed_report`；包括尚未尝试和已确认 provider definite failure 后仍为 pending 的 envelope，但不包括 ambiguous/unknown；
+- `confirmed fixed_failure`：同 run 不再发送 fixed report；
+- `ambiguous/unknown fixed_failure`：冻结并交给现有 reconciliation，不自动换消息；
+- exact retry 必须复用原 envelope bytes、message hash、delivery key 和 token；
+- notification authority receipt 的 account-run/channel dedupe 保持“一 run 一 channel 一个终态发送”。
+
+### 5.2 Mixed old/new state
+
+- 现有 normal token v1 与旧 envelope 内的 token v1 继续按原契约执行；executor 仍校验 account/source/identity/mode/generation，不新增 delivery-kind 要求；
+- 所有新准备的 fixed-failure envelope 必须使用 failure token v2，并在 delivery identity 中携带 `delivery_kind=fixed_failure`；
+- 新 brief 的 `notification_allowed` 与 `token` 仍只表示 normal delivery；
+- 没有 `fixed_failure_delivery_allowed` 的旧 brief 按 false 解释，不凭空构造 failure token；
+- 不迁移、不回填历史 brief、delivery envelope 或 authority receipt；
+- 新代码必须能读取旧 receipt 中没有新增审计摘要的 `delivery_identity`。
+
+## 6. Observability
+
+Daily Brief lifecycle audit 与 tick metrics 增加：
+
+```json
+{
+  "normal_delivery_allowed": false,
+  "fixed_failure_delivery_allowed": true,
+  "authority_identity_source": "current_run_portfolio_receipt",
+  "authority_resolution_status": "resolved",
+  "authority_resolved_mode": "v1",
+  "authority_generation": 3,
+  "identity_snapshot_id": "<sha256>",
+  "identity_receipt_hash": "<sha256>",
+  "decision": "fixed_failure",
+  "decision_reason": "fixed_normal_authority_unavailable"
+}
+```
+
+失败 reason 至少区分：
+
+```text
+current_run_portfolio_receipt_missing
+current_run_portfolio_receipt_ambiguous
+current_run_portfolio_receipt_invalid
+current_run_portfolio_receipt_stale
+current_run_portfolio_identity_mismatch
+position_advice_authority_conflict
+position_advice_failure_token_build_failed
+```
+
+日志不得包含 payload、broker account identifiers、完整 receipt 或 webhook secret。
+
+## 7. 实施切片
+
+### Slice 1 — Current-run identity reader
+
+文件：
+
+- 新增 `src/application/position_advice_account_identity_reader.py`
+- 更新 `tests/test_position_advice_account_identity_reader.py`
+
+验收：
+
+- 唯一合法 receipt 返回重算后的 source/identity；
+- 缺失、多个、symlink/path escape、坏 JSON、schema/hash/payload mismatch、stale、run/account/market mismatch 全部 fail closed；
+- reader 无写入、无 ledger/publisher 依赖；
+- receipt/payload 在读取期间变化时拒绝。
+
+### Slice 2 — Purpose-restricted failure token v2
+
+文件：
+
+- `src/application/position_advice_notification_authority.py`
+- `src/application/daily_decision_brief_repository.py`
+- `docs/POSITION_ADVICE_V2_CONTRACT.md`
+- `tests/test_position_advice_notification_authority.py`
+- `tests/test_daily_decision_brief_repository_v2.py`
+
+验收：
+
+- 现有 normal builder/token v1 行为不变；新窄 builder 只生成 failure token v2；
+- v2 failure token 拒绝 `fixed_report` / `candidate_alert`，且在 provider call 前失败；
+- caller 自报 kind 与 persisted envelope kind 不一致时 provider attempt 为 0；
+- normal/旧 v1 token 的 validation、发送与 exact retry 继续成功；
+- 新 authority receipt 保留 delivery kind，旧 receipt 继续可读和 reconciliation；
+- public contract 文档同步 token purpose、v1 compatibility 和 one-terminal-send 语义。
+
+### Slice 3 — Advice 与 notification authority 分离
+
+文件：
+
+- `src/application/daily_decision_brief_service.py`
+- `tests/test_daily_decision_brief_service.py`
+
+验收：
+
+- summary missing 永远不恢复 normal v1；
+- valid identity + resolved v1/v2_shadow/v2 分别产生 formal `v1/v1/v2` failure token；
+- conflict/invalid identity 无 failure token；
+- `human_review_rows=[]` 时 report 必须 blocked，不能作为 normal delivery；
+- legacy normal aliases 保持兼容。
+
+### Slice 4 — Domain action 与 application orchestration
+
+文件：
+
+- `domain/domain/daily_decision_brief.py`
+- `src/application/tick_notification_flow.py`
+- `tests/test_daily_decision_brief_notification_flow.py`
+
+验收：
+
+- domain 覆盖完整矩阵，application 不再事后覆盖；
+- normal action 只能取 normal token，fixed failure 只能取 failure token；
+- fixed failure envelope 保持 plain text、无 candidates、绑定 scan failure digest；
+- send-time authority conflict 仍阻断 provider call；
+- `lx` normal fixed report 与 `sy` fixed failure 可在同一 tick 各自产生独立 delivery key/provider attempt；
+- 任一账户 token/receipt 错误不影响另一账户。
+
+### Slice 5 — Retry、状态转换与回归
+
+验收：
+
+- pending failure 可升级为 normal report；
+- confirmed/ambiguous failure 不升级；
+- old envelope exact retry；
+- duplicate tick/provider retry 不重复发送；
+- normal v1/v2_shadow/v2 paths、nonfixed candidate alerts、`no_send`、multi-market 现有行为不回归。
+
+## 8. 测试与验证
+
+先运行 focused tests：
+
+```bash
+python3.12 -m pytest -q \
+  tests/test_position_advice_account_identity_reader.py \
+  tests/test_daily_decision_brief_service.py \
+  tests/test_daily_decision_brief_notification_flow.py \
+  tests/test_daily_decision_brief_repository_v2.py \
+  tests/test_position_advice_notification_authority.py \
+  tests/test_position_advice_v2_authority_service.py \
+  tests/test_position_advice_promotion.py
+```
+
+再运行通知与 tick 回归：
+
+```bash
+python3.12 -m pytest -q \
+  tests/test_notify_symbols_markdown.py \
+  tests/test_multi_tick_notify_format.py \
+  tests/test_multi_tick_*.py \
+  tests/test_unified_tick_entrypoint.py
+```
+
+若 import graph 改变：
+
+```bash
+python3.12 scripts/generate_dependency_graph.py
+python3.12 scripts/generate_dependency_graph.py --check
+```
+
+实现后的 read-only dry-run 必须证明：
+
+```text
+sy:
+  decision=fixed_failure
+  delivery_key!=null
+  rendered message 为不可行动失败文案
+  candidate identities=[]
+  no real provider call
+
+lx:
+  原 normal fixed report 行为不变
+```
+
+不得用真实 webhook 作为测试信号。
+
+## 9. Rollout 与回滚
+
+本计划只定义代码修复，不授权 release 或 upgrade。
+
+后续若另行授权发布/升级：
+
+1. 先验证 focused + regression tests；
+2. 用受控 dry-run 检查双账户 lifecycle audit；
+3. 发布与远端升级保持独立边界；
+4. 升级后只读核对每账户 `decision`、`delivery_key`、authority receipt 与 provider attempt；
+5. 若发现 normal action 被 failure token 授权、跨账户干扰或 duplicate send，回滚到上一 release，保留 delivery/authority receipts，不删除状态。
+
+## 10. Deferred follow-up
+
+以下问题另开 work unit，不作为本修复的隐含扩展：
+
+1. 为 PA source graph 输出 typed run outcome，区分 `coverage_incomplete`、`dependency_unavailable`、`integrity_failure`、`unknown_failure`；
+2. 建立 lifecycle review completeness contract；
+3. 只 allowlist 明确的 symbol-scoped coverage failure 后，评估是否开放正常 v1 degraded report；
+4. 诊断并改善 `EMPTY_CHAIN` 的上游 provider/data-quality 行为；
+5. 若未来正式支持绕过 `tick-cron` market lock 的同账户/同市场并发 tick，单独设计 persisted-envelope prepare/upgrade 与 provider in-flight claim 的原子状态；当前生产 guarded tick 串行假设不扩展为通用并发承诺。
+
+在这些条件完成前，identity receipt fallback 只能授权 fixed failure，不能授权 normal report。

--- a/docs/reviews/code-review-20260730-125627.md
+++ b/docs/reviews/code-review-20260730-125627.md
@@ -1,0 +1,62 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `main`，仅工作区改动；`main..HEAD` 无提交
+- Base: `main@d2a69ba02ad102312285aa9aed92c4dd0fd2c42b`
+- Output file: `docs/reviews/code-review-20260730-125627.md`
+- Included scope: `sy` Daily Brief fixed-failure authority 修复的计划与契约、current-run portfolio identity reader、normal/failure token、notification executor、Daily Brief domain decision、delivery repository、tick notification orchestration、相关测试与生成依赖图
+- Excluded scope: 真实 provider 调用、生产 runtime artifact 验证、release、deployment、生产配置与服务变更
+- Parallel review coverage: 无
+
+## Findings
+
+### 1-已修复-高-Failure token 未绑定 persisted envelope，可用另一个 run 的 token 发送旧 envelope
+
+- **入口/函数**: `run_tick_notification_flow()` -> `_execute_with_notification_authority()` -> `execute_notification_with_authority()` -> `validate_daily_decision_brief_delivery_identity()`
+- **文件(行号)**: `src/application/position_advice_notification_authority.py:141-159, 217-295`; `src/application/daily_decision_brief_repository.py:556-585`; `tests/test_position_advice_notification_authority.py:108-180`
+- **输入场景**: 账户 `lx` 已有 run A 的 `pending fixed_failure` envelope；调用方另持有同账户、同 authority generation、但 `account_run_id=run B` 的合法 failure-token v2，并把 run A envelope 的 delivery identity 与 run B token 一起交给 executor。
+- **实际分支**: executor 用传入 token 的 `account_run_id` 计算 notification dedupe key；repository validator 只校验 account/date/delivery key/source/message/transport，并返回 persisted kind/status。executor 随后只比较 `delivery_kind` 和 `status=pending`，没有比较 persisted `render_context.notification_authority_token` 与传入 token，也没有验证 envelope 所属 account run。
+- **预期行为**: failure-token v2 必须与同一个 persisted envelope 内冻结的 token 完全一致；token 缺失、token hash 不同或 `account_run_id` 不同都应在 provider call 前返回 `AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED`，attempt count 为 0。
+- **实际行为**: 最小复现以 `run-failure` 的 persisted envelope 配 `different-current-run` token，provider 被调用 1 次且 authority receipt 为 `accepted`。现有正向测试甚至用不含 `notification_authority_token` 的 envelope 配独立 token，并把发送成功固化为预期。
+- **直接证据**: `notification_key` 只使用传入 token 的 scope/generation/account-run/channel；`persisted_delivery["envelope"]` 已由 validator 返回，但 executor 没有读取其 `render_context.notification_authority_token`。复现输出为 `{"persisted_envelope_run":"run-failure","supplied_token_run":"different-current-run","provider_calls":1,"receipt_status":"accepted"}`。
+- **影响**: 旧失败消息可以被记到新 run 的 authority 去重槽位，既破坏 exact-envelope/exact-retry 绑定，又可能让后续真正属于新 run 的消息被 duplicate suppression 阻断。账户仍被校验，但同账户跨 run 的消息与授权身份可以错配。
+- **建议改法和验证点**: 对 failure-token v2，在 send lock 内取得 persisted envelope 后，要求其 `render_context.notification_authority_token` 存在、通过同一 token validator，且 `token_hash` 和完整 canonical payload 与传入 token 一致；不匹配结构化拒绝。新增三类回归：tokenless envelope、run A envelope + run B token、同 run 但 token hash/policy 被替换，均断言 provider 0 calls；保留旧 v1 envelope exact retry 兼容测试。
+- **修复状态与证据**: `execute_notification_with_authority()` 现在在 send lock 内读取并验证持久化 envelope 的冻结 token，且要求其 canonical payload 与调用 token 完全一致；缺失、坏 hash 或跨 run 替换都会在写 inflight receipt/provider call 前结构化拒绝。对应实现位于 `src/application/position_advice_notification_authority.py:217-320`，回归位于 `tests/test_position_advice_notification_authority.py:263-355`。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### 2-已修复-高-Pending fixed failure 的正常报告升级在真实 tick 编排中不可达
+
+- **入口/函数**: `_prepare_daily_brief_notification()` -> `decide_daily_brief_notification()` -> `read_retryable_daily_decision_brief_delivery()` -> `prepare_daily_decision_brief_delivery()`
+- **文件(行号)**: `src/application/tick_notification_flow.py:837-985`; `src/application/daily_decision_brief_repository.py:385-405`; `docs/plans/sy-daily-brief-fixed-failure-authority-fix-plan-20260730.md:398-414`; `tests/test_daily_decision_brief_repository_v2.py:360-458`
+- **输入场景**: 某 fixed target 的第一次扫描不可靠，已准备 `pending fixed_failure`，但尚未调用 provider，或 provider 返回 definite failure 后 envelope 仍为 pending；随后同一 target 的新 tick 恢复为 reliable 且 normal authority 可用。
+- **实际分支**: domain 正确返回 `fixed_report`，但编排层读取到任意 retryable envelope 后把 `should_prepare` 设为 false，因此不会调用 normal 分支的 `prepare_daily_decision_brief_delivery()`。repository 中 `fixed_failure -> fixed_report` 的原子升级条件完全没有机会执行；随后第二次 `read_retryable...` 又选回旧 failure envelope。
+- **预期行为**: 对计划明确允许的 pending 状态，编排层应进入受控升级，使 repository 在锁内把 failure envelope 替换为当前 normal report；confirmed 或 ambiguous/unknown failure 必须继续冻结。
+- **实际行为**: 最小复现中 domain/audit 为 `decision=fixed_report`、`reason=fixed_report_due`，但最终 envelope 仍是 run A 的 `fixed_failure`，其中 token 的 `account_run_id` 也仍为 run A；恢复后的 run B 会继续投递旧失败消息。repository 单元测试只证明直接调用可升级，没有覆盖真实编排短路。
+- **直接证据**: `should_prepare = not existing_retry.envelope` 位于 action-specific prepare 之前；normal prepare 整段受 `should_prepare` 限制。复现输出为 `{"decision":"fixed_report","first_kind":"fixed_failure","second_kind":"fixed_failure","second_envelope_run_id":"failed-run","recovered_run_id":"recovered-run","retry_reason":"pending_fixed"}`。
+- **影响**: 扫描已经恢复时用户仍会收到“本轮扫描失败”，且 metrics 声称决策是 `fixed_report`，形成消息内容、审计结论和当前 run 身份三方不一致；计划承诺的 pending upgrade 与 mixed-state 语义没有在生产入口实现。
+- **建议改法和验证点**: 不要对所有 retryable envelope 一刀切跳过 prepare。先按 existing kind/status 和当前 action 分类：仅 `pending fixed_failure + fixed_report` 进入升级判定，其余继续 exact retry。升级前还必须排除“provider 已 accepted、但 delivery repository 尚未 confirm”的崩溃窗口；不能只信任 repository 的 `pending`，应在同一受控边界核对旧 envelope 对应的 authority accepted/unknown/inflight receipt。新增真实 orchestration 回归，覆盖未尝试 pending、definite failure pending、accepted-but-unconfirmed、confirmed、ambiguous/unknown 五类状态，并同时断言 envelope kind、token run id、provider message 和 lifecycle audit 一致。
+- **修复状态与证据**: tick 编排现在只对 `pending fixed_failure + 当前 fixed_report` 调用通知权威状态判定；`clear`（未尝试或 definite failure）允许进入 repository 原子升级，其余状态保持 exact envelope。通知权威以旧冻结 token + 实际 channel 核对 accepted/unknown/inflight receipt，读失败一律 fail closed。实现位于 `src/application/tick_notification_flow.py:855-904, 1204-1246` 与 `src/application/position_advice_notification_authority.py:410-478`；真实编排回归覆盖未尝试、definite failure、accepted-but-unconfirmed 和 ambiguous，位于 `tests/test_daily_decision_brief_notification_flow.py:598-805`，confirmed repository 不升级约束继续由 `tests/test_daily_decision_brief_repository_v2.py:360-458` 固化。
+- **修复风险（低/中/高）**: 高
+- **严重程度（低/中/高/严重）**: 高
+
+## Open Questions
+
+- 无。旧 envelope 对应的 provider receipt 状态由 notification authority 模块在其 send lock 下统一裁决；Daily Brief repository 继续只拥有 envelope 状态与原子升级写入。
+
+## Residual Risk
+
+- 生产 `tick-cron` 的 per-market lock 能降低正常部署下的并发风险，但绕过 guarded wrapper 的同账户/同市场 raw tick 仍不在本次验证范围内。
+- 未调用真实通知 provider，也未读取或修改生产 runtime state。
+- 修复前定向验证结果为 `145 passed`，但不覆盖上述状态组合。修复后的验证结果见下方 Fix Verification。
+
+## Fix Verification
+
+- 聚焦 suite：`181 passed`。
+- 通知与 tick 回归：`102 passed`（4 个既有 deprecation warnings）。
+- Ruff：通过。
+- Dependency graph：559 production modules、0 cycles，生成结果与 check 一致。
+- `git diff --check`：通过。
+- 未调用真实通知 provider，未读取或修改生产 runtime state。

--- a/docs/reviews/plan-review-20260730-115457.md
+++ b/docs/reviews/plan-review-20260730-115457.md
@@ -1,0 +1,112 @@
+# Plan Review — sy Daily Brief 消息抑制修复方案
+
+- 审查时间：2026-07-30 11:54:57 +08:00
+- 审查对象：当前会话中提出的 sy Daily Brief 修复设计
+- 审查范围：身份来源回退、PA authority 状态矩阵、正常/失败通知授权、Daily Brief 决策归属、模块边界、幂等与测试
+- 不在范围：实际代码修改、真实通知发送、版本发布、远端升级
+- 最终结论：`fail`
+
+## Reviewed target and scope
+
+被审方案的核心路径是：
+
+1. 当当前 Account Run 缺少 `position_advice_sources.v2.json` 时，从当前 run 的 immutable portfolio source receipt 重建并验证账户身份。
+2. 用该身份调用 `read_authority_resolution()`。
+3. authority 为 `v1` / `v2_shadow` 时继续生成降级的 v1 Daily Brief；authority 为 `v2` 时保持 PA unavailable。
+4. 将普通报告通知与固定失败通知拆成两个授权布尔值，并允许在普通报告不具备 authority 时仍构造失败通知 token。
+5. 把最终通知决策收口到 domain 层，删除 application 层对 domain 决策的事后覆盖。
+6. 不改变成功态 `position_advice_sources.v2.json`，不复用历史成功 summary，不放宽 PA v2 source completeness。
+
+## Assumptions tested
+
+1. “当前 run 的 portfolio receipt 身份有效”是否足以证明缺失 PA summary 属于可安全降级的普通覆盖缺口。
+2. 正常 v1 报告是否能在没有当前 PA v2 结果时保持既有 lifecycle human-review 可见性。
+3. 复用现有 notification authority token 是否仍保持最小授权和 exact-delivery 约束。
+4. 把 receipt reader 放入 `position_advice_account_sources.py` 是否符合模块所有权和依赖方向。
+5. 新状态矩阵是否覆盖 pending/confirmed/ambiguous、失败后恢复、旧 envelope 重试和多账户隔离。
+
+## Review lenses
+
+- **Architecture boundary**：身份 receipt 的读取验证、Account Run source outcome、Daily Brief 组装和通知执行必须各自在所属边界内负责。
+- **Best-practice**：身份、数据完整性、报告可靠性和发送授权必须分别证明，不能用单一布尔值互相替代。
+- **Optimal-solution**：最小安全修复应先恢复“明确失败消息可送达”，不必同时承诺“缺少 PA graph 时正常报告仍可靠”。
+- **Overengineering**：为本次消息抑制问题重构全部 Daily Brief domain 决策不是必要前提；可以在保留现有决策器的前提下补充受限失败授权。
+- **Overcoupling**：Daily Brief 不应依赖 PA source publisher 的内部目录布局、组装顺序或重型账本依赖。
+
+## Findings
+
+### PR-01-未修复-高-有效账户身份被错误等同为正常报告可安全降级
+
+- **位置**：方案第 2、3、4 步；`src/application/position_advice_account_sources.py:87-277`；`src/application/account_run.py:582-659`
+- **问题类型**：Best-practice / Optimal-solution / fail-open 状态分类
+- **当前写法**：只要完整 `position_advice_sources.v2.json` 缺失但 portfolio receipt 身份验证成功，就读取 authority；`v1` / `v2_shadow` 随即按正常 v1 报告继续，只有 `v2` 才固定失败。
+- **反例/失败场景**：portfolio receipt 已在第 87 行成功发布，随后可能因 candidate capture schema/run/account 不匹配、quote receipt hash/path/freshness 校验失败、FX 缺失、option-position fingerprint 不匹配、账本 decision snapshot 不可信、现金担保或备兑股份事实不完整而失败。这些情况都会留下合法 portfolio receipt，同时不产生成功 summary。
+- **为什么有问题**：portfolio receipt 只证明账户来源和身份，不证明后续 source graph 的失败原因属于可降级覆盖缺口。方案会把数据完整性失败、跨 run 污染、账本指纹冲突和未知异常，与 `EMPTY_CHAIN` 造成的 symbol-scoped candidate coverage gap 合并成同一个正常降级分支。
+- **直接证据**：`publish_portfolio_source_snapshot()` 发生在 candidate capture 校验之前（`position_advice_account_sources.py:87-147`）；其后仍有 FX、option context fingerprint、cash capacity、share coverage 等失败点（`:178-277`、`:370-437`、`:514-555`）。Account Run 在 `account_run.py:651-659` 用通用 `Exception` 记录 degraded，没有给 Daily Brief 一个可判定的 typed source outcome。
+- **影响**：完整性故障可能被误报为可行动的正常 v1 报告；本来只需解决“失败消息被抑制”的修复，反而扩大了正常报告的 fail-open 面。
+- **建议改法和验证点**：把修复拆成两级。第一阶段只允许“身份和 authority 已解析、正常报告不可靠”生成 `fixed_failure`，不要据此把报告改判为正常 v1；这已经能修复 sy 无消息。若确实要恢复正常 v1，则必须由 Account Run 所有者输出 run-scoped typed outcome，例如 `coverage_incomplete`、`dependency_unavailable`、`integrity_failure`、`unknown_failure`，且只 allowlist 明确的 symbol-scoped coverage failure。验证 candidate `EMPTY_CHAIN` 可降级，而 receipt/hash/fingerprint/run mismatch、FX/账本/容量失败和未知异常全部保持 fixed failure。
+- **修复风险**：中
+- **严重程度**：高
+
+### PR-02-未修复-高-缺少 PA 当前结果时会静默丢失 lifecycle human-review 安全事实
+
+- **位置**：方案第 3 步；`src/application/daily_decision_brief_service.py:342-375`、`:789-952`；`tests/test_daily_decision_brief_service.py:776-835`
+- **问题类型**：Architecture boundary / safety completeness
+- **当前写法**：缺少完整 PA summary 时仅从 portfolio receipt 取得身份并解析 authority；在 `v1` / `v2_shadow` 下返回降级 v1，但方案没有定义 `human_review_rows` 的来源、缺失语义或阻断条件。
+- **反例/失败场景**：账户存在 `lifecycle_state=needs_review` 的 short put 或 covered call。正常 PA v2 read 会在任何 authority mode 下把该行作为 `human_review_required` 暴露；本轮 source publication 因 candidate gap 失败后，receipt fallback 只能得到身份，不能得到该 lifecycle row。降级 v1 报告仍可被标为正常可发送，但复核事项从消息中消失。
+- **为什么有问题**：当前实现明确把 lifecycle human review 视为跨 `v1`、`v2_shadow`、`v2` 都必须可见的安全事实，而不是 v2 trade advice 的可选预览。方案没有为“当前 PA plan 不可读”建立显式 completeness 状态。
+- **直接证据**：非 v2 正式模式仍在 `daily_decision_brief_service.py:369-375` 把 `human_review_rows` 加入 positions/actions；这些 rows 只在 PA read `available + fresh` 时产生（`:890-920`）。参数化测试 `test_daily_brief_keeps_lifecycle_human_review_visible_in_every_mode` 明确覆盖三个 authority mode（`tests/test_daily_decision_brief_service.py:776-835`）。
+- **影响**：正常报告可能遗漏到期、指派衔接或账本生命周期异常等需要人工确认的事项；这比不发送正常报告更危险。
+- **建议改法和验证点**：第一阶段 fixed-failure 修复不得声称 lifecycle coverage 完整。后续若开放正常 v1 降级，计划必须增加独立的 `lifecycle_review_completeness` 判定，并复用 PA/ledger 所有者的现有分类逻辑，不能在 renderer 中平行推导。无法证明完整时至少输出 P0 非交易型数据缺口；若账户存在未完成 lifecycle case，则 normal report 不得授权，改发 fixed failure。增加回归测试：当前 run 有 human-review case 且 PA graph 缺失时，该 case 不得静默消失为一个无警告的正常报告。
+- **修复风险**：高
+- **严重程度**：高
+
+### PR-03-未修复-中-失败通知复用现有 token 的授权语义和一次发送状态机未定义
+
+- **位置**：方案第 4 步；`src/application/daily_decision_brief_service.py:955-1015`；`src/application/position_advice_notification_authority.py:93-225`、`:661-705`；`src/application/tick_notification_flow.py:390-435`
+- **问题类型**：Best-practice / public contract / idempotency
+- **当前写法**：方案提出保持 token schema 不变，在 normal notification 不允许但 failure notification 允许时仍构造 token；没有说明 token 中 `selected_advice_contract` 对 fixed failure 的含义，也没有定义同一 run 中 fixed failure 与后来恢复的 fixed report 如何竞争。
+- **反例/失败场景**：同一 account run 先准备或发送 fixed failure，随后 source graph 恢复并准备 fixed report；authority notification key 只包含 scope、generation、account_run_id、channel，不含 delivery kind。另一个场景是旧版本 envelope 只有 `notification_allowed`，新执行器读取新增的双布尔字段。
+- **为什么有问题**：现有 token 的隐含契约是“选中的 v1/v2 advice contract 可以通知”；计划将其扩展成“即使没有可用 advice，仍可发送失败文本”，但没有版本化或写清约束。虽然现有 `delivery_identity` 已绑定 delivery key、source digest 和 message hash，repository 也限制 fixed failure 为无 candidates 的纯文本，但 plan 必须把这条事实链写成正式安全前提，并明确一 run 一 channel 只允许一个终态发送。
+- **直接证据**：token 构造当前仅在 `allowed` 时执行（`daily_decision_brief_service.py:963-1015`）；执行层 notification key 不含 delivery kind（`position_advice_notification_authority.py:116-123`）；delivery identity 会校验 `delivery_key`、`source_digest`、`message_sha256` 和 transport key（`:661-705`），因此可以支持精确受限发送，但方案尚未把它纳入裁决和测试。
+- **影响**：可能出现新旧 envelope 解释不一致、同 run 恢复后消息被意外抑制，或未来调用方把 failure token 误当成正常 advice 授权。
+- **建议改法和验证点**：把 contract 明确为 `normal_delivery_allowed` 与 `fixed_failure_delivery_allowed`，保留旧 `notification_allowed` 作为只读兼容别名；token 必须只随已经持久化并通过 repository 校验的 fixed-failure envelope 使用，执行时继续绑定精确 delivery identity。明确“accepted/unknown fixed failure 后同 run 不再升级；仅 pending 且未尝试的 failure 可原子升级为 fixed report”。覆盖旧 envelope exact retry、pending upgrade、accepted suppression、ambiguous freeze、跨账户/跨 run 不互相抑制。
+- **修复风险**：中
+- **严重程度**：中
+
+### PR-04-未修复-中-receipt reader 放入 publisher 模块会让 Daily Brief 依赖 PA 组装内部
+
+- **位置**：方案第 2 步；`src/application/position_advice_account_sources.py:42-367`；`src/application/daily_decision_brief_service.py:789-853`
+- **问题类型**：Architecture boundary / Overcoupling
+- **当前写法**：方案指定把当前 run portfolio receipt reader 放进 `position_advice_account_sources.py`，再由 Daily Brief 调用。
+- **反例/失败场景**：Daily Brief 为读取身份而导入一个同时打开 ledger repository、发布 portfolio/ledger/candidate/FX/cash/share receipts、计算容量并知道 Account Run 目录所有权的 orchestration 模块。后续 publisher 顺序或依赖变化会无意改变 read path，且更容易形成循环依赖。
+- **为什么有问题**：receipt 验证是不可变 source evidence 的读取边界，不是 account source publisher 的职责。把读路径放入 publisher 会扩大依赖面，也让 Daily Brief 知道 content-addressed producer layout。
+- **直接证据**：`position_advice_account_sources.py:42-296` 是多 source 发布和容量组装器；其 facade 在 `:299-367` 打开 ledger 并返回发布摘要。Daily Brief 当前只依赖 summary 和 authority reader（`daily_decision_brief_service.py:789-853`），没有理由引入整个 publisher。
+- **影响**：增加导入耦合、测试替身复杂度和未来重构风险；安全验证规则可能在 publisher 与 consumer 间分叉。
+- **建议改法和验证点**：把通用 receipt/path/hash/payload 校验留在 `position_advice_source_receipts.py`，必要时新增一个窄的 `position_advice_account_identity_reader.py` facade，仅返回 typed identity evidence，不暴露目录路径或发布细节。增加 dependency/import test，确保 reader 不打开 ledger、不发布文件、无副作用。
+- **修复风险**：低
+- **严重程度**：中
+
+## Open Questions
+
+1. 本次成功标准究竟是“恢复任意明确消息”还是“必须恢复正常 v1 Daily Brief”？两者的安全证明和实施范围不同。
+2. 对存在 open option positions 但当前 PA lifecycle completeness 不可证明的账户，产品裁决应是 P0 数据缺口随正常报告展示，还是直接 fixed failure？
+3. fixed failure 已被 provider 接受后，同一 account run 数据恢复是否明确禁止再发 fixed report？现有 notification authority key 倾向于“一 run 一 channel 一个终态发送”，计划应确认这是产品语义。
+
+## Residual risks and tracking
+
+- 即使修复通知抑制，`EMPTY_CHAIN` 的上游链路质量问题仍存在；本次不应把 provider 空链误解释成“无机会”。
+- fixed failure 只能证明系统明确报告失败，不能证明候选、容量或 lifecycle 数据完整。
+- 真实 provider send、远端运行目录和生产 systemd 状态不在本次 plan review 范围内；实现完成后仍需 dry-run、focused tests、全量相关测试和受控运行验证。
+- 无需迁移历史 source summary；旧 envelope 必须 exact replay，缺少新字段时按旧契约 fail closed。
+
+## Final conclusion
+
+`fail`
+
+方案识别了正确的根因边界：成功 PA summary 不应被伪造，历史 summary 不应复用，失败消息与正常消息的授权必须分开。但当前方案用“身份有效”替代“报告完整性可降级”，并会在缺少当前 PA 结果时静默失去 lifecycle human-review 事实，因此不能直接进入实现。
+
+建议将计划改为两阶段：
+
+1. **最小安全修复**：验证当前 run 身份与 authority 后，只授权精确绑定 envelope 的 non-action `fixed_failure`，删除 application 对该失败决策的无条件抑制。
+2. **受控恢复正常 v1**：增加 typed source outcome 和 lifecycle completeness 证明，仅 allowlist 明确的 symbol-scoped coverage failure，再允许 normal v1 degraded report。

--- a/docs/reviews/plan-review-20260730-121703.md
+++ b/docs/reviews/plan-review-20260730-121703.md
@@ -1,0 +1,135 @@
+# Plan Review — sy Daily Brief Fixed Failure Authority 修订方案
+
+- 审查时间：2026-07-30 12:17:03 +08:00
+- Reviewed target：`docs/plans/sy-daily-brief-fixed-failure-authority-fix-plan-20260730.md`
+- 对照审查：`docs/reviews/plan-review-20260730-115457.md`
+- 审查范围：目标收敛、身份 evidence、normal/failure authority、token schema compatibility、delivery state、锁顺序、实施切片、测试和 rollout 边界
+- 最终结论：`pass-with-risks`
+
+## Reviewed target and scope
+
+修订方案把本 work unit 的成功标准收敛为：
+
+```text
+缺少成功 PA summary
+  -> normal report 继续 blocked
+  -> 当前 run portfolio identity 可验证
+  -> authority 可解析
+  -> 只授权 plain-text、non-action fixed_failure
+```
+
+它不再承诺在缺少 PA source graph 时恢复正常 v1 report，也不尝试在 Daily Brief 内补算 lifecycle、candidate、cash capacity 或 share coverage。
+
+实施边界包含：
+
+- current-run portfolio identity 的窄只读 reader；
+- failure-only authority token v2；
+- normal/failure permission 分离；
+- domain 最终 action matrix；
+- persisted envelope kind/source/message 的 send-before validation；
+- v1 normal token 与旧 envelope exact-retry 兼容。
+
+## Assumptions tested
+
+1. portfolio receipt 只用于账户身份，不再被用作正常报告 completeness 证明；
+2. missing-summary 分支是否始终阻断 normal report；
+3. failure token 是否无法授权 `fixed_report` 或 `candidate_alert`；
+4. caller 自报 delivery kind 是否会被 persisted envelope 事实覆盖；
+5. token v2 是否需要迁移已有 v1 envelope/receipt；
+6. domain permission 是否 fail closed，是否仍存在 application 事后覆盖；
+7. pending、confirmed、ambiguous、definite failure 和 exact retry 是否有确定语义；
+8. reader、token、service、orchestration slices 的顺序是否可独立验收；
+9. guarded production tick 与未受保护并发入口的边界是否明确。
+
+## Review lenses
+
+### Architecture boundary review
+
+- identity reader 位于窄 application read facade，复用通用 receipt validator，不导入 publisher、不打开 ledger、不扫描历史 run；
+- PA advice authority 继续拥有 normal report availability；fixed-failure authority 不反向修改 advice mode 或 rows；
+- domain 只消费 generic reliability/permission booleans；receipt、token、envelope 和 provider 细节留在 application/repository；
+- token v2 与 public contract 文档位于 notification authority 所有者 slice，先于 Daily Brief integration。
+
+结论：依赖方向清晰，没有发现跨层平行推导或循环所有权。
+
+### Best-practice review
+
+- identity、report completeness、delivery permission 与 exact send identity 分别证明；
+- security permission 参数无 permissive default；
+- failure token purpose 进入 token hash，executor 在 provider call 前验证 persisted envelope kind；
+- invalid/stale/ambiguous identity 和 authority conflict 均保持 no-send；
+- fixed failure 沿用 scan-failure digest、plain text、空 candidate identities 与 send-time authority re-resolution。
+
+结论：满足 fail-closed、least privilege、immutable evidence、exact retry 和 per-account isolation 的本地约束。
+
+### Optimal-solution review
+
+修订方案选择“先恢复明确失败消息”，而不是同时实现 typed PA source outcome 和 normal v1 degraded allowlist。这是当前目标下风险最低、收益直接的路径。failure-only token v2 保持 normal token v1 不变，也避免为本次修复迁移所有正常通知 token。
+
+结论：未发现更小且同等安全的替代路径。
+
+### Overengineering review
+
+- 没有新增 PA 成功态、source outcome artifact、ledger classifier、通知渠道或通用 snapshot framework；
+- 新 token v2 只服务 fixed failure，不把 normal token 一并升级；
+- 新 reader 只有一个 current-run identity read surface；
+- deferred normal-v1 recovery 与 lifecycle completeness 被明确拆出。
+
+结论：新增契约均由本次最小权限要求直接驱动，没有无当前需求的抽象。
+
+### Overcoupling review
+
+- normal token 与 failure token 使用独立字段；
+- action-specific token selection 不依赖 renderer 文本解析；
+- envelope kind 从 repository 读取，不只信任 caller；
+- v1 compatibility 与 v2 failure path 可分别测试；
+- slices 按 reader -> token/repository -> service -> domain/orchestration -> recovery 排序。
+
+结论：没有发现必须跨多个 future work unit 同步演进的耦合。
+
+## Prior finding closure
+
+| 上一轮 finding | 修订结果 | 裁决 |
+|---|---|---|
+| PR-01 身份有效被等同为正常降级安全 | missing summary 永远 normal blocked；identity 只授权 fixed failure | 已关闭 |
+| PR-02 lifecycle human-review 静默丢失 | 不再生成正常降级报告，不声称 lifecycle completeness | 已关闭 |
+| PR-03 failure token 与一次发送契约未定义 | failure-only token v2、persisted kind validation、v1 exact retry、one-terminal-send 状态均明确 | 已关闭 |
+| PR-04 reader 放在 publisher 造成过度耦合 | 新建窄 identity reader，禁止 publisher/ledger/history 依赖 | 已关闭 |
+
+## Findings
+
+无未修复 material finding。
+
+## Open Questions
+
+无 implementation-blocking open question。
+
+产品层仍需接受计划已明确的成功语义：本 work unit 恢复的是“明确失败消息”，不是同轮正常策略报告。
+
+## Residual risks and suggested tracking
+
+1. **Unguarded concurrent tick**：production `tick-cron` 通过 per-market nonblocking file lock 串行；绕过 wrapper 的同账户/同市场并发 raw tick，仍可能触及现有 pending failure -> fixed report upgrade 与 provider in-flight 的原子性边界。按计划 §10.5 作为独立 delivery-state hardening work unit 跟踪，不扩展本次生产承诺。
+2. **Normal token v1**：现有 normal token v1 仍未 purpose-bind delivery kind；本方案不扩大其能力，只保证新 failure token 不能授权 normal message。若要统一 capability model，应另立 token-v2 migration work unit。
+3. **Stale/invalid identity**：current-run portfolio receipt 超时、重复或 integrity failure 时仍会 no-send。这是明确的 fail-closed 选择，需要通过 metrics/receipt evidence 运维诊断，不能用历史 identity 补发。
+4. **Upstream data quality**：`EMPTY_CHAIN` 仍可能导致本轮失败；本 work unit 只恢复 failure visibility，不修 provider coverage。
+5. **Runtime proof**：本次只审 plan。实现后仍需 focused tests、相关 tick regression 和 `--no-send` 双账户 dry-run；真实 provider send、release 和 upgrade 需要单独授权。
+
+建议跟踪位置：
+
+- 方案 §10 Deferred follow-up；
+- 后续实现 artifact 的 residual-risk 段；
+- 若正式支持 unguarded concurrent tick，新增独立 delivery state-machine plan。
+
+## Final conclusion
+
+`pass-with-risks`
+
+修订方案已达到 code-generation-ready：
+
+- root cause 修复不再放宽正常报告；
+- lifecycle completeness 风险不再被隐藏；
+- failure capability 被 token v2 和 persisted envelope kind 双重限制；
+- legacy normal delivery 与 exact retry 有明确兼容边界；
+- implementation slices、tests、rollout 和非目标足够具体。
+
+剩余风险均已明确限制在本 work unit 之外，不阻止按当前 guarded scheduled tick 范围进入实现。

--- a/domain/domain/daily_decision_brief.py
+++ b/domain/domain/daily_decision_brief.py
@@ -98,6 +98,8 @@ def decide_daily_brief_notification(
     *,
     ran_scan: bool,
     pipeline_reliable: bool,
+    normal_delivery_allowed: bool,
+    fixed_failure_delivery_allowed: bool,
     fixed_due: bool,
     pending_candidate_identities: list[str] | tuple[str, ...],
     retryable_envelope_kind: str | None = None,
@@ -110,13 +112,29 @@ def decide_daily_brief_notification(
             "action": "retry_exact" if retry_kind else "none",
             "reason": "retryable_envelope" if retry_kind else "no_scan_no_retry",
         }
-    if not pipeline_reliable:
-        return {
-            "action": "fixed_failure" if fixed_due else "none",
-            "reason": "fixed_scan_failed" if fixed_due else "nonfixed_scan_failed",
-        }
     if fixed_due:
-        return {"action": "fixed_report", "reason": "fixed_report_due"}
+        if pipeline_reliable and normal_delivery_allowed:
+            return {
+                "action": "fixed_report",
+                "reason": "fixed_report_due",
+            }
+        if fixed_failure_delivery_allowed:
+            return {
+                "action": "fixed_failure",
+                "reason": (
+                    "fixed_scan_failed"
+                    if not pipeline_reliable
+                    else "fixed_normal_authority_unavailable"
+                ),
+            }
+        return {
+            "action": "none",
+            "reason": "fixed_failure_authority_unavailable",
+        }
+    if not pipeline_reliable:
+        return {"action": "none", "reason": "nonfixed_scan_failed"}
+    if not normal_delivery_allowed:
+        return {"action": "none", "reason": "normal_authority_unavailable"}
     if pending_candidate_identities:
         return {"action": "candidate_alert", "reason": "pending_candidates"}
     return {"action": "none", "reason": "no_pending_candidates"}

--- a/src/application/daily_decision_brief_repository.py
+++ b/src/application/daily_decision_brief_repository.py
@@ -553,6 +553,38 @@ def record_daily_decision_brief_delivery_attempt(
         }
 
 
+def validate_daily_decision_brief_delivery_identity(
+    *,
+    base: Path,
+    account: str,
+    market: str,
+    market_trading_date: str,
+    delivery_key: str,
+    source_digest: str,
+    message_sha256: str,
+    transport_idempotency_key: str,
+) -> dict[str, Any]:
+    """Validate and return the exact persisted envelope without mutating it."""
+
+    with _locked_delivery_envelope(
+        base=base,
+        account=account,
+        market=market,
+        market_trading_date=market_trading_date,
+        delivery_key=delivery_key,
+        source_digest=source_digest,
+        message_sha256=message_sha256,
+        transport_idempotency_key=transport_idempotency_key,
+    ) as (_state, _day, envelope, delivery_path):
+        return {
+            "available": True,
+            "delivery_kind": str(envelope["delivery_kind"]),
+            "status": str(envelope["status"]),
+            "envelope": dict(envelope),
+            "path": delivery_path,
+        }
+
+
 def confirm_daily_decision_brief_delivery_v2(
     *,
     base: Path,
@@ -2486,4 +2518,5 @@ __all__ = [
     "read_latest_daily_decision_brief",
     "read_retryable_daily_decision_brief_delivery",
     "record_daily_decision_brief_candidates",
+    "validate_daily_decision_brief_delivery_identity",
 ]

--- a/src/application/daily_decision_brief_service.py
+++ b/src/application/daily_decision_brief_service.py
@@ -26,7 +26,6 @@ from domain.domain.engine import (
 )
 from domain.domain.risk_capacity import compute_sell_call_share_capacity, compute_sell_put_cash_capacity
 from domain.domain.cash_secured_utils import read_cash_secured_total_cny
-from domain.domain.position_advice_authority import scope_for
 from domain.domain.symbol_identity import canonical_symbol, symbol_market
 from domain.storage import paths
 from src.application import candidate_reject_summary as candidate_rejections
@@ -41,11 +40,16 @@ from src.application.config_loader import resolve_data_config_path
 from src.application.position_advice_reader import (
     read_position_advice_v2_from_ledger,
 )
-from src.application.position_advice_notification_authority import (
-    build_notification_authority_token,
+from src.application.position_advice_account_identity_reader import (
+    PositionAdviceAccountIdentityError,
+    read_current_run_portfolio_identity,
 )
-from src.infrastructure.position_advice_manifest_lock import (
-    position_advice_state_root,
+from src.application.position_advice_authority_service import (
+    read_authority_resolution,
+)
+from src.application.position_advice_notification_authority import (
+    build_fixed_failure_notification_authority_token,
+    build_notification_authority_token,
 )
 
 
@@ -125,6 +129,13 @@ def assemble_daily_decision_brief(
         account=account_norm,
         market=market_norm,
         config=config_map,
+        now_utc=effective_now,
+    )
+    current_run_identity = _daily_brief_current_run_identity(
+        state_dir=state_dir,
+        account_run_id=run_id_norm,
+        account=account_norm,
+        market=market_norm,
         now_utc=effective_now,
     )
     position_advice_rows: list[dict[str, Any]] = []
@@ -590,8 +601,10 @@ def assemble_daily_decision_brief(
             ),
             "notification_authority": _daily_brief_notification_authority(
                 advice_authority,
+                base=base_path,
                 account=account_norm,
                 account_run_id=run_id_norm,
+                current_run_identity=current_run_identity,
             ),
         }
     )
@@ -796,29 +809,13 @@ def _daily_brief_advice_authority(
     now_utc: datetime,
 ) -> dict[str, Any]:
     summary_path = state_dir / "position_advice_sources.v2.json"
-    scope_id = scope_for(account)
     if not summary_path.exists():
-        scope_dir = position_advice_state_root(base) / scope_id
-        historical = (
-            scope_dir.exists()
-            and scope_dir.is_dir()
-            and any(
-                item.name != ".current.lock" for item in scope_dir.iterdir()
-            )
-        )
-        if historical:
-            return {
-                "mode": "authority_conflict",
-                "available": False,
-                "blocker": "position_advice_identity_source_missing",
-                "rows": [],
-                "preview": {},
-            }
         return {
-            "mode": "v1",
-            "available": True,
-            "blocker": None,
+            "mode": "authority_conflict",
+            "available": False,
+            "blocker": "position_advice_source_summary_missing",
             "rows": [],
+            "human_review_rows": [],
             "preview": {},
         }
     try:
@@ -955,25 +952,29 @@ def _daily_brief_advice_authority(
 def _daily_brief_notification_authority(
     advice_authority: Mapping[str, Any],
     *,
+    base: Path,
     account: str,
     account_run_id: str,
+    current_run_identity: Mapping[str, Any],
 ) -> dict[str, Any]:
     selected = str(advice_authority.get("mode") or "").strip()
     available = bool(advice_authority.get("available"))
-    allowed = selected == "v1" or (selected == "v2" and available)
+    normal_allowed = selected == "v1" or (
+        selected == "v2" and available
+    )
     resolved_mode = str(
         advice_authority.get("resolved_mode") or selected
     ).strip()
-    token: dict[str, Any] | None = None
+    normal_token: dict[str, Any] | None = None
     source = str(
         advice_authority.get("normalized_portfolio_source") or ""
     ).strip()
     identity_hash = str(
         advice_authority.get("portfolio_account_identity_hash") or ""
     ).strip()
-    if allowed and source and len(identity_hash) == 64:
+    if normal_allowed and source and len(identity_hash) == 64:
         try:
-            token = build_notification_authority_token(
+            normal_token = build_notification_authority_token(
                 normalized_account=account,
                 normalized_portfolio_source=source,
                 portfolio_account_identity_hash=identity_hash,
@@ -988,9 +989,84 @@ def _daily_brief_notification_authority(
                 account_run_id=account_run_id,
             )
         except (TypeError, ValueError):
-            allowed = False
-    if allowed and token is None:
-        allowed = False
+            normal_allowed = False
+    if normal_allowed and normal_token is None:
+        normal_allowed = False
+
+    failure_token: dict[str, Any] | None = None
+    failure_allowed = False
+    failure_blocker = "position_advice_failure_identity_unavailable"
+    failure_source = source
+    failure_identity_hash = identity_hash
+    failure_identity_source = (
+        "successful_position_advice_summary"
+        if failure_source and len(failure_identity_hash) == 64
+        else None
+    )
+    if not failure_source or len(failure_identity_hash) != 64:
+        if current_run_identity.get("status") == "available":
+            failure_source = str(
+                current_run_identity.get(
+                    "normalized_portfolio_source"
+                )
+                or ""
+            ).strip()
+            failure_identity_hash = str(
+                current_run_identity.get(
+                    "portfolio_account_identity_hash"
+                )
+                or ""
+            ).strip()
+            failure_identity_source = "current_run_portfolio_receipt"
+        else:
+            failure_blocker = str(
+                current_run_identity.get("reason")
+                or failure_blocker
+            )
+    failure_resolution = None
+    if failure_source and len(failure_identity_hash) == 64:
+        try:
+            failure_resolution = read_authority_resolution(
+                base=base,
+                normalized_account=account,
+                normalized_portfolio_source=failure_source,
+                portfolio_account_identity_hash=failure_identity_hash,
+            )
+        except (OSError, TypeError, ValueError, RuntimeError):
+            failure_blocker = (
+                "position_advice_authority_resolution_failed"
+            )
+        else:
+            if failure_resolution.notifications_allowed:
+                failure_selected = (
+                    "v2" if failure_resolution.mode == "v2" else "v1"
+                )
+                try:
+                    failure_token = build_fixed_failure_notification_authority_token(
+                        normalized_account=account,
+                        normalized_portfolio_source=failure_source,
+                        portfolio_account_identity_hash=(
+                            failure_identity_hash
+                        ),
+                        selected_advice_contract=failure_selected,
+                        resolved_mode=str(failure_resolution.mode),
+                        authority_generation=(
+                            failure_resolution.generation
+                        ),
+                        authority_policy_hash=(
+                            failure_resolution.policy_hash
+                        ),
+                        account_run_id=account_run_id,
+                    )
+                except (TypeError, ValueError):
+                    failure_blocker = (
+                        "position_advice_failure_token_build_failed"
+                    )
+                else:
+                    failure_allowed = True
+                    failure_blocker = ""
+            else:
+                failure_blocker = "position_advice_authority_conflict"
     return {
         "selected_advice_contract": (
             selected if selected in {"v1", "v2"} else None
@@ -1002,16 +1078,109 @@ def _daily_brief_notification_authority(
         "authority_policy_hash": advice_authority.get(
             "authority_policy_hash"
         ),
-        "notification_allowed": allowed,
+        "normal_delivery_allowed": normal_allowed,
+        "fixed_failure_delivery_allowed": failure_allowed,
+        "notification_allowed": normal_allowed,
         "blocker": (
             None
-            if allowed
+            if normal_allowed
             else str(
                 advice_authority.get("blocker")
                 or "position_advice_notification_authority_unavailable"
             )
         ),
-        "token": token,
+        "fixed_failure_blocker": failure_blocker or None,
+        "normal_delivery_token": normal_token,
+        "fixed_failure_delivery_token": failure_token,
+        "token": normal_token,
+        "failure_authority_resolution_status": (
+            failure_resolution.resolution_status
+            if failure_resolution is not None
+            else None
+        ),
+        "failure_authority_resolved_mode": (
+            failure_resolution.mode
+            if failure_resolution is not None
+            else None
+        ),
+        "failure_authority_generation": (
+            failure_resolution.generation
+            if failure_resolution is not None
+            else None
+        ),
+        "failure_authority_policy_hash": (
+            failure_resolution.policy_hash
+            if failure_resolution is not None
+            else None
+        ),
+        "normalized_portfolio_source": (
+            failure_source or source or None
+        ),
+        "portfolio_account_identity_hash": (
+            failure_identity_hash
+            if len(failure_identity_hash) == 64
+            else None
+        ),
+        "authority_identity_source": failure_identity_source,
+        "identity_snapshot_id": current_run_identity.get("snapshot_id"),
+        "identity_receipt_hash": current_run_identity.get(
+            "receipt_hash"
+        ),
+        "identity_evidence": _identity_evidence_audit(
+            current_run_identity
+        ),
+    }
+
+
+def _daily_brief_current_run_identity(
+    *,
+    state_dir: Path,
+    account_run_id: str,
+    account: str,
+    market: str,
+    now_utc: datetime,
+) -> dict[str, Any]:
+    try:
+        return read_current_run_portfolio_identity(
+            account_state_dir=state_dir,
+            account_run_id=account_run_id,
+            expected_account=account,
+            expected_market=market,
+            now=now_utc,
+        )
+    except PositionAdviceAccountIdentityError as exc:
+        return {
+            "status": "unavailable",
+            "reason": exc.reason_code,
+        }
+    except (OSError, TypeError, ValueError, RuntimeError):
+        return {
+            "status": "unavailable",
+            "reason": "current_run_portfolio_receipt_invalid",
+        }
+
+
+def _identity_evidence_audit(
+    evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    allowed_fields = (
+        "status",
+        "reason",
+        "account",
+        "normalized_portfolio_source",
+        "portfolio_account_identity_hash",
+        "producer_account_run_id",
+        "included_markets",
+        "snapshot_id",
+        "receipt_hash",
+        "payload_sha256",
+        "source_observed_at",
+        "expires_at",
+    )
+    return {
+        field: evidence.get(field)
+        for field in allowed_fields
+        if evidence.get(field) is not None
     }
 
 

--- a/src/application/position_advice_account_identity_reader.py
+++ b/src/application/position_advice_account_identity_reader.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.position_advice_authority import (
+    normalize_account_label,
+    normalize_portfolio_source,
+    portfolio_account_identity_hash,
+)
+from src.application.position_advice_source_producers import (
+    PORTFOLIO_SOURCE_SCHEMA,
+)
+from src.application.position_advice_source_receipts import (
+    PositionAdviceSourceError,
+    safe_existing_relative_path,
+    sha256_bytes,
+    validate_source_receipt,
+)
+
+
+class PositionAdviceAccountIdentityError(RuntimeError):
+    """Raised when current-run portfolio identity cannot be proven."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def read_current_run_portfolio_identity(
+    *,
+    account_state_dir: Path,
+    account_run_id: str,
+    expected_account: str,
+    expected_market: str,
+    now: datetime,
+) -> dict[str, Any]:
+    """Read one immutable current-run portfolio receipt without history fallback."""
+
+    root = _existing_real_directory(
+        Path(account_state_dir),
+        reason_code="current_run_portfolio_receipt_missing",
+        label="account state directory",
+    )
+    run_id = _required_text(account_run_id, "account_run_id")
+    account = normalize_account_label(expected_account)
+    market = _market(expected_market)
+    run_key = canonical_sha256({"producer_run_id": run_id})
+    run_dir = (
+        root
+        / "position_advice_producers"
+        / "portfolio"
+        / run_key
+    )
+    receipt_path = _locate_unique_receipt(run_dir)
+
+    try:
+        receipt_path = safe_existing_relative_path(
+            root,
+            receipt_path.relative_to(root).as_posix(),
+        )
+        receipt_bytes = _stable_read(receipt_path, "portfolio receipt")
+        receipt = _json_object(receipt_bytes, "portfolio receipt")
+        validated = validate_source_receipt(
+            receipt,
+            producer_root=root,
+            now=now,
+            require_fresh=True,
+            expected_source_kind="portfolio",
+            expected_account=account,
+            expected_producer_account_run_id=run_id,
+        )
+    except PositionAdviceSourceError as exc:
+        reason = (
+            "current_run_portfolio_receipt_stale"
+            if "stale" in str(exc).lower()
+            else "current_run_portfolio_receipt_invalid"
+        )
+        raise PositionAdviceAccountIdentityError(reason, str(exc)) from exc
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            str(exc),
+        ) from exc
+
+    content_dir = receipt_path.parent
+    expected_run_dir = run_dir.resolve()
+    if (
+        content_dir.parent != expected_run_dir
+        or receipt_path.name != "receipt.json"
+        or receipt.get("producer_run_id") != run_id
+        or receipt.get("producer_schema_version") != PORTFOLIO_SOURCE_SCHEMA
+    ):
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "portfolio receipt does not belong to the expected account run",
+        )
+
+    payload_path = Path(validated["payload_path"])
+    expected_payload_path = content_dir / "payload.json"
+    expected_payload_relpath = expected_payload_path.relative_to(root).as_posix()
+    if (
+        payload_path != expected_payload_path
+        or receipt.get("payload_relpath") != expected_payload_relpath
+    ):
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "portfolio payload path does not match its receipt directory",
+        )
+
+    try:
+        payload_bytes = _stable_read(payload_path, "portfolio payload")
+        if sha256_bytes(payload_bytes) != validated["payload_sha256"]:
+            raise ValueError("portfolio payload hash changed after validation")
+        payload = _json_object(payload_bytes, "portfolio payload")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            str(exc),
+        ) from exc
+
+    if (
+        set(payload)
+        != {
+            "schema_version",
+            "normalized_portfolio_source",
+            "portfolio_context",
+        }
+        or payload.get("schema_version") != PORTFOLIO_SOURCE_SCHEMA
+        or content_dir.name != canonical_sha256(payload)
+    ):
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "portfolio payload schema or content directory hash is invalid",
+        )
+
+    context = payload.get("portfolio_context")
+    if not isinstance(context, dict):
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "portfolio context must be an object",
+        )
+    identifiers = context.get("source_account_identifiers")
+    if (
+        not isinstance(identifiers, list)
+        or not identifiers
+        or any(not isinstance(item, str) or not item.strip() for item in identifiers)
+    ):
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "portfolio source account identifiers are unavailable",
+        )
+    try:
+        portfolio_source = normalize_portfolio_source(
+            payload.get("normalized_portfolio_source")
+        )
+        computed_identity_hash = portfolio_account_identity_hash(
+            normalized_portfolio_source=portfolio_source,
+            broker_account_identifiers=identifiers,
+        )
+    except ValueError as exc:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            str(exc),
+        ) from exc
+
+    receipt_identity_hash = validated.get("portfolio_account_identity_hash")
+    if computed_identity_hash != receipt_identity_hash:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_identity_mismatch",
+            "portfolio payload identity does not match its receipt",
+        )
+    included_markets = sorted(
+        {str(item or "").strip().upper() for item in receipt.get("included_markets", [])}
+    )
+    if market not in included_markets:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "portfolio receipt does not include the expected market",
+        )
+
+    return {
+        "status": "available",
+        "account": account,
+        "normalized_portfolio_source": portfolio_source,
+        "portfolio_account_identity_hash": computed_identity_hash,
+        "producer_account_run_id": validated["producer_account_run_id"],
+        "included_markets": included_markets,
+        "snapshot_id": validated["snapshot_id"],
+        "receipt_hash": sha256_bytes(receipt_bytes),
+        "payload_sha256": validated["payload_sha256"],
+        "source_observed_at": validated["source_observed_at"],
+        "expires_at": validated["expires_at"],
+    }
+
+
+def _locate_unique_receipt(run_dir: Path) -> Path:
+    if not run_dir.exists():
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_missing",
+            "current-run portfolio receipt is missing",
+        )
+    if run_dir.is_symlink() or not run_dir.is_dir():
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "current-run portfolio directory is invalid",
+        )
+    try:
+        children = list(run_dir.iterdir())
+    except OSError as exc:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            str(exc),
+        ) from exc
+    if any(child.is_symlink() for child in children):
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            "current-run portfolio directory may not contain symlinks",
+        )
+    candidates = [
+        child / "receipt.json"
+        for child in children
+        if child.is_dir() and (child / "receipt.json").exists()
+    ]
+    if not candidates:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_missing",
+            "current-run portfolio receipt is missing",
+        )
+    if len(candidates) != 1:
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_ambiguous",
+            "multiple current-run portfolio receipts were found",
+        )
+    return candidates[0]
+
+
+def _existing_real_directory(
+    path: Path,
+    *,
+    reason_code: str,
+    label: str,
+) -> Path:
+    if not path.exists():
+        raise PositionAdviceAccountIdentityError(reason_code, f"{label} is missing")
+    if path.is_symlink() or not path.is_dir():
+        raise PositionAdviceAccountIdentityError(
+            "current_run_portfolio_receipt_invalid",
+            f"{label} is invalid",
+        )
+    return path.resolve()
+
+
+def _stable_read(path: Path, label: str) -> bytes:
+    first = path.read_bytes()
+    second = path.read_bytes()
+    if first != second:
+        raise ValueError(f"{label} changed while it was being read")
+    return first
+
+
+def _json_object(payload: bytes, label: str) -> dict[str, Any]:
+    value = json.loads(payload.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _required_text(value: Any, field: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field} is required")
+    return text
+
+
+def _market(value: Any) -> str:
+    market = str(value or "").strip().upper()
+    if market not in {"US", "HK"}:
+        raise ValueError(f"unsupported market: {value}")
+    return market
+
+
+__all__ = [
+    "PositionAdviceAccountIdentityError",
+    "read_current_run_portfolio_identity",
+]

--- a/src/application/position_advice_notification_authority.py
+++ b/src/application/position_advice_notification_authority.py
@@ -24,6 +24,9 @@ from src.infrastructure.position_advice_manifest_lock import (
 NOTIFICATION_AUTHORITY_TOKEN_SCHEMA = (
     "position_advice_notification_authority_token.v1"
 )
+NOTIFICATION_AUTHORITY_FAILURE_TOKEN_SCHEMA_V2 = (
+    "position_advice_notification_authority_token.v2"
+)
 NOTIFICATION_AUTHORITY_RECEIPT_SCHEMA = (
     "position_advice_notification_authority_receipt.v1"
 )
@@ -87,6 +90,39 @@ def build_notification_authority_token(
         or not payload["account_run_id"]
     ):
         raise ValueError("notification authority identity is incomplete")
+    return {**payload, "token_hash": canonical_sha256(payload)}
+
+
+def build_fixed_failure_notification_authority_token(
+    *,
+    normalized_account: str,
+    normalized_portfolio_source: str,
+    portfolio_account_identity_hash: str,
+    selected_advice_contract: str,
+    resolved_mode: str,
+    authority_generation: int | None,
+    authority_policy_hash: str | None,
+    account_run_id: str,
+) -> dict[str, Any]:
+    """Build a purpose-bound token that can authorize only fixed failure."""
+
+    normal_token = build_notification_authority_token(
+        normalized_account=normalized_account,
+        normalized_portfolio_source=normalized_portfolio_source,
+        portfolio_account_identity_hash=portfolio_account_identity_hash,
+        selected_advice_contract=selected_advice_contract,
+        resolved_mode=resolved_mode,
+        authority_generation=authority_generation,
+        authority_policy_hash=authority_policy_hash,
+        account_run_id=account_run_id,
+    )
+    payload = {
+        key: value
+        for key, value in normal_token.items()
+        if key != "token_hash"
+    }
+    payload["schema_version"] = NOTIFICATION_AUTHORITY_FAILURE_TOKEN_SCHEMA_V2
+    payload["authorized_delivery_kinds"] = ["fixed_failure"]
     return {**payload, "token_hash": canonical_sha256(payload)}
 
 
@@ -178,6 +214,111 @@ def execute_notification_with_authority(
                     error_code="AUTHORITY_NOTIFICATION_INFLIGHT",
                 )
 
+            if (
+                item["schema_version"]
+                == NOTIFICATION_AUTHORITY_FAILURE_TOKEN_SCHEMA_V2
+            ):
+                requested_kind = (
+                    str(
+                        (delivery_identity_value or {}).get(
+                            "delivery_kind"
+                        )
+                        or ""
+                    )
+                    .strip()
+                    .lower()
+                )
+                if requested_kind not in item["authorized_delivery_kinds"]:
+                    return _delivery_kind_denied_result(
+                        account=str(item["normalized_account"])
+                    )
+                try:
+                    from src.application.daily_decision_brief_repository import (
+                        DailyDecisionBriefStateError,
+                        validate_daily_decision_brief_delivery_identity,
+                    )
+
+                    persisted_delivery = (
+                        validate_daily_decision_brief_delivery_identity(
+                            base=base,
+                            account=str(
+                                delivery_identity_value["account"]
+                            ),
+                            market=str(
+                                delivery_identity_value["market"]
+                            ),
+                            market_trading_date=str(
+                                delivery_identity_value[
+                                    "market_trading_date"
+                                ]
+                            ),
+                            delivery_key=str(
+                                delivery_identity_value["delivery_key"]
+                            ),
+                            source_digest=str(
+                                delivery_identity_value["source_digest"]
+                            ),
+                            message_sha256=str(
+                                delivery_identity_value["message_sha256"]
+                            ),
+                            transport_idempotency_key=str(
+                                delivery_identity_value[
+                                    "transport_idempotency_key"
+                                ]
+                            ),
+                        )
+                    )
+                except (
+                    DailyDecisionBriefStateError,
+                    OSError,
+                    TypeError,
+                    ValueError,
+                ):
+                    return _delivery_kind_denied_result(
+                        account=str(item["normalized_account"])
+                    )
+                if (
+                    persisted_delivery.get("delivery_kind")
+                    != requested_kind
+                    or persisted_delivery.get("status") != "pending"
+                ):
+                    return _delivery_kind_denied_result(
+                        account=str(item["normalized_account"])
+                    )
+                persisted_envelope = persisted_delivery.get("envelope")
+                persisted_render_context = (
+                    persisted_envelope.get("render_context")
+                    if isinstance(persisted_envelope, Mapping)
+                    else None
+                )
+                persisted_token = (
+                    persisted_render_context.get(
+                        "notification_authority_token"
+                    )
+                    if isinstance(persisted_render_context, Mapping)
+                    else None
+                )
+                if not isinstance(persisted_token, Mapping):
+                    return _delivery_kind_denied_result(
+                        account=str(item["normalized_account"])
+                    )
+                try:
+                    persisted_token_item = _validate_token(persisted_token)
+                except PositionAdviceNotificationAuthorityError:
+                    return _delivery_kind_denied_result(
+                        account=str(item["normalized_account"])
+                    )
+                if persisted_token_item != item:
+                    return _delivery_kind_denied_result(
+                        account=str(item["normalized_account"])
+                    )
+                delivery_identity_value = {
+                    **delivery_identity_value,
+                    "delivery_kind": str(
+                        persisted_delivery["delivery_kind"]
+                    ),
+                }
+
             attempt_number = _next_attempt_number(
                 state_dir,
                 notification_key,
@@ -263,6 +404,77 @@ def execute_notification_with_authority(
                 **result,
                 "authority_receipt_id": receipt_id,
                 "authority_receipt_status": terminal_status,
+            }
+
+
+def read_notification_authority_delivery_state(
+    *,
+    base: Path,
+    token: Mapping[str, Any],
+    channel: str,
+    timeout_seconds: float = 5.0,
+) -> dict[str, Any]:
+    """Read whether one token has delivered or unresolved provider evidence."""
+
+    item = _validate_token(token)
+    scope_id = str(item["portfolio_scope_id"])
+    channel_value = str(channel or "").strip().lower()
+    if not channel_value:
+        raise ValueError("notification channel is required")
+    notification_key = canonical_sha256(
+        {
+            "portfolio_scope_id": scope_id,
+            "authority_generation": int(item["authority_generation"]),
+            "account_run_id": item["account_run_id"],
+            "channel": channel_value,
+        }
+    )
+    state_dir = (
+        portfolio_scope_state_dir(base, scope_id)
+        / "notification_authority"
+    )
+    with position_advice_manifest_locks(
+        base=base,
+        portfolio_scope_id=scope_id,
+        global_mode="shared",
+        scope_mode="shared",
+        timeout_seconds=timeout_seconds,
+    ):
+        with manifest_file_lock(
+            state_dir / ".send.lock",
+            mode="exclusive",
+            timeout_seconds=timeout_seconds,
+        ):
+            existing = _existing_terminal(state_dir, notification_key)
+            if existing is not None:
+                status, receipt = existing
+                return {
+                    "status": status,
+                    "notification_key": notification_key,
+                    "receipt_id": receipt.get("receipt_id"),
+                    "safe_to_replace_pending": False,
+                }
+            inflight_state = _inflight_state_for_dedupe(
+                state_dir,
+                notification_key,
+            )
+            if inflight_state is not None:
+                inflight_status, receipt = inflight_state
+                return {
+                    "status": (
+                        "accepted"
+                        if inflight_status == "delivered"
+                        else "inflight"
+                    ),
+                    "notification_key": notification_key,
+                    "receipt_id": receipt.get("receipt_id"),
+                    "safe_to_replace_pending": False,
+                }
+            return {
+                "status": "clear",
+                "notification_key": notification_key,
+                "receipt_id": None,
+                "safe_to_replace_pending": True,
             }
 
 
@@ -434,9 +646,36 @@ def unresolved_notification_authority_exists(
 def _validate_token(token: Mapping[str, Any]) -> dict[str, Any]:
     item = dict(token or {})
     actual = item.pop("token_hash", None)
-    if item.get("schema_version") != NOTIFICATION_AUTHORITY_TOKEN_SCHEMA:
+    schema = item.get("schema_version")
+    common_fields = {
+        "schema_version",
+        "normalized_account",
+        "portfolio_scope_id",
+        "normalized_portfolio_source",
+        "portfolio_account_identity_hash",
+        "selected_advice_contract",
+        "resolved_mode",
+        "authority_generation",
+        "authority_policy_hash",
+        "account_run_id",
+    }
+    expected_fields = (
+        common_fields
+        if schema == NOTIFICATION_AUTHORITY_TOKEN_SCHEMA
+        else common_fields | {"authorized_delivery_kinds"}
+        if schema == NOTIFICATION_AUTHORITY_FAILURE_TOKEN_SCHEMA_V2
+        else set()
+    )
+    if not expected_fields or set(item) != expected_fields:
         raise PositionAdviceNotificationAuthorityError(
             "notification authority token schema is invalid"
+        )
+    if (
+        schema == NOTIFICATION_AUTHORITY_FAILURE_TOKEN_SCHEMA_V2
+        and item.get("authorized_delivery_kinds") != ["fixed_failure"]
+    ):
+        raise PositionAdviceNotificationAuthorityError(
+            "notification authority token delivery purpose is invalid"
         )
     if actual != canonical_sha256(item):
         raise PositionAdviceNotificationAuthorityError(
@@ -658,6 +897,22 @@ def _blocked_result(
     }
 
 
+def _delivery_kind_denied_result(*, account: str) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "account": account,
+        "command_ok": False,
+        "delivery_confirmed": False,
+        "error_code": "AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED",
+        "attempts": 0,
+        "retry_attempt_count": 0,
+        "ambiguous_send": False,
+        "duplicate_risk": False,
+        "authority_receipt_id": None,
+        "authority_receipt_status": "denied",
+    }
+
+
 def _validate_delivery_identity(
     raw: Mapping[str, Any] | None,
     *,
@@ -692,7 +947,7 @@ def _validate_delivery_identity(
         value = str(item[field]).strip()
         if len(value) != 64:
             raise ValueError(f"daily brief delivery identity {field} is invalid")
-    return {
+    normalized = {
         "account": account,
         "market": str(item["market"]).strip().upper(),
         "market_trading_date": str(
@@ -703,6 +958,18 @@ def _validate_delivery_identity(
         "message_sha256": str(item["message_sha256"]).strip(),
         "transport_idempotency_key": transport_key,
     }
+    if "delivery_kind" in item:
+        delivery_kind = str(item.get("delivery_kind") or "").strip().lower()
+        if delivery_kind not in {
+            "fixed_report",
+            "fixed_failure",
+            "candidate_alert",
+        }:
+            raise ValueError(
+                "daily brief delivery identity delivery kind is invalid"
+            )
+        normalized["delivery_kind"] = delivery_kind
+    return normalized
 
 
 def _resolution_source_receipt(
@@ -895,12 +1162,15 @@ def _parse_timestamp(value: datetime | str) -> datetime:
 
 
 __all__ = [
+    "NOTIFICATION_AUTHORITY_FAILURE_TOKEN_SCHEMA_V2",
     "NOTIFICATION_AUTHORITY_RECEIPT_SCHEMA",
     "NOTIFICATION_AUTHORITY_RESOLUTION_SCHEMA",
     "NOTIFICATION_AUTHORITY_TOKEN_SCHEMA",
     "PositionAdviceNotificationAuthorityError",
+    "build_fixed_failure_notification_authority_token",
     "build_notification_authority_token",
     "execute_notification_with_authority",
+    "read_notification_authority_delivery_state",
     "resolve_notification_unknown",
     "unresolved_notification_authority_exists",
 ]

--- a/src/application/tick_notification_flow.py
+++ b/src/application/tick_notification_flow.py
@@ -47,6 +47,7 @@ from src.application.notification_delivery_adapter import (
 )
 from src.application.position_advice_notification_authority import (
     execute_notification_with_authority,
+    read_notification_authority_delivery_state,
 )
 from src.application.scheduled_notification import (
     PreparedPerAccountMessages,
@@ -428,6 +429,7 @@ def run_tick_notification_flow(request: TickNotificationRequest) -> int:
                     "delivery_key": delivery_key,
                     "source_digest": envelope.get("source_digest"),
                     "message_sha256": envelope.get("message_sha256"),
+                    "delivery_kind": envelope.get("delivery_kind"),
                     "transport_idempotency_key": (
                         build_notification_transport_key(delivery_key)
                     ),
@@ -774,7 +776,7 @@ def _prepare_daily_brief_notification(
                     if request.trigger_kind == "scheduled"
                     else ""
                 )
-                reliable = bool(
+                pipeline_reliable = bool(
                     account in ran_pipeline_accounts
                     and brief.get("status") in {"ready", "degraded"}
                     and brief.get("actionability") != "blocked"
@@ -786,17 +788,29 @@ def _prepare_daily_brief_notification(
                     )
                     else {}
                 )
-                authority_allows_notification = (
-                    notification_authority.get("notification_allowed")
-                    is not False
+                normal_delivery_allowed = bool(
+                    notification_authority.get(
+                        "normal_delivery_allowed",
+                        notification_authority.get(
+                            "notification_allowed"
+                        )
+                        is not False,
+                    )
                 )
-                if not authority_allows_notification:
-                    reliable = False
+                fixed_failure_delivery_allowed = (
+                    notification_authority.get(
+                        "fixed_failure_delivery_allowed"
+                    )
+                    is True
+                )
+                normal_report_reliable = (
+                    pipeline_reliable and normal_delivery_allowed
+                )
                 pending: list[str] = []
                 persisted: dict[str, Any] | None = None
                 diff: dict[str, Any] = {}
                 failure_source: tuple[str, str] | None = None
-                if reliable:
+                if normal_report_reliable:
                     persisted = persist_daily_decision_brief_success(base=request.base, brief=brief)
                     previous = persisted.get("previous_successful_brief")
                     if isinstance(previous, dict) and previous.get("market_trading_date") == persisted["brief"]["market_trading_date"]:
@@ -824,21 +838,19 @@ def _prepare_daily_brief_notification(
                 decision = (
                     decide_daily_brief_notification(
                         ran_scan=True,
-                        pipeline_reliable=reliable,
+                        pipeline_reliable=pipeline_reliable,
+                        normal_delivery_allowed=(
+                            normal_delivery_allowed
+                        ),
+                        fixed_failure_delivery_allowed=(
+                            fixed_failure_delivery_allowed
+                        ),
                         fixed_due=bool(fixed_target),
                         pending_candidate_identities=pending,
                     )
                     if scheduled_trigger
                     else {"action": "none", "reason": "non_scheduled_snapshot_only"}
                 )
-                if not authority_allows_notification:
-                    decision = {
-                        "action": "none",
-                        "reason": str(
-                            notification_authority.get("blocker")
-                            or "position_advice_notification_authority_unavailable"
-                        ),
-                    }
                 action = str(decision["action"])
                 existing_retry = None
                 if scheduled_trigger and not multi_market:
@@ -848,13 +860,49 @@ def _prepare_daily_brief_notification(
                         market=market,
                         market_trading_date=str(brief["market_trading_date"]),
                     )
+                existing_envelope = (
+                    existing_retry.get("envelope")
+                    if isinstance(existing_retry, dict)
+                    else None
+                )
+                pending_failure_upgrade = (
+                    _pending_fixed_failure_upgrade_decision(
+                        request=request,
+                        action=action,
+                        envelope=existing_envelope,
+                    )
+                )
                 should_prepare = not (
                     isinstance(existing_retry, dict)
-                    and isinstance(existing_retry.get("envelope"), dict)
+                    and isinstance(existing_envelope, dict)
+                ) or pending_failure_upgrade["allowed"]
+                authority_token = (
+                    notification_authority.get(
+                        "fixed_failure_delivery_token"
+                    )
+                    if action == "fixed_failure"
+                    else notification_authority.get(
+                        "normal_delivery_token",
+                        notification_authority.get("token"),
+                    )
                 )
+                if (
+                    should_prepare
+                    and action
+                    in {
+                        "fixed_report",
+                        "candidate_alert",
+                        "fixed_failure",
+                    }
+                    and not isinstance(authority_token, Mapping)
+                ):
+                    decision = {
+                        "action": "none",
+                        "reason": "daily_brief_authority_token_missing",
+                    }
+                    action = "none"
                 if not multi_market and not request.no_send and should_prepare and action in {"fixed_report", "candidate_alert", "fixed_failure"}:
                     render_context = _daily_brief_render_context(request, scheduler_decision=scheduler)
-                    authority_token = notification_authority.get("token")
                     if isinstance(authority_token, Mapping):
                         render_context["notification_authority_token"] = dict(
                             authority_token
@@ -965,12 +1013,99 @@ def _prepare_daily_brief_notification(
                         "market": market,
                         "market_trading_date": str(brief["market_trading_date"]),
                         "brief_id": (persisted or {}).get("brief", brief).get("brief_id"),
-                        "pipeline_reliable": reliable,
+                        "pipeline_reliable": pipeline_reliable,
+                        "normal_report_reliable": normal_report_reliable,
+                        "normal_delivery_allowed": normal_delivery_allowed,
+                        "fixed_failure_delivery_allowed": (
+                            fixed_failure_delivery_allowed
+                        ),
+                        "authority_source": (
+                            notification_authority.get(
+                                "normalized_portfolio_source"
+                            )
+                            or (
+                                notification_authority.get(
+                                    "identity_evidence"
+                                )
+                                or {}
+                            ).get("normalized_portfolio_source")
+                        ),
+                        "authority_identity_source": (
+                            notification_authority.get(
+                                "authority_identity_source"
+                            )
+                        ),
+                        "authority_resolution_status": (
+                            notification_authority.get(
+                                "failure_authority_resolution_status"
+                            )
+                        ),
+                        "authority_resolved_mode": (
+                            notification_authority.get(
+                                "failure_authority_resolved_mode"
+                            )
+                            or notification_authority.get("resolved_mode")
+                        ),
+                        "authority_generation": (
+                            notification_authority.get(
+                                "failure_authority_generation"
+                            )
+                            if action == "fixed_failure"
+                            else notification_authority.get(
+                                "authority_generation"
+                            )
+                        ),
+                        "authority_policy_hash": (
+                            notification_authority.get(
+                                "failure_authority_policy_hash"
+                            )
+                            if action == "fixed_failure"
+                            else notification_authority.get(
+                                "authority_policy_hash"
+                            )
+                        ),
+                        "portfolio_account_identity_hash": (
+                            notification_authority.get(
+                                "portfolio_account_identity_hash"
+                            )
+                            or (
+                                notification_authority.get(
+                                    "identity_evidence"
+                                )
+                                or {}
+                            ).get(
+                                "portfolio_account_identity_hash"
+                            )
+                        ),
+                        "identity_snapshot_id": (
+                            notification_authority.get(
+                                "identity_snapshot_id"
+                            )
+                        ),
+                        "identity_receipt_hash": (
+                            notification_authority.get(
+                                "identity_receipt_hash"
+                            )
+                        ),
                         "decision": action,
                         "decision_reason": decision["reason"],
                         "fixed_target": fixed_target or None,
                         "pending_candidate_count": len(pending),
+                        "pending_failure_upgrade_status": (
+                            pending_failure_upgrade["status"]
+                        ),
+                        "pending_failure_upgrade_applied": bool(
+                            pending_failure_upgrade["allowed"]
+                            and isinstance(selected_envelope, dict)
+                            and selected_envelope.get("delivery_kind")
+                            == "fixed_report"
+                        ),
                         "retry_reason": retry.get("reason") if isinstance(retry, dict) else None,
+                        "selected_delivery_kind": (
+                            selected_envelope.get("delivery_kind")
+                            if isinstance(selected_envelope, dict)
+                            else None
+                        ),
                         "delivery_key": selected_envelope.get("delivery_key") if isinstance(selected_envelope, dict) else None,
                         "message_sha256": selected_envelope.get("message_sha256") if isinstance(selected_envelope, dict) else None,
                         "rendered_transport_sha256": (
@@ -1064,6 +1199,51 @@ def _write_daily_brief_failure_artifact(
     )
     relative = path.resolve().relative_to(request.base.resolve()).as_posix()
     return relative, hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _pending_fixed_failure_upgrade_decision(
+    *,
+    request: TickNotificationRequest,
+    action: str,
+    envelope: Any,
+) -> dict[str, Any]:
+    if (
+        action != "fixed_report"
+        or not isinstance(envelope, Mapping)
+        or envelope.get("delivery_kind") != "fixed_failure"
+        or envelope.get("status") != "pending"
+    ):
+        return {"allowed": False, "status": "not_applicable"}
+    render_context = envelope.get("render_context")
+    token = (
+        render_context.get("notification_authority_token")
+        if isinstance(render_context, Mapping)
+        else None
+    )
+    if not isinstance(token, Mapping):
+        return {"allowed": False, "status": "token_missing"}
+    route_hint = _notification_perception_route_hint(request.base_cfg)
+    channel = str(
+        route_hint.get("channel")
+        or route_hint.get("provider")
+        or ""
+    ).strip()
+    if not channel:
+        return {"allowed": False, "status": "channel_unavailable"}
+    try:
+        authority_state = read_notification_authority_delivery_state(
+            base=request.base,
+            token=token,
+            channel=channel,
+        )
+    except (OSError, RuntimeError, TimeoutError, TypeError, ValueError):
+        return {"allowed": False, "status": "authority_state_unavailable"}
+    return {
+        "allowed": (
+            authority_state.get("safe_to_replace_pending") is True
+        ),
+        "status": str(authority_state.get("status") or "unknown"),
+    }
 
 
 def _daily_brief_envelope_audit(account: str, market: str, envelope: dict[str, Any], *, retry: bool) -> dict[str, Any]:

--- a/tests/test_daily_decision_brief_domain.py
+++ b/tests/test_daily_decision_brief_domain.py
@@ -585,13 +585,16 @@ def test_daily_brief_notification_decision_matrix() -> None:
     from domain.domain.daily_decision_brief import decide_daily_brief_notification
 
     cases = [
-        ({"ran_scan": False, "pipeline_reliable": False, "fixed_due": False, "pending_candidate_identities": [], "retryable_envelope_kind": "fixed_report"}, "retry_exact"),
-        ({"ran_scan": False, "pipeline_reliable": False, "fixed_due": False, "pending_candidate_identities": []}, "none"),
-        ({"ran_scan": True, "pipeline_reliable": False, "fixed_due": True, "pending_candidate_identities": []}, "fixed_failure"),
-        ({"ran_scan": True, "pipeline_reliable": False, "fixed_due": False, "pending_candidate_identities": ["candidate:v1:lx:US:NVDA:sell_put"]}, "none"),
-        ({"ran_scan": True, "pipeline_reliable": True, "fixed_due": True, "pending_candidate_identities": ["candidate:v1:lx:US:NVDA:sell_put"]}, "fixed_report"),
-        ({"ran_scan": True, "pipeline_reliable": True, "fixed_due": False, "pending_candidate_identities": ["candidate:v1:lx:US:NVDA:sell_put"]}, "candidate_alert"),
-        ({"ran_scan": True, "pipeline_reliable": True, "fixed_due": False, "pending_candidate_identities": []}, "none"),
+        ({"ran_scan": False, "pipeline_reliable": False, "normal_delivery_allowed": False, "fixed_failure_delivery_allowed": False, "fixed_due": False, "pending_candidate_identities": [], "retryable_envelope_kind": "fixed_report"}, "retry_exact"),
+        ({"ran_scan": False, "pipeline_reliable": False, "normal_delivery_allowed": False, "fixed_failure_delivery_allowed": False, "fixed_due": False, "pending_candidate_identities": []}, "none"),
+        ({"ran_scan": True, "pipeline_reliable": False, "normal_delivery_allowed": False, "fixed_failure_delivery_allowed": True, "fixed_due": True, "pending_candidate_identities": []}, "fixed_failure"),
+        ({"ran_scan": True, "pipeline_reliable": False, "normal_delivery_allowed": True, "fixed_failure_delivery_allowed": True, "fixed_due": False, "pending_candidate_identities": ["candidate:v1:lx:US:NVDA:sell_put"]}, "none"),
+        ({"ran_scan": True, "pipeline_reliable": True, "normal_delivery_allowed": True, "fixed_failure_delivery_allowed": True, "fixed_due": True, "pending_candidate_identities": ["candidate:v1:lx:US:NVDA:sell_put"]}, "fixed_report"),
+        ({"ran_scan": True, "pipeline_reliable": True, "normal_delivery_allowed": True, "fixed_failure_delivery_allowed": True, "fixed_due": False, "pending_candidate_identities": ["candidate:v1:lx:US:NVDA:sell_put"]}, "candidate_alert"),
+        ({"ran_scan": True, "pipeline_reliable": True, "normal_delivery_allowed": True, "fixed_failure_delivery_allowed": True, "fixed_due": False, "pending_candidate_identities": []}, "none"),
+        ({"ran_scan": True, "pipeline_reliable": True, "normal_delivery_allowed": False, "fixed_failure_delivery_allowed": True, "fixed_due": True, "pending_candidate_identities": []}, "fixed_failure"),
+        ({"ran_scan": True, "pipeline_reliable": True, "normal_delivery_allowed": False, "fixed_failure_delivery_allowed": False, "fixed_due": True, "pending_candidate_identities": []}, "none"),
+        ({"ran_scan": True, "pipeline_reliable": True, "normal_delivery_allowed": False, "fixed_failure_delivery_allowed": True, "fixed_due": False, "pending_candidate_identities": ["candidate:v1:lx:US:NVDA:sell_put"]}, "none"),
     ]
 
     for inputs, expected in cases:

--- a/tests/test_daily_decision_brief_notification_flow.py
+++ b/tests/test_daily_decision_brief_notification_flow.py
@@ -14,6 +14,7 @@ from src.application.position_advice_authority_service import (
     read_authority_resolution,
 )
 from src.application.position_advice_notification_authority import (
+    build_fixed_failure_notification_authority_token,
     build_notification_authority_token,
 )
 
@@ -166,6 +167,16 @@ def _brief(
         authority_policy_hash=resolution.policy_hash,
         account_run_id=run_id,
     )
+    failure_token = build_fixed_failure_notification_authority_token(
+        normalized_account=account,
+        normalized_portfolio_source="futu",
+        portfolio_account_identity_hash=_portfolio_identity_hash(account),
+        selected_advice_contract="v1",
+        resolved_mode="v1",
+        authority_generation=resolution.generation,
+        authority_policy_hash=resolution.policy_hash,
+        account_run_id=run_id,
+    )
     return {
         "market": market,
         "market_trading_date": MARKET_DATE,
@@ -197,9 +208,26 @@ def _brief(
             "resolved_mode": "v1",
             "authority_generation": resolution.generation,
             "authority_policy_hash": resolution.policy_hash,
+            "normal_delivery_allowed": True,
+            "fixed_failure_delivery_allowed": True,
             "notification_allowed": True,
             "blocker": None,
+            "normal_delivery_token": notification_token,
+            "fixed_failure_delivery_token": failure_token,
             "token": notification_token,
+            "failure_authority_resolution_status": (
+                resolution.resolution_status
+            ),
+            "failure_authority_resolved_mode": resolution.mode,
+            "failure_authority_generation": resolution.generation,
+            "failure_authority_policy_hash": resolution.policy_hash,
+            "identity_evidence": {
+                "status": "available",
+                "normalized_portfolio_source": "futu",
+                "portfolio_account_identity_hash": (
+                    _portfolio_identity_hash(account)
+                ),
+            },
         },
     }
 
@@ -565,6 +593,315 @@ def test_pipeline_failure_fixed_sends_explicit_failure_without_advancing_current
     assert envelope["delivery_kind"] == "fixed_failure"
     assert "数据异常" in envelope["rendered_message"]
     assert read_latest_daily_decision_brief(base=tmp_path, account="lx", market="US")["available"] is False
+
+
+def test_pending_fixed_failure_without_provider_attempt_upgrades_to_fixed_report(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.tick_notification_flow as mod
+
+    _patch_assembler(monkeypatch, blocked=True)
+    failed = _request(
+        tmp_path,
+        run_id="failed-before-provider",
+        pipeline_ok=False,
+    )
+    failed_prep = mod._prepare_daily_brief_notification(failed.request)
+    failed_envelope = failed_prep.lifecycles_by_account["lx"]["envelope"]
+    assert failed_envelope["delivery_kind"] == "fixed_failure"
+
+    _patch_assembler(monkeypatch)
+    recovered = _request(tmp_path, run_id="recovered-before-provider")
+    recovered_prep = mod._prepare_daily_brief_notification(
+        recovered.request
+    )
+    recovered_envelope = recovered_prep.lifecycles_by_account["lx"][
+        "envelope"
+    ]
+    audit = recovered.request.tick_metrics["daily_brief"]["prepared"][0]
+
+    assert recovered_envelope["delivery_kind"] == "fixed_report"
+    assert recovered_envelope["render_context"][
+        "notification_authority_token"
+    ]["account_run_id"] == "recovered-before-provider"
+    assert audit["pending_failure_upgrade_status"] == "clear"
+    assert audit["pending_failure_upgrade_applied"] is True
+    assert audit["selected_delivery_kind"] == "fixed_report"
+
+
+def test_pending_fixed_failure_after_definite_failure_upgrades_to_fixed_report(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.tick_notification_flow as mod
+    from src.application.daily_decision_brief_repository import (
+        read_daily_decision_brief_delivery_state,
+    )
+
+    _patch_assembler(monkeypatch, blocked=True)
+    failed_calls: list[dict] = []
+    _patch_sender(
+        monkeypatch,
+        calls=failed_calls,
+        result={
+            "ok": False,
+            "command_ok": False,
+            "delivery_confirmed": False,
+            "returncode": 1,
+            "error_code": "SEND_FAILED",
+        },
+    )
+    failed = _request(
+        tmp_path,
+        run_id="failed-provider-attempt",
+        pipeline_ok=False,
+    )
+    assert mod.run_tick_notification_flow(failed.request) == 1
+
+    _patch_assembler(monkeypatch)
+    recovered_calls: list[dict] = []
+    _patch_sender(monkeypatch, calls=recovered_calls)
+    recovered = _request(tmp_path, run_id="recovered-provider-attempt")
+    assert mod.run_tick_notification_flow(recovered.request) == 0
+
+    state = read_daily_decision_brief_delivery_state(
+        base=tmp_path,
+        account="lx",
+        market="US",
+    )["state"]
+    envelope = state["days"][MARKET_DATE]["fixed_reports"][FIXED_TARGET]
+    audit = recovered.request.tick_metrics["daily_brief"]["prepared"][0]
+    assert envelope["delivery_kind"] == "fixed_report"
+    assert envelope["status"] == "confirmed"
+    assert len(failed_calls) >= 1
+    assert all("数据异常" in call["message"] for call in failed_calls)
+    assert len(recovered_calls) == 1
+    assert "数据异常" not in recovered_calls[0]["message"]
+    assert audit["pending_failure_upgrade_status"] == "clear"
+    assert audit["pending_failure_upgrade_applied"] is True
+
+
+def test_provider_accepted_unconfirmed_failure_is_not_upgraded(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.tick_notification_flow as mod
+    from src.application.notification_delivery_adapter import (
+        build_notification_transport_key,
+    )
+    from src.application.position_advice_notification_authority import (
+        execute_notification_with_authority,
+    )
+
+    _patch_assembler(monkeypatch, blocked=True)
+    failed = _request(
+        tmp_path,
+        run_id="accepted-before-confirm",
+        pipeline_ok=False,
+    )
+    failed_prep = mod._prepare_daily_brief_notification(failed.request)
+    failed_envelope = failed_prep.lifecycles_by_account["lx"]["envelope"]
+    failed_token = failed_envelope["render_context"][
+        "notification_authority_token"
+    ]
+    provider_calls: list[str] = []
+    accepted = execute_notification_with_authority(
+        base=tmp_path,
+        token=failed_token,
+        channel="wechat_clawbot",
+        delivery_identity={
+            "account": "lx",
+            "market": "US",
+            "market_trading_date": MARKET_DATE,
+            "delivery_key": failed_envelope["delivery_key"],
+            "source_digest": failed_envelope["source_digest"],
+            "message_sha256": failed_envelope["message_sha256"],
+            "transport_idempotency_key": (
+                build_notification_transport_key(
+                    failed_envelope["delivery_key"]
+                )
+            ),
+            "delivery_kind": "fixed_failure",
+        },
+        send=lambda: provider_calls.append("sent") or {
+            "ok": True,
+            "command_ok": True,
+            "delivery_confirmed": True,
+        },
+    )
+    assert accepted["authority_receipt_status"] == "accepted"
+    assert provider_calls == ["sent"]
+
+    _patch_assembler(monkeypatch)
+    recovered = _request(tmp_path, run_id="accepted-recovery")
+    recovered_prep = mod._prepare_daily_brief_notification(
+        recovered.request
+    )
+    selected = recovered_prep.lifecycles_by_account["lx"]["envelope"]
+    audit = recovered.request.tick_metrics["daily_brief"]["prepared"][0]
+
+    assert selected["delivery_kind"] == "fixed_failure"
+    assert selected["render_context"]["notification_authority_token"][
+        "account_run_id"
+    ] == "accepted-before-confirm"
+    assert audit["pending_failure_upgrade_status"] == "accepted"
+    assert audit["pending_failure_upgrade_applied"] is False
+    assert audit["selected_delivery_kind"] == "fixed_failure"
+
+
+def test_ambiguous_fixed_failure_is_not_upgraded_or_resent(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.tick_notification_flow as mod
+    from src.application.daily_decision_brief_repository import (
+        read_daily_decision_brief_delivery_state,
+    )
+
+    _patch_assembler(monkeypatch, blocked=True)
+    ambiguous_calls: list[dict] = []
+    _patch_sender(
+        monkeypatch,
+        calls=ambiguous_calls,
+        result={
+            "ok": False,
+            "command_ok": True,
+            "delivery_confirmed": False,
+            "returncode": 1,
+            "error_code": "SEND_UNCONFIRMED",
+            "ambiguous_send": True,
+        },
+    )
+    failed = _request(
+        tmp_path,
+        run_id="ambiguous-provider-attempt",
+        pipeline_ok=False,
+    )
+    assert mod.run_tick_notification_flow(failed.request) == 1
+
+    _patch_assembler(monkeypatch)
+    recovered_calls: list[dict] = []
+    _patch_sender(monkeypatch, calls=recovered_calls)
+    recovered = _request(tmp_path, run_id="ambiguous-recovery")
+    assert mod.run_tick_notification_flow(recovered.request) == 1
+
+    state = read_daily_decision_brief_delivery_state(
+        base=tmp_path,
+        account="lx",
+        market="US",
+    )["state"]
+    envelope = state["days"][MARKET_DATE]["fixed_reports"][FIXED_TARGET]
+    audit = recovered.request.tick_metrics["daily_brief"]["prepared"][0]
+    assert len(ambiguous_calls) >= 1
+    assert recovered_calls == []
+    assert envelope["delivery_kind"] == "fixed_failure"
+    assert envelope["status"] == "ambiguous"
+    assert envelope["render_context"]["notification_authority_token"][
+        "account_run_id"
+    ] == "ambiguous-provider-attempt"
+    assert audit["pending_failure_upgrade_status"] == "not_applicable"
+    assert audit["pending_failure_upgrade_applied"] is False
+    assert audit["selected_delivery_kind"] == "fixed_failure"
+
+
+def test_lx_normal_and_sy_failure_are_prepared_and_sent_independently(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.tick_notification_flow as mod
+    from src.application.daily_decision_brief_repository import (
+        read_daily_decision_brief_delivery_state,
+    )
+
+    def assemble(
+        *,
+        base: Path,
+        run_id: str,
+        account: str,
+        markets_to_run: list[str],
+        **_kwargs,
+    ) -> dict[str, dict]:
+        out: dict[str, dict] = {}
+        for market in markets_to_run:
+            brief = _brief(
+                base=base,
+                run_id=run_id,
+                account=account,
+                market=market,
+                blocked=account == "sy",
+            )
+            if account == "sy":
+                authority = dict(brief["notification_authority"])
+                authority.update(
+                    {
+                        "selected_advice_contract": None,
+                        "normal_delivery_allowed": False,
+                        "notification_allowed": False,
+                        "blocker": (
+                            "position_advice_source_summary_missing"
+                        ),
+                        "normal_delivery_token": None,
+                        "token": None,
+                        "authority_identity_source": (
+                            "current_run_portfolio_receipt"
+                        ),
+                        "identity_snapshot_id": "b" * 64,
+                        "identity_receipt_hash": "c" * 64,
+                    }
+                )
+                brief["notification_authority"] = authority
+            out[market] = brief
+        return out
+
+    monkeypatch.setattr(mod, "assemble_daily_decision_briefs", assemble)
+    calls: list[dict] = []
+    _patch_sender(monkeypatch, calls=calls)
+    bundle = _request(
+        tmp_path,
+        run_id="mixed-authority",
+        accounts=("lx", "sy"),
+    )
+
+    assert mod.run_tick_notification_flow(bundle.request) == 0
+
+    lx_state = read_daily_decision_brief_delivery_state(
+        base=tmp_path,
+        account="lx",
+        market="US",
+    )["state"]
+    sy_state = read_daily_decision_brief_delivery_state(
+        base=tmp_path,
+        account="sy",
+        market="US",
+    )["state"]
+    lx_envelope = lx_state["days"][MARKET_DATE]["fixed_reports"][
+        FIXED_TARGET
+    ]
+    sy_envelope = sy_state["days"][MARKET_DATE]["fixed_reports"][
+        FIXED_TARGET
+    ]
+
+    assert lx_envelope["delivery_kind"] == "fixed_report"
+    assert lx_envelope["status"] == "confirmed"
+    assert sy_envelope["delivery_kind"] == "fixed_failure"
+    assert sy_envelope["status"] == "confirmed"
+    assert sy_envelope["rendered_transport"] is None
+    assert sy_envelope["candidate_identities"] == []
+    assert "数据异常" in sy_envelope["rendered_message"]
+    assert len(calls) == 2
+    prepared = {
+        item["account"]: item
+        for item in bundle.request.tick_metrics["daily_brief"]["prepared"]
+    }
+    assert prepared["lx"]["decision"] == "fixed_report"
+    assert prepared["lx"]["normal_report_reliable"] is True
+    assert prepared["sy"]["decision"] == "fixed_failure"
+    assert prepared["sy"]["normal_report_reliable"] is False
+    assert prepared["sy"]["fixed_failure_delivery_allowed"] is True
+    assert prepared["sy"]["authority_identity_source"] == (
+        "current_run_portfolio_receipt"
+    )
 
 
 def test_fixed_report_without_candidates_still_contains_positions_and_funds(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_daily_decision_brief_repository_v2.py
+++ b/tests/test_daily_decision_brief_repository_v2.py
@@ -357,6 +357,221 @@ def test_fixed_failure_validates_source_once_then_retries_from_durable_envelope(
     assert retry["envelope"]["source_reference"] == source_reference
 
 
+def test_pending_fixed_failure_can_upgrade_but_confirmed_failure_cannot(
+    tmp_path: Path,
+) -> None:
+    from src.application.daily_decision_brief_repository import (
+        confirm_daily_decision_brief_delivery_v2,
+        prepare_daily_decision_brief_delivery,
+    )
+    from src.application.notification_delivery_adapter import (
+        build_notification_transport_key,
+    )
+
+    persisted = _persist(tmp_path, actions=[_action()])
+    artifact = (
+        tmp_path
+        / "output_runs"
+        / "run-fail"
+        / "accounts"
+        / "lx"
+        / "state"
+        / "pipeline_failure.US.json"
+    )
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{"reason":"pipeline_failed"}\n', encoding="utf-8")
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    failure = prepare_daily_decision_brief_delivery(
+        base=tmp_path,
+        account="lx",
+        market="US",
+        market_trading_date=MARKET_DATE,
+        run_id="run-fail",
+        delivery_kind="fixed_failure",
+        source_kind="scan_failure",
+        source_digest=digest,
+        source_reference=artifact.relative_to(tmp_path).as_posix(),
+        scheduled_target_market=TARGET_1000,
+        rendered_message="# 本轮扫描失败",
+        render_context={"projection": "fixed_failure"},
+    )
+
+    upgraded = _prepare_fixed(tmp_path, persisted)
+    assert upgraded["prepared"] is True
+    assert upgraded["envelope"]["delivery_kind"] == "fixed_report"
+    assert upgraded["envelope"]["status"] == "pending"
+
+    other_root = tmp_path / "confirmed"
+    confirmed_persisted = _persist(
+        other_root,
+        actions=[_action()],
+    )
+    confirmed_artifact = (
+        other_root
+        / "output_runs"
+        / "run-fail"
+        / "accounts"
+        / "lx"
+        / "state"
+        / "pipeline_failure.US.json"
+    )
+    confirmed_artifact.parent.mkdir(parents=True)
+    confirmed_artifact.write_text(
+        '{"reason":"pipeline_failed"}\n',
+        encoding="utf-8",
+    )
+    confirmed_digest = hashlib.sha256(
+        confirmed_artifact.read_bytes()
+    ).hexdigest()
+    confirmed_failure = prepare_daily_decision_brief_delivery(
+        base=other_root,
+        account="lx",
+        market="US",
+        market_trading_date=MARKET_DATE,
+        run_id="run-fail",
+        delivery_kind="fixed_failure",
+        source_kind="scan_failure",
+        source_digest=confirmed_digest,
+        source_reference=confirmed_artifact.relative_to(
+            other_root
+        ).as_posix(),
+        scheduled_target_market=TARGET_1000,
+        rendered_message="# 本轮扫描失败",
+        render_context={"projection": "fixed_failure"},
+    )["envelope"]
+    confirm_daily_decision_brief_delivery_v2(
+        base=other_root,
+        account="lx",
+        market="US",
+        market_trading_date=MARKET_DATE,
+        delivery_key=confirmed_failure["delivery_key"],
+        source_digest=confirmed_failure["source_digest"],
+        message_sha256=confirmed_failure["message_sha256"],
+        transport_idempotency_key=build_notification_transport_key(
+            confirmed_failure["delivery_key"]
+        ),
+    )
+
+    retained = _prepare_fixed(other_root, confirmed_persisted)
+    assert retained["prepared"] is False
+    assert retained["envelope"]["delivery_kind"] == "fixed_failure"
+    assert retained["envelope"]["status"] == "confirmed"
+
+
+def test_ambiguous_fixed_failure_cannot_upgrade_to_normal_report(
+    tmp_path: Path,
+) -> None:
+    from src.application.daily_decision_brief_repository import (
+        DailyDecisionBriefStateError,
+        prepare_daily_decision_brief_delivery,
+        record_daily_decision_brief_delivery_attempt,
+    )
+    from src.application.notification_delivery_adapter import (
+        build_notification_transport_key,
+    )
+
+    persisted = _persist(tmp_path, actions=[_action()])
+    artifact = (
+        tmp_path
+        / "output_runs"
+        / "run-fail"
+        / "accounts"
+        / "lx"
+        / "state"
+        / "pipeline_failure.US.json"
+    )
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{"reason":"pipeline_failed"}\n', encoding="utf-8")
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    failure = prepare_daily_decision_brief_delivery(
+        base=tmp_path,
+        account="lx",
+        market="US",
+        market_trading_date=MARKET_DATE,
+        run_id="run-fail",
+        delivery_kind="fixed_failure",
+        source_kind="scan_failure",
+        source_digest=digest,
+        source_reference=artifact.relative_to(tmp_path).as_posix(),
+        scheduled_target_market=TARGET_1000,
+        rendered_message="# 本轮扫描失败",
+        render_context={"projection": "fixed_failure"},
+    )["envelope"]
+    record_daily_decision_brief_delivery_attempt(
+        base=tmp_path,
+        account="lx",
+        market="US",
+        market_trading_date=MARKET_DATE,
+        delivery_key=failure["delivery_key"],
+        source_digest=failure["source_digest"],
+        message_sha256=failure["message_sha256"],
+        transport_idempotency_key=build_notification_transport_key(
+            failure["delivery_key"]
+        ),
+        ambiguous=True,
+    )
+
+    with pytest.raises(DailyDecisionBriefStateError, match="frozen"):
+        _prepare_fixed(tmp_path, persisted)
+
+
+def test_delivery_identity_validator_returns_persisted_kind_and_status(
+    tmp_path: Path,
+) -> None:
+    from src.application.daily_decision_brief_repository import (
+        prepare_daily_decision_brief_delivery,
+        validate_daily_decision_brief_delivery_identity,
+    )
+    from src.application.notification_delivery_adapter import (
+        build_notification_transport_key,
+    )
+
+    artifact = (
+        tmp_path
+        / "output_runs"
+        / "run-fail"
+        / "accounts"
+        / "lx"
+        / "state"
+        / "pipeline_failure.US.json"
+    )
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{"reason":"pipeline_failed"}\n', encoding="utf-8")
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    prepared = prepare_daily_decision_brief_delivery(
+        base=tmp_path,
+        account="lx",
+        market="US",
+        market_trading_date=MARKET_DATE,
+        run_id="run-fail",
+        delivery_kind="fixed_failure",
+        source_kind="scan_failure",
+        source_digest=digest,
+        source_reference=artifact.relative_to(tmp_path).as_posix(),
+        scheduled_target_market=TARGET_1000,
+        rendered_message="# 本轮扫描失败",
+        render_context={"projection": "fixed_failure"},
+    )
+    envelope = prepared["envelope"]
+
+    validated = validate_daily_decision_brief_delivery_identity(
+        base=tmp_path,
+        account="lx",
+        market="US",
+        market_trading_date=MARKET_DATE,
+        delivery_key=envelope["delivery_key"],
+        source_digest=envelope["source_digest"],
+        message_sha256=envelope["message_sha256"],
+        transport_idempotency_key=build_notification_transport_key(
+            envelope["delivery_key"]
+        ),
+    )
+
+    assert validated["delivery_kind"] == "fixed_failure"
+    assert validated["status"] == "pending"
+    assert validated["envelope"] == envelope
+
+
 def test_ambiguous_envelope_is_frozen_and_tampered_hash_fails_closed(tmp_path: Path) -> None:
     from src.application.daily_decision_brief_repository import (
         DailyDecisionBriefStateError,

--- a/tests/test_daily_decision_brief_service.py
+++ b/tests/test_daily_decision_brief_service.py
@@ -3,11 +3,39 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 
 from src.application.multi_tick.misc import AccountResult
+
+
+@pytest.fixture(autouse=True)
+def _default_successful_v1_position_advice_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.application import daily_decision_brief_service as service
+
+    monkeypatch.setattr(
+        service,
+        "read_position_advice_v2_from_ledger",
+        lambda **_kwargs: {
+            "availability_status": "unavailable",
+            "freshness": {"status": "fresh", "reason_codes": []},
+            "authority_mode": "v1",
+            "authority_generation": 0,
+            "authority_policy_hash": None,
+            "portfolio_plan_id": None,
+            "account_run_id": "run-1",
+            "row_count": 0,
+            "actionable_count": 0,
+            "model_actionable_count": 0,
+            "model_trade_actionable_count": 0,
+            "human_review_required_count": 0,
+            "rows": [],
+        },
+    )
 
 
 def _account_dir(base: Path, run_id: str = "run-1", account: str = "lx") -> Path:
@@ -35,6 +63,16 @@ def _account_dir(base: Path, run_id: str = "run-1", account: str = "lx") -> Path
                     "rates": {"USDCNY": 7.0, "HKDCNY": 0.9},
                     "timestamp": "2026-07-17T13:59:30+00:00",
                 },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (state_dir / "position_advice_sources.v2.json").write_text(
+        json.dumps(
+            {
+                "account": account,
+                "normalized_portfolio_source": "futu",
+                "portfolio_account_identity_hash": "a" * 64,
             }
         ),
         encoding="utf-8",
@@ -129,6 +167,160 @@ def _put_row(
     if priority is not None:
         row["tier"] = priority
     return row
+
+
+def test_missing_success_summary_blocks_normal_delivery_but_current_run_identity_allows_failure(
+    tmp_path: Path,
+) -> None:
+    from domain.domain.position_advice_authority import (
+        portfolio_account_identity_hash,
+    )
+    from src.application.position_advice_source_producers import (
+        publish_portfolio_source_snapshot,
+    )
+
+    account_dir = _account_dir(tmp_path)
+    state_dir = account_dir / "state"
+    (state_dir / "position_advice_sources.v2.json").unlink()
+    identifiers = ["futu-lx-current"]
+    identity_hash = portfolio_account_identity_hash(
+        normalized_portfolio_source="futu",
+        broker_account_identifiers=identifiers,
+    )
+    publish_portfolio_source_snapshot(
+        producer_root=state_dir,
+        account_run_id="run-1",
+        account="lx",
+        broker="futu",
+        normalized_portfolio_source="futu",
+        portfolio_account_identity_hash=identity_hash,
+        included_markets=["US"],
+        portfolio_context={
+            "source_observed_at": "2026-07-17T14:00:00+00:00",
+            "source_account_identifiers": identifiers,
+            "cash_by_currency": {"USD": 1000},
+        },
+        completed_at="2026-07-17T14:00:01+00:00",
+    )
+
+    brief = _assemble(tmp_path)
+    authority = brief["notification_authority"]
+
+    assert brief["actionability"] == "blocked"
+    assert authority["normal_delivery_allowed"] is False
+    assert authority["notification_allowed"] is False
+    assert authority["blocker"] == "position_advice_source_summary_missing"
+    assert authority["normal_delivery_token"] is None
+    assert authority["fixed_failure_delivery_allowed"] is True
+    assert authority["fixed_failure_delivery_token"][
+        "schema_version"
+    ] == "position_advice_notification_authority_token.v2"
+    assert authority["fixed_failure_delivery_token"][
+        "authorized_delivery_kinds"
+    ] == ["fixed_failure"]
+    assert authority["identity_evidence"]["status"] == "available"
+    assert authority["authority_identity_source"] == (
+        "current_run_portfolio_receipt"
+    )
+    assert len(authority["identity_snapshot_id"]) == 64
+    assert len(authority["identity_receipt_hash"]) == 64
+    assert (
+        authority["identity_evidence"][
+            "portfolio_account_identity_hash"
+        ]
+        == identity_hash
+    )
+
+
+def test_missing_success_summary_without_current_run_identity_blocks_all_delivery(
+    tmp_path: Path,
+) -> None:
+    account_dir = _account_dir(tmp_path)
+    (
+        account_dir
+        / "state"
+        / "position_advice_sources.v2.json"
+    ).unlink()
+
+    brief = _assemble(tmp_path)
+    authority = brief["notification_authority"]
+
+    assert authority["normal_delivery_allowed"] is False
+    assert authority["fixed_failure_delivery_allowed"] is False
+    assert authority["normal_delivery_token"] is None
+    assert authority["fixed_failure_delivery_token"] is None
+    assert authority["identity_evidence"]["reason"] == (
+        "current_run_portfolio_receipt_missing"
+    )
+
+
+@pytest.mark.parametrize(
+    ("authority_allowed", "builder_fails", "expected_blocker"),
+    (
+        (
+            False,
+            False,
+            "position_advice_authority_conflict",
+        ),
+        (
+            True,
+            True,
+            "position_advice_failure_token_build_failed",
+        ),
+    ),
+)
+def test_failure_authority_reason_codes_remain_distinct(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    authority_allowed: bool,
+    builder_fails: bool,
+    expected_blocker: str,
+) -> None:
+    from src.application import daily_decision_brief_service as service
+
+    monkeypatch.setattr(
+        service,
+        "read_authority_resolution",
+        lambda **_kwargs: SimpleNamespace(
+            notifications_allowed=authority_allowed,
+            resolution_status=(
+                "resolved" if authority_allowed else "authority_conflict"
+            ),
+            mode="v1" if authority_allowed else None,
+            generation=0 if authority_allowed else None,
+            policy_hash=None,
+        ),
+    )
+    if builder_fails:
+        monkeypatch.setattr(
+            service,
+            "build_fixed_failure_notification_authority_token",
+            lambda **_kwargs: (_ for _ in ()).throw(
+                ValueError("invalid token")
+            ),
+        )
+
+    result = service._daily_brief_notification_authority(
+        {
+            "mode": "authority_conflict",
+            "available": False,
+            "blocker": "position_advice_source_summary_missing",
+        },
+        base=tmp_path,
+        account="sy",
+        account_run_id="run-sy",
+        current_run_identity={
+            "status": "available",
+            "normalized_portfolio_source": "futu",
+            "portfolio_account_identity_hash": "a" * 64,
+            "snapshot_id": "b" * 64,
+            "receipt_hash": "c" * 64,
+        },
+    )
+
+    assert result["fixed_failure_delivery_allowed"] is False
+    assert result["fixed_failure_delivery_token"] is None
+    assert result["fixed_failure_blocker"] == expected_blocker
 
 
 def _call_row(*, symbol: str = "NVDA", contract: str = "NVDA260821C00140000", annualized: float = 0.1) -> dict:

--- a/tests/test_position_advice_account_identity_reader.py
+++ b/tests/test_position_advice_account_identity_reader.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from domain.domain.position_advice_authority import (
+    portfolio_account_identity_hash,
+)
+from src.application.position_advice_account_identity_reader import (
+    PositionAdviceAccountIdentityError,
+    read_current_run_portfolio_identity,
+)
+from src.application.position_advice_source_producers import (
+    publish_portfolio_source_snapshot,
+)
+
+
+NOW = datetime(2026, 7, 30, 10, 0, tzinfo=timezone.utc)
+RUN_ID = "account-run-sy"
+ACCOUNT = "sy"
+IDENTIFIERS = ["futu-sy-123"]
+IDENTITY_HASH = portfolio_account_identity_hash(
+    normalized_portfolio_source="futu",
+    broker_account_identifiers=IDENTIFIERS,
+)
+
+
+def _publish(
+    root: Path,
+    *,
+    run_id: str = RUN_ID,
+    account: str = ACCOUNT,
+    identifiers: list[str] | None = None,
+    observed_at: datetime = NOW,
+) -> Path:
+    path, _receipt = publish_portfolio_source_snapshot(
+        producer_root=root,
+        account_run_id=run_id,
+        account=account,
+        broker="futu",
+        normalized_portfolio_source="futu",
+        portfolio_account_identity_hash=portfolio_account_identity_hash(
+            normalized_portfolio_source="futu",
+            broker_account_identifiers=identifiers or IDENTIFIERS,
+        ),
+        included_markets=["US"],
+        portfolio_context={
+            "source_observed_at": observed_at.isoformat(),
+            "source_account_identifiers": identifiers or IDENTIFIERS,
+            "cash_by_currency": {"USD": 1000},
+        },
+        completed_at=observed_at + timedelta(seconds=1),
+    )
+    return path
+
+
+def _read(root: Path, **overrides: object) -> dict:
+    arguments = {
+        "account_state_dir": root,
+        "account_run_id": RUN_ID,
+        "expected_account": ACCOUNT,
+        "expected_market": "US",
+        "now": NOW + timedelta(seconds=2),
+    }
+    arguments.update(overrides)
+    return read_current_run_portfolio_identity(**arguments)
+
+
+def test_reads_unique_fresh_current_run_portfolio_identity(tmp_path: Path) -> None:
+    receipt_path = _publish(tmp_path)
+
+    result = _read(tmp_path)
+
+    assert result == {
+        "status": "available",
+        "account": "sy",
+        "normalized_portfolio_source": "futu",
+        "portfolio_account_identity_hash": IDENTITY_HASH,
+        "producer_account_run_id": RUN_ID,
+        "included_markets": ["US"],
+        "snapshot_id": json.loads(receipt_path.read_text())["snapshot_id"],
+        "receipt_hash": result["receipt_hash"],
+        "payload_sha256": json.loads(receipt_path.read_text())["payload_sha256"],
+        "source_observed_at": "2026-07-30T10:00:00Z",
+        "expires_at": "2026-07-30T10:30:00Z",
+    }
+    assert len(result["receipt_hash"]) == 64
+
+
+def test_never_falls_back_to_another_account_run(tmp_path: Path) -> None:
+    _publish(tmp_path, run_id="older-run")
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as exc_info:
+        _read(tmp_path)
+
+    assert exc_info.value.reason_code == "current_run_portfolio_receipt_missing"
+
+
+def test_rejects_ambiguous_current_run_receipts(tmp_path: Path) -> None:
+    first = _publish(tmp_path)
+    duplicate = first.parent.parent / ("f" * 64) / "receipt.json"
+    duplicate.parent.mkdir()
+    duplicate.write_bytes(first.read_bytes())
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as exc_info:
+        _read(tmp_path)
+
+    assert exc_info.value.reason_code == "current_run_portfolio_receipt_ambiguous"
+
+
+def test_rejects_stale_receipt(tmp_path: Path) -> None:
+    _publish(tmp_path, observed_at=NOW - timedelta(minutes=31))
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as exc_info:
+        _read(tmp_path)
+
+    assert exc_info.value.reason_code == "current_run_portfolio_receipt_stale"
+
+
+def test_rejects_payload_identity_mismatch(tmp_path: Path) -> None:
+    receipt_path = _publish(tmp_path)
+    receipt = json.loads(receipt_path.read_text())
+    receipt["portfolio_account_identity_hash"] = "f" * 64
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as exc_info:
+        _read(tmp_path)
+
+    assert exc_info.value.reason_code == "current_run_portfolio_identity_mismatch"
+
+
+def test_rejects_market_and_account_mismatch(tmp_path: Path) -> None:
+    _publish(tmp_path)
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as market_error:
+        _read(tmp_path, expected_market="HK")
+    assert market_error.value.reason_code == "current_run_portfolio_receipt_invalid"
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as account_error:
+        _read(tmp_path, expected_account="lx")
+    assert account_error.value.reason_code == "current_run_portfolio_receipt_invalid"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("bad_json", "path_escape", "payload_hash_mismatch"),
+)
+def test_rejects_unreadable_or_unbound_receipt_payload(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    receipt_path = _publish(tmp_path)
+    receipt = json.loads(receipt_path.read_text())
+    if mutation == "bad_json":
+        receipt_path.write_text("{", encoding="utf-8")
+    elif mutation == "path_escape":
+        receipt["payload_relpath"] = "../payload.json"
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+    else:
+        Path(receipt_path.parent / "payload.json").write_text(
+            '{"tampered":true}\n',
+            encoding="utf-8",
+        )
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as exc_info:
+        _read(tmp_path)
+
+    assert exc_info.value.reason_code == "current_run_portfolio_receipt_invalid"
+
+
+def test_rejects_symlinked_receipt(tmp_path: Path) -> None:
+    receipt_path = _publish(tmp_path)
+    real_path = receipt_path.with_name("receipt.real.json")
+    receipt_path.rename(real_path)
+    receipt_path.symlink_to(real_path.name)
+
+    with pytest.raises(PositionAdviceAccountIdentityError) as exc_info:
+        _read(tmp_path)
+
+    assert exc_info.value.reason_code == "current_run_portfolio_receipt_invalid"

--- a/tests/test_position_advice_notification_authority.py
+++ b/tests/test_position_advice_notification_authority.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -16,8 +17,10 @@ from src.application.position_advice_authority_service import (
 )
 from src.application.position_advice_notification_authority import (
     PositionAdviceNotificationAuthorityError,
+    build_fixed_failure_notification_authority_token,
     build_notification_authority_token,
     execute_notification_with_authority,
+    read_notification_authority_delivery_state,
     resolve_notification_unknown,
     unresolved_notification_authority_exists,
 )
@@ -83,6 +86,362 @@ def _token(
         authority_policy_hash=str(policy["policy_hash"]),
         account_run_id=account_run_id,
     )
+
+
+def _failure_token(
+    policy: dict[str, object],
+    *,
+    account_run_id: str = "run-failure",
+) -> dict[str, object]:
+    mode = str(policy["mode"])
+    return build_fixed_failure_notification_authority_token(
+        normalized_account="lx",
+        normalized_portfolio_source="futu",
+        portfolio_account_identity_hash=IDENTITY,
+        selected_advice_contract="v1" if mode != "v2" else "v2",
+        resolved_mode=mode,
+        authority_generation=int(policy["generation"]),
+        authority_policy_hash=str(policy["policy_hash"]),
+        account_run_id=account_run_id,
+    )
+
+
+def _prepare_fixed_failure(
+    base: Path,
+    *,
+    token: dict[str, object] | None,
+) -> dict[str, object]:
+    from src.application.daily_decision_brief_repository import (
+        prepare_daily_decision_brief_delivery,
+    )
+    from src.application.notification_delivery_adapter import (
+        build_notification_transport_key,
+    )
+
+    artifact = (
+        base
+        / "output_runs"
+        / "run-failure"
+        / "accounts"
+        / "lx"
+        / "state"
+        / "pipeline_failure.US.json"
+    )
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{"reason":"pipeline_failed"}\n', encoding="utf-8")
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    envelope = prepare_daily_decision_brief_delivery(
+        base=base,
+        account="lx",
+        market="US",
+        market_trading_date="2026-07-27",
+        run_id="run-failure",
+        delivery_kind="fixed_failure",
+        source_kind="scan_failure",
+        source_digest=digest,
+        source_reference=artifact.relative_to(base).as_posix(),
+        scheduled_target_market="2026-07-27T10:00:00-04:00",
+        rendered_message="# 本轮扫描失败",
+        render_context={
+            "projection": "fixed_failure",
+            **(
+                {"notification_authority_token": token}
+                if token is not None
+                else {}
+            ),
+        },
+        prepared_at_utc=NOW,
+    )["envelope"]
+    return {
+        "account": "lx",
+        "market": "US",
+        "market_trading_date": "2026-07-27",
+        "delivery_key": envelope["delivery_key"],
+        "source_digest": envelope["source_digest"],
+        "message_sha256": envelope["message_sha256"],
+        "transport_idempotency_key": build_notification_transport_key(
+            str(envelope["delivery_key"])
+        ),
+        "delivery_kind": "fixed_failure",
+    }
+
+
+def test_failure_token_sends_only_persisted_pending_fixed_failure(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    token = _failure_token(dict(applied["policy"]))
+    delivery_identity = _prepare_fixed_failure(tmp_path, token=token)
+    calls: list[str] = []
+
+    result = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: calls.append("sent") or {
+            "ok": True,
+            "command_ok": True,
+            "delivery_confirmed": True,
+            "message_id": "fixed-failure-1",
+        },
+        now=NOW,
+    )
+
+    assert result["authority_receipt_status"] == "accepted"
+    assert calls == ["sent"]
+    receipt_path = (
+        tmp_path
+        / "output_shared"
+        / "state"
+        / "position_advice"
+        / scope_for("lx")
+        / "notification_authority"
+        / "accepted"
+        / f"{result['authority_receipt_id']}.json"
+    )
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["delivery_identity"]["delivery_kind"] == "fixed_failure"
+
+
+def test_failure_token_rejects_delivery_kind_substitution_before_send(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    token = _failure_token(dict(applied["policy"]))
+    delivery_identity = {
+        **_prepare_fixed_failure(tmp_path, token=token),
+        "delivery_kind": "fixed_report",
+    }
+    calls: list[str] = []
+
+    result = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: calls.append("sent") or {
+            "ok": True,
+            "delivery_confirmed": True,
+        },
+        now=NOW,
+    )
+
+    assert result["error_code"] == (
+        "AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED"
+    )
+    assert result["attempts"] == 0
+    assert calls == []
+
+
+def test_failure_token_requires_persisted_delivery_identity(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    token = _failure_token(dict(applied["policy"]))
+    calls: list[str] = []
+
+    result = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=None,
+        send=lambda: calls.append("sent") or {
+            "ok": True,
+            "delivery_confirmed": True,
+        },
+        now=NOW,
+    )
+
+    assert result["error_code"] == (
+        "AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED"
+    )
+    assert result["attempts"] == 0
+    assert calls == []
+
+
+def test_failure_token_requires_same_token_frozen_in_envelope(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    persisted_token = _failure_token(
+        dict(applied["policy"]),
+        account_run_id="run-failure",
+    )
+    substituted_token = _failure_token(
+        dict(applied["policy"]),
+        account_run_id="different-run",
+    )
+    delivery_identity = _prepare_fixed_failure(
+        tmp_path,
+        token=persisted_token,
+    )
+    calls: list[str] = []
+
+    result = execute_notification_with_authority(
+        base=tmp_path,
+        token=substituted_token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: calls.append("sent") or {
+            "ok": True,
+            "delivery_confirmed": True,
+        },
+        now=NOW,
+    )
+
+    assert result["error_code"] == (
+        "AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED"
+    )
+    assert result["attempts"] == 0
+    assert calls == []
+
+
+def test_failure_token_rejects_tokenless_persisted_envelope(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    token = _failure_token(dict(applied["policy"]))
+    delivery_identity = _prepare_fixed_failure(tmp_path, token=None)
+    calls: list[str] = []
+
+    result = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: calls.append("sent") or {
+            "ok": True,
+            "delivery_confirmed": True,
+        },
+        now=NOW,
+    )
+
+    assert result["error_code"] == (
+        "AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED"
+    )
+    assert result["attempts"] == 0
+    assert calls == []
+
+
+def test_failure_token_rejects_invalid_token_frozen_in_envelope(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    token = _failure_token(dict(applied["policy"]))
+    invalid_frozen_token = {**token, "token_hash": "f" * 64}
+    delivery_identity = _prepare_fixed_failure(
+        tmp_path,
+        token=invalid_frozen_token,
+    )
+    calls: list[str] = []
+
+    result = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: calls.append("sent") or {
+            "ok": True,
+            "delivery_confirmed": True,
+        },
+        now=NOW,
+    )
+
+    assert result["error_code"] == (
+        "AUTHORITY_NOTIFICATION_DELIVERY_KIND_DENIED"
+    )
+    assert result["attempts"] == 0
+    assert calls == []
+
+
+def test_failure_token_definite_failure_can_retry_exact_pending_envelope(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    token = _failure_token(dict(applied["policy"]))
+    delivery_identity = _prepare_fixed_failure(tmp_path, token=token)
+    calls: list[str] = []
+
+    first = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: calls.append("failed") or {
+            "ok": False,
+            "command_ok": False,
+            "delivery_confirmed": False,
+            "error_code": "SEND_FAILED",
+        },
+        now=NOW,
+    )
+    second = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: calls.append("accepted") or {
+            "ok": True,
+            "command_ok": True,
+            "delivery_confirmed": True,
+            "message_id": "fixed-failure-retry",
+        },
+        now=NOW + timedelta(seconds=1),
+    )
+
+    assert first["authority_receipt_status"] == "failed"
+    assert second["authority_receipt_status"] == "accepted"
+    assert calls == ["failed", "accepted"]
+
+
+def test_failure_token_unknown_is_unsafe_until_resolved_failed(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, mode="v2_shadow")
+    token = _failure_token(dict(applied["policy"]))
+    delivery_identity = _prepare_fixed_failure(tmp_path, token=token)
+    result = execute_notification_with_authority(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+        delivery_identity=delivery_identity,
+        send=lambda: {
+            "ok": False,
+            "command_ok": True,
+            "delivery_confirmed": False,
+            "error_code": "SEND_UNCONFIRMED",
+            "ambiguous_send": True,
+        },
+        now=NOW,
+    )
+
+    unresolved = read_notification_authority_delivery_state(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+    )
+    assert unresolved["status"] == "unknown"
+    assert unresolved["safe_to_replace_pending"] is False
+
+    resolve_notification_unknown(
+        base=tmp_path,
+        normalized_account="lx",
+        receipt_id=str(result["authority_receipt_id"]),
+        resolution="failed",
+        evidence={"provider_audit_id": "audit-fixed-failure"},
+        actor="operator@example",
+        resolved_at=NOW + timedelta(minutes=1),
+        confirm=True,
+        dry_run=False,
+    )
+    resolved = read_notification_authority_delivery_state(
+        base=tmp_path,
+        token=token,
+        channel="feishu",
+    )
+    assert resolved["status"] == "clear"
+    assert resolved["safe_to_replace_pending"] is True
 
 
 def test_notification_receipt_accepts_once_and_suppresses_duplicate(


### PR DESCRIPTION
## Summary

- allow `sy` scheduled Daily Brief to emit a purpose-restricted fixed-failure notification when normal Position Advice sources are unavailable but current-run portfolio identity remains authoritative
- bind every failure authority token to the exact persisted Daily Brief envelope and reject tokenless, tampered, or cross-run substitutions before any provider call
- safely upgrade a pending failure envelope to a recovered fixed report only when notification authority proves there is no accepted, unknown, or in-flight provider evidence
- add the implementation plan, two plan reviews, deepreview disposition, contract updates, and regenerated dependency graph

## Root cause

Normal notification authority required the complete current-run Position Advice source graph. When `sy` lacked that graph, notification preparation failed closed without a narrow failure-only authority. The first implementation then left two integrity gaps: a valid token from another account run could authorize an older persisted failure envelope, and tick orchestration always preferred any retryable envelope so the repository's safe `fixed_failure -> fixed_report` upgrade was unreachable.

## Impact

Scheduled failures now produce an explicit non-actionable account-scoped message without weakening normal-report authority. Exact-envelope retry, accepted/ambiguous crash windows, multi-account isolation, and recovery upgrades remain fail closed.

## Validation

- focused Daily Brief / Position Advice suite: 181 passed
- notification and tick regression suite: 102 passed; 4 existing deprecation warnings
- Ruff: passed
- dependency graph: 559 production modules, 0 cycles, check current
- `git diff --check`: passed

No real notification provider call, release, deployment, production configuration change, or runtime mutation was performed.
