### PR TITLE
fix: harden IQ evidence and Strategy Lab sampling

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 905 (`src`: 492, `domain`: 76, `scripts`: 8, `tests`: 329)
-- Internal import edges: 5518 total, 2457 production/script edges excluding tests
+- Internal import edges: 5526 total, 2458 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -45,11 +45,11 @@ flowchart LR
   scripts -->|12| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2186| application
+  tests -->|2192| application
   tests -->|481| domain
   tests -->|2| domain_services
   tests -->|133| infrastructure
-  tests -->|201| interfaces
+  tests -->|202| interfaces
   tests -->|13| scripts
   tests -->|16| storage
 ```
@@ -77,9 +77,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2186 |
+| tests | application | 2192 |
 | tests | domain | 481 |
-| tests | interfaces | 201 |
+| tests | interfaces | 202 |
 | tests | infrastructure | 133 |
 | tests | storage | 16 |
 | tests | scripts | 13 |

--- a/src/application/quality/service.py
+++ b/src/application/quality/service.py
@@ -988,6 +988,7 @@ class OMQualityService:
     ) -> dict[str, Any]:
         intents: list[dict[str, Any]] = []
         enabled = False
+        activity_observed = False
         for runtime in runtime_for_config:
             intake = runtime.get("trade_intake") if isinstance(runtime.get("trade_intake"), dict) else {}
             for source in intake.get("sources") or []:
@@ -1000,9 +1001,23 @@ class OMQualityService:
                 intent = summary.get("last_stock_holdings_sync_intent")
                 if isinstance(intent, dict):
                     intents.append(intent)
+                activity_observed = activity_observed or bool(
+                    summary.get("last_push_received_utc")
+                    or summary.get("last_deal_result")
+                    or summary.get("last_backfill_result")
+                    or summary.get("last_backfill_deal_count") not in (None, "", 0, "0")
+                    or summary.get("last_backfill_applied_count") not in (None, "", 0, "0")
+                )
                 enabled = enabled or bool(intake.get("holdings_sync", {}).get("enabled"))
         if not enabled and not intents:
             status, reason, message = "pass", "STOCK_REFRESH_INTENT_NOT_APPLICABLE", "PM stock-refresh intent is not enabled for this source."
+            verdict = "trusted"
+        elif not intents and not activity_observed:
+            status, reason, message = (
+                "pass",
+                "STOCK_REFRESH_INTENT_NOT_TRIGGERED",
+                "No trade activity requiring a PM stock-refresh intent has been observed.",
+            )
             verdict = "trusted"
         elif not intents:
             status, reason, message = "unknown", "STOCK_REFRESH_INTENT_EVIDENCE_MISSING", "Stock-refresh intent is enabled but no result evidence is available."
@@ -1010,13 +1025,40 @@ class OMQualityService:
         else:
             latest = intents[-1]
             result_status = str(latest.get("status") or "").strip().lower()
-            ok = result_status in {"succeeded", "success", "queued", "debounced", "scheduled"}
-            status, reason, message = (
-                ("pass", "STOCK_REFRESH_INTENT_CONFIRMED", "Stock-refresh intent has a PM handoff result.")
-                if ok
-                else ("warn", "STOCK_REFRESH_INTENT_DELAYED", "Stock-refresh intent has not reached a successful PM handoff.")
-            )
-            verdict = "trusted" if ok else "partial"
+            result_reason = str(latest.get("reason") or "").strip().lower()
+            not_triggered = result_status == "skipped" and result_reason in {
+                "dry_run",
+                "option_deal",
+            }
+            ok = result_status in {
+                "coalesced",
+                "debounced",
+                "queued",
+                "scheduled",
+                "succeeded",
+                "success",
+            } or (result_status == "skipped" and result_reason == "already_synchronized")
+            if not_triggered:
+                status, reason, message = (
+                    "pass",
+                    "STOCK_REFRESH_INTENT_NOT_TRIGGERED",
+                    "The observed trade does not require a PM stock refresh.",
+                )
+                verdict = "trusted"
+            elif ok:
+                status, reason, message = (
+                    "pass",
+                    "STOCK_REFRESH_INTENT_CONFIRMED",
+                    "Stock-refresh intent has a PM handoff result.",
+                )
+                verdict = "trusted"
+            else:
+                status, reason, message = (
+                    "warn",
+                    "STOCK_REFRESH_INTENT_DELAYED",
+                    "Stock-refresh intent has not reached a successful PM handoff.",
+                )
+                verdict = "partial"
         check = check_result(
             check_id="OM-HSYNC-001",
             status=status,
@@ -1024,8 +1066,11 @@ class OMQualityService:
             observed_at_utc=observed_at,
             reason_code=reason,
             message=message,
-            observed={"intent_count": len(intents)},
-            expected={"latest_intent_result": "successful"},
+            observed={
+                "intent_count": len(intents),
+                "activity_observed": activity_observed,
+            },
+            expected={"latest_intent_result": "successful_or_not_applicable"},
             evidence_refs=[],
         )
         return dataset_status(

--- a/src/application/required_data_fetching.py
+++ b/src/application/required_data_fetching.py
@@ -38,6 +38,7 @@ class RequiredDataFetchRequest:
     expiration_window_sec: float = 30.0
     expiration_max_calls: int = 60
     include_realized_volatility: bool = False
+    no_retry: bool = False
 
 
 def execute_required_data_opend(*, base: Path, request: RequiredDataFetchRequest) -> dict[str, object]:
@@ -74,6 +75,7 @@ def execute_required_data_opend(*, base: Path, request: RequiredDataFetchRequest
             expiration_window_sec=float(request.expiration_window_sec),
             expiration_max_calls=int(request.expiration_max_calls),
             include_realized_volatility=bool(request.include_realized_volatility),
+            no_retry=bool(request.no_retry),
         )
     )
 

--- a/src/application/shadow_replay/collection.py
+++ b/src/application/shadow_replay/collection.py
@@ -6,6 +6,7 @@ import tempfile
 from typing import Any
 
 from src.application.opend_symbol_outputs import save_outputs
+from src.application.option_chain_fetching import classify_option_chain_error
 from src.application.required_data_fetching import RequiredDataFetchRequest, execute_required_data_opend
 from src.application.shadow_replay.common import (
     OPTIONAL_CLOSE_DATASET_FILES,
@@ -40,6 +41,7 @@ def collect_shadow_replay_marks(
     chain_cache_force_refresh: bool = False,
     include_realized_volatility: bool = False,
     max_symbols: int | None = None,
+    fail_fast_on_opend_rate_limit: bool = False,
 ) -> dict[str, Any]:
     """Collect one replay mark sample from local cache or a fresh OpenD pull."""
 
@@ -80,6 +82,7 @@ def collect_shadow_replay_marks(
                 chain_cache_force_refresh=chain_cache_force_refresh,
                 include_realized_volatility=include_realized_volatility,
                 max_symbols=max_symbols,
+                fail_fast_on_rate_limit=bool(fail_fast_on_opend_rate_limit),
             )
 
         marking = mark_shadow_replay_dataset(
@@ -128,6 +131,11 @@ def collect_shadow_replay_marks(
         "generated_at_utc": utc_now(),
         "summary": {
             "status": (
+                "deferred"
+                if source_norm == "opend"
+                and bool(fetch_summary["summary"].get("rate_limit_circuit_open"))
+                and int(fetch_summary["summary"].get("non_rate_limit_error_count") or 0) == 0
+                else
                 "failed"
                 if source_norm == "opend"
                 and int(fetch_summary["summary"]["ok_count"] or 0) == 0
@@ -145,6 +153,13 @@ def collect_shadow_replay_marks(
             "opend_fetch_attempted": source_norm == "opend",
             "opend_fetch_ok_count": fetch_summary["summary"]["ok_count"],
             "opend_fetch_error_count": fetch_summary["summary"]["error_count"],
+            "opend_rate_limit_count": fetch_summary["summary"].get("rate_limit_count", 0),
+            "opend_non_rate_limit_error_count": fetch_summary["summary"].get(
+                "non_rate_limit_error_count", 0
+            ),
+            "opend_rate_limit_circuit_open": bool(
+                fetch_summary["summary"].get("rate_limit_circuit_open")
+            ),
             "opend_fetch_persisted": source_norm == "opend" and bool(write),
             "generated_mark_snapshot_count": marking["summary"]["generated_mark_snapshot_count"],
             "usable_mark_snapshot_count": marking["summary"]["usable_mark_snapshot_count"],
@@ -265,6 +280,9 @@ def _empty_fetch_summary(*, source: str, candidate_snapshots: list[dict[str, Any
             "error_count": 0,
             "row_count": 0,
             "skipped_symbol_count": 0,
+            "rate_limit_count": 0,
+            "non_rate_limit_error_count": 0,
+            "rate_limit_circuit_open": False,
         },
         "requests": [],
     }
@@ -282,6 +300,7 @@ def _fetch_required_data_from_opend(
     chain_cache_force_refresh: bool,
     include_realized_volatility: bool,
     max_symbols: int | None,
+    fail_fast_on_rate_limit: bool,
 ) -> dict[str, Any]:
     plans = _fetch_plans_from_candidates(
         candidate_snapshots,
@@ -309,6 +328,7 @@ def _fetch_required_data_from_opend(
             chain_cache_force_refresh=bool(chain_cache_force_refresh),
             freshness_policy=("force_refresh" if chain_cache_force_refresh else "cache_first"),
             include_realized_volatility=bool(include_realized_volatility),
+            no_retry=bool(fail_fast_on_rate_limit),
         )
         item = {
             "symbol": plan["symbol"],
@@ -321,6 +341,9 @@ def _fetch_required_data_from_opend(
             "raw_path": None,
             "csv_path": None,
             "error": None,
+            "error_code": None,
+            "source_outcome": None,
+            "reason_code": None,
         }
         try:
             payload = execute_required_data_opend(base=base, request=request)
@@ -336,30 +359,51 @@ def _fetch_required_data_from_opend(
                     "raw_path": str(raw_path),
                     "csv_path": str(csv_path),
                     "error": meta.get("error"),
+                    "error_code": meta.get("error_code"),
+                    "source_outcome": meta.get("source_outcome"),
+                    "reason_code": meta.get("reason_code"),
                 }
             )
         except Exception as exc:
             item["error"] = f"{type(exc).__name__}: {exc}"
+            item["error_code"] = classify_option_chain_error(exc)
         requests.append(item)
+        if fail_fast_on_rate_limit and text(item.get("error_code")).upper() == "RATE_LIMIT":
+            skipped.extend(requested[len(requests) :])
+            break
 
     ok_count = sum(1 for item in requests if item["status"] == "ok")
     partial_count = sum(1 for item in requests if item["status"] == "partial")
     error_count = sum(1 for item in requests if item["status"] not in {"ok", "partial"})
+    rate_limit_count = sum(
+        1 for item in requests if text(item.get("error_code")).upper() == "RATE_LIMIT"
+    )
+    non_rate_limit_error_count = sum(
+        1
+        for item in requests
+        if item["status"] not in {"ok", "partial"}
+        and text(item.get("error_code")).upper() != "RATE_LIMIT"
+    )
+    rate_limit_circuit_open = bool(fail_fast_on_rate_limit and rate_limit_count)
     return {
         "schema_version": "shadow_replay_required_data_fetch.v1",
         "source": "opend",
         "summary": {
             "candidate_snapshot_count": len(candidate_snapshots),
             "symbol_count": len(plans),
-            "requested_symbol_count": len(requested),
+            "requested_symbol_count": len(requests),
             "ok_count": ok_count,
             "partial_count": partial_count,
             "error_count": error_count,
+            "rate_limit_count": rate_limit_count,
+            "non_rate_limit_error_count": non_rate_limit_error_count,
+            "rate_limit_circuit_open": rate_limit_circuit_open,
             "row_count": sum(int(item.get("rows") or 0) for item in requests),
             "skipped_symbol_count": len(skipped),
         },
         "requests": requests,
         "skipped_symbols": [plan["symbol"] for plan in skipped],
+        "stop_reason": "opend_rate_limited" if rate_limit_circuit_open else None,
     }
 
 

--- a/src/application/shadow_replay/data_plan.py
+++ b/src/application/shadow_replay/data_plan.py
@@ -45,6 +45,7 @@ def run_shadow_replay_data_plan(
     include_realized_volatility: bool = False,
     max_symbols: int | None = None,
     now_utc: str | None = None,
+    fail_fast_on_opend_rate_limit: bool = False,
 ) -> dict[str, Any]:
     """Dry-run or execute local Shadow Replay data-maintenance actions.
 
@@ -92,6 +93,7 @@ def run_shadow_replay_data_plan(
         include_realized_volatility=bool(include_realized_volatility),
         max_symbols=max_symbols,
         generated_at=generated_at,
+        fail_fast_on_opend_rate_limit=bool(fail_fast_on_opend_rate_limit),
     )
     receipt_path = _resolve_receipt_path(
         base=base,
@@ -161,9 +163,11 @@ def _run_plan_rows(
     include_realized_volatility: bool,
     max_symbols: int | None,
     generated_at: str,
+    fail_fast_on_opend_rate_limit: bool,
 ) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     executed_or_planned = 0
+    opend_rate_limit_circuit_open = False
     plan_rows = rows if isinstance(rows, list) else []
     for row in plan_rows:
         if not isinstance(row, dict):
@@ -173,6 +177,15 @@ def _run_plan_rows(
         if action not in action_set:
             out.append({**base, "result_status": "skipped", "reason": "action_not_enabled"})
             continue
+        if action == "collect_marks" and opend_rate_limit_circuit_open:
+            out.append(
+                {
+                    **base,
+                    "result_status": "deferred",
+                    "reason": "opend_rate_limit_circuit_open",
+                }
+            )
+            continue
         if max_datasets is not None and executed_or_planned >= max_datasets:
             out.append({**base, "result_status": "skipped", "reason": "max_datasets_reached"})
             continue
@@ -180,23 +193,25 @@ def _run_plan_rows(
         if not write:
             out.append({**base, "result_status": "planned", "reason": "dry_run"})
             continue
-        out.append(
-            _execute_plan_row(
-                row,
-                repo_root=repo_root,
-                required_data_root=required_data_root,
-                source=source,
-                settle_after_collect=settle_after_collect,
-                opend_host=opend_host,
-                opend_port=opend_port,
-                limit_expirations=limit_expirations,
-                chain_cache=chain_cache,
-                chain_cache_force_refresh=chain_cache_force_refresh,
-                include_realized_volatility=include_realized_volatility,
-                max_symbols=max_symbols,
-                generated_at=generated_at,
-            )
+        result = _execute_plan_row(
+            row,
+            repo_root=repo_root,
+            required_data_root=required_data_root,
+            source=source,
+            settle_after_collect=settle_after_collect,
+            opend_host=opend_host,
+            opend_port=opend_port,
+            limit_expirations=limit_expirations,
+            chain_cache=chain_cache,
+            chain_cache_force_refresh=chain_cache_force_refresh,
+            include_realized_volatility=include_realized_volatility,
+            max_symbols=max_symbols,
+            generated_at=generated_at,
+            fail_fast_on_opend_rate_limit=fail_fast_on_opend_rate_limit,
         )
+        out.append(result)
+        if result.get("reason") == "opend_rate_limited":
+            opend_rate_limit_circuit_open = True
     return out
 
 
@@ -215,6 +230,7 @@ def _execute_plan_row(
     include_realized_volatility: bool,
     max_symbols: int | None,
     generated_at: str,
+    fail_fast_on_opend_rate_limit: bool,
 ) -> dict[str, Any]:
     base = _action_base(row)
     dataset_dir = text(row.get("dataset_dir"))
@@ -239,6 +255,7 @@ def _execute_plan_row(
                 chain_cache_force_refresh=chain_cache_force_refresh,
                 include_realized_volatility=include_realized_volatility,
                 max_symbols=max_symbols,
+                fail_fast_on_opend_rate_limit=fail_fast_on_opend_rate_limit,
             )
         elif action == "settle":
             payload = settle_shadow_replay_dataset(dataset=dataset_dir, write=True, replace=False)
@@ -253,6 +270,17 @@ def _execute_plan_row(
         }
     operation = _operation_payload(payload)
     operation_summary = operation.get("summary") or {}
+    operation_deferred = (
+        text(operation_summary.get("status")).lower() == "deferred"
+        and int(operation_summary.get("opend_non_rate_limit_error_count") or 0) == 0
+    )
+    if operation_deferred:
+        return {
+            **base,
+            "result_status": "deferred",
+            "reason": "opend_rate_limited",
+            "operation": operation,
+        }
     operation_failed = (
         text(operation_summary.get("status")).lower()
         in {"error", "failed", "partial_failed"}
@@ -321,12 +349,15 @@ def _summary(
     rows = plan_rows if isinstance(plan_rows, list) else []
     counts = Counter(text(row.get("result_status")) for row in action_results)
     error_count = counts.get("error", 0)
+    deferred_count = counts.get("deferred", 0)
     return {
         "status": (
             "failed"
             if error_count and counts.get("ok", 0) == 0
             else "partial_failed"
             if error_count
+            else "deferred"
+            if deferred_count
             else "success"
         ),
         "plan_action_count": len(rows),
@@ -334,6 +365,7 @@ def _summary(
         "planned_count": counts.get("planned", 0),
         "executed_count": counts.get("ok", 0),
         "skipped_count": counts.get("skipped", 0),
+        "deferred_count": deferred_count,
         "error_count": error_count,
         "receipt_written": receipt_path is not None,
         "receipt_path": str(receipt_path) if receipt_path is not None else None,
@@ -379,14 +411,16 @@ def _safety(
     dataset_wrote = bool(
         write
         and any(
-            row.get("action") in {"collect_marks", "settle"} and row.get("result_status") == "ok"
+            row.get("action") in {"collect_marks", "settle"}
+            and row.get("result_status") in {"ok", "deferred"}
             for row in action_results
         )
     )
     collect_attempted = bool(
         write
         and any(
-            row.get("action") == "collect_marks" and row.get("result_status") in {"ok", "error"}
+            row.get("action") == "collect_marks"
+            and row.get("result_status") in {"ok", "error", "deferred"}
             for row in action_results
         )
     )

--- a/src/application/strategy_lab/update.py
+++ b/src/application/strategy_lab/update.py
@@ -116,6 +116,7 @@ def run_strategy_lab_update(
         chain_cache_force_refresh=bool(chain_cache_force_refresh),
         include_realized_volatility=bool(include_realized_volatility),
         max_symbols=max_symbols,
+        fail_fast_on_opend_rate_limit=text(source).lower() == "opend",
     )
     status = data_plan.get("status_after") if write and data_plan.get("status_after") else data_plan.get("status_before")
     result: dict[str, Any] = {
@@ -390,6 +391,7 @@ def _summary(
     error_count = int(plan_summary.get("error_count") or 0)
     executed_count = int(plan_summary.get("executed_count") or 0)
     planned_count = int(plan_summary.get("planned_count") or 0)
+    deferred_count = int(plan_summary.get("deferred_count") or 0)
     build_requested = bool(dataset_build.get("requested"))
     build_executed = bool(dataset_build.get("executed"))
     close_build_requested = bool(close_dataset_build.get("requested"))
@@ -398,6 +400,8 @@ def _summary(
         "status": (
             "error"
             if error_count
+            else "deferred"
+            if deferred_count
             else (
                 "updated"
                 if write and (executed_count or build_executed or close_build_executed)
@@ -421,6 +425,7 @@ def _summary(
         "planned_count": planned_count,
         "executed_count": executed_count,
         "skipped_count": int(plan_summary.get("skipped_count") or 0),
+        "deferred_count": deferred_count,
         "error_count": error_count,
         "ready_for_experiment_count": status_summary.get("review_queue_count"),
         "sampling_due_count": status_summary.get("sampling_due_count"),
@@ -455,6 +460,8 @@ def _next_action(
     summary = data_plan.get("summary") or {}
     if int(summary.get("error_count") or 0) > 0:
         return "inspect_data_plan_errors"
+    if int(summary.get("deferred_count") or 0) > 0:
+        return "retry_after_opend_rate_limit_window"
     if bool(dataset_build.get("requested")) and not write:
         return "rerun_with_write_to_build_latest_dataset"
     if not write and int(summary.get("planned_count") or 0) > 0:

--- a/tests/quality/test_om_quality_service.py
+++ b/tests/quality/test_om_quality_service.py
@@ -39,6 +39,90 @@ class _OpenD:
         )
 
 
+def test_holdings_sync_quality_treats_no_activity_as_not_triggered() -> None:
+    runtime = {
+        "trade_intake": {
+            "holdings_sync": {"enabled": True},
+            "sources": [
+                {
+                    "account": "lx",
+                    "summary": {
+                        "last_push_received_utc": None,
+                        "last_backfill_deal_count": 0,
+                        "last_backfill_applied_count": 0,
+                        "last_stock_holdings_sync_intent": None,
+                    },
+                }
+            ],
+        }
+    }
+
+    dataset = OMQualityService._holdings_sync_dataset(
+        runtime_for_config=[runtime],
+        account="lx",
+        market="us",
+        observed_at="2026-08-01T00:00:00Z",
+    )
+
+    assert dataset["status"] == "trusted"
+    assert dataset["reason_codes"] == []
+    assert dataset["checks"][0]["status"] == "pass"
+    assert dataset["checks"][0]["reason_code"] == "STOCK_REFRESH_INTENT_NOT_TRIGGERED"
+    assert dataset["checks"][0]["observed"] == {
+        "intent_count": 0,
+        "activity_observed": False,
+    }
+
+
+def test_holdings_sync_quality_preserves_missing_and_failed_evidence() -> None:
+    def _dataset(summary: dict) -> dict:
+        return OMQualityService._holdings_sync_dataset(
+            runtime_for_config=[
+                {
+                    "trade_intake": {
+                        "holdings_sync": {"enabled": True},
+                        "sources": [{"account": "lx", "summary": summary}],
+                    }
+                }
+            ],
+            account="lx",
+            market="us",
+            observed_at="2026-08-01T00:00:00Z",
+        )
+
+    missing = _dataset(
+        {
+            "last_push_received_utc": "2026-08-01T00:00:00Z",
+            "last_stock_holdings_sync_intent": None,
+        }
+    )
+    not_applicable = _dataset(
+        {
+            "last_push_received_utc": "2026-08-01T00:00:00Z",
+            "last_stock_holdings_sync_intent": {
+                "status": "skipped",
+                "reason": "option_deal",
+            },
+        }
+    )
+    failed = _dataset(
+        {
+            "last_push_received_utc": "2026-08-01T00:00:00Z",
+            "last_stock_holdings_sync_intent": {
+                "status": "rejected",
+                "reason": "queue_full",
+            },
+        }
+    )
+
+    assert missing["status"] == "unavailable"
+    assert missing["checks"][0]["reason_code"] == "STOCK_REFRESH_INTENT_EVIDENCE_MISSING"
+    assert not_applicable["status"] == "trusted"
+    assert not_applicable["checks"][0]["reason_code"] == "STOCK_REFRESH_INTENT_NOT_TRIGGERED"
+    assert failed["status"] == "partial"
+    assert failed["checks"][0]["reason_code"] == "STOCK_REFRESH_INTENT_DELAYED"
+
+
 def test_service_publishes_schema_valid_artifact_without_business_writes(
     monkeypatch,
     tmp_path: Path,

--- a/tests/test_shadow_replay.py
+++ b/tests/test_shadow_replay.py
@@ -1154,6 +1154,67 @@ def test_shadow_replay_data_plan_dry_run_is_read_only(tmp_path: Path) -> None:
     assert result["safety"]["sends_notifications"] is False
 
 
+def test_shadow_replay_data_plan_defers_remaining_collects_after_opend_rate_limit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.shadow_replay.data_plan as data_plan_module
+
+    plan_rows = [
+        {
+            "dataset_id": dataset_id,
+            "dataset_dir": str(tmp_path / dataset_id),
+            "action": "collect_marks",
+            "reason": "sampling_due",
+        }
+        for dataset_id in ("first", "second")
+    ]
+    monkeypatch.setattr(
+        data_plan_module,
+        "shadow_replay_dataset_status",
+        lambda **_kwargs: {
+            "dataset_root": str(tmp_path),
+            "summary": {"dataset_count": 2},
+            "data_plan": plan_rows,
+            "datasets": [],
+        },
+    )
+    calls: list[dict] = []
+
+    def _rate_limited_collect(**kwargs):
+        calls.append(kwargs)
+        return {
+            "schema_version": "shadow_replay_mark_collection.v1",
+            "summary": {
+                "status": "deferred",
+                "opend_fetch_error_count": 1,
+                "opend_rate_limit_count": 1,
+                "opend_non_rate_limit_error_count": 0,
+                "opend_rate_limit_circuit_open": True,
+            },
+            "safety": {"writes_local_dataset": True},
+        }
+
+    monkeypatch.setattr(data_plan_module, "collect_shadow_replay_marks", _rate_limited_collect)
+
+    result = data_plan_module.run_shadow_replay_data_plan(
+        repo_root=tmp_path,
+        source="opend",
+        write=True,
+        fail_fast_on_opend_rate_limit=True,
+        now_utc="2026-08-01T00:00:00Z",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["fail_fast_on_opend_rate_limit"] is True
+    assert result["summary"]["status"] == "deferred"
+    assert result["summary"]["deferred_count"] == 2
+    assert result["summary"]["error_count"] == 0
+    assert [row["result_status"] for row in result["actions"]] == ["deferred", "deferred"]
+    assert result["actions"][0]["reason"] == "opend_rate_limited"
+    assert result["actions"][1]["reason"] == "opend_rate_limit_circuit_open"
+
+
 def test_shadow_replay_data_plan_rejects_review_and_dry_run_receipt_writes(tmp_path: Path) -> None:
     from src.application.shadow_replay import run_shadow_replay_data_plan
 
@@ -1782,6 +1843,80 @@ def test_shadow_replay_collect_marks_does_not_reuse_stale_cache_after_partial_op
     assert marks["NVDA260619P00100000"]["point_in_time_status"] == "verified_fresh_collection"
     assert marks["AMD260619P00080000"]["quote_status"] == "missing_quote"
     assert marks["AMD260619P00080000"]["point_in_time_status"] == "missing_quote"
+
+
+def test_shadow_replay_collect_marks_fail_fast_on_opend_rate_limit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from src.application.shadow_replay import collect_shadow_replay_marks
+    import src.application.shadow_replay.collection as collection
+
+    dataset_dir = (
+        tmp_path
+        / "output_shared"
+        / "research"
+        / "shadow_replay"
+        / "datasets"
+        / "case-rate-limit"
+    )
+    _write_jsonl(
+        dataset_dir / "candidate_snapshots.jsonl",
+        [
+            {
+                "symbol": symbol,
+                "contract_symbol": contract,
+                "option_type": "put",
+                "expiration": "2026-06-19",
+                "strike": strike,
+                "status": "accepted",
+            }
+            for symbol, contract, strike in (
+                ("AMD", "AMD260619P00080000", 80),
+                ("NVDA", "NVDA260619P00100000", 100),
+            )
+        ],
+    )
+    _seal_dataset(dataset_dir)
+    calls = []
+
+    def _rate_limited_fetch(*, base: Path, request):
+        calls.append(request)
+        return {
+            "symbol": request.symbol,
+            "expiration_count": 0,
+            "expirations": [],
+            "rows": [],
+            "meta": {
+                "source": "opend",
+                "status": "error",
+                "error_code": "RATE_LIMIT",
+                "error": "every 30 seconds at most 10 calls",
+                "source_outcome": "provider_error",
+                "reason_code": "RATE_LIMIT",
+            },
+        }
+
+    monkeypatch.setattr(collection, "execute_required_data_opend", _rate_limited_fetch)
+
+    result = collect_shadow_replay_marks(
+        dataset=dataset_dir,
+        required_data_root=tmp_path / "output_shared" / "required_data",
+        source="opend",
+        repo_root=tmp_path,
+        write=True,
+        fail_fast_on_opend_rate_limit=True,
+    )
+
+    assert [request.symbol for request in calls] == ["AMD"]
+    assert calls[0].no_retry is True
+    assert result["summary"]["status"] == "deferred"
+    assert result["summary"]["opend_rate_limit_count"] == 1
+    assert result["summary"]["opend_non_rate_limit_error_count"] == 0
+    assert result["fetch"]["summary"]["requested_symbol_count"] == 1
+    assert result["fetch"]["summary"]["skipped_symbol_count"] == 1
+    assert result["fetch"]["skipped_symbols"] == ["NVDA"]
+    assert result["fetch"]["stop_reason"] == "opend_rate_limited"
 
 
 def test_shadow_replay_collect_marks_opend_preview_does_not_persist(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_strategy_lab.py
+++ b/tests/test_strategy_lab.py
@@ -1641,6 +1641,48 @@ def test_strategy_lab_update_dry_run_wraps_shadow_replay_data_plan(tmp_path: Pat
     assert result["safety"]["sends_notifications"] is False
 
 
+def test_strategy_lab_update_treats_opend_rate_limit_as_deferred(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.shadow_replay.data_plan as data_plan_module
+    from src.application.strategy_lab import run_strategy_lab_update
+
+    dataset = tmp_path / "output_shared" / "research" / "shadow_replay" / "datasets" / "case-update"
+    _write_update_dataset(dataset)
+    observed: dict[str, object] = {}
+
+    def _rate_limited_collect(**kwargs):
+        observed.update(kwargs)
+        return {
+            "schema_version": "shadow_replay_mark_collection.v1",
+            "summary": {
+                "status": "deferred",
+                "opend_fetch_error_count": 1,
+                "opend_rate_limit_count": 1,
+                "opend_non_rate_limit_error_count": 0,
+                "opend_rate_limit_circuit_open": True,
+            },
+            "safety": {"writes_local_dataset": True},
+        }
+
+    monkeypatch.setattr(data_plan_module, "collect_shadow_replay_marks", _rate_limited_collect)
+
+    result = run_strategy_lab_update(
+        repo_root=tmp_path,
+        source="opend",
+        min_sample=1,
+        write=True,
+    )
+
+    assert observed["fail_fast_on_opend_rate_limit"] is True
+    assert result["summary"]["status"] == "deferred"
+    assert result["summary"]["deferred_count"] == 1
+    assert result["summary"]["error_count"] == 0
+    assert result["strategy_lab"]["next_action"] == "retry_after_opend_rate_limit_window"
+    assert result["strategy_lab"]["data_plan_actions"][0]["reason"] == "opend_rate_limited"
+
+
 def test_strategy_lab_update_build_dataset_dry_run_does_not_write(tmp_path: Path) -> None:
     from src.application.strategy_lab import run_strategy_lab_update
 
@@ -2167,6 +2209,41 @@ def test_cli_strategy_lab_update_latest_dry_run(capsys, monkeypatch, tmp_path: P
     assert payload["data"]["schema_version"] == "strategy_lab_update.v1"
     assert payload["data"]["summary"]["planned_count"] == 1
     assert payload["data"]["safety"]["runtime_config_write_allowed"] is False
+
+
+def test_cli_strategy_lab_update_opend_rate_limit_deferred_exits_success(
+    capsys,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.strategy_lab as strategy_lab
+    import src.interfaces.cli.main as cli
+
+    monkeypatch.setattr(cli, "repo_base", lambda: tmp_path)
+    monkeypatch.setattr(
+        strategy_lab,
+        "run_strategy_lab_update",
+        lambda **_kwargs: {
+            "schema_version": "strategy_lab_update.v1",
+            "summary": {"status": "deferred", "deferred_count": 1, "error_count": 0},
+        },
+    )
+
+    rc = cli.main(
+        [
+            "research",
+            "strategy-lab",
+            "update",
+            "--source",
+            "opend",
+            "--write",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["data"]["summary"]["status"] == "deferred"
 
 
 def test_cli_strategy_lab_update_builds_latest_dataset(capsys, monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Stop Strategy Lab OpenD sampling after the first confirmed provider rate limit, defer the remaining collection work, and treat retryable throttling as a successful bounded run.
- Distinguish stock-refresh evidence that was not triggered or explicitly skipped for option-only activity from genuinely missing or failed handoff evidence.

## Root cause

Strategy Lab continued sampling across symbols and datasets after OpenD rate limiting, which could consume the full systemd time budget. IQ also classified enabled-but-untriggered refresh intent and option-only skipped intent as unavailable even when no stock refresh was required.

## Impact

- OpenD sampling is bounded and preserves fail-closed behavior for real collection errors.
- Stock-refresh evidence becomes trusted only for confirmed no-trigger/explicit non-stock cases; missing intent after activity and rejected/failed refreshes remain unavailable or partial.
- No runtime configuration, PM sync, option-position ledger, notification, or production data changes.

## Validation

- Full test suite: 3896 passed, 10 skipped.
- Relevant suites: 265 passed.
- Ruff checks passed for all touched Python files.
- Dependency graph check passed: 576 production modules, 0 cycles.
- Git diff checks passed.