### PR TITLE
Fix IQ coherent reads and promotion source compatibility

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 905 (`src`: 492, `domain`: 76, `scripts`: 8, `tests`: 329)
-- Internal import edges: 5515 total, 2457 production/script edges excluding tests
+- Internal import edges: 5518 total, 2457 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -45,11 +45,11 @@ flowchart LR
   scripts -->|12| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2185| application
-  tests -->|480| domain
+  tests -->|2186| application
+  tests -->|481| domain
   tests -->|2| domain_services
   tests -->|133| infrastructure
-  tests -->|200| interfaces
+  tests -->|201| interfaces
   tests -->|13| scripts
   tests -->|16| storage
 ```
@@ -77,9 +77,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2185 |
-| tests | domain | 480 |
-| tests | interfaces | 200 |
+| tests | application | 2186 |
+| tests | domain | 481 |
+| tests | interfaces | 201 |
 | tests | infrastructure | 133 |
 | tests | storage | 16 |
 | tests | scripts | 13 |

--- a/docs/POSITION_ADVICE_COMPATIBILITY.md
+++ b/docs/POSITION_ADVICE_COMPATIBILITY.md
@@ -39,7 +39,10 @@ Run, Daily Brief, and notification consumers support
 6. The mandatory daily promotion timer accumulates immutable shadow evidence.
    v2 rows remain non-authoritative and v1 continues to notify. Only canonical
    plans beneath the same runtime `output_runs` tree and bound to the exact
-   current shadow generation may enter persisted promotion evidence. The timer
+   current shadow generation and current position-fact snapshot contract may
+   enter persisted promotion evidence. Integrity-valid older-contract sources
+   remain archived but are classified incompatible; an all-incompatible set
+   waits for compatible shadow plans instead of failing the timer. The timer
    copies the exact plan/input pairs into a content-addressed gzip archive;
    ordinary output-run cleanup continues without discarding replay evidence.
 7. Use `om position-advice ... promotion status --account <account>` to review

--- a/docs/POSITION_ADVICE_V2_CONTRACT.md
+++ b/docs/POSITION_ADVICE_V2_CONTRACT.md
@@ -300,6 +300,13 @@ automatic reports bind the exact same source-plan hash set and match the
 top-level counters. Caller-supplied zero counters or `true` fixture flags
 without those reports remain `insufficient_evidence`.
 
+Promotion eligibility also requires the current position-fact snapshot
+contract. Integrity-valid sources from an older contract remain in the
+immutable archive but are excluded from evidence. If no compatible source is
+available, refresh reports `waiting_for_compatible_shadow_plans` and publishes
+nothing. A source that declares the current contract but fails its validation
+remains a hard error.
+
 The fixed promotion gate (`position_advice_promotion_gate.v1`) requires:
 
 - all safety counters equal zero;

--- a/src/application/position_advice_promotion.py
+++ b/src/application/position_advice_promotion.py
@@ -29,6 +29,7 @@ from domain.domain.position_advice_promotion import (
     unique_decision_opportunity_key,
 )
 from src.application.ledger.api import (
+    POSITION_FACT_SNAPSHOT_CONTRACT,
     validate_position_fact_snapshot_contract,
 )
 from src.application.position_advice_authority_service import (
@@ -456,12 +457,38 @@ def refresh_position_advice_promotion(
             confirm=confirm,
             policy=policy,
         )
+    compatible_plan_paths, incompatible_plan_paths = (
+        _classify_promotion_plan_paths(
+            plan_paths,
+            expected_account=account,
+            expected_scope_id=scope_for(account),
+            expected_portfolio_source=str(
+                policy["normalized_portfolio_source"]
+            ),
+            expected_identity_hash=str(
+                policy["portfolio_account_identity_hash"]
+            ),
+            expected_generation=int(policy["generation"]),
+            expected_policy_hash=str(policy["policy_hash"]),
+        )
+    )
+    if not compatible_plan_paths:
+        return _inactive_refresh(
+            account=account,
+            status="waiting_for_compatible_shadow_plans",
+            reason_code="current_contract_shadow_plan_set_empty",
+            confirm=confirm,
+            policy=policy,
+            discovered_source_plan_count=len(plan_paths),
+            compatible_source_plan_count=0,
+            incompatible_source_plan_count=len(incompatible_plan_paths),
+        )
     generated_at = max(
         _timestamp(_read_json_object(path).get("advice_checked_at"))
-        for path in plan_paths
+        for path in compatible_plan_paths
     )
     kwargs = {
-        "plan_paths": plan_paths,
+        "plan_paths": compatible_plan_paths,
         "normalized_account": account,
         "normalized_portfolio_source": str(
             policy["normalized_portfolio_source"]
@@ -484,7 +511,12 @@ def refresh_position_advice_promotion(
             **result,
             "schema_version": PROMOTION_REFRESH_SCHEMA,
             "normalized_account": account,
-            "source_plan_count": len(plan_paths),
+            "source_plan_count": len(compatible_plan_paths),
+            "discovered_source_plan_count": len(plan_paths),
+            "compatible_source_plan_count": len(compatible_plan_paths),
+            "incompatible_source_plan_count": len(
+                incompatible_plan_paths
+            ),
             "dry_run": False,
             "published": True,
         }
@@ -499,7 +531,10 @@ def refresh_position_advice_promotion(
         "status": gate["status"],
         "normalized_account": account,
         "portfolio_scope_id": policy["portfolio_scope_id"],
-        "source_plan_count": len(plan_paths),
+        "source_plan_count": len(compatible_plan_paths),
+        "discovered_source_plan_count": len(plan_paths),
+        "compatible_source_plan_count": len(compatible_plan_paths),
+        "incompatible_source_plan_count": len(incompatible_plan_paths),
         "promotion_evidence_hash": canonical_sha256(evidence),
         "promotion_gate_hash": gate["gate_hash"],
         "evidence": evidence,
@@ -831,7 +866,7 @@ def archive_current_shadow_plans(
         )
         _ensure_safe_archive_directory(archive_root)
         for path in canonical_paths:
-            plan, immutable_input = _read_bound_plan(
+            plan, immutable_input = _read_bound_plan_envelope(
                 path,
                 expected_account=account,
                 expected_scope_id=scope_id,
@@ -959,6 +994,9 @@ def _inactive_refresh(
     reason_code: str,
     confirm: bool,
     policy: Mapping[str, Any] | None = None,
+    discovered_source_plan_count: int = 0,
+    compatible_source_plan_count: int = 0,
+    incompatible_source_plan_count: int = 0,
 ) -> dict[str, Any]:
     return {
         "schema_version": PROMOTION_REFRESH_SCHEMA,
@@ -969,7 +1007,10 @@ def _inactive_refresh(
             dict(policy or {}).get("portfolio_scope_id")
             or scope_for(account)
         ),
-        "source_plan_count": 0,
+        "source_plan_count": compatible_source_plan_count,
+        "discovered_source_plan_count": discovered_source_plan_count,
+        "compatible_source_plan_count": compatible_source_plan_count,
+        "incompatible_source_plan_count": incompatible_source_plan_count,
         "dry_run": not confirm,
         "published": False,
     }
@@ -1038,7 +1079,7 @@ def _covered_strategy_families(
     return sorted(families)
 
 
-def _read_bound_plan(
+def _read_bound_plan_envelope(
     path: Path,
     *,
     expected_account: str,
@@ -1092,14 +1133,6 @@ def _read_bound_plan(
     immutable_input["input_hash"] = input_hash
     if immutable_input.get("schema_version") != POSITION_ADVICE_INPUT_SCHEMA:
         raise PositionAdvicePromotionError("position advice input schema is invalid")
-    position_fact_reasons = validate_position_fact_snapshot_contract(
-        dict(immutable_input.get("decision_state_snapshot") or {})
-    )
-    if position_fact_reasons:
-        raise PositionAdvicePromotionError(
-            "position advice input decision facts are invalid: "
-            + ",".join(position_fact_reasons)
-        )
     for field in (
         "account_run_id",
         "normalized_account",
@@ -1119,6 +1152,80 @@ def _read_bound_plan(
     if plan.get("input_hash") != input_hash:
         raise PositionAdvicePromotionError("position advice plan input hash mismatch")
     return plan, immutable_input
+
+
+def _read_bound_plan(
+    path: Path,
+    *,
+    expected_account: str,
+    expected_scope_id: str,
+    expected_portfolio_source: str,
+    expected_identity_hash: str,
+    expected_generation: int,
+    expected_policy_hash: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    plan, immutable_input = _read_bound_plan_envelope(
+        path,
+        expected_account=expected_account,
+        expected_scope_id=expected_scope_id,
+        expected_portfolio_source=expected_portfolio_source,
+        expected_identity_hash=expected_identity_hash,
+        expected_generation=expected_generation,
+        expected_policy_hash=expected_policy_hash,
+    )
+    position_fact_reasons = validate_position_fact_snapshot_contract(
+        dict(immutable_input.get("decision_state_snapshot") or {})
+    )
+    if position_fact_reasons:
+        raise PositionAdvicePromotionError(
+            "position advice input decision facts are invalid: "
+            + ",".join(position_fact_reasons)
+        )
+    return plan, immutable_input
+
+
+def _classify_promotion_plan_paths(
+    plan_paths: Iterable[Path],
+    *,
+    expected_account: str,
+    expected_scope_id: str,
+    expected_portfolio_source: str,
+    expected_identity_hash: str,
+    expected_generation: int,
+    expected_policy_hash: str,
+) -> tuple[list[Path], list[Path]]:
+    compatible: list[Path] = []
+    incompatible: list[Path] = []
+    for path in sorted({Path(item).resolve() for item in plan_paths}, key=str):
+        _plan, immutable_input = _read_bound_plan_envelope(
+            path,
+            expected_account=expected_account,
+            expected_scope_id=expected_scope_id,
+            expected_portfolio_source=expected_portfolio_source,
+            expected_identity_hash=expected_identity_hash,
+            expected_generation=expected_generation,
+            expected_policy_hash=expected_policy_hash,
+        )
+        decision_snapshot = dict(
+            immutable_input.get("decision_state_snapshot") or {}
+        )
+        position_fact_reasons = validate_position_fact_snapshot_contract(
+            decision_snapshot
+        )
+        if not position_fact_reasons:
+            compatible.append(path)
+            continue
+        if (
+            decision_snapshot.get("position_fact_contract_version")
+            != POSITION_FACT_SNAPSHOT_CONTRACT
+        ):
+            incompatible.append(path)
+            continue
+        raise PositionAdvicePromotionError(
+            "position advice input decision facts are invalid: "
+            + ",".join(position_fact_reasons)
+        )
+    return compatible, incompatible
 
 
 def _canonical_promotion_plan_paths(

--- a/src/application/quality/position_checks.py
+++ b/src/application/quality/position_checks.py
@@ -286,6 +286,7 @@ def build_position_dataset(
     lifecycle_cases: list[dict[str, Any]] | None = None,
     lifecycle_read_models_by_case: dict[str, dict[str, Any]] | None = None,
     lifecycle_timing_policies_by_case: dict[str, dict[str, Any]] | None = None,
+    lifecycle_coherent_read_available: bool = True,
     day_end_strict: bool = False,
     persistent_after_seconds: int = 300,
     next_authoritative_refresh_due_utc: str | None = None,
@@ -418,6 +419,26 @@ def build_position_dataset(
                 "local_normalization_error_count": 0,
                 "opend_normalization_error_count": 0,
             },
+            evidence_refs=[evidence],
+        )
+        verdict = "unavailable"
+    elif raw_comparison and not lifecycle_coherent_read_available:
+        mismatches.pop(state_key, None)
+        convergence = check_result(
+            check_id="OM-POS-002",
+            status="unknown",
+            scope=scope,
+            observed_at_utc=observed_at_utc,
+            reason_code="POSITION_LIFECYCLE_COHERENT_READ_UNAVAILABLE",
+            message=(
+                "Position convergence cannot classify a mismatch without "
+                "an account-coherent lifecycle read."
+            ),
+            observed={
+                "observed_mismatch_count": len(raw_comparison),
+                "lifecycle_coherent_read_available": False,
+            },
+            expected={"lifecycle_coherent_read_available": True},
             evidence_refs=[evidence],
         )
         verdict = "unavailable"

--- a/src/application/quality/service.py
+++ b/src/application/quality/service.py
@@ -10,12 +10,15 @@ from zoneinfo import ZoneInfo
 
 from src.application.account_config import accounts_from_config
 from src.application.agent_tool_config import load_runtime_config, repo_base
-from src.application.ledger.api import open_trade_reconciliation_evidence_repo
+from src.application.ledger.api import (
+    lifecycle_account_coherent_facts,
+    open_trade_reconciliation_evidence_repo,
+)
 from src.application.quality.intake_checks import build_trade_intake_datasets
 from src.application.quality.ledger_checks import build_ledger_datasets
 from src.application.quality.lifecycle_checks import build_lifecycle_datasets
 from src.application.trades.lifecycle_reconciliation import (
-    lifecycle_case_read_model,
+    build_lifecycle_read_models_from_resolved_account,
 )
 from src.application.quality.model import (
     POLICY_VERSION,
@@ -57,6 +60,73 @@ _MARKET_TIMEZONES = {
 }
 _DAY_END_REFRESH_TIME = time(hour=16, minute=30)
 _DAY_END_GRACE = timedelta(minutes=15)
+
+
+def _coherent_account_lifecycle_inputs(
+    repo: Any,
+    *,
+    account: str,
+    now_ms: int,
+) -> dict[str, Any]:
+    facts = lifecycle_account_coherent_facts(repo, account=account)
+    cases = [
+        dict(item)
+        for item in facts.get("account_lifecycle_cases") or []
+        if isinstance(item, dict)
+    ]
+    evidence_rows = [
+        dict(item)
+        for item in facts.get("account_lifecycle_evidence") or []
+        if isinstance(item, dict)
+    ]
+    timing_policies = [
+        dict(item)
+        for item in facts.get("account_lifecycle_timing_policies") or []
+        if isinstance(item, dict)
+    ]
+    local_lots = [
+        dict(item)
+        for item in facts.get("account_position_lots") or []
+        if isinstance(item, dict)
+    ]
+    models_by_lot = build_lifecycle_read_models_from_resolved_account(
+        cases=cases,
+        allocations=[
+            dict(item)
+            for item in facts.get("account_lifecycle_allocations") or []
+            if isinstance(item, dict)
+        ],
+        timing_policies=timing_policies,
+        position_lots=local_lots,
+        account_resolution=dict(
+            facts.get("account_lifecycle_resolution") or {}
+        ),
+        void_event_ids=list(facts.get("effective_void_event_ids") or []),
+        now_ms=now_ms,
+    )
+    models_by_case: dict[str, dict[str, Any]] = {}
+    for model in models_by_lot.values():
+        case_ids = {
+            str(item or "").strip()
+            for item in model.get("lifecycle_case_ids") or []
+            if str(item or "").strip()
+        }
+        case_id = str(model.get("lifecycle_case_id") or "").strip()
+        if case_id:
+            case_ids.add(case_id)
+        for model_case_id in case_ids:
+            models_by_case[model_case_id] = dict(model)
+    return {
+        "cases": cases,
+        "evidence_rows": evidence_rows,
+        "timing_policies_by_case": {
+            str(item.get("case_id") or "").strip(): item
+            for item in timing_policies
+            if str(item.get("case_id") or "").strip()
+        },
+        "local_lots": local_lots,
+        "read_models_by_case": models_by_case,
+    }
 
 
 class OMQualityService:
@@ -135,6 +205,9 @@ class OMQualityService:
         datasets: list[dict[str, Any]] = []
         control_state = self.control_repository.read()
         ledger_cache: dict[Path, Any] = {}
+        lifecycle_account_cache: dict[
+            tuple[Path, str], tuple[dict[str, Any] | None, str | None]
+        ] = {}
         authoritative_refresh_scopes: list[dict[str, str]] = []
 
         for key, _path, cfg, market in configs:
@@ -192,34 +265,92 @@ class OMQualityService:
                 if repo is not None
                 else {}
             )
-            read_models_by_case: dict[str, dict[str, Any]] = {}
-            if repo is not None:
-                for item in cases:
-                    case_id = str(
-                        item.get("case_id") or ""
-                    ).strip()
-                    if not case_id:
-                        continue
-                    try:
-                        read_models_by_case[case_id] = (
-                            lifecycle_case_read_model(
-                                repo,
-                                case_id=case_id,
-                                now_ms=int(now.timestamp() * 1000),
-                            )
-                        )
-                    except (TypeError, ValueError):
-                        continue
             local_lots = repo.list_position_lots() if repo is not None else []
             calendar_start = self._calendar_start(cases, now=now)
             for account in accounts:
+                account_cases = [
+                    dict(item)
+                    for item in cases
+                    if str(item.get("account") or "").strip().lower()
+                    == account
+                ]
+                account_evidence_rows = [
+                    dict(item)
+                    for item in evidence_rows
+                    if str(item.get("account") or "").strip().lower()
+                    == account
+                ]
+                account_case_ids = {
+                    str(item.get("case_id") or "").strip()
+                    for item in account_cases
+                    if str(item.get("case_id") or "").strip()
+                }
+                account_timing_policies_by_case = {
+                    case_id: dict(item)
+                    for case_id, item in timing_policies_by_case.items()
+                    if case_id in account_case_ids
+                }
+                account_local_lots = local_lots
+                account_read_models_by_case: dict[str, dict[str, Any]] = {}
+                lifecycle_coherent_read_available = repo is not None
+                if repo is not None and ledger_path is not None:
+                    cache_key = (ledger_path, account)
+                    if cache_key not in lifecycle_account_cache:
+                        try:
+                            lifecycle_account_cache[cache_key] = (
+                                _coherent_account_lifecycle_inputs(
+                                    repo,
+                                    account=account,
+                                    now_ms=int(now.timestamp() * 1000),
+                                ),
+                                None,
+                            )
+                        except (
+                            sqlite3.Error,
+                            TypeError,
+                            ValueError,
+                            OverflowError,
+                        ) as exc:
+                            lifecycle_account_cache[cache_key] = (
+                                None,
+                                str(exc),
+                            )
+                    account_inputs, lifecycle_read_error = (
+                        lifecycle_account_cache[cache_key]
+                    )
+                    if account_inputs is None:
+                        lifecycle_coherent_read_available = False
+                        runtime_errors.append(
+                            {
+                                "config_key": key,
+                                "account": account,
+                                "reason": (
+                                    lifecycle_read_error
+                                    or "coherent lifecycle account read unavailable"
+                                ),
+                            }
+                        )
+                    else:
+                        account_cases = list(account_inputs["cases"])
+                        account_evidence_rows = list(
+                            account_inputs["evidence_rows"]
+                        )
+                        account_timing_policies_by_case = dict(
+                            account_inputs["timing_policies_by_case"]
+                        )
+                        account_local_lots = list(
+                            account_inputs["local_lots"]
+                        )
+                        account_read_models_by_case = dict(
+                            account_inputs["read_models_by_case"]
+                        )
                 previous_position = previous_positions.get((account, market))
                 refresh_authoritative = bool(
                     deep
                     or day_end_strict
                     or self._authoritative_refresh_required(
                         previous=previous_position,
-                        local_lots=local_lots,
+                        local_lots=account_local_lots,
                         account=account,
                         market=market,
                         now=now,
@@ -260,16 +391,21 @@ class OMQualityService:
                     )
                     position_dataset, control_state = build_position_dataset(
                         snapshot=snapshot,
-                        local_lots=local_lots,
+                        local_lots=account_local_lots,
                         account=account,
                         market=market,
                         observed_at_utc=observed_at,
                         now=now,
                         control_state=control_state,
-                        lifecycle_cases=cases,
-                        lifecycle_read_models_by_case=read_models_by_case,
+                        lifecycle_cases=account_cases,
+                        lifecycle_read_models_by_case=(
+                            account_read_models_by_case
+                        ),
                         lifecycle_timing_policies_by_case=(
-                            timing_policies_by_case
+                            account_timing_policies_by_case
+                        ),
+                        lifecycle_coherent_read_available=(
+                            lifecycle_coherent_read_available
                         ),
                         day_end_strict=day_end_strict,
                         next_authoritative_refresh_due_utc=(
@@ -296,8 +432,8 @@ class OMQualityService:
                 datasets.append(position_dataset)
                 datasets.extend(
                     build_lifecycle_datasets(
-                        cases=cases,
-                        evidence_rows=evidence_rows,
+                        cases=account_cases,
+                        evidence_rows=account_evidence_rows,
                         account=account,
                         market=market,
                         observed_at_utc=observed_at,
@@ -307,9 +443,9 @@ class OMQualityService:
                             control_state.get("lifecycle_first_deep_reconcile") or {}
                         ),
                         timing_policies_by_case=(
-                            timing_policies_by_case
+                            account_timing_policies_by_case
                         ),
-                        read_models_by_case=read_models_by_case,
+                        read_models_by_case=account_read_models_by_case,
                     )
                 )
                 datasets.append(

--- a/tests/quality/test_om_quality_checks.py
+++ b/tests/quality/test_om_quality_checks.py
@@ -263,6 +263,29 @@ def test_position_lifecycle_exact_coverage_is_partial_but_non_blocking() -> None
     assert state["position_mismatches"] == {}
 
 
+def test_position_mismatch_fails_closed_when_coherent_lifecycle_read_is_unavailable() -> None:
+    now = datetime(2026, 7, 13, 10, tzinfo=timezone.utc)
+    dataset, state = build_position_dataset(
+        snapshot=_snapshot(qty=0),
+        local_lots=[_local_lot()],
+        account="lx",
+        market="us",
+        observed_at_utc="2026-07-13T10:00:00Z",
+        now=now,
+        control_state={"position_mismatches": {}},
+        lifecycle_coherent_read_available=False,
+        day_end_strict=True,
+    )
+
+    convergence = dataset["checks"][1]
+    assert dataset["status"] == "unavailable"
+    assert convergence["status"] == "unknown"
+    assert convergence["reason_code"] == (
+        "POSITION_LIFECYCLE_COHERENT_READ_UNAVAILABLE"
+    )
+    assert state["position_mismatches"] == {}
+
+
 def test_position_lifecycle_partial_quantity_does_not_hide_divergence() -> None:
     now = datetime(2026, 7, 13, 10, tzinfo=timezone.utc)
     lifecycle_case, read_model = _pending_lifecycle_case(contracts=1)

--- a/tests/quality/test_om_quality_service.py
+++ b/tests/quality/test_om_quality_service.py
@@ -7,9 +7,13 @@ from pathlib import Path
 from jsonschema import Draft202012Validator, FormatChecker
 
 import src.application.quality.service as service_module
+from domain.domain.option_lifecycle import build_lifecycle_case
 from src.application.ledger.repository import SQLiteOptionPositionsRepository
 from src.application.ledger.position_records import PositionLotRecord
 from src.application.quality.service import OMQualityService
+from src.application.trades.close_reason_evidence import (
+    build_lifecycle_timing_policy,
+)
 from src.infrastructure.quality.artifact_repository import QualityArtifactRepository
 from src.infrastructure.quality.control_state_repository import QualityControlStateRepository
 from src.infrastructure.quality.opend_position_adapter import OpenDOptionSnapshot
@@ -121,6 +125,136 @@ def test_service_publishes_schema_valid_artifact_without_business_writes(
         )
     )
     Draft202012Validator(schema, format_checker=FormatChecker()).validate(payload)
+
+
+def test_service_uses_account_coherent_lifecycle_read_for_position_coverage(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    ledger_path = tmp_path / "option_positions.sqlite3"
+    repo = SQLiteOptionPositionsRepository(ledger_path)
+    repo.replace_position_lots(
+        [
+            PositionLotRecord(
+                record_id="lot-nvda",
+                fields={
+                    "account": "lx",
+                    "broker": "futu",
+                    "symbol": "NVDA",
+                    "option_type": "put",
+                    "side": "short",
+                    "contracts": 1,
+                    "contracts_open": 1,
+                    "contracts_closed": 0,
+                    "currency": "USD",
+                    "strike": 100,
+                    "multiplier": 100,
+                    "expiration": 1784246400000,
+                    "expiration_ymd": "2026-07-17",
+                    "status": "open",
+                },
+            )
+        ]
+    )
+    lifecycle_case = build_lifecycle_case(
+        account="lx",
+        broker="futu",
+        contract_key="futu|lx|NVDA|put|short|100|2026-07-17",
+        position_side="short",
+        expiration_ymd="2026-07-17",
+        market="US",
+        target_contracts_by_lot={"lot-nvda": 1},
+    )
+    lifecycle_case.update(
+        {
+            "market": "US",
+            "symbol": "NVDA",
+            "option_type": "put",
+            "strike": 100,
+            "multiplier": 100,
+        }
+    )
+    assert repo.upsert_trade_lifecycle_case(lifecycle_case)
+    now = datetime(2026, 7, 13, 10, tzinfo=timezone.utc)
+    assert repo.insert_trade_lifecycle_timing_policy_once(
+        build_lifecycle_timing_policy(
+            case_id=str(lifecycle_case["case_id"]),
+            market="US",
+            expiration_ymd="2026-07-17",
+            contract_metadata={
+                "settlement_style": "physical",
+                "underlying_security_type": "equity",
+                "last_trade_cutoff_ms": int(now.timestamp() * 1000),
+                "last_trade_cutoff_source": "instrument_policy_registry",
+            },
+            trading_days=[
+                {"date": "2026-07-17", "type": "TRADING"},
+                {"date": "2026-07-20", "type": "TRADING"},
+                {"date": "2026-07-21", "type": "TRADING"},
+            ],
+            calendar_source="test_calendar",
+            calendar_observed_at_ms=int(now.timestamp() * 1000),
+        )
+    )
+    config_path = tmp_path / "config.us.json"
+    config_path.write_text("{}", encoding="utf-8")
+    cfg = {
+        "accounts": ["lx"],
+        "account_settings": {
+            "lx": {
+                "type": "futu",
+                "futu": {
+                    "host": "127.0.0.1",
+                    "port": 11111,
+                    "account_id": "123456",
+                    "trd_env": "REAL",
+                },
+            }
+        },
+    }
+    monkeypatch.setattr(
+        service_module,
+        "load_runtime_config",
+        lambda **_kwargs: (config_path, cfg),
+    )
+    monkeypatch.setattr(
+        service_module,
+        "infer_runtime_config_market",
+        lambda **_kwargs: "US",
+    )
+    runtime = {
+        "config": {"config_key": "us"},
+        "summary": {"ok": True},
+        "ledger_store": {"sqlite_path": str(ledger_path)},
+        "trade_intake": {
+            "holdings_sync": {"enabled": False},
+            "sources": [],
+        },
+        "service_profile": {"loaded": True},
+    }
+    payload = OMQualityService(
+        artifact_repository=QualityArtifactRepository(
+            tmp_path / "status.v1.json"
+        ),
+        control_repository=QualityControlStateRepository(
+            tmp_path / "control.v1.json"
+        ),
+        opend_adapter=_OpenD(),
+        runtime_status_fn=lambda *_args: {"ok": True, "data": runtime},
+        now_fn=lambda: now,
+        instance_id="test-instance",
+    ).refresh(config_keys=["us"], day_end_strict=True)
+
+    position = next(
+        item
+        for item in payload["datasets"]
+        if item["dataset_id"] == "om.option_positions"
+    )
+    assert position["status"] == "partial"
+    assert position["checks"][1]["reason_code"] == (
+        "POSITIONS_PENDING_LIFECYCLE"
+    )
+    assert position["blocked_consumers"] == []
 
 
 def test_no_deep_refresh_carries_current_snapshot_and_due_probe_rechecks(

--- a/tests/test_position_advice_cli.py
+++ b/tests/test_position_advice_cli.py
@@ -19,6 +19,7 @@ from src.application.position_advice_source_receipts import (
     publish_source_receipt,
     sha256_bytes,
 )
+import src.interfaces.cli.position_advice_ops as position_advice_ops
 from src.interfaces.cli.position_advice_ops import main
 
 
@@ -281,3 +282,45 @@ def test_position_advice_promotion_cli_is_safe_without_authority(
     status = json.loads(capsys.readouterr().out)
     assert status["status"] == "not_applicable"
     assert status["ready_for_final_cas"] is False
+
+
+def test_position_advice_promotion_cli_treats_compatible_source_wait_as_success(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        position_advice_ops,
+        "refresh_position_advice_promotion",
+        lambda **_kwargs: {
+            "schema_version": "position_advice_promotion_refresh.v1",
+            "status": "waiting_for_compatible_shadow_plans",
+            "reason_codes": ["current_contract_shadow_plan_set_empty"],
+            "normalized_account": "lx",
+            "source_plan_count": 0,
+            "discovered_source_plan_count": 4,
+            "compatible_source_plan_count": 0,
+            "incompatible_source_plan_count": 4,
+            "dry_run": False,
+            "published": False,
+        },
+    )
+
+    result = main(
+        [
+            "--runtime-root",
+            str(tmp_path),
+            "promotion",
+            "refresh",
+            "--accounts",
+            "lx",
+            "--confirm",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload["status"] == "completed"
+    assert payload["results"][0]["status"] == (
+        "waiting_for_compatible_shadow_plans"
+    )

--- a/tests/test_position_advice_promotion.py
+++ b/tests/test_position_advice_promotion.py
@@ -318,6 +318,29 @@ def _binding() -> dict[str, object]:
     )
 
 
+def _rewrite_position_fact_contract(
+    path: Path,
+    *,
+    legacy: bool,
+) -> None:
+    input_path = path.parent / "state" / "position_advice_input.v2.json"
+    immutable_input = json.loads(input_path.read_text())
+    decision_snapshot = immutable_input["decision_state_snapshot"]
+    if legacy:
+        decision_snapshot.pop("position_fact_contract_version")
+    else:
+        decision_snapshot.pop("account_lifecycle_cases")
+    immutable_input.pop("input_hash")
+    immutable_input["input_hash"] = canonical_sha256(immutable_input)
+    _write_json(input_path, immutable_input)
+
+    plan = json.loads(path.read_text())
+    plan["input_hash"] = immutable_input["input_hash"]
+    plan.pop("artifact_hash")
+    plan["artifact_hash"] = canonical_sha256(plan)
+    _write_json(path, plan)
+
+
 def test_promotion_aggregator_builds_non_vacuous_passing_evidence(
     tmp_path: Path,
 ) -> None:
@@ -385,6 +408,133 @@ def test_legacy_v2_position_fact_snapshot_is_promotion_ineligible(
                 for name in REQUIRED_CRITICAL_REPLAY_FIXTURES
             },
             generated_at=NOW,
+        )
+
+
+def test_refresh_waits_when_only_legacy_position_fact_source_is_available(
+    tmp_path: Path,
+) -> None:
+    applied = apply_authority_change(
+        base=tmp_path,
+        normalized_account="lx",
+        normalized_portfolio_source="futu",
+        portfolio_account_identity_hash=IDENTITY,
+        target_mode="v2_shadow",
+        expected_policy_hash="absent",
+        actor="operator@example",
+        requested_at=NOW,
+        confirm=True,
+        identity_binding_evidence=_binding(),
+    )
+    policy = dict(applied["policy"])
+    path = _plan(
+        tmp_path,
+        index=0,
+        selected=True,
+        alternative=False,
+        authority_generation=int(policy["generation"]),
+        authority_policy_hash=str(policy["policy_hash"]),
+    )
+    _rewrite_position_fact_contract(path, legacy=True)
+
+    result = refresh_position_advice_promotion(
+        base=tmp_path,
+        normalized_account="lx",
+        confirm=True,
+    )
+
+    assert result["status"] == "waiting_for_compatible_shadow_plans"
+    assert result["reason_codes"] == [
+        "current_contract_shadow_plan_set_empty"
+    ]
+    assert result["source_plan_count"] == 0
+    assert result["discovered_source_plan_count"] == 1
+    assert result["compatible_source_plan_count"] == 0
+    assert result["incompatible_source_plan_count"] == 1
+    assert result["published"] is False
+    assert len(
+        list(
+            (
+                tmp_path
+                / "output_shared"
+                / "state"
+                / "position_advice"
+                / scope_for("lx")
+                / "promotion_sources"
+            ).glob("*/position_advice.v2.json.gz")
+        )
+    ) == 1
+
+
+def test_refresh_uses_only_compatible_position_fact_sources(
+    tmp_path: Path,
+) -> None:
+    applied = apply_authority_change(
+        base=tmp_path,
+        normalized_account="lx",
+        normalized_portfolio_source="futu",
+        portfolio_account_identity_hash=IDENTITY,
+        target_mode="v2_shadow",
+        expected_policy_hash="absent",
+        actor="operator@example",
+        requested_at=NOW,
+        confirm=True,
+        identity_binding_evidence=_binding(),
+    )
+    policy = dict(applied["policy"])
+    paths = _plans(
+        tmp_path,
+        authority_generation=int(policy["generation"]),
+        authority_policy_hash=str(policy["policy_hash"]),
+    )
+    _rewrite_position_fact_contract(paths[0], legacy=True)
+
+    result = refresh_position_advice_promotion(
+        base=tmp_path,
+        normalized_account="lx",
+    )
+
+    assert result["source_plan_count"] == 29
+    assert result["discovered_source_plan_count"] == 30
+    assert result["compatible_source_plan_count"] == 29
+    assert result["incompatible_source_plan_count"] == 1
+    assert len(result["evidence"]["opportunities"]) == 29
+    assert result["published"] is False
+
+
+def test_refresh_rejects_malformed_current_position_fact_source(
+    tmp_path: Path,
+) -> None:
+    applied = apply_authority_change(
+        base=tmp_path,
+        normalized_account="lx",
+        normalized_portfolio_source="futu",
+        portfolio_account_identity_hash=IDENTITY,
+        target_mode="v2_shadow",
+        expected_policy_hash="absent",
+        actor="operator@example",
+        requested_at=NOW,
+        confirm=True,
+        identity_binding_evidence=_binding(),
+    )
+    policy = dict(applied["policy"])
+    path = _plan(
+        tmp_path,
+        index=0,
+        selected=True,
+        alternative=False,
+        authority_generation=int(policy["generation"]),
+        authority_policy_hash=str(policy["policy_hash"]),
+    )
+    _rewrite_position_fact_contract(path, legacy=False)
+
+    with pytest.raises(
+        PositionAdvicePromotionError,
+        match="position advice input decision facts are invalid",
+    ):
+        refresh_position_advice_promotion(
+            base=tmp_path,
+            normalized_account="lx",
         )
 
 


### PR DESCRIPTION
## What changed

- Read IQ lifecycle facts from one account-coherent SQLite snapshot and fail closed when lifecycle coverage cannot be established.
- Classify promotion inputs by the current position-fact contract after integrity, identity, authority, and binding checks.
- Exclude valid legacy-contract sources, wait without timer failure when none are compatible, and retain hard failure for malformed current-contract sources.
- Update compatibility documentation and dependency graph.

## Root cause

IQ attempted per-case reads against a read-only repository that only exposes account-coherent reads, then silently treated missing models as zero lifecycle coverage. Promotion treated integrity-valid archived inputs from an older position-fact contract as malformed current inputs, causing the maintenance timer to fail.

## Validation

- `python3.12 -m ruff check .`
- `python3.12 scripts/generate_dependency_graph.py --check`
- `python3.12 -m pytest -q -p no:cacheprovider` — 3890 passed, 10 skipped

## Boundaries

No VERSION or release metadata changes. No release, deployment, production data repair, ledger mutation, notification, service change, or timing-policy binding.
