### PR TITLE
Batch lifecycle receipts to prevent reconciliation storms

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 905 (`src`: 492, `domain`: 76, `scripts`: 8, `tests`: 329)
-- Internal import edges: 5545 total, 2460 production/script edges excluding tests
+- Python files scanned: 907 (`src`: 493, `domain`: 76, `scripts`: 8, `tests`: 330)
+- Internal import edges: 5565 total, 2463 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -45,11 +45,11 @@ flowchart LR
   scripts -->|12| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2203| application
+  tests -->|2219| application
   tests -->|481| domain
   tests -->|2| domain_services
   tests -->|133| infrastructure
-  tests -->|208| interfaces
+  tests -->|209| interfaces
   tests -->|13| scripts
   tests -->|16| storage
 ```
@@ -77,9 +77,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2203 |
+| tests | application | 2219 |
 | tests | domain | 481 |
-| tests | interfaces | 208 |
+| tests | interfaces | 209 |
 | tests | infrastructure | 133 |
 | tests | storage | 16 |
 | tests | scripts | 13 |
@@ -200,7 +200,7 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | src.application.agent_tools.analysis | 28 |
 | src.application.close_advice_runner | 28 |
 | src.interfaces.cli.main | 28 |
-| src.application.trades.auto_intake | 26 |
+| src.application.trades.auto_intake | 27 |
 | src.application.agent_tools.materialization | 25 |
 | src.application.daily_decision_brief_service | 24 |
 | src.application.multi_account_tick | 24 |

--- a/docs/FUTU_TRADE_HOLDINGS_SYNC.md
+++ b/docs/FUTU_TRADE_HOLDINGS_SYNC.md
@@ -160,6 +160,17 @@ Inbox、生命周期原因、逐意图 Outbox 与 delivery batch 分开显示，
 意图、未知批次、批次成员数及已减少消息数，同时保留 source 的 `pid`、
 `source_id`、OpenD host/port、账户和启动时间。
 
+监听进程只创建一个全局 `LifecycleReceiptBatchDispatcher`，统一领取全部启用账户
+的同路由批次；source listener 不再按账户发送回执。dispatcher 每秒进行一次可
+取消轮询，每轮最多尝试一个批次，并在所有 source listener 停止后、运行时资源
+关闭前退出。provider I/O 位于 `process_lock` 和 SQLite 事务之外，慢发送不会
+阻塞新的成交、Inbox 或生命周期事实写入。
+
+每个 source 的 status 在 `lifecycle_delivery.dispatcher` 下显示全局调度器状态、
+允许账户、最近一次批次结果或错误及 provider/channel/route 指纹；这里不会显示
+原始 target。`dry-run`、所有 receipt 均禁用或路由不可用时不会启动 dispatcher，
+状态分别显示 `dry_run`、`receipt_disabled` 或 `route_unavailable`。
+
 ## 运维命令
 
 以下命令均以 dry-run 为默认。示例同时列出预览和显式 one-shot applied 形式；

--- a/docs/FUTU_TRADE_HOLDINGS_SYNC.md
+++ b/docs/FUTU_TRADE_HOLDINGS_SYNC.md
@@ -122,30 +122,49 @@ date cash flow、交易日历和合约元数据的查询输入、返回码、覆
 payload hash。任一来源不完整、日历 hash 变化、零价锚点无法在历史成交中
 唯一复核、source claim 不匹配或数量超出冻结余量，统一进入人工复核。
 
-## 通知 Outbox
+## 通知 Outbox 与批量回执
 
-业务事务只写冻结的通知意图，不在 ledger 事务内调用飞书。dispatcher 使用
-CAS 状态流转：
+业务事务仍然一条状态变化写一条冻结通知意图，用于案件级审计；它不在 ledger
+事务内调用飞书。外部发送单位改为 delivery batch：同一
+provider/channel/target 的 `lx`、`sy` 等账户意图可进入同一批次，一条意图不会
+因批量发送而丢失或改写。只有 enabled source 且 receipt enabled 的账户可被
+绑定；禁用账户的历史意图保持可见、pending、unbound。
+
+planner 等待最新意图安静 10 秒，但最老意图最多等待 60 秒；到点后把当时所有
+符合条件的意图一次性冻结到一个批次，不按成员数拆分。批次只保存目标指纹，
+不保存或输出原始 target。绑定后的成员状态为 `batched`，旧版逐行 dispatcher
+不会重新认领这些行。
+
+批次使用 CAS 状态流转：
 
 ```text
 pending -> claimed -> send_started
 send_started -> confirmed | accepted | explicit_failed | unknown
 ```
 
-- `claimed` 在发送前租约过期可安全退回 `pending`。
-- `send_started` 后进程失联必须冻结为 `unknown`，不能自动重发。
-- `explicit_failed` 只按有限退避重试，达到上限后保持可观测。
+- `claimed` 在发送前租约过期可安全退回 `pending`；成员保持 `batched`。
+- `send_started` 后进程失联、超时、瞬时错误或 fallback 歧义必须把整个批次
+  冻结为 `unknown`，不能自动重发。
+- 明确的发送前失败、HTTP 4xx 或无歧义的 provider 拒绝才进入
+  `explicit_failed`；最多尝试三次，退避 60 秒、5 分钟。
+- 每次尝试都以稳定 `batch_id` 作为 transport idempotency key；同一路由
+  60 秒内最多开始一次发送。
 - `accepted` 表示 provider 已接受但尚无强确认；不能伪装成 `confirmed`。
-- `unknown` 只能由操作员依据 provider 证据标记确认，或创建增加
-  `delivery_revision` 的补偿发送；原记录不重开。
+- `confirmed`、`accepted`、`unknown` 或耗尽重试的失败会原子投影到全部成员。
+- `unknown` 只能由操作员依据 provider 证据确认，或为每个原成员创建增加
+  `delivery_revision` 的补偿意图；原批次和原记录都不重开。
 
-trade-intake status 将 Inbox、生命周期原因状态和 Outbox 状态分开显示，并
-保留 source 的 `pid`、`source_id`、OpenD host/port、账户以及启动时间。
+单成员批次沿用原有回执文本。多成员批次按案件选代表，最多展开 12 个案件，
+其余只显示数量；展示截断不改变批次完整成员集合。trade-intake status 将
+Inbox、生命周期原因、逐意图 Outbox 与 delivery batch 分开显示，并提供未绑定
+意图、未知批次、批次成员数及已减少消息数，同时保留 source 的 `pid`、
+`source_id`、OpenD host/port、账户和启动时间。
 
 ## 运维命令
 
-以下命令均以 dry-run 为默认。这里只列只读或预览形式；实际写入必须同时给出
-`--apply` 和 `--confirm`（或 `--yes`），发送通知还需要明确授权真实发送。
+以下命令均以 dry-run 为默认。示例同时列出预览和显式 one-shot applied 形式；
+实际写入必须同时给出 `--apply` 和 `--confirm`（或 `--yes`），发送通知还需要
+明确授权真实发送。
 
 ```bash
 # 查看 case、证据和当前 revision
@@ -169,13 +188,23 @@ trade-intake status 将 Inbox、生命周期原因状态和 Outbox 状态分开�
   --broker-ref <canonical-broker-ref> \
   --note "<correction evidence>" --dry-run
 
-# 查看或预览处理通知
+# 查看逐意图及其所属批次，或直接查看完整批次
 ./om option-positions lifecycle receipts inspect \
   --outbox-id <outbox-id>
+./om option-positions lifecycle receipts inspect \
+  --batch-id <batch-id>
+
+# 发送预览可按账户观察，但不会绑定或发送
 ./om option-positions lifecycle receipts dispatch \
   --once --account lx --config config.us.json --dry-run
+
+# applied dispatch 必须是全局的，不能带 --account
+./om option-positions lifecycle receipts dispatch \
+  --once --config config.us.json --apply --confirm
+
+# 多成员批次只能用 batch-id 整体收敛
 ./om option-positions lifecycle receipts reconcile \
-  --outbox-id <outbox-id> --mark confirmed \
+  --batch-id <batch-id> --mark confirmed \
   --broker-ref <provider-ref> --note "<verification>" --dry-run
 
 # 历史切换：先 inventory，再显式选择 exact target
@@ -189,9 +218,10 @@ trade-intake status 将 Inbox、生命周期原因状态和 Outbox 状态分开�
   --manifest <frozen-manifest.json> --dry-run
 ```
 
-`accepted` 只能人工收敛为 `confirmed` 或 `unknown`，不能直接 resend；
-进入 `unknown` 后才允许显式 `--mark resend`。人工收敛会保留原始
-provider receipt。
+`--outbox-id` 仍可处理 legacy 未绑定记录和单成员批次；如果成员属于多成员
+批次，命令会拒绝并提示准确的 `--batch-id`。`accepted` 只能人工收敛为
+`confirmed` 或 `unknown`，不能直接 resend；进入 `unknown` 后才允许显式
+`--mark resend`。人工收敛会保留原始 provider receipt。
 
 `lifecycle confirm-expired` 已退役。禁止用人工按钮直接制造
 `expiration_no_settlement`；该结论必须来自完整且冻结的 broker settlement

--- a/docs/gateflow/lifecycle-receipt-batching/aggregate-code-review.md
+++ b/docs/gateflow/lifecycle-receipt-batching/aggregate-code-review.md
@@ -1,0 +1,22 @@
+# Gateflow Aggregate Code Review
+
+- Gate: aggregate code review
+- Work unit: `lifecycle-receipt-batching`
+- Review artifact: `docs/reviews/code-review-20260802-063319.md`
+- Decision: pass
+- Findings: none
+- Status: accepted
+- Next gate: aggregate acceptance commit, push and Draft PR
+
+## Coverage
+
+- Reviewed the full diff from `origin/main@51275d59`, not only S3.
+- Revalidated immutable intent authority, atomic membership, attempt accounting, rate gating, provider classification, manual group recovery, enabled-account authority and process ownership as one end-to-end state machine.
+- Audited all current receipt-named external and internal surfaces in `receipt-risk-inventory.md`; only lifecycle reconciliation had active row-linear external fan-out, and that path is now batch-only.
+- Removed the unused, exported legacy per-row dispatcher so no repository call site can restore row-at-a-time lifecycle delivery by importing the old turnkey function.
+
+## Accepted residuals
+
+- Production rollout requires single-active-process topology evidence.
+- Provider calls already in progress use adapter timeouts and ambiguity freeze rather than forced cancellation.
+- Auto-close remains one aggregate receipt per account/run; future large account counts may warrant a separate cross-account digest work unit.

--- a/docs/gateflow/lifecycle-receipt-batching/aggregate-validation.md
+++ b/docs/gateflow/lifecycle-receipt-batching/aggregate-validation.md
@@ -1,0 +1,38 @@
+# Gateflow Aggregate Validation
+
+- Gate: aggregate validation
+- Work unit: `lifecycle-receipt-batching`
+- Base: `origin/main@51275d59`
+- S3 accepted commit: `8ca39a73`
+- Status: pass
+
+## Deterministic acceptance evidence
+
+- Historical storm fixture: `lx=15`, `sy=9`, one route, one real dispatcher object, exactly one fake sender call.
+- Durable result: one 24-member batch and all 24 member intents atomically `confirmed`.
+- Rendering: at most 12 representatives displayed while all 24 members remain frozen and settled.
+- Rate limit: a new intent remains idle until 60 seconds after the previous route `send_started`.
+- Retry: explicit failures reuse one batch/transport key and stop after attempt three.
+- Ambiguity: exception, accepted and stale send-started do not auto-resend.
+- Migration: legacy suppressed/confirmed rows remain terminal and unbound.
+- Ownership: source listener has no lifecycle provider call and the legacy per-row dispatcher is absent.
+- Concurrency: an independent ledger write completes while a fake provider call is blocked.
+
+## Test and static gates
+
+- Work-unit focused suite: `169 passed`.
+- Related lifecycle/maintenance/multi-tick suite: `122 passed`, four pre-existing renderer deprecation warnings.
+- Full suite: initial final-code sandbox run reported `3951 passed`, `10 skipped`, one loopback-bind permission failure and one stale generated-graph failure.
+  - Regenerated the dependency graph after the final aggregate hardening; generator check and its two tests passed.
+  - Re-ran the read-only HTTP test outside the restricted socket sandbox; `1 passed`.
+  - Effective final result: all `3953` non-skipped full-suite tests passed; `10 skipped`.
+- Ruff across every changed Python production/test file: pass.
+- Python compile checks for the new runtime owner and modified listener: pass.
+- `git diff --check`: pass.
+- Dependency graph: `907` Python files, `577` production modules, `0` parse errors, `0` production cycles; boundary guard pass.
+
+## Safety evidence
+
+- Provider tests use fake senders only.
+- All ledgers are temporary test SQLite stores.
+- No production configuration, runtime data, service state, real notification, Release, deployment or remote environment was changed.

--- a/docs/gateflow/lifecycle-receipt-batching/final-closeout.md
+++ b/docs/gateflow/lifecycle-receipt-batching/final-closeout.md
@@ -1,0 +1,75 @@
+# Gateflow Final Closeout
+
+- Gate: `final closeout`
+- Work unit: `lifecycle-receipt-batching`
+- Completion status: `final closeout pass`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/130`
+- Accepted PR review commit: `0bdde888`
+- Artifact path: `docs/gateflow/lifecycle-receipt-batching/final-closeout.md`
+
+## What Changed
+
+- Every lifecycle case transition still creates one immutable intent row for fact and audit authority.
+- Same provider/channel/target intents are atomically bound to a durable delivery batch across enabled accounts, with a 10-second quiet window, 60-second maximum wait, and at most one send start per route every 60 seconds.
+- Multi-member digests display at most 12 representative cases without splitting membership; one provider outcome atomically settles the whole batch and every member.
+- Explicit pre-acceptance failure retries at most three times with one stable batch transport key. Accepted or ambiguous work freezes, and stale send-started work becomes `unknown` instead of auto-resending.
+- A single process-level dispatcher owns lifecycle delivery for all source listeners. Source loops and the legacy turnkey per-row dispatcher can no longer produce row-linear provider calls.
+- CLI recovery and status are batch-aware, fail closed for multi-member child operations, and expose fingerprints instead of raw targets.
+
+## Receipt Risk Inventory
+
+- Lifecycle reconciliation was the only active high-risk row-linear external receipt path; it is now batch-only.
+- Auto-close maintenance emits one aggregate receipt per account/run, so it has bounded account fan-out rather than position/row fan-out.
+- Assistant upgrade completion uses one durable outbox item per operation with stable retry identity.
+- Ordinary trade-intake delivery has an implementation but no runtime caller; it is dormant and must be separately reviewed before reconnection.
+- Settlement source and migration receipts are internal durable evidence, not external messages.
+- Scheduled local receipt IDs record delivery evidence and do not create additional messages.
+
+## Verification
+
+- Historical storm fixture: `lx=15` plus `sy=9`, same route, exactly one fake sender call, one 24-member batch, and 24 atomically confirmed member intents.
+- Focused work-unit suite: `169 passed`.
+- Related lifecycle/maintenance/multi-tick suite: `122 passed`.
+- Full suite: all `3953` non-skipped tests passed; `10 skipped`.
+- Ruff, targeted compile checks, dependency boundary/cycle scan, and `git diff --check`: passed.
+- Dependency graph: 907 Python files, 577 production modules, zero parse errors, zero production cycles.
+- PlanReview: initial findings fixed; re-review passed with recorded risks.
+- Slice DeepReviews: all accepted findings fixed and re-reviewed.
+- Aggregate DeepReview: passed with no findings.
+- PR `#130` DeepReview: passed with no findings; accepted evidence is commit `0bdde888`.
+- After the PR-review evidence push, GitHub reported PR `#130` open, Draft, mergeable, and at head `0bdde888`.
+
+## Documentation
+
+- `docs/FUTU_TRADE_HOLDINGS_SYNC.md` documents the batch delivery contract, status semantics, and operator commands.
+- `docs/gateflow/lifecycle-receipt-batching/receipt-risk-inventory.md` records every receipt-named surface and its storm classification.
+- Goal, plan, PlanReview, slice implementation/review/fix, aggregate validation/review, PR review, and this closeout are preserved under `docs/gateflow/` and `docs/reviews/`.
+
+## Finding Status
+
+- PlanReview findings: all accepted findings fixed and re-reviewed.
+- Slice DeepReview findings: all accepted findings fixed and re-reviewed.
+- Aggregate DeepReview findings: none.
+- PR DeepReview findings: none.
+- Unclassified findings: none.
+
+## Remaining Risks and Owners
+
+- Production topology must prove exactly one active listener process before rollout. Owner: separately authorized deployment preflight; failure to prove single ownership blocks rollout.
+- Provider work already in flight relies on existing adapter timeout. Owner: lifecycle operator recovery; uncertain evidence remains frozen as `unknown`.
+- Auto-close cross-account batching is deferred because its current path is already one aggregate receipt per account/run. Owner: a future work unit if account count makes bounded fan-out operationally noisy.
+- Ordinary trade-intake delivery must not be reconnected without a separate runtime-owner and storm review. Owner: future trade-intake work unit.
+
+## Issue Link Status
+
+This work unit was initiated from the confirmed conversation and is not tied to a GitHub issue, so no issue closing keyword or issue closeout comment is required.
+
+## Safety Boundary
+
+- Tests used fake senders and temporary SQLite stores; no real notification was sent.
+- No production config, ledger, position state, trade event, or service was changed.
+- No merge, approval, reviewer request, Ready transition, release, deployment, or remote upgrade was performed.
+
+## Next Entry Point
+
+The Draft PR is ready for user review. Merge remains a separate authorization. Release and production rollout remain later independent boundaries, and rollout must start with the single-active-listener topology preflight above.

--- a/docs/gateflow/lifecycle-receipt-batching/goal-confirmation.md
+++ b/docs/gateflow/lifecycle-receipt-batching/goal-confirmation.md
@@ -1,0 +1,57 @@
+# Gateflow Goal Confirmation — lifecycle receipt batching
+
+- **Recorded at**: 2026-08-01T21:12:55Z
+- **Work unit**: `lifecycle-receipt-batching`
+- **Branch**: `codex/lifecycle-receipt-batching`
+- **Base**: `origin/main@51275d59` (`v1.8.5`)
+- **User confirmation**: 已确认按 Gateflow 实现并自动推进后续 gates。
+
+## Goal
+
+保留每个 lifecycle case/transition 一行不可变通知意图作为事实与审计真源，但把真实外部投递从“逐行发送”改成“同一路由持久化批次发送”，避免数据核对一次产生多条回执时形成消息风暴。
+
+## Confirmed delivery contract
+
+1. 相同 provider/channel/target 的 `lx`、`sy` lifecycle 回执允许进入同一批次。
+2. 聚合静默窗口为 10 秒，最久等待 60 秒。
+3. 同一路由最多每 60 秒开始一次真实发送；显式失败重试也计入该预算。
+4. 单成员批次保持现有单条回执格式。
+5. 多成员批次最多展示 12 个代表项，剩余只显示数量；一个批次永不因展示上限自动拆包。
+6. 一个 provider receipt 必须在一个 SQLite 事务内结算批次及全部成员。
+7. 显式 pre-acceptance failure 最多尝试 3 次，并复用稳定 transport idempotency key。
+8. `accepted`、ambiguous/exception、或 stale `send_started` 批次必须冻结，不得自动重试。
+9. 旧 `suppressed`、`confirmed` 行不得因迁移或 dispatcher 切换重新激活。
+
+## Success signals
+
+- 用历史风暴形态的 24 行 fixture（`lx=15`、`sy=9`、同一路由）验证只调用一次 sender。
+- 成功回执后，批次和全部 24 个逐案意图原子变为 `confirmed`。
+- 多成员内容确定性展示最多 12 项并报告剩余数量，但 24 个成员全部被结算。
+- 失败重试始终使用同一批次 ID/transport key，第三次显式失败后停止。
+- 模糊结果与 stale send-started 全批冻结；manual reconcile/resend 明确按批次操作。
+- 现有 suppressed/confirmed migration fixture 保持原状态且没有 batch binding。
+- focused tests、相关自动 intake/CLI tests、full pytest、Ruff、dependency graph check 和 `git diff --check` 全部通过。
+
+## Scope
+
+- SQLite lifecycle notification outbox schema/repository。
+- lifecycle batch planner、claim/send/complete/recovery/manual reconcile 状态机。
+- lifecycle batch renderer、route fingerprint 和 transport idempotency key。
+- auto-intake 进程级全局 dispatcher ownership。
+- lifecycle receipt CLI/diagnostics、测试与相应文档。
+
+## Non-goals and safety boundary
+
+- 不改变 lifecycle 事实判断、allocation、close reason 或 migration decision。
+- 不改 Daily Brief、自动平仓、交易 intake 普通回执或 assistant reply 的投递模型。
+- 不建设通用消息总线、分布式锁或跨主机调度系统。
+- 不修改生产配置，不发送真实通知，不写生产 ledger，不发布 Release，不升级或部署远端。
+- Draft PR 前的提交和推送仅按 Gateflow gate 执行；不 merge、不 approve、不 mark ready、不请求 reviewer。
+
+## First-principles boundary
+
+逐案 outbox row 证明“哪一个 case transition 需要通知”；delivery batch 证明“哪一次外部调用承载了哪些逐案意图”。外部 provider receipt 属于后者，不能继续由每个逐案 row 各自声称一次发送。
+
+## Blocking questions
+
+无。若实现发现当前 runtime 存在同一进程之外的并发 dispatcher，或通知目标实际按账户动态变化且无法在创建批次前可靠解析，则停止 implementation 并重新进入 plan review。

--- a/docs/gateflow/lifecycle-receipt-batching/plan-fix.md
+++ b/docs/gateflow/lifecycle-receipt-batching/plan-fix.md
@@ -1,0 +1,30 @@
+# Gateflow Plan Fix
+
+- Gate: plan fix
+- Work unit: `lifecycle-receipt-batching`
+- Input review: `docs/reviews/plan-review-20260802-052141.md`
+- Status: all accepted findings repaired; pending re-review
+
+## PR-01 — accepted — fixed
+
+- Bound non-terminal members now use `status=batched`, which v1.8.5 does not claim.
+- Batch owns pending/claimed/send-started/retryable-failure states.
+- Only frozen terminal outcomes project to members; exhausted failure also writes `attempt_count=3`.
+- Plan requires a rollback-compatibility regression using the old claim predicate.
+
+## PR-02 — accepted — fixed
+
+- The process-level dispatcher no longer holds `process_lock` during provider I/O.
+- Planner/claim, send-started and completion use separate short SQLite transactions.
+- Plan requires a blocking-sender concurrency regression proving unrelated ledger work can proceed.
+
+## PR-03 — accepted — fixed
+
+- The plan now defines exact evidence classes for confirmed, accepted, explicit pre-acceptance failure and unknown.
+- 4xx/provider rejection with unambiguous response may retry; timeout/transient/fallback ambiguity always freezes unknown.
+- Classifier evidence is preserved in the batch provider receipt and tested explicitly.
+
+## Additional clarification
+
+- The account allow-set is derived from `source.account` and normalized `account_mapping` values using existing source/global receipt precedence.
+- `batch_id` is fixed to a provider-safe `tlb_` plus 32 lowercase hex characters.

--- a/docs/gateflow/lifecycle-receipt-batching/plan-review-initial.md
+++ b/docs/gateflow/lifecycle-receipt-batching/plan-review-initial.md
@@ -1,0 +1,12 @@
+# Gateflow Plan Review — initial
+
+- Gate: plan review
+- Work unit: `lifecycle-receipt-batching`
+- Reviewed target: `docs/gateflow/lifecycle-receipt-batching/plan.md`
+- Review artifact: `docs/reviews/plan-review-20260802-052141.md`
+- Decision: fail
+- Findings: PR-01, PR-02, PR-03
+- Status: findings accepted for plan repair
+- Next gate: fix plan, then planreview re-review
+
+The initial architecture direction is retained. Implementation is blocked until the plan makes rollback fail-closed, removes provider I/O from the shared process lock, and defines evidence-based explicit-failure classification.

--- a/docs/gateflow/lifecycle-receipt-batching/plan-review.md
+++ b/docs/gateflow/lifecycle-receipt-batching/plan-review.md
@@ -1,0 +1,13 @@
+# Gateflow Plan Review Decision
+
+- Gate: plan review / re-review
+- Work unit: `lifecycle-receipt-batching`
+- Initial review: `docs/reviews/plan-review-20260802-052141.md` (`fail`)
+- Fix artifact: `docs/gateflow/lifecycle-receipt-batching/plan-fix.md`
+- Re-review: `docs/reviews/plan-review-20260802-052412.md`
+- Decision: pass-with-risks
+- Findings: PR-01, PR-02 and PR-03 accepted and fixed; none unresolved
+- Status: accepted
+- Next gate: accepted plan commit
+
+Residual risks are cross-host topology, forward-only resumption of frozen `batched` rows, and unusually large batch payload capacity; none permits scope expansion during implementation.

--- a/docs/gateflow/lifecycle-receipt-batching/plan.md
+++ b/docs/gateflow/lifecycle-receipt-batching/plan.md
@@ -1,0 +1,271 @@
+# Gateflow Plan — lifecycle receipt batching
+
+## Gate state
+
+- Work unit: `lifecycle-receipt-batching`
+- Base: `origin/main@51275d59` (`v1.8.5`)
+- Current gate: accepted plan commit
+- Next gate: S1 implementation
+- Status: planreview re-review passed with classified residual risks
+- Design source: confirmed goal artifact plus current source/schema/tests; no separate design document
+
+## Goal and motivation
+
+Lifecycle reconciliation correctly persists one immutable notification intent per case transition, but the current dispatcher claims and sends one outbox row per external call. A burst of row-level reconciliation can therefore become a burst of Feishu/other channel messages even though the intended human action is one review session.
+
+The implementation keeps row-level intent and audit semantics, while introducing one durable external-delivery batch that binds all eligible intents sharing the same resolved provider/channel/target. This moves batching to the external delivery ownership boundary without weakening lifecycle facts or hiding member-level audit evidence.
+
+## Direct code evidence and owners
+
+- `src/application/ledger/writer.py` creates a transition-specific immutable outbox intent inside the lifecycle state transaction. That remains the fact/audit owner.
+- `src/application/ledger/repository.py::_ensure_notification_outbox_v2()` and notification repository methods own SQLite durability and compare-and-set writes.
+- `src/application/trades/lifecycle_outbox.py` owns delivery claim, attempt, recovery, ambiguity freeze and manual resolution semantics.
+- `src/application/trades/receipt.py` owns lifecycle receipt rendering, route resolution and provider adaptation.
+- `src/application/trades/auto_intake.py` currently invokes `dispatch_notifications_once()` from every source loop every five seconds, filtered by account. This is the storm-producing delivery ownership boundary.
+- `src/application/notification_delivery_adapter.py` already accepts a caller-provided `idempotency_key`; lifecycle delivery currently does not pass one.
+
+## Scope and non-goals
+
+### In scope
+
+- additive SQLite batch storage and nullable member binding;
+- deterministic batch formation, state transitions and recovery;
+- deterministic single/multi-member rendering and stable transport identity;
+- one process-level dispatcher shared by all configured source accounts;
+- batch-aware CLI inspection/reconciliation and delivery diagnostics;
+- deterministic migration, failure, concurrency and integration tests;
+- operator documentation for the changed lifecycle receipt contract.
+
+### Out of scope
+
+- lifecycle decision/allocation/reconciliation policy;
+- Daily Brief, normal trade-intake receipt, auto-close and assistant-reply delivery;
+- arbitrary notification batching framework or general message bus;
+- new public config keys for timing/limits in this work unit;
+- distributed scheduling or cross-host locks;
+- production sends, production config, ledger mutation, Release, deployment or remote apply.
+
+## Data model and migration contract
+
+### Existing intent row
+
+Add nullable `delivery_batch_id TEXT` to `trade_lifecycle_notification_outbox` and an index on `(delivery_batch_id, created_at_ms, outbox_id)`. It is assigned once and is not part of the intent identity/hash. Existing rows retain all state and payload fields unchanged.
+
+The member row remains the per-transition audit surface. Binding atomically changes every non-terminal member to a new fail-closed sentinel status `batched`. While the batch is pending, claimed, send-started or retryable-explicit-failed, the member stays `batched`; only the batch owns those mutable delivery states. Old code does not select `batched`, so rollback cannot reopen bound rows as per-line sends.
+
+When a batch reaches a frozen/terminal outcome, the same transaction projects that outcome to all members: `confirmed`, `accepted`, `unknown`, or exhausted `explicit_failed`. Exhausted failure also writes member `attempt_count=3` and `next_attempt_at_ms=NULL`. Provider receipt authority remains on the batch; member inspection resolves and displays the owning batch rather than duplicating an external receipt per member.
+
+### New delivery batch
+
+Create `trade_lifecycle_notification_delivery_batches` with:
+
+- immutable identity: `batch_id`, `route_fingerprint`, `provider`, `channel`, `target_fingerprint`, `renderer_version`, `payload_json`, `payload_hash`, `member_count`, `first_intent_created_at_ms`, `last_intent_created_at_ms`, `created_at_ms`;
+- mutable delivery state: `status`, `claim_id`, `claimed_at_ms`, `send_started_at_ms`, `attempt_count`, `next_attempt_at_ms`, `last_error`, `provider_message_id`, `provider_receipt_json`, `updated_at_ms`, `confirmed_at_ms`.
+
+No raw target is persisted. `target_fingerprint` is SHA-256 of the normalized target; `route_fingerprint` is SHA-256 of canonical provider/channel/target components. The current raw route is resolved only at dispatch and must reproduce the frozen fingerprint before provider I/O.
+
+The frozen batch payload contains ordered member envelopes with `outbox_id`, transition identity/revision, timestamps and the existing immutable member payload. A batch insert and all member bindings happen in one `BEGIN IMMEDIATE` transaction; any missing/already-bound member aborts the transaction.
+
+### Additive migration rules
+
+- New table/column/index creation is idempotent.
+- Existing `suppressed`, `confirmed`, `accepted`, `unknown`, `batched` and exhausted `explicit_failed` rows are never rebound automatically.
+- Existing unbound `pending`, and retryable `explicit_failed`, may enter the new batching path; the batch inherits the maximum prior member attempt count so cutover cannot exceed three total attempts.
+- Existing v1/v2 upgrade tests are extended to prove provider receipt, status and payload preservation plus a null `delivery_batch_id`.
+- Binding uses one repository method whose update predicate requires `delivery_batch_id IS NULL` and status in `pending/explicit_failed`, then sets `delivery_batch_id` and `status='batched'` together. Binding cardinality must equal the frozen member count or the whole transaction rolls back.
+- Rolling back to v1.8.5 remains read-compatible and fail-closed for bound work because its claim predicate only selects `pending/explicit_failed`. It cannot finish batches, so forward upgrade is required to resume them, but it cannot recreate the storm. No existing lifecycle fact data is rewritten.
+
+## Route and eligibility contract
+
+The process-level dispatcher resolves the effective notification route from the same runtime config used by the current sender. It builds an allow-set from each source's explicit `account` plus every normalized value in its `account_mapping`; for each bound account it applies the existing `source.receipt or trade_intake.receipt` precedence. A batch may contain members from any enabled account when their provider/channel/target fingerprints match. Disabled-account rows remain visible and unbound; they are not silently suppressed. Tests use the repository's current multi-source config fixture to pin this precedence.
+
+Current OM runtime has one effective notification route per config. If source/account-specific route resolution is discovered, the planner must receive one route snapshot per account and group by fingerprint; it must not fall back to account grouping. This is a stop condition if it cannot be expressed without new config semantics.
+
+## Batch formation contract
+
+Constants owned by `lifecycle_outbox.py`:
+
+```text
+QUIET_WINDOW_MS = 10_000
+MAX_BATCH_WAIT_MS = 60_000
+TARGET_SEND_INTERVAL_MS = 60_000
+MAX_DISPLAY_ITEMS = 12
+MAX_ATTEMPTS = 3
+RETRY_BACKOFF_MS = (60_000, 300_000)
+RENDERER_VERSION = trade_lifecycle_batch.v1
+```
+
+Within one `BEGIN IMMEDIATE` transaction, the planner:
+
+1. excludes bound rows and every non-retryable state;
+2. filters to allowed accounts and due `pending`/`explicit_failed` rows with attempts below three;
+3. orders rows by `(created_at_ms, outbox_id)`;
+4. waits while both `now - newest_created < 10s` and `now - oldest_created < 60s`;
+5. refuses to form a second active batch for the route;
+6. enforces the last `send_started_at_ms` route budget before forming a new batch;
+7. freezes every eligible member for the route into one batch, with no member-count split;
+8. derives a provider-safe `batch_id` as `tlb_` plus 32 lowercase hex characters from renderer version, route fingerprint and the sorted complete member outbox IDs;
+9. inserts the batch and atomically binds every member while changing its status to `batched`.
+
+New intents arriving after this transaction stay unbound for the next batch. The 12-item limit is only a rendering limit and never a membership limit.
+
+## Delivery state machine
+
+```text
+pending -> claimed -> send_started -> confirmed
+                                  -> accepted   (frozen)
+                                  -> unknown    (frozen)
+                                  -> explicit_failed -> claimed (due, attempts < 3)
+
+stale claimed before send -> pending
+stale send_started        -> unknown (frozen)
+```
+
+- Batch claim, send-started and retryable failure transitions update only the batch; bound members remain `batched`. Confirmed/accepted/unknown/exhausted-failure completion and stale send-started recovery atomically settle the batch plus every member to the same terminal outcome.
+- Stale batch claim recovery changes only the batch from `claimed` to `pending`; members remain `batched`.
+- A batch attempt increments once, regardless of member count.
+- Every actual provider call passes `batch_id` as the lifecycle transport idempotency key. All explicit-failure retries reuse it.
+- Explicit failures use 60 seconds then 5 minutes backoff. Attempt three remains terminal `explicit_failed` with no next due time.
+- Exceptions after durable `send_started` are ambiguous and settle the entire batch to `unknown`; no automatic resend occurs.
+- `accepted` may be manually changed to `confirmed` or `unknown`; `unknown` may be manually changed to `confirmed` or explicitly resent.
+- Manual resend keeps the original batch frozen and transactionally creates one compensating intent per original member, each with the next delivery revision. Those new intents are later aggregated into one new batch.
+
+The dispatcher must re-check the route send budget during claim as well as planning so a stale pre-created pending batch cannot bypass the one-per-60-second rule.
+
+## Rendering and provider contract
+
+- One display representative is selected per case by highest `resolution_revision`, then latest creation time, then deterministic transition precedence (`conflict`, `needs_review`, `resolution_corrected`, `resolution_confirmed`, `option_leg_closed`), with the full membership still retained and settled.
+- Representatives are sorted by severity, account, symbol, expiration, strike, case ID and outbox ID.
+- A single representative delegates to the existing `build_trade_lifecycle_notification_message()` so the current receipt format remains byte-for-byte stable apart from transport metadata not rendered in the message.
+- Multiple representatives render one Markdown-friendly Chinese digest with total intent count, case count, accounts, up to 12 rows and `另有 N 项` when truncated.
+- Missing member display fields render explicit `-`/`待确认`; no member may disappear because of malformed optional data.
+- Before calling the adapter, the sender resolves the current route and compares provider/channel/target fingerprints with the frozen batch. Missing/mismatched route is an explicit pre-acceptance failure.
+- The selected adapter receives `idempotency_key=batch_id`; normalization continues to determine confirmed/accepted/explicit failure/ambiguous outcome.
+- The lifecycle sender owns a narrow fail-closed classifier:
+  - `delivery_confirmed` or confirmed provider status -> `confirmed`;
+  - `command_ok` without confirmation -> `accepted`;
+  - route preflight failure, adapter-declared pre-I/O failure, HTTP 4xx, or a provider business rejection with a received response and `ambiguous_send=false` -> `explicit_failed`;
+  - exception, timeout, transient HTTP attempt, fallback ambiguity, `ambiguous_send=true`, or missing proof of non-acceptance -> `unknown`.
+- The batch provider receipt records the normalized classifier inputs (`http_status`, provider code, `ambiguous_send`, fallback/idempotency evidence) and decision. No broad shared-adapter contract is introduced unless implementation proves an existing identical owner.
+
+## Runtime ownership and scheduling
+
+Introduce one `LifecycleReceiptBatchDispatcher` owned by `auto_intake.main()` for the lifetime of the process. It is started only when writes are enabled and at least one effective receipt configuration is enabled. It polls with a cancellable one-second wait and closes before repository/runtime teardown.
+
+The dispatcher never holds the shared `process_lock` across provider I/O. Planner/claim, send-started and completion each use their own short SQLite `BEGIN IMMEDIATE` transaction. The provider call occurs after durable `send_started` and outside every SQLite transaction and `process_lock`; completion then uses claim-ID CAS. This lets trade push/inbox and lifecycle fact writes proceed while notification delivery is slow.
+
+Remove lifecycle notification dispatch from `_run_listener_source_loop()`. Source threads continue to create intents and run lifecycle reconciliation, but cannot call the provider. This makes cross-account batching independent of source loop timing and ensures one process-level sender owner.
+
+The dispatcher performs one batch attempt per poll. The durable target budget, not thread timing, is authoritative. On restart it first recovers stale batch states and then resumes due work.
+
+## CLI and observability contract
+
+- `lifecycle receipts inspect` accepts exactly one of `--outbox-id` or new `--batch-id`. Member inspection includes its batch; batch inspection includes ordered member summaries.
+- `lifecycle receipts reconcile` accepts the same identity choice. `--outbox-id` remains valid for legacy unbatched rows and single-member batches. It refuses multi-member batch mutation and instructs the operator to use `--batch-id` so one row cannot accidentally mutate a group.
+- `lifecycle receipts dispatch` becomes batch-aware. Its dry-run previews eligibility/window/rate-gate without binding or sending. Applied dispatch is global; an account-scoped applied dispatch is refused because it would split same-route delivery semantics.
+- `_lifecycle_delivery_status()` advances to `trade_lifecycle_delivery_status.v2` and adds: unbound eligible count/oldest age, batch status counts, oldest unknown batch, total batched member count, confirmed/accepted `messages_avoided`, and dispatcher last-result/error when available. Existing case/evidence/outbox fields remain.
+- No raw route target is printed or stored; only provider/channel and fingerprints are visible.
+
+## Implementation slices
+
+### S1 — Durable batch storage and atomic state machine
+
+- **Objective**: establish schema, immutable binding, planner, CAS transitions, retry/recovery and manual batch reconciliation without changing runtime sender ownership.
+- **Allowed production files**: `src/application/ledger/repository.py`, `src/application/ledger/api.py` only if export boundaries require it, `src/application/trades/lifecycle_outbox.py`.
+- **Allowed test files**: `tests/test_lifecycle_redesign_contracts.py` and a new focused `tests/test_trades_lifecycle_batch_outbox.py` if separation materially improves reviewability.
+- **Exact changes**:
+  1. add migration/table/row serializers and repository methods;
+  2. add route snapshot/batch identity pure helpers and batch planner preview/create paths;
+  3. implement batch recovery/claim/send-started plus atomic terminal completion, with members held in `batched` until terminal;
+  4. implement batch-level manual resolution and compensating-intent creation;
+  5. keep legacy unbatched functions only where CLI migration compatibility needs them, and prevent them from claiming bound rows.
+- **Required tests**: migration preservation, 24-member atomic binding, quiet/max window, target rate gate at plan and claim, no split, concurrent planner/claim winner, confirmed all-member settlement, explicit failure attempt ceiling/key stability metadata, ambiguous freeze, stale recovery, multi-member manual safety, compensating resend, old suppressed/confirmed non-reactivation, and a v1.8.5-equivalent selection predicate proving `batched` members cannot be claimed after rollback.
+- **Completion signal**: repository/state-machine tests prove all transitions without any provider call.
+- **Stop conditions**: inability to bind atomically with existing SQLite authority; need to mutate immutable transition payloads; evidence of another process writing delivery state.
+
+### S2 — Batch renderer, sender, CLI and diagnostics
+
+- **Objective**: make the external payload and operator surfaces batch-aware while keeping provider behavior fail-closed.
+- **Allowed production files**: `src/application/trades/receipt.py`, `src/interfaces/cli/option_positions.py`, `src/application/trades/auto_intake.py` only for the pure status projection, plus S1 files for directly exposed repository queries.
+- **Allowed tests**: `tests/test_trades_receipt.py`, `tests/test_option_positions_cli.py`, `tests/test_lifecycle_redesign_contracts.py`, and the focused batch test file.
+- **Exact changes**:
+  1. deterministic representative selection and digest renderer;
+  2. route fingerprint preflight and `idempotency_key=batch_id` provider call;
+  3. batch-aware inspect/reconcile/dispatch dry-run contract;
+  4. delivery status v2 counters and no-sensitive-target assertions;
+  5. update CLI/operator documentation.
+- **Required tests**: byte-stable single member, 24-member/top-12 digest, deterministic ordering/collapse, route mismatch no-send, provider 4xx/rejection -> explicit retry, transient/timeout/fallback ambiguity -> unknown/no retry, stable idempotency across retries, multi-member CLI refusal by outbox ID, batch-level dry-run/no-write and diagnostics counts.
+- **Completion signal**: all provider calls in tests are fakes; message and CLI contracts are deterministic and member-complete.
+- **Stop conditions**: adapter does not support stable caller keys for an active provider; current CLI identity cannot be extended without breaking unrelated commands.
+
+### S3 — Global dispatcher cutover and storm regression
+
+- **Objective**: remove per-source delivery ownership and prove one process-level cross-account dispatcher.
+- **Allowed production files**: `src/application/trades/auto_intake.py`, new narrow `src/application/trades/lifecycle_batch_dispatcher.py` if needed, lifecycle receipt docs.
+- **Allowed tests**: `tests/test_trades_auto_intake_cli.py`, `tests/test_trades_auto_intake_restart_policy.py`, `tests/test_trades_auto_intake_audit.py`, focused batch tests.
+- **Exact changes**:
+  1. construct/start/close one dispatcher in `main()` without wrapping provider I/O in `process_lock`;
+  2. remove the five-second per-source outbox dispatch block and account filter;
+  3. preserve listener stop/restart semantics and expose dispatcher result through status refresh;
+  4. execute the historical 15+9 same-route fixture through the real batch dispatcher with one fake sender call.
+- **Required tests**: single- and multi-source lifecycle ownership, orderly cancellation, no source-local send call, same-target `lx`+`sy` one call, next intent held until target budget expires, no dispatch when dry-run/disabled, source-level receipt enable precedence, and a blocking fake sender proving an independent ledger write can complete before delivery returns.
+- **Completion signal**: 24 members across two accounts produce one sender call and one confirmed batch; existing listener restart tests pass.
+- **Stop conditions**: global dispatcher cannot share current SQLite/process-lock lifetime safely, or a source-specific route cannot be represented by the confirmed grouping contract.
+
+## Validation commands
+
+Use the repository Python 3.12 contract because the checked-in `.venv` may not contain pytest:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_batch_focused python3.12 -m pytest -q -p no:cacheprovider \
+  tests/test_trades_lifecycle_batch_outbox.py \
+  tests/test_lifecycle_redesign_contracts.py \
+  tests/test_trades_receipt.py \
+  tests/test_option_positions_cli.py \
+  tests/test_trades_auto_intake_cli.py \
+  tests/test_trades_auto_intake_restart_policy.py \
+  tests/test_trades_auto_intake_audit.py
+
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_batch_related python3.12 -m pytest -q -p no:cacheprovider \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_trade_event_ledger_long_lifecycle.py \
+  tests/test_combo_yield_lifecycle.py \
+  tests/test_positions_maintenance_receipt.py \
+  tests/test_multi_tick_*.py \
+  tests/test_unified_tick_entrypoint.py
+
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_batch_full python3.12 -m pytest -q -p no:cacheprovider
+python3.12 -m ruff check <changed-python-files>
+python3.12 scripts/generate_dependency_graph.py
+python3.12 scripts/generate_dependency_graph.py --check
+git diff --check
+```
+
+Required assertions, not merely green commands: one sender call for 24 members; atomic all-member settlement; stable batch ID on retries; no retry of unknown/accepted; legacy terminal rows unbound; no source-local dispatch path remains.
+
+## Rollout, rollback and safety
+
+- This Gateflow work unit ends at a passing Draft PR. Release and production upgrade remain separate explicit authorization boundaries.
+- No live notification canary is run in this task. Tests use fake adapters and temporary SQLite ledgers.
+- A code rollback leaves non-terminal bound members in unknown-to-old-code `batched`, so old dispatcher selection is fail-closed. Old code cannot progress those batches; restore a batch-aware version for forward recovery. The additive schema itself need not be removed.
+- Before any later deployment, stop the listener, take a WAL-safe ledger snapshot, upgrade code, start one service instance, verify v2 delivery status and only then allow real delivery. That future operation requires explicit authorization.
+
+## Risks and classified residuals
+
+- **Cross-process duplicate dispatcher — deferred/blocking for rollout**: current scope guarantees one owner inside one process. Before production apply, service topology must prove a single active listener instance. If not, add a lease owner in a separate work unit.
+- **Route configuration changes with queued unbound rows — accepted**: unbound intent has no prior external route commitment; it joins the route active when the batch freezes. Once frozen, mismatch fails before provider I/O.
+- **Continuous event stream — fixed here**: the oldest-member 60-second deadline forces a batch; new arrivals after the freeze wait for the next target budget.
+- **Digest hides individual detail — fixed here**: display truncation never changes membership, full intent/batch evidence stays inspectable, and counts are explicit.
+- **Mixed-version rollback — mitigated**: `batched` blocks old per-row claim. Old/new concurrent writers remain unsupported; forward repair is required to resume batch delivery.
+
+## Docs decision
+
+Update the lifecycle receipt/operator section in `docs/AGENT_WIKI.md` (or its current owning document discovered by call-site search) because CLI identity, batch state and manual resolution semantics are operator-facing. Do not modify VERSION/CHANGELOG until a separately authorized release.
+
+## Open questions
+
+None blocking in the initial plan. Planreview must specifically challenge account-to-route ownership, transactional target rate enforcement, member/batch status synchronization, manual multi-member recovery and mixed-version migration.
+
+## Completion report
+
+Report accepted plan/review artifacts and commits; per-slice files/tests/review findings; aggregate and PR review outcomes; exact 24-row storm proof; branch/PR URL; pending release/production boundaries; and every residual risk with owner/destination.

--- a/docs/gateflow/lifecycle-receipt-batching/pr-code-review.md
+++ b/docs/gateflow/lifecycle-receipt-batching/pr-code-review.md
@@ -1,0 +1,35 @@
+# Gateflow PR Code Review
+
+- Gate: `PR review`
+- Work unit: `lifecycle-receipt-batching`
+- Reviewed target: GitHub Draft PR `#130`
+- Base/head: `main@51275d59` -> `codex/lifecycle-receipt-batching@056fa54f`
+- Review artifact: `docs/reviews/pr-130-review-20260802-064129.md`
+- Artifact path: `docs/gateflow/lifecycle-receipt-batching/pr-code-review.md`
+- Completion status: pass; no fix or re-review required
+
+## Decision
+
+The PR-level DeepReview found no actionable findings. GitHub reports the exact base and head used by the accepted aggregate review, the remote 37-file diff matches the local work unit, and the PR remains open, Draft, and mergeable.
+
+## Validation
+
+- Historical storm fixture: 24 same-route intents, one fake sender call, one atomic 24-member confirmation.
+- Focused suite: `169 passed`; related suite: `122 passed`.
+- Full suite: all `3953` non-skipped tests passed; `10 skipped`.
+- Ruff, compile checks, dependency graph/boundaries, and diff check passed.
+- GitHub `Agent Plugin` passed at review time; `Guardrails` was still running and must be rechecked after this evidence is pushed.
+
+## Docs Decision
+
+The operator contract, complete receipt-risk inventory, generated dependency graph, validation evidence, and every Gateflow review/fix decision are included. No production config, release, deployment, or service documentation was changed.
+
+## Residual Risks
+
+- Production remains blocked on single-active-listener topology evidence.
+- In-flight provider calls rely on adapter timeout and ambiguity freeze.
+- Hosted checks still running are recorded explicitly rather than treated as success.
+
+## Next Gate
+
+Commit and push the accepted PR review evidence, recheck the remote Draft PR head and hosted checks, then record final closeout.

--- a/docs/gateflow/lifecycle-receipt-batching/receipt-risk-inventory.md
+++ b/docs/gateflow/lifecycle-receipt-batching/receipt-risk-inventory.md
@@ -1,0 +1,40 @@
+# 回执发送面与消息风暴风险清单
+
+- Work unit: `lifecycle-receipt-batching`
+- Review base: `origin/main@51275d59`
+- Evidence scope: current `src/application`, `src/interfaces`, `scripts`, tests and accepted Gateflow implementation
+- Safety: 本清单为代码与测试审计；未发送真实通知，未读取或写入生产 ledger
+
+## 结论
+
+本次发现的高风险活动路径只有 lifecycle 数据核对回执：原实现按 source/account 每五秒逐行领取，一次核对产生 24 行时可以形成 24 次外部发送。该路径已改为同路由持久化批次，并删除可直接逐行发送的 legacy dispatcher。
+
+其他回执要么已经在一次业务运行内聚合、要么是一项操作一个 durable outbox、要么只是内部证据对象；当前没有第二条“数据一行一条外部消息”的活动路径。普通 trade-intake sender 虽仍保留兼容实现，但当前 runtime 没有调用者；若将来重新启用，必须重新做批量与幂等评审。
+
+## 风险矩阵
+
+| 回执面 | 当前外部发送单位 | 批量/风暴风险 | 当前控制与结论 |
+|---|---|---|---|
+| Lifecycle reconciliation receipt | 同 provider/channel/target 的 durable delivery batch | 改造前高；改造后低 | 10 秒 quiet、最久 60 秒、同路由 60 秒一次、24 members 不拆包、稳定 batch key、unknown/accepted 冻结；进程级单 owner |
+| Lifecycle CLI one-shot dispatch | 一次显式确认命令最多尝试一个 batch | 低 | applied 只允许全局语义，使用 canonical enabled-account allow-set；account-scoped applied 被拒绝 |
+| Auto-close / expired-position maintenance receipt | 每账户、每次 maintenance run 一条汇总 | 中低、按账户有界 fan-out | 一个账户内所有 position decision 已汇总；receipt identity/state 防重复。多账户运行仍可能一账户一条，但不是逐 position 风暴 |
+| Assistant upgrade final receipt | 每个 upgrade operation 一个 durable outbox | 低 | operation/outbox claim，Feishu UUID 或 WeChat idempotency key 稳定；内部重试承载同一逻辑回执 |
+| Ordinary trade-intake receipt sender | 当前无 production caller | dormant；若重新接线则高 | `auto_intake` callback 只声明 `outbox_managed`，不会调用兼容 sender。重新启用逐 deal sender 必须另开 work unit |
+| Settlement source receipt / migration receipt | SQLite/JSON 内部证据与审计对象 | 无外部消息风险 | 名称为 receipt，但没有 notification adapter/provider call |
+| Scheduled notification `local_receipt_id` 等 transport receipt | 已发送通知的 transport evidence | 无新增发送风险 | 只是 delivery result 字段，不是另一条消息 |
+
+## Lifecycle 改造后的硬边界
+
+- 逐案件 outbox row 只证明通知意图，不再拥有 provider call。
+- 唯一活动 sender 是 `LifecycleReceiptBatchDispatcher -> dispatch_notification_batch_once()`。
+- `_run_listener_source_loop()` 不包含 lifecycle sender；legacy `dispatch_notifications_once()` 已删除且不再导出。
+- provider I/O 发生在 SQLite transaction 与 `process_lock` 之外。
+- 一个 receipt 在同一事务中结算 batch 与全部 members。
+- `accepted`、异常/歧义、stale `send_started` 不自动重发。
+- 单进程内只有一个 owner；生产升级前仍须以 service topology 证明只有一个 active process。
+
+## 后续监控建议
+
+- 观察 `lifecycle_delivery.dispatcher.last_result`、`batch_status_counts`、`oldest_unknown_batch`、`unbound_eligible_count` 与 `messages_avoided`。
+- 若 auto-close 账户数显著增长，单独评估“跨账户一条 maintenance digest”；当前无需把不同业务回执强行并入通用消息总线。
+- 任何重新引入 ordinary trade-intake sender 或新的 row-loop notification call site，都应以“外部调用次数是否随数据行数线性增长”为 Gateflow/DeepReview 必查项。

--- a/docs/gateflow/lifecycle-receipt-batching/s1-code-review.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s1-code-review.md
@@ -1,0 +1,12 @@
+# Gateflow S1 Code Review
+
+- Gate: code review S1
+- Work unit: `lifecycle-receipt-batching`
+- Review artifact: `docs/reviews/code-review-20260802-053512.md`
+- Initial decision: fail
+- Findings: `DR-S1-01`, `DR-S1-02`
+- Fix artifact: `docs/gateflow/lifecycle-receipt-batching/s1-fix.md`
+- Re-review: `docs/reviews/code-review-20260802-053937.md`
+- Final decision: pass
+- Status: accepted
+- Next gate: accepted S1 commit

--- a/docs/gateflow/lifecycle-receipt-batching/s1-fix.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s1-fix.md
@@ -1,0 +1,27 @@
+# Gateflow S1 Review Fix
+
+- Gate: S1 fix
+- Work unit: `lifecycle-receipt-batching`
+- Input review: `docs/reviews/code-review-20260802-053512.md`
+- Status: accepted findings fixed; pending re-review
+
+## DR-S1-01 — accepted — fixed
+
+- `claim_next_notification_batch()` now acquires only the lease.
+- `attempt_count` increments atomically at `claimed -> send_started`, the first durable proof that provider I/O may begin.
+- Three consecutive stale claims keep attempt count at zero; a later send-started becomes attempt one.
+- Added a deterministic lease-recovery regression.
+
+## DR-S1-02 — accepted — fixed
+
+- Repository insertion now validates batch/schema/route self-consistency.
+- Frozen member IDs must exactly match the ordered binding input.
+- Every envelope is compared with the stored outbox row's immutable identity, revision, timestamps, payload hash and payload.
+- Frozen first/last timestamps must equal the bound rows.
+- Tampered member ID, payload hash and payload tests all prove full rollback with no batch or binding.
+
+## Validation
+
+- Focused S1 suite after fixes: `40 passed`.
+- Ruff: pass.
+- `git diff --check`: pass.

--- a/docs/gateflow/lifecycle-receipt-batching/s1-implementation.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s1-implementation.md
@@ -1,0 +1,26 @@
+# Gateflow S1 Implementation
+
+- Gate: implementation S1
+- Work unit: `lifecycle-receipt-batching`
+- Accepted plan commit: `3b845f01`
+- Status: implementation complete; pending code review
+
+## Implemented scope
+
+- Added additive lifecycle delivery-batch schema, indexes and nullable member binding.
+- Added repository create/read/list/CAS/member-settlement operations.
+- Added `batched` fail-closed member state and prevented legacy row claims from selecting bound members.
+- Added deterministic route/batch identities, 10-second quiet/60-second maximum window, route send budget and no-split membership freeze.
+- Added batch claim/send-started/completion, explicit failure retry, ambiguity freeze, stale recovery and batch-wide manual resend.
+- Added focused regressions for 24-row aggregation, concurrency, retry ceiling, target budget, stale recovery, rollback selection, manual resend and migration preservation.
+
+## Validation
+
+- `python3.12 -m pytest -q -p no:cacheprovider tests/test_trades_lifecycle_batch_outbox.py tests/test_lifecycle_redesign_contracts.py`: `36 passed`.
+- Ruff on S1 production/test files: pass.
+- `git diff --check`: pass.
+
+## Safety boundaries
+
+- No renderer, CLI, runtime dispatcher, production config or provider behavior changed in S1.
+- No real notification or production ledger write occurred.

--- a/docs/gateflow/lifecycle-receipt-batching/s2-code-review.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s2-code-review.md
@@ -1,0 +1,19 @@
+# Gateflow S2 Code Review
+
+- Gate: code review S2
+- Work unit: `lifecycle-receipt-batching`
+- Review artifact: `docs/reviews/code-review-20260802-055541.md`
+- Initial decision: fail
+- Accepted findings: `DR-S2-01`, `DR-S2-02`, `DR-S2-03`, `DR-S2-04`
+- Fix artifact: `docs/gateflow/lifecycle-receipt-batching/s2-fix.md`
+- Re-review: `docs/reviews/code-review-20260802-060531.md`
+- Final decision: pass
+- Status: accepted
+- Next gate: accepted S2 commit
+
+## Decision rationale
+
+- Provider business rejection must not be frozen as accepted.
+- CLI dispatch must preserve configured account/receipt enablement before binding.
+- Single-case rendering must follow the accepted representative-level compatibility contract.
+- Write evidence must distinguish durable mutation from an applied no-op.

--- a/docs/gateflow/lifecycle-receipt-batching/s2-fix.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s2-fix.md
@@ -1,0 +1,36 @@
+# Gateflow S2 Review Fix
+
+- Gate: S2 fix
+- Work unit: `lifecycle-receipt-batching`
+- Input review: `docs/reviews/code-review-20260802-055541.md`
+- Status: accepted findings fixed; pending re-review
+
+## DR-S2-01 — accepted — fixed
+
+- Classifier now evaluates unambiguous HTTP/provider/pre-I/O rejection before `command_ok -> accepted`.
+- Added a regression using the actual WeChat normalizer shape: HTTP 200, `command_ok=true`, nonzero provider code now becomes `explicit_failed`.
+- 4xx, transient 5xx and fallback/ambiguous cases remain pinned.
+
+## DR-S2-02 — accepted — fixed
+
+- CLI resolves the canonical trade-intake sources and builds a fail-closed allow-set from enabled source account/mapping values whose receipt is enabled.
+- Both dry-run planner and applied dispatcher receive that allow-set.
+- Empty/global-disabled allow-sets return an idle/no-write result before batching or sending.
+- Added enabled `lx` plus disabled `sy`, and global receipt-disabled regressions; disabled rows remain pending and unbound.
+
+## DR-S2-03 — accepted — fixed
+
+- Renderer now collapses members first and delegates to the existing single-case renderer whenever exactly one representative remains.
+- Added exact message equality for two transitions of one case.
+
+## DR-S2-04 — accepted — fixed
+
+- CLI write evidence now requires an actual returned batch, a newly created batch, or a nonzero stale-recovery mutation.
+- Added applied empty-ledger coverage proving idle returns `write_applied=false`.
+
+## Validation
+
+- Focused S2/S1 suite after fixes: `114 passed`.
+- Ruff: pass.
+- Python compile checks: pass.
+- `git diff --check`: pass.

--- a/docs/gateflow/lifecycle-receipt-batching/s2-implementation.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s2-implementation.md
@@ -1,0 +1,28 @@
+# Gateflow S2 Implementation
+
+- Gate: implementation S2
+- Work unit: `lifecycle-receipt-batching`
+- Accepted S1 commit: `2adf049b`
+- Status: implementation complete; pending code review
+
+## Implemented scope
+
+- Added deterministic lifecycle batch rendering with byte-stable single-member output, one representative per case, twelve displayed cases and explicit remainder count.
+- Added canonical route preflight, frozen fingerprint comparison and stable `batch_id` transport idempotency.
+- Added a lifecycle-specific fail-closed delivery classifier: confirmed and accepted outcomes remain distinct; explicit pre-acceptance failures may retry; transient, timeout and fallback ambiguity freeze as unknown.
+- Made lifecycle receipt inspect, reconcile and one-shot dispatch batch-aware. Multi-member mutation by child outbox ID is refused, dry-run never binds, and applied account-scoped dispatch is refused.
+- Advanced lifecycle delivery diagnostics to `trade_lifecycle_delivery_status.v2` with unbound eligibility, batch states, unknown-batch evidence, member counts and batch-scope messages avoided. Raw delivery targets remain absent.
+- Updated the lifecycle operator contract for aggregation windows, retry/idempotency behavior and batch-level commands.
+
+## Validation
+
+- Focused S2/S1 regression suite: `109 passed`.
+- Ruff on all changed S2 production and test files: pass.
+- Python compile checks: pass.
+- `git diff --check`: pass.
+
+## Safety boundaries
+
+- Every provider test uses a fake sender; no real notification was sent.
+- No production config, runtime ledger, service, Release, deployment or remote environment was changed.
+- Process-level dispatcher ownership remains intentionally unchanged until S3.

--- a/docs/gateflow/lifecycle-receipt-batching/s3-code-review.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s3-code-review.md
@@ -1,0 +1,17 @@
+# Gateflow S3 Code Review
+
+- Gate: code review S3
+- Work unit: `lifecycle-receipt-batching`
+- Review artifact: `docs/reviews/code-review-20260802-062328.md`
+- Decision: pass
+- Findings: none
+- Status: accepted
+- Next gate: accepted S3 commit, then aggregate review
+
+## Decision rationale
+
+- One process-level owner replaces every source-local lifecycle sender.
+- Cross-account aggregation and the sixty-second target budget are exercised through the real dispatcher class.
+- Provider I/O holds neither the source process lock nor a SQLite transaction.
+- Dry-run, disabled receipt scope and unavailable route remain no-thread/no-send paths.
+- Poll cancellation, close idempotency, repeated-error visibility and sanitized status projection are deterministic.

--- a/docs/gateflow/lifecycle-receipt-batching/s3-implementation.md
+++ b/docs/gateflow/lifecycle-receipt-batching/s3-implementation.md
@@ -1,0 +1,37 @@
+# Gateflow S3 Implementation
+
+- Gate: implementation S3
+- Work unit: `lifecycle-receipt-batching`
+- Accepted S2 commit: `032a9dde`
+- Status: implementation complete; pending code review
+
+## Implemented scope
+
+- Added one process-owned `LifecycleReceiptBatchDispatcher` with a cancellable one-second poll, one durable batch attempt per poll and orderly close before other listener resources are closed.
+- Resolved one account allow-set from enabled sources using source receipt precedence. Dry-run, fully disabled receipt scope and unavailable routes do not start a dispatcher.
+- Removed the five-second account-scoped delivery block from `_run_listener_source_loop()`. Source loops continue to write lifecycle facts and intents but no longer own provider delivery.
+- Kept planner/claim/send-started/completion in their existing short SQLite transactions while provider I/O runs outside both SQLite transactions and the shared `process_lock`.
+- Added a sanitized dispatcher snapshot to each source's `lifecycle_delivery` status. It contains provider/channel/fingerprints and summarized durable results, never the raw route target or frozen member payloads.
+- Updated the lifecycle operator documentation with process ownership, cancellation, non-blocking write behavior and disabled/unavailable status reasons.
+
+## Storm and concurrency evidence
+
+- A real dispatcher fixture with 15 `lx` plus 9 `sy` intents on one route produced exactly one fake provider call, one 24-member batch and atomic confirmation of all members.
+- A blocking fake provider call left an independent ledger write under the normal process lock able to complete before provider release, proving the dispatcher holds neither the process lock nor a SQLite transaction over provider I/O.
+- Single- and two-source `main()` fixtures each constructed, started and closed exactly one dispatcher; every source received the same global status callback.
+- Static ownership regression proves `_run_listener_source_loop()` contains no lifecycle dispatch or provider-send call.
+- Cancellable-wait regression proves close wakes a one-second poll immediately and reaches `stopped`.
+
+## Validation
+
+- Focused S3 runtime suite: `68 passed`.
+- Full work-unit focused suite through S3: `168 passed`.
+- Ruff on changed S3 production and test files: pass.
+- Python compile checks: pass.
+- `git diff --check`: pass.
+
+## Safety boundaries
+
+- All delivery tests use fake senders and temporary SQLite ledgers; no real notification was sent.
+- No production config, runtime ledger, service, Release, deployment or remote environment was changed.
+- Cross-process ownership remains a rollout prerequisite, as classified in the accepted plan; S3 establishes one owner inside one listener process.

--- a/docs/reviews/code-review-20260802-053512.md
+++ b/docs/reviews/code-review-20260802-053512.md
@@ -1,0 +1,48 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `codex/lifecycle-receipt-batching`
+- Base: accepted plan commit `3b845f01`
+- Output file: `docs/reviews/code-review-20260802-053512.md`
+- Included scope: S1 additive schema, repository batch/member authority, planner, batch state machine, stale recovery, manual resend and focused tests.
+- Excluded scope: S2 renderer/CLI/diagnostics, S3 runtime dispatcher, real provider I/O and production apply.
+- Parallel review coverage: 无；review沿 repository -> planner -> claim/send-started -> complete/recover -> member projection 主链逐行检查。
+
+## Findings
+
+### DR-S1-01-未修复-高-stale claim 会消耗发送次数并最终把 pending batch 永久卡死
+- **入口/函数**: `claim_next_notification_batch()` -> `recover_stale_notification_batches()` -> next claim
+- **文件(行号)**: `src/application/trades/lifecycle_outbox.py:779-804, 880-938`; `_batch_is_active()` at `529-534`
+- **输入场景**: dispatcher 成功 claim 一个 batch 后、在 `mark_notification_batch_send_started()` 前进程连续崩溃或被中断三次。
+- **实际分支**: 每次 claim 在 provider I/O 尚未开始时就把 `attempt_count + 1`；stale recovery 只把 `claimed -> pending`，不恢复次数。第三次 recovery 后 batch 为 `pending/attempt_count=3`。
+- **预期行为**: 只有 durable `send_started` 对应一次真实 provider attempt；send 前丢失的 claim 应可无限按 lease 回收，不消耗三次外部发送预算。
+- **实际行为**: claim selector 因 `attempt_count < 3` 不再领取该 batch，而 `_batch_is_active()` 又把任意 pending batch 视为 active，planner 永远不建新批次；成员保持 `batched`，整个 route 的新意图也被这个 active batch 阻断。
+- **直接证据**: lines 915-927 在 `pending/explicit_failed -> claimed` 时递增次数；lines 785-803 recovery 没有回退；lines 883-885 排除 attempt=3；lines 531-534 对 pending 不检查 attempt ceiling。
+- **影响**: 没有发生任何外部发送也会耗尽 batch，造成永久静默、route backlog 和需要人工数据库修复的孤儿状态。
+- **建议改法和验证点**: claim 只写 claim lease，不递增 attempt；在 `claimed -> send_started` 的同一 CAS 中递增 attempt。stale claim recovery 保持次数不变。增加连续三次 claim/recover 后第四次仍可 send-started 的回归，并断言三次 recovery 后 attempt 仍为 0；同时让 active predicate 对不可能的 exhausted pending fail closed/可诊断。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-S1-02-未修复-高-repository 可把一组成员绑定到描述另一组成员的冻结 payload
+- **入口/函数**: `SQLiteOptionPositionsRepository.insert_trade_lifecycle_notification_batch_once()`
+- **文件(行号)**: `src/application/ledger/repository.py:2037-2168`
+- **输入场景**: application caller 因排序/组装 bug 传入 `member_outbox_ids=[A,B]`，但 `batch.payload.members` 描述 `[A,C]`，或 envelope 中的 case/payload hash 已陈旧。
+- **实际分支**: repository 只验证 payload 自身 hash、`member_count == len(member_outbox_ids)`、member rows 存在且可绑定；它不比较 frozen payload 的 member IDs/immutable fields 与实际查询行。随后插入 payload 并把 A/B 标成 `batched`。
+- **预期行为**: 外部要发送的冻结 member envelopes 与被原子结算的 outbox rows 必须是同一不可变集合，repository storage boundary 应拒绝任何错配。
+- **实际行为**: sender 会展示/发送 A/C 的事实，但 provider receipt completion 会结算 A/B；B 被静默确认却未出现在消息中，C 出现在消息中却没有被该 receipt 结算。
+- **直接证据**: lines 2066-2077 仅检查 ID list/count；lines 2150-2168 的 member query 只读取 `outbox_id,status,delivery_batch_id`；没有读取或比对 case/transition/revision/payload hash/payload。冻结 payload 在 lines 2039-2052 只做 self-hash。
+- **影响**: 外部消息与 durable audit/settlement 一一对应关系损坏，manual reconcile 也会针对错误成员集，属于难以恢复的数据一致性错误。
+- **建议改法和验证点**: repository 在插入前解析 `payload.members`，要求 batch ID/route fields一致、member IDs顺序/集合与参数一致，并把每个 envelope 的 immutable identity、timestamps、payload hash和payload与实际 outbox row逐项比较；任一错配整事务回滚。新增 tampered member ID、payload hash与payload内容三类测试，并断言无 batch、无 binding。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- S1 尚未接入真实 renderer/adapter 与 runtime ownership；这些按已接受计划分别留给 S2/S3 review。
+- 当前 focused tests 使用临时 SQLite，不覆盖跨主机不同 ledger；该风险归 production rollout topology gate。

--- a/docs/reviews/code-review-20260802-053937.md
+++ b/docs/reviews/code-review-20260802-053937.md
@@ -1,0 +1,28 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes re-review
+- Branch: `codex/lifecycle-receipt-batching`
+- Base: accepted plan commit `3b845f01`
+- Output file: `docs/reviews/code-review-20260802-053937.md`
+- Included scope: S1 implementation plus fixes for `DR-S1-01` and `DR-S1-02`.
+- Excluded scope: S2/S3, provider integration, runtime cutover and production apply.
+- Parallel review coverage: 无；复审重新走读 claim/recovery/send-started attempt chain，以及 repository frozen-envelope/binding transaction。
+
+## Findings
+
+未发现实质性问题。
+
+`DR-S1-01` 已修复：claim 不再增加次数；send-started CAS 才增加一次。连续 stale claims 不会耗尽预算，相关 regression 证明三次 recovery 后仍可进入 attempt one。
+
+`DR-S1-02` 已修复：repository 在 batch insert 前核对 payload batch/route、完整有序 member IDs、每个 immutable envelope 和真实 outbox row，以及 first/last timestamps。三类 tamper fixture 均在写入前失败，事务后 batch 数为零且成员仍 pending/unbound。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- S1 有意未切换真实 runtime sender；旧 per-row dispatcher 只会在最终 S3 前的开发分片中继续存在，本分支不会在中间 slice 发布。
+- Provider classifier、CLI group semantics 和 process-level cancellation 仍分别归 S2/S3 review。

--- a/docs/reviews/code-review-20260802-055541.md
+++ b/docs/reviews/code-review-20260802-055541.md
@@ -1,0 +1,75 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `codex/lifecycle-receipt-batching`
+- Base: accepted S1 commit `2adf049b`
+- Output file: `docs/reviews/code-review-20260802-055541.md`
+- Included scope: S2 renderer, route preflight, provider classifier, lifecycle receipt CLI, delivery status v2, operator documentation and focused tests.
+- Excluded scope: S3 process-level dispatcher ownership/cancellation, real provider I/O, production config/apply, Release and deployment.
+- Parallel review coverage: 无；review 沿 frozen batch -> representative renderer -> route/classifier -> batch dispatch CLI -> status evidence 主链逐行检查，并与实际 WeChat/Feishu normalization contract 交叉核对。
+
+## Findings
+
+### DR-S2-01-未修复-高-WeChat 业务拒绝会被误判为 accepted 并永久冻结
+- **入口/函数**: `send_trade_lifecycle_outbox_payload()` -> `classify_trade_lifecycle_delivery_result()`
+- **文件(行号)**: `src/application/trades/receipt.py:398-447`; `src/application/channels/wechat_clawbot/notification.py:150-190`; test fixture at `tests/test_trades_receipt.py:216-236`
+- **输入场景**: WeChat ClawBot 返回 HTTP 200，但 response business code 非零；adapter normalization 产出 `command_ok=True`, `delivery_confirmed=False`, `provider_response_code!=0`。
+- **实际分支**: classifier 虽然计算出 `provider_rejected=True`，却先在 `elif command_ok` 返回 `accepted`，只有 command 不成功时才检查 provider rejection。当前测试把 HTTP 200 rejection 人工构造成 `command_ok=False`，没有覆盖真实 adapter shape。
+- **预期行为**: 收到无歧义的 provider business rejection 应为 `explicit_failed`，按稳定 batch key 有限重试；只有 business acceptance 成立但缺少强确认时才是 `accepted`。
+- **实际行为**: 整个 batch 和全部成员被冻结为 accepted，不能自动重试；实际通知未送达，却需要操作员人工收敛。
+- **直接证据**: WeChat normalizer 以 `http_status == 200` 单独定义 `command_ok`，business success 只参与 `delivery_confirmed`；classifier lines 442-445 的判断顺序让 `command_ok` 遮蔽 lines 419-429 已识别的 provider rejection。
+- **影响**: 一次正常的 provider 业务拒绝会造成整批生命周期回执静默丢失，且状态错误声称 provider 已接受。
+- **建议改法和验证点**: 在排除 ambiguity 后先判定 `provider_rejected/pre_io_failure`，再判定 accepted；用真实 WeChat normalized shape 增加 HTTP 200/nonzero code regression，并保留 Feishu、4xx、5xx 与 fallback ambiguity cases。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-S2-02-未修复-高-applied CLI 会绑定并发送配置上未启用账户的意图
+- **入口/函数**: `option-positions lifecycle receipts dispatch --apply` -> `dispatch_notification_batch_once()`
+- **文件(行号)**: `src/interfaces/cli/option_positions.py:1873-1933`; `src/application/trades/lifecycle_outbox.py:1111-1132`; CLI fixture at `tests/test_option_positions_cli.py:2223-2246`
+- **输入场景**: ledger 中同时存在 enabled 与 disabled trade-intake account 的历史 pending 意图，或全局 `trade_intake.receipt.enabled=false`，操作员运行全局 applied one-shot dispatch。
+- **实际分支**: CLI 只读取全局 receipt object，调用 dispatcher 时不传 `allowed_accounts`。planner 因 `None` 接受所有账户并先原子绑定；全局 disabled 直到 send-started 后才由 sender 返回 explicit failure，account disabled 且全局 enabled 时则会真实发送。测试 runtime config 没有 accounts/source enablement，无法证明 eligibility contract。
+- **预期行为**: allow-set 应来自每个 enabled source 的显式 account 与 account mapping，并遵守 source/global receipt precedence；disabled-account rows 保持可见、pending、unbound。
+- **实际行为**: 全局 CLI 绕过 enablement 边界，可能发送本应禁用的回执；即使全局 receipt disabled，也会把行改成 `batched` 并消耗 attempt。
+- **直接证据**: lines 1921-1933 没有 `allowed_accounts`；dispatcher default is `None` and passes it to planner；sender receipt-enabled check occurs only after planner/claim/send-started。CLI tests only pin account-scoped applied refusal, not configured eligibility。
+- **影响**: 通知配置边界被操作路径绕过，造成非预期外发或把禁用账户 backlog 锁入批次状态。
+- **建议改法和验证点**: 从 `resolve_trade_intake_config(cfg)["sources"]` 生成 fail-closed enabled receipt account allow-set，并在 dry-run/global apply 都传给 planner/dispatcher；空集合必须 idle/no-write。新增 enabled lx + disabled sy fixture，以及 global receipt disabled fixture，断言 sy/全部禁用 rows 不绑定且 sender 不调用。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-S2-03-未修复-中-同一案件多条意图不会走既有单案件回执格式
+- **入口/函数**: `build_trade_lifecycle_notification_batch_message()`
+- **文件(行号)**: `src/application/trades/receipt.py:286-368`; `tests/test_trades_receipt.py:86-140`
+- **输入场景**: quiet window 内同一 lifecycle case 先后产生 `option_leg_closed` 与更高 revision 的 `resolution_confirmed/conflict`，batch 有两个 members，但 representative collapse 后只有一个案件。
+- **实际分支**: function 在 collapse 前用 `len(members)==1` 决定旧格式；两个 members 因此输出“期权平仓批次”digest，即使最终只有一个 representative。
+- **预期行为**: accepted plan 要求单个 representative 委托既有 `build_trade_lifecycle_notification_message()`，保持单案件回执 byte-stable；完整两个 members 仍在 batch audit 中结算。
+- **实际行为**: 同一案件的普通回执格式、标题和字段发生不必要变化；现有 byte-stable test 只覆盖一个 member，没有覆盖多 member/单 representative。
+- **直接证据**: lines 303-306 在 `_batch_representatives()` 调用之前判断 raw member count；collapse regression 同时加入另一个 case，所以无法触发该反例。
+- **影响**: 常见快速状态推进会出现不一致的人类界面，也偏离已接受的 renderer contract。
+- **建议改法和验证点**: 先计算 representatives，再以 `len(representatives)==1` 委托旧 renderer；增加同 case 两 transitions 的 exact equality regression，并确认 batch member count/settlement 不变。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### DR-S2-04-未修复-中-idle applied dispatch 会错误报告 write_applied=true
+- **入口/函数**: lifecycle receipt dispatch CLI write contract
+- **文件(行号)**: `src/interfaces/cli/option_positions.py:1934-1947`; `src/application/trades/lifecycle_outbox.py:1119-1140`
+- **输入场景**: route 可用，但没有 eligible intent、aggregation window 未到、route 正在 rate-limit，且 stale recovery count 为零；操作员运行 applied one-shot dispatch。
+- **实际分支**: dispatcher 返回 `status=idle` 且没有 batch/recovery mutation；CLI 只排除 route unavailable，仍设置 `write_applied=true`。
+- **预期行为**: write contract 应基于实际 durable change：创建/claim/settle batch 或 stale recovery count 非零才为 true；纯 idle 必须为 false。
+- **实际行为**: 运维回执声称已经写入，实际 SQLite 没有变化，破坏完成证据和自动化判断。
+- **直接证据**: lines 1943-1947 的 predicate 与 result 中 `batch/planning/recovery` 无关；dispatcher lines 1133-1140 明确可无写返回 idle。
+- **影响**: 操作员和上层 automation 无法从 CLI receipt 区分真正 delivery-state mutation 与 no-op。
+- **建议改法和验证点**: 增加纯函数从 `batch`, `planning.status`, recovery counters 判断实际写入；补 applied empty-ledger 和 waiting/rate-limited no-write tests，以及 stale recovery/write true test。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- S3 尚未移除 source-loop per-row dispatcher；本分支在 S3 完成前不可发布。
+- 当前测试只使用 fake provider；真实 provider canary 明确不在本 work unit 授权范围内。
+- Cross-host single-owner topology 仍是未来 production rollout gate，不属于 S2 修复范围。

--- a/docs/reviews/code-review-20260802-060531.md
+++ b/docs/reviews/code-review-20260802-060531.md
@@ -1,0 +1,33 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes re-review
+- Branch: `codex/lifecycle-receipt-batching`
+- Base: accepted S1 commit `2adf049b`
+- Output file: `docs/reviews/code-review-20260802-060531.md`
+- Included scope: S2 implementation plus fixes for `DR-S2-01` through `DR-S2-04`.
+- Excluded scope: S3 runtime owner/cancellation, real provider I/O, production apply, Release and deployment.
+- Parallel review coverage: 无；复审重新走读 actual adapter normalized result -> classifier ordering、source config -> account allow-set -> planner/claim、representative collapse -> renderer，以及 dispatcher result -> write contract。
+
+## Findings
+
+未发现实质性问题。
+
+`DR-S2-01` 已修复：在排除歧义后，HTTP/provider/pre-I/O rejection 先于 accepted 判定。真实 WeChat HTTP 200/nonzero business code fixture 现为 `explicit_failed`；4xx、5xx 和 fallback ambiguity 保持预期。
+
+`DR-S2-02` 已修复：CLI 从 canonical resolved sources 提取 enabled receipt account/mapping allow-set，并把集合同时传给 preview planner 和 applied dispatcher。禁用 `sy` 与全局 receipt disabled fixtures 均证明不绑定、不发送。
+
+`DR-S2-03` 已修复：renderer 先 collapse representatives；同一 case 两个 members、一个 representative 时与既有单案件 message 完全一致。
+
+`DR-S2-04` 已修复：write evidence 只在 batch mutation/creation 或 stale recovery 实际发生时为 true；applied empty-ledger returns idle/no-write。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- S3 必须完成 source-loop sender 移除与 process-level single-owner cutover；S2 不可独立发布。
+- Existing frozen batches遇到后续账户 enablement 变化时仍按冻结 batch authority 处理；本 work unit 不回写或拆分既有 batch。
+- Cross-host duplicate owners 继续由未来 production rollout topology gate 阻断。

--- a/docs/reviews/code-review-20260802-062328.md
+++ b/docs/reviews/code-review-20260802-062328.md
@@ -1,0 +1,33 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `codex/lifecycle-receipt-batching`
+- Base: accepted S2 commit `032a9dde`
+- Output file: `docs/reviews/code-review-20260802-062328.md`
+- Included scope: S3 process-level dispatcher ownership, source-loop cutover, account enablement, poll/cancellation lifecycle, provider-I/O lock boundary, dispatcher status projection, operator documentation and focused regressions.
+- Excluded scope: S1/S2 accepted implementation except as an integration dependency, real provider I/O, production config/runtime mutation, Release and deployment.
+- Parallel review coverage: 无；本次逐条走读 `main -> dispatcher thread -> durable batch state machine -> provider -> completion`，以及 single/multi-source stop paths、disabled paths 和 status readback。
+
+## Findings
+
+未发现实质性问题。
+
+单一 owner 已落实在 `auto_intake.main()`：无论一个还是多个 listener source，只构造、启动和关闭一个 dispatcher；source loop 的旧五秒逐账户 dispatch 分支和 account filter 已删除。静态回归固定 source loop 不再包含 lifecycle provider 调用。
+
+发送并发边界符合 accepted plan：dispatcher 不接收 `process_lock`，既有 batch dispatcher 在短 SQLite 事务间调用 provider。阻塞 sender fixture 证明 `send_started` 已提交后，另一线程仍可在 provider 返回前完成独立 ledger intent 写入。
+
+风暴合同已由真实 dispatcher 路径覆盖：15 条 `lx` 加 9 条 `sy` 同路由意图只产生一次 fake sender 调用、一个 24-member batch，并把全部成员原子结算为 `confirmed`；第二批意图在首个 `send_started` 后 60 秒内保持 idle。
+
+启停和观测面 fail closed：dry-run、无 enabled receipt account、route unavailable 均不创建线程；一秒 poll wait 可被 close 立即唤醒，重复 close 保持 stopped；相同基础设施错误只首次记日志但持续保留状态证据。状态摘要不包含 raw target 或冻结 member payload。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 本切片只保证单进程内一个 owner；生产升级前仍必须验证仅有一个 active listener service instance。跨进程/跨主机租约属于 accepted plan 明确 deferred 的 rollout blocker。
+- 已开始的 provider 调用依赖现有 adapter 网络超时完成；close 可取消 poll wait，但不会中断已 durable `send_started` 的外部调用。异常或失联仍由 batch stale recovery 冻结为 `unknown`，不会自动重发。
+- Listener 最终停止状态文件可能保留关闭前最后一次 dispatcher snapshot；运行态真实性仍需结合 PID/service evidence，生产拓扑验证不在本 work unit 授权范围内。

--- a/docs/reviews/code-review-20260802-063319.md
+++ b/docs/reviews/code-review-20260802-063319.md
@@ -1,0 +1,38 @@
+# Code Review
+
+## Scope
+
+- Mode: aggregate current branch review
+- Branch: `codex/lifecycle-receipt-batching`
+- Base: `origin/main@51275d59` (`v1.8.5`)
+- Output file: `docs/reviews/code-review-20260802-063319.md`
+- Included scope: complete lifecycle receipt batching work unit across SQLite migration/repository, intent-to-batch binding, delivery state machine, renderer/provider classifier, CLI/manual recovery, runtime owner/cancellation, diagnostics, receipt-risk inventory, generated dependency graph, tests and operator documentation.
+- Excluded scope: lifecycle fact/allocation/close-reason policy, non-lifecycle delivery redesign, real provider I/O, production runtime/config mutation, Release, deployment and remote apply.
+- Parallel review coverage: 无；聚合审查重新走读 `case transition -> immutable intent -> route/window planner -> atomic member binding -> claim/send_started -> provider classifier -> atomic completion/manual recovery`，并从 runtime 与 CLI 两个入口反向检查 enablement、rate gate 和旁路。
+
+## Findings
+
+未发现实质性问题。
+
+逐行事实与外部调用权已分离：既有 immutable intent 继续作为案件审计真源，只有 delivery batch 拥有 provider receipt 和可变投递状态。batch insert 与完整 frozen membership binding 在一个 SQLite transaction 中完成；terminal completion 对 batch 和全部 members 原子结算，cardinality 或 payload mismatch 会整体回滚。
+
+重试/歧义边界一致：attempt 在 durable `send_started` 时才增加；stale claim 不消耗预算，stale send-started/exception/timeout/fallback ambiguity 全批冻结为 `unknown`。只有明确 pre-acceptance failure 可以按 60 秒、5 分钟退避重试，三次后停止，且 transport key 始终复用 stable `batch_id`。
+
+风暴路径已关闭：15 条 `lx` 加 9 条 `sy` 同路由意图通过真实 process dispatcher 只产生一次 fake sender call；12 项展示上限不拆 membership，24 个 members 全部确认。source-loop sender 与可直接逐行发送的 legacy dispatcher 均已删除；repo 内唯一活动 lifecycle provider path 是 batch dispatch。
+
+配置与运行时边界 fail closed：runtime 与 applied CLI 都从 canonical resolved sources 建立 enabled receipt account allow-set；dry-run、全禁用、route unavailable 不绑定/不发送。一个进程无论多少 source 只拥有一个 dispatcher，provider I/O 不持有 `process_lock` 或 SQLite transaction。
+
+人工恢复与观测按批次：multi-member child reconcile 被 CLI 拒绝并指向 batch ID；accepted/unknown 的确认或补偿重发不重开原批次。status v2 区分 unbound intents、batch states、unknown batch、member count 和 messages avoided，并只暴露 route/target fingerprint，不暴露 raw target。
+
+全仓依赖边界保持通过：generated graph 扫描 907 个 Python files、577 个 production modules，parse errors 0、production cycles 0。全量 pytest 的代码用例均通过；沙箱内唯一 HTTP failure 来自禁止绑定 loopback 临时端口，获准环境单独复跑通过。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 单进程 single-owner 已证明；生产升级前仍须验证 service topology 只有一个 active listener process。跨进程/跨主机 lease 明确 deferred，若不能证明单实例则阻断 rollout。
+- 已 durable `send_started` 的 provider call 不被 close 强行中断，而依赖现有 adapter timeout；任何失联由 stale recovery 冻结为 unknown，需 operator evidence 后处理。
+- Auto-close maintenance 仍是一账户一次汇总回执；账户数显著增长时可能形成有界的跨账户 fan-out，但当前不是逐 position/逐 row 风暴。本 work unit 不引入通用消息总线。
+- Ordinary trade-intake sender 仅保留无 runtime caller 的兼容实现；任何重新接线都必须另行评审，不能绕过 lifecycle batch owner。

--- a/docs/reviews/plan-review-20260802-052141.md
+++ b/docs/reviews/plan-review-20260802-052141.md
@@ -1,0 +1,77 @@
+# Plan Review — lifecycle receipt batching
+
+## Reviewed target and scope
+
+- Target: `docs/gateflow/lifecycle-receipt-batching/plan.md`
+- Work unit: `lifecycle-receipt-batching`
+- Base: `origin/main@51275d59`
+- Scope reviewed: additive SQLite migration, intent-to-batch ownership, delivery state machine, route/idempotency contract, process-level dispatcher, CLI/manual recovery, validation and rollback semantics.
+- Excluded: lifecycle fact/allocation policy, unrelated notification products, production deployment and real provider calls.
+
+## Assumptions tested
+
+1. Mirroring batch status onto member rows is safe across restart and rollback.
+2. Holding the existing `process_lock` around a batch attempt is an acceptable coordinator boundary.
+3. Current provider normalization supplies enough evidence to distinguish retryable explicit pre-acceptance failure from ambiguous delivery.
+4. One process-level route can aggregate `lx` and `sy` because `resolve_notification_delivery_route()` resolves from the shared runtime config rather than account state.
+5. SQLite `BEGIN IMMEDIATE` plus immutable member binding can serialize local planners/claimers without a new distributed abstraction.
+6. Display truncation does not affect durable membership or settlement.
+
+## Findings
+
+### PR-01-未修复-高-成员镜像 retryable 状态会让旧版本回滚重新逐行发送
+- **位置**: `Data model and migration contract`、`Delivery state machine`、`Rollout, rollback and safety`
+- **问题类型**: 状态机漏洞 / migration hazards / rollback safety
+- **当前写法**: 计划让已绑定成员镜像 batch 的 `pending`、`claimed`、`send_started`、`explicit_failed` 等状态，同时仅声明“新批次存在后不支持回滚到旧代码”。
+- **反例/失败场景**: 新版本创建 24 成员 pending batch 后服务因无关故障回滚到 v1.8.5。旧 `claim_next_notification()` 不认识 `delivery_batch_id`，会领取所有 `pending` 或 retryable `explicit_failed` 成员并恢复逐行发送；stale `claimed` 也会被旧 recovery 改回 `pending`。
+- **为什么有问题**: 一个常规代码回滚即可重新触发本 work unit 正要消除的消息风暴。把回滚标为“不支持”不能让生产路径 fail-closed，也不满足 operations-sensitive repo 的恢复边界。
+- **直接证据**: `src/application/trades/lifecycle_outbox.py:106-157` 的旧 claim 只按 member `status in {pending, explicit_failed}`、due time 和 attempt count 选择，不检查未来的 batch binding；`recover_stale_notifications()` 会把 stale `claimed` 恢复成 `pending`。初版计划明确要求成员镜像这些状态。
+- **影响**: 回滚期间重复投递、跨 24 行消息风暴、batch receipt 与逐行 receipt 分叉，且难以判断哪些外部消息已被接受。
+- **建议改法和验证点**: 绑定时把所有非终态成员原子置为新 sentinel `batched`，旧代码无法领取；batch 自己持有 pending/claimed/send_started/retryable-explicit-failed 状态。只有 `confirmed`、`accepted`、`unknown` 或 attempts=3 的终态才原子投影到成员。最终 `explicit_failed` 同时把 member attempt count 写为 3。新增 rollback-compat test：用旧选择谓词扫描已绑定 pending/retryable batch，候选必须为零。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-02-未修复-高-全局 dispatcher 持有 process_lock 经过 provider I/O 会阻塞交易事实写入
+- **位置**: `Runtime ownership and scheduling`
+- **问题类型**: 过度耦合 / concurrency recovery risk / best-practice deviation
+- **当前写法**: dispatcher 在“每次 SQLite state transition/send attempt”外围使用现有 `process_lock`，没有明确把真实 provider call 移到锁外。
+- **反例/失败场景**: Feishu/网络发送耗尽超时预算。dispatcher 从 claim 到 provider 返回一直持有 `process_lock`；同一期间 source callback、lifecycle reconcile、combo reconcile 与 backfill 都等待该锁，push inbox 不能及时落账或结算。
+- **为什么有问题**: 新 durable batch 状态机已经用短 SQLite 事务提供 claim/CAS 权威。再把网络 I/O 与全部交易 intake 串行化没有一致性收益，却把通知依赖故障传播成交易事实处理停顿。
+- **直接证据**: `src/application/trades/auto_intake.py` 的 `process_lock` 同时保护 deal processing、当前 outbox dispatch、lifecycle reconcile 和 combo reconciliation；初版计划把新 dispatcher 继续绑定到这个锁。`send_trade_lifecycle_outbox_payload()` 包含真实 adapter call，耗时不受 SQLite transaction 控制。
+- **影响**: broker push backlog、listener health degradation、事实与通知故障耦合，最坏情况下因服务重启产生额外 recovery/ambiguity。
+- **建议改法和验证点**: 全局 dispatcher 不持有 `process_lock` 经过网络调用。claim/send-started/complete 各自使用短 `BEGIN IMMEDIATE` 事务；`send_started` 持久化后在所有锁外调用 provider，再用 CAS completion。新增阻塞 sender 测试，证明另一个 repo transaction/交易处理回调在 sender 阻塞时仍可完成。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-03-未修复-高-计划没有定义可执行的 explicit-failure 证据分类
+- **位置**: `Delivery state machine`、`Rendering and provider contract`、S2 tests
+- **问题类型**: 契约缺失 / 状态机漏洞 / 不可直接实施
+- **当前写法**: 计划说 normalization 会决定 explicit failure/ambiguous outcome，但没有给出判据；当前 lifecycle sender 对非成功只返回 `unknown`，除 route disabled/unavailable 外不会设置 `explicit_pre_acceptance_failure`。
+- **反例/失败场景**: provider 明确返回 4xx/业务拒绝，或者本地在发起 HTTP 前明确失败。若沿用当前 sender，dispatcher 将它们全部冻结为 `unknown`，三次稳定重试契约永远无法触发；若实现者简单把所有 `command_ok=false` 当 explicit failure，网络 transient/timeout 又会被不安全重发。
+- **为什么有问题**: “最多 3 次稳定 idempotency retry”需要可证明未被接受的分类边界。该边界缺失会迫使 implementation agent 临场猜测最安全的失败语义。
+- **直接证据**: `src/application/trades/receipt.py:192-266` 仅根据 `delivery_confirmed`/`command_ok` 返回 confirmed/accepted/unknown；`notification_delivery_adapter.py:223-316` 暴露 `ambiguous_send`、HTTP/provider code、idempotency/fallback evidence，但不生成 `explicit_pre_acceptance_failure`。
+- **影响**: 要么丧失安全重试和可用性，要么在可能已送达时重复投递；两者都破坏 success signals。
+- **建议改法和验证点**: 在 lifecycle sender 定义 fail-closed classifier：仅显式 route preflight failure、明确 provider rejection/4xx、或 adapter 明确给出的 pre-I/O failure 可标记 explicit failure；timeout、exception、transient attempt、fallback ambiguity、缺失证据一律 unknown。把分类字段和 transport key写入 batch receipt。测试至少覆盖 provider rejection→retry、transient/timeout→unknown/no retry、fallback ambiguity→unknown。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+## Architecture, optimality and overengineering judgment
+
+Intent row加一个 immutable batch binding、再增加一个 batch delivery entity，是让“一次 provider receipt 对应多 intent”的最小可信模型；用 join table 或通用消息总线都没有当前需求支撑。SQLite `BEGIN IMMEDIATE` 适合当前单 ledger/local process authority。方向本身成立，但上述 rollback 和 failure-classification 缺口会让安全目标在真实故障下失效。
+
+## Open questions
+
+- `source.receipt.enabled` 的账户 allow-set必须从 `source.account` 与 `account_mapping` 的实际绑定构造；当前全局 route 代码事实支持跨账户合并，但实施前仍需用现有 config fixture 验证 source-level disable 语义。
+- Provider-specific explicit rejection fields应留在 lifecycle sender的窄 classifier，还是提升到 shared adapter contract；优先前者，除非现有其它调用者已经需要完全相同的语义。
+
+## Residual risks and tracking destination
+
+- 跨进程/双 service instance 不在本 work unit 解决；在未来 production apply gate 以 service topology preflight 阻断，若真实存在多 writer，单独建立 lease/leadership work unit。
+- 已冻结 batch 之后修改通知 route 会 fail closed 并需要人工处理；记录在 operator docs/manual reconcile contract。
+- 大批次完整 payload 会增长 SQLite 行大小；当前 60 秒窗口与 top-12 render 不构成已证实 blocker，作为 aggregate deepreview 的容量检查项。
+
+## Final conclusion
+
+`fail`
+
+批次实体与全局 ownership 方向正确，但 rollback fail-open、网络调用锁耦合和 explicit-failure 分类三项均需先修订计划，再进行第二次 planreview，才可交给 implementation。

--- a/docs/reviews/plan-review-20260802-052412.md
+++ b/docs/reviews/plan-review-20260802-052412.md
@@ -1,0 +1,58 @@
+# Plan Re-review — lifecycle receipt batching
+
+## Reviewed target and scope
+
+- Target: repaired `docs/gateflow/lifecycle-receipt-batching/plan.md`
+- Prior review: `docs/reviews/plan-review-20260802-052141.md`
+- Scope: all initial findings plus the complete storage, state-machine, routing, runtime, CLI, test and rollback plan.
+- Base: `origin/main@51275d59`
+
+## Assumptions retested
+
+1. Old claim/recovery code cannot select a member after new batch binding.
+2. Batch transitions remain atomic without a process-wide lock around provider I/O.
+3. Explicit failure retries are possible without treating ambiguous delivery as safe to retry.
+4. One batch receipt remains the authority while member-level facts stay independently inspectable.
+5. Slice order lets schema/state behavior land before sender/CLI and runtime ownership cutover.
+
+## Initial finding disposition
+
+### PR-01-已修复-高-成员镜像 retryable 状态会让旧版本回滚重新逐行发送
+
+The plan now binds members as `batched`, a status outside v1.8.5's `pending/explicit_failed` claim predicate. Retryable batch states do not leak back to member rows. Terminal projection and exhausted-attempt handling are explicit, and the required test directly executes the old selection semantics. This is a fail-closed rollback contract rather than an operator-only prohibition.
+
+### PR-02-已修复-高-全局 dispatcher 持有 process_lock 经过 provider I/O 会阻塞交易事实写入
+
+The repaired plan separates short SQLite transactions from the network call and explicitly forbids holding either `process_lock` or a SQLite transaction while calling the provider. Claim-ID CAS preserves completion ownership. The blocking-sender regression is sufficient to catch accidental lock reintroduction.
+
+### PR-03-已修复-高-计划没有定义可执行的 explicit-failure 证据分类
+
+The repaired classifier is fail-closed: only route/pre-I/O failures or an unambiguous provider rejection are retryable; timeouts, exceptions, transient attempts and fallback ambiguity freeze unknown. The plan now lists concrete fixtures for both branches and requires preservation of classifier evidence.
+
+## Special lens results
+
+- **Architecture boundary**: pass. Intent creation remains in ledger writer, batch durability/CAS in repository and lifecycle outbox, rendering/provider adaptation in receipt, and process lifetime in auto-intake.
+- **Best practice**: pass. Immutable membership, stable idempotency, short transactions, ambiguity freeze, additive migration and recovery-first tests match the local repository's established outbox patterns.
+- **Optimal solution**: pass. One nullable binding plus one batch entity is the smallest model capable of mapping one external receipt to many immutable intents.
+- **Overengineering**: pass. No config surface, generic bus, join-table abstraction, distributed lock or new notification framework is introduced.
+- **Overcoupling**: pass. S1 can prove state without provider/runtime code; S2 can prove rendering/CLI using fakes; S3 only changes process ownership after the prior contracts are accepted.
+
+## Findings
+
+No unresolved material findings.
+
+## Open questions
+
+None blocking. If one account appears in multiple source bindings with conflicting receipt enablement, implementation should preserve old effective behavior (`enabled` if any source capable of dispatching that account was enabled) and pin it in the existing multi-source fixture; divergence is a stop-and-re-review condition.
+
+## Residual risks and tracking destination
+
+- Cross-host replicas with separate ledgers remain outside scope; production apply must verify one active service topology or open a separate leader/lease work unit.
+- Old code can safely leave `batched` work frozen but cannot resume it; operator documentation must state forward upgrade as recovery.
+- Capacity of unusually large 60-second batches is not a current blocker because the provider message is bounded to 12 representatives; aggregate deepreview should verify payload-size observability and no accidental auto-split.
+
+## Final conclusion
+
+`pass-with-risks`
+
+The repaired plan is code-generation-ready. Initial safety blockers are closed with testable contracts, and remaining risks have explicit rollout or aggregate-review destinations.

--- a/docs/reviews/pr-130-review-20260802-064129.md
+++ b/docs/reviews/pr-130-review-20260802-064129.md
@@ -1,0 +1,47 @@
+# Code Review
+
+## Scope
+
+- Mode: PR
+- PR: #130, `Batch lifecycle receipts to prevent reconciliation storms`
+- URL: https://github.com/liuxie066/options-monitor/pull/130
+- Author: `liuxie066`
+- Head: `codex/lifecycle-receipt-batching@056fa54f`
+- Base: `main@51275d59`
+- Output file: `docs/reviews/pr-130-review-20260802-064129.md`
+- Included scope: exact 37-file remote PR diff, commit set, SQLite schema and repository transitions, planner and route budget, rendering and provider classification, process-level dispatcher ownership, CLI/manual recovery, diagnostics, tests, receipt-risk inventory, and operator documentation.
+- Excluded scope: lifecycle fact/allocation/close-reason policy, real provider delivery, production topology, release, deployment, and remote apply.
+- Parallel review coverage: none.
+
+## Findings
+
+No material findings.
+
+The remote PR base/head and diff statistics match the locally reviewed aggregate work unit exactly. The review rechecked the complete authority chain from immutable per-case intent through atomic batch membership, durable `send_started`, provider classification, and atomic terminal settlement. A batch cannot silently omit or rewrite members, and a terminal completion rolls back if frozen member identity, payload hash, or cardinality no longer matches.
+
+Retry and ambiguity remain fail closed: stale claims do not consume an attempt; every actual send start consumes the route budget and reuses the stable batch key; only explicit pre-acceptance failure retries; accepted, exception, timeout, fallback ambiguity, and stale send-started work freeze without automatic resend.
+
+The original storm path is closed at runtime ownership, not only at formatting: all enabled accounts share one process dispatcher, source loops no longer send lifecycle receipts, and the exported turnkey per-row dispatcher is absent. The historical `lx=15` plus `sy=9` same-route fixture therefore produces one fake provider call while atomically settling all 24 member intents. Provider I/O occurs outside the process lock and SQLite transactions.
+
+Configuration, recovery, and observability preserve the boundary: dry-run/disabled/unavailable routes do not start a dispatcher; applied CLI dispatch is global; multi-member recovery requires the batch ID; raw targets remain fingerprinted; legacy terminal rows are not reactivated.
+
+## CI and validation
+
+- GitHub `Agent Plugin`: pass at review time.
+- GitHub `Guardrails`: in progress at review time; final remote status must be checked after the review-evidence push.
+- Focused work-unit suite: `169 passed`.
+- Related lifecycle/maintenance/multi-tick suite: `122 passed`.
+- Full suite: all `3953` non-skipped tests passed; `10 skipped`.
+- Ruff, Python compile checks, dependency boundary/cycle check, and `git diff --check`: pass.
+- Dependency graph: `577` production modules, zero parse errors, zero production cycles.
+
+## Open Questions
+
+- None.
+
+## Residual Risk
+
+- Production rollout is blocked until runtime topology proves exactly one active listener process; this PR deliberately does not add a cross-process or cross-host lease.
+- A provider call already in progress relies on the existing adapter timeout. If the process loses delivery certainty, stale recovery freezes the whole batch as `unknown` for operator evidence.
+- Auto-close maintenance remains one aggregate receipt per account/run. It is bounded and not row-linear, but a future large account count may justify separate cross-account batching.
+- Ordinary trade-intake delivery remains a dormant compatibility implementation with no runtime caller; reconnecting it requires a separate review.

--- a/src/application/ledger/repository.py
+++ b/src/application/ledger/repository.py
@@ -205,6 +205,74 @@ def _ensure_notification_outbox_v2(conn: sqlite3.Connection) -> None:
     conn.execute(f"ALTER TABLE {replacement} RENAME TO {table}")
 
 
+def _ensure_notification_delivery_batches_v1(
+    conn: sqlite3.Connection,
+) -> None:
+    _add_column_if_missing(
+        conn,
+        "trade_lifecycle_notification_outbox",
+        "delivery_batch_id",
+        "TEXT",
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS
+        trade_lifecycle_notification_delivery_batches (
+          batch_id TEXT PRIMARY KEY,
+          route_fingerprint TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          channel TEXT NOT NULL,
+          target_fingerprint TEXT NOT NULL,
+          renderer_version TEXT NOT NULL,
+          status TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          payload_hash TEXT NOT NULL,
+          member_count INTEGER NOT NULL CHECK(member_count > 0),
+          first_intent_created_at_ms INTEGER NOT NULL,
+          last_intent_created_at_ms INTEGER NOT NULL,
+          provider_message_id TEXT,
+          claim_id TEXT,
+          claimed_at_ms INTEGER,
+          send_started_at_ms INTEGER,
+          attempt_count INTEGER NOT NULL DEFAULT 0,
+          next_attempt_at_ms INTEGER,
+          last_error TEXT,
+          provider_receipt_json TEXT,
+          created_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL,
+          confirmed_at_ms INTEGER
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+        idx_trade_lifecycle_delivery_batches_dispatch
+        ON trade_lifecycle_notification_delivery_batches(
+          status, next_attempt_at_ms, created_at_ms, batch_id
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+        idx_trade_lifecycle_delivery_batches_route
+        ON trade_lifecycle_notification_delivery_batches(
+          route_fingerprint, send_started_at_ms, created_at_ms, batch_id
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+        idx_trade_lifecycle_outbox_delivery_batch
+        ON trade_lifecycle_notification_outbox(
+          delivery_batch_id, created_at_ms, outbox_id
+        )
+        """
+    )
+
+
 def initialize_ledger_connection(conn: sqlite3.Connection) -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys=ON")
@@ -450,6 +518,7 @@ class SQLiteOptionPositionsRepository:
                 """
             )
             _ensure_notification_outbox_v2(conn)
+            _ensure_notification_delivery_batches_v1(conn)
             conn.execute(
                 """
                 CREATE INDEX IF NOT EXISTS idx_trade_lifecycle_outbox_dispatch
@@ -1964,6 +2033,455 @@ class SQLiteOptionPositionsRepository:
             )
         return int(cursor.rowcount or 0) == 1
 
+    def insert_trade_lifecycle_notification_batch_once(
+        self,
+        batch: dict[str, Any],
+        *,
+        member_outbox_ids: Sequence[str],
+        conn: sqlite3.Connection | None = None,
+    ) -> bool:
+        payload = dict(batch.get("payload") or {})
+        payload_json = _json_text(payload)
+        payload_hash = hashlib.sha256(
+            payload_json.encode("utf-8")
+        ).hexdigest()
+        supplied_hash = str(batch.get("payload_hash") or "").strip()
+        if supplied_hash and supplied_hash != payload_hash:
+            raise ValueError(
+                "notification delivery batch payload hash mismatch"
+            )
+        batch_id = str(batch.get("batch_id") or "").strip()
+        route_fingerprint = str(
+            batch.get("route_fingerprint") or ""
+        ).strip()
+        provider = str(batch.get("provider") or "").strip().lower()
+        channel = str(batch.get("channel") or "").strip().lower()
+        target_fingerprint = str(
+            batch.get("target_fingerprint") or ""
+        ).strip()
+        renderer_version = str(
+            batch.get("renderer_version") or ""
+        ).strip()
+        status = str(batch.get("status") or "pending").strip().lower()
+        member_ids = tuple(
+            str(value or "").strip() for value in member_outbox_ids
+        )
+        if not member_ids or any(not value for value in member_ids):
+            raise ValueError(
+                "notification delivery batch members are incomplete"
+            )
+        if len(set(member_ids)) != len(member_ids):
+            raise ValueError(
+                "notification delivery batch members must be unique"
+            )
+        payload_members_raw = payload.get("members")
+        payload_members = (
+            list(payload_members_raw)
+            if isinstance(payload_members_raw, list)
+            else []
+        )
+        payload_route = (
+            dict(payload.get("route") or {})
+            if isinstance(payload.get("route"), dict)
+            else {}
+        )
+        payload_member_ids = tuple(
+            str(item.get("outbox_id") or "").strip()
+            for item in payload_members
+            if isinstance(item, dict)
+        )
+        member_count = int(batch.get("member_count") or 0)
+        first_created = int(
+            batch.get("first_intent_created_at_ms") or 0
+        )
+        last_created = int(
+            batch.get("last_intent_created_at_ms") or 0
+        )
+        created_at = int(batch.get("created_at_ms") or 0)
+        attempts = int(batch.get("attempt_count") or 0)
+        next_attempt = batch.get("next_attempt_at_ms")
+        if (
+            not batch_id
+            or not route_fingerprint
+            or not provider
+            or not channel
+            or not target_fingerprint
+            or not renderer_version
+            or status != "pending"
+            or member_count != len(member_ids)
+            or first_created <= 0
+            or last_created < first_created
+            or created_at <= 0
+            or attempts < 0
+            or str(payload.get("batch_id") or "").strip() != batch_id
+            or str(payload.get("schema_version") or "").strip()
+            != renderer_version
+            or payload_member_ids != member_ids
+            or len(payload_members) != len(member_ids)
+            or str(payload_route.get("provider") or "").strip().lower()
+            != provider
+            or str(payload_route.get("channel") or "").strip().lower()
+            != channel
+            or str(
+                payload_route.get("target_fingerprint") or ""
+            ).strip()
+            != target_fingerprint
+            or str(
+                payload_route.get("route_fingerprint") or ""
+            ).strip()
+            != route_fingerprint
+        ):
+            raise ValueError(
+                "notification delivery batch is incomplete"
+            )
+        with self._optional_conn(conn, commit=True) as active_conn:
+            existing = active_conn.execute(
+                """
+                SELECT *
+                FROM trade_lifecycle_notification_delivery_batches
+                WHERE batch_id = ?
+                """,
+                (batch_id,),
+            ).fetchone()
+            if existing is not None:
+                stored = _notification_delivery_batch_row(existing)
+                immutable_conflict = any(
+                    stored[key] != value
+                    for key, value in {
+                        "route_fingerprint": route_fingerprint,
+                        "provider": provider,
+                        "channel": channel,
+                        "target_fingerprint": target_fingerprint,
+                        "renderer_version": renderer_version,
+                        "payload_hash": payload_hash,
+                        "member_count": member_count,
+                        "first_intent_created_at_ms": first_created,
+                        "last_intent_created_at_ms": last_created,
+                    }.items()
+                )
+                if immutable_conflict or stored["payload"] != payload:
+                    raise ValueError(
+                        "notification delivery batch immutable conflict"
+                    )
+                bound = active_conn.execute(
+                    """
+                    SELECT outbox_id
+                    FROM trade_lifecycle_notification_outbox
+                    WHERE delivery_batch_id = ?
+                    ORDER BY created_at_ms ASC, outbox_id ASC
+                    """,
+                    (batch_id,),
+                ).fetchall()
+                if {str(row["outbox_id"]) for row in bound} != set(
+                    member_ids
+                ):
+                    raise ValueError(
+                        "notification delivery batch membership conflict"
+                    )
+                return False
+            placeholders = ",".join("?" for _ in member_ids)
+            member_rows = active_conn.execute(
+                f"""
+                SELECT *
+                FROM trade_lifecycle_notification_outbox
+                WHERE outbox_id IN ({placeholders})
+                """,
+                member_ids,
+            ).fetchall()
+            if len(member_rows) != len(member_ids):
+                raise ValueError(
+                    "notification delivery batch member not found"
+                )
+            members_by_id = {
+                str(row["outbox_id"]): _notification_outbox_row(row)
+                for row in member_rows
+            }
+            for envelope in payload_members:
+                if not isinstance(envelope, dict):
+                    raise ValueError(
+                        "notification delivery batch member payload is invalid"
+                    )
+                outbox_id = str(
+                    envelope.get("outbox_id") or ""
+                ).strip()
+                row = members_by_id.get(outbox_id)
+                if not isinstance(row, dict):
+                    raise ValueError(
+                        "notification delivery batch member not found"
+                    )
+                if row["delivery_batch_id"] is not None or str(
+                    row["status"] or ""
+                ) not in {"pending", "explicit_failed"}:
+                    raise ValueError(
+                        "notification delivery batch member is not bindable"
+                    )
+                expected_envelope = {
+                    "outbox_id": str(row["outbox_id"]),
+                    "case_id": str(row["case_id"]),
+                    "transition_type": str(row["transition_type"]),
+                    "resolution_revision": int(
+                        row["resolution_revision"]
+                    ),
+                    "delivery_revision": int(
+                        row.get("delivery_revision") or 0
+                    ),
+                    "transition_key": str(row["transition_key"]),
+                    "state_fingerprint": str(
+                        row["state_fingerprint"]
+                    ),
+                    "payload_hash": str(row["payload_hash"]),
+                    "created_at_ms": int(row["created_at_ms"]),
+                    "payload": dict(row.get("payload") or {}),
+                }
+                if envelope != expected_envelope:
+                    raise ValueError(
+                        "notification delivery batch member payload mismatch"
+                    )
+            actual_created = [
+                int(row["created_at_ms"])
+                for row in members_by_id.values()
+            ]
+            if (
+                min(actual_created) != first_created
+                or max(actual_created) != last_created
+            ):
+                raise ValueError(
+                    "notification delivery batch member time range mismatch"
+                )
+            active_conn.execute(
+                """
+                INSERT INTO trade_lifecycle_notification_delivery_batches (
+                  batch_id, route_fingerprint, provider, channel,
+                  target_fingerprint, renderer_version, status,
+                  payload_json, payload_hash, member_count,
+                  first_intent_created_at_ms,
+                  last_intent_created_at_ms, attempt_count,
+                  next_attempt_at_ms, created_at_ms, updated_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    batch_id,
+                    route_fingerprint,
+                    provider,
+                    channel,
+                    target_fingerprint,
+                    renderer_version,
+                    status,
+                    payload_json,
+                    payload_hash,
+                    member_count,
+                    first_created,
+                    last_created,
+                    attempts,
+                    next_attempt,
+                    created_at,
+                    created_at,
+                ),
+            )
+            cursor = active_conn.execute(
+                f"""
+                UPDATE trade_lifecycle_notification_outbox
+                SET delivery_batch_id = ?, status = 'batched',
+                    claim_id = NULL, claimed_at_ms = NULL,
+                    send_started_at_ms = NULL,
+                    next_attempt_at_ms = NULL,
+                    updated_at_ms = ?
+                WHERE outbox_id IN ({placeholders})
+                  AND delivery_batch_id IS NULL
+                  AND status IN ('pending', 'explicit_failed')
+                """,
+                (batch_id, created_at, *member_ids),
+            )
+            if int(cursor.rowcount or 0) != len(member_ids):
+                raise ValueError(
+                    "notification delivery batch binding lost"
+                )
+        return True
+
+    def get_trade_lifecycle_notification_batch(
+        self,
+        batch_id: str,
+        *,
+        conn: sqlite3.Connection | None = None,
+    ) -> dict[str, Any] | None:
+        with self._optional_conn(conn) as active_conn:
+            row = active_conn.execute(
+                """
+                SELECT *
+                FROM trade_lifecycle_notification_delivery_batches
+                WHERE batch_id = ?
+                """,
+                (str(batch_id or "").strip(),),
+            ).fetchone()
+        return (
+            _notification_delivery_batch_row(row)
+            if row is not None
+            else None
+        )
+
+    def list_trade_lifecycle_notification_batches(
+        self,
+        *,
+        status: str | None = None,
+        route_fingerprint: str | None = None,
+        conn: sqlite3.Connection | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if status:
+            clauses.append("status = ?")
+            params.append(str(status).strip().lower())
+        if route_fingerprint:
+            clauses.append("route_fingerprint = ?")
+            params.append(str(route_fingerprint).strip())
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._optional_conn(conn) as active_conn:
+            rows = active_conn.execute(
+                f"""
+                SELECT *
+                FROM trade_lifecycle_notification_delivery_batches
+                {where}
+                ORDER BY created_at_ms ASC, batch_id ASC
+                """,
+                params,
+            ).fetchall()
+        return [_notification_delivery_batch_row(row) for row in rows]
+
+    def list_trade_lifecycle_notification_batch_members(
+        self,
+        batch_id: str,
+        *,
+        conn: sqlite3.Connection | None = None,
+    ) -> list[dict[str, Any]]:
+        with self._optional_conn(conn) as active_conn:
+            rows = active_conn.execute(
+                """
+                SELECT *
+                FROM trade_lifecycle_notification_outbox
+                WHERE delivery_batch_id = ?
+                ORDER BY created_at_ms ASC, outbox_id ASC
+                """,
+                (str(batch_id or "").strip(),),
+            ).fetchall()
+        return [_notification_outbox_row(row) for row in rows]
+
+    def compare_and_set_trade_lifecycle_notification_batch(
+        self,
+        *,
+        batch_id: str,
+        expected_status: str,
+        new_status: str,
+        claim_id: str | None = None,
+        expected_claim_id: str | None = None,
+        fields: dict[str, Any] | None = None,
+        conn: sqlite3.Connection | None = None,
+    ) -> bool:
+        allowed_fields = {
+            "provider_message_id",
+            "claim_id",
+            "claimed_at_ms",
+            "send_started_at_ms",
+            "attempt_count",
+            "next_attempt_at_ms",
+            "last_error",
+            "provider_receipt_json",
+            "confirmed_at_ms",
+        }
+        updates = dict(fields or {})
+        invalid = sorted(set(updates) - allowed_fields)
+        if invalid:
+            raise ValueError(
+                "unsupported notification delivery batch fields: "
+                + ",".join(invalid)
+            )
+        if claim_id is not None:
+            updates["claim_id"] = claim_id
+        assignments = ["status = ?", "updated_at_ms = ?"]
+        values: list[Any] = [
+            str(new_status or "").strip().lower(),
+            int(now_ms()),
+        ]
+        for key in sorted(updates):
+            value = updates[key]
+            if key == "provider_receipt_json" and isinstance(value, dict):
+                value = _json_text(value)
+            assignments.append(f"{key} = ?")
+            values.append(value)
+        clauses = ["batch_id = ?", "status = ?"]
+        values.extend(
+            (
+                str(batch_id or "").strip(),
+                str(expected_status or "").strip().lower(),
+            )
+        )
+        if expected_claim_id is not None:
+            clauses.append("claim_id = ?")
+            values.append(str(expected_claim_id))
+        with self._optional_conn(conn, commit=True) as active_conn:
+            cursor = active_conn.execute(
+                f"""
+                UPDATE trade_lifecycle_notification_delivery_batches
+                SET {', '.join(assignments)}
+                WHERE {' AND '.join(clauses)}
+                """,
+                values,
+            )
+        return int(cursor.rowcount or 0) == 1
+
+    def update_trade_lifecycle_notification_batch_members(
+        self,
+        *,
+        batch_id: str,
+        expected_statuses: Sequence[str],
+        new_status: str,
+        fields: dict[str, Any] | None = None,
+        conn: sqlite3.Connection | None = None,
+    ) -> int:
+        statuses = tuple(
+            str(value or "").strip().lower()
+            for value in expected_statuses
+            if str(value or "").strip()
+        )
+        if not statuses:
+            raise ValueError(
+                "notification batch member expected status is required"
+            )
+        allowed_fields = {
+            "attempt_count",
+            "next_attempt_at_ms",
+            "last_error",
+            "confirmed_at_ms",
+        }
+        updates = dict(fields or {})
+        invalid = sorted(set(updates) - allowed_fields)
+        if invalid:
+            raise ValueError(
+                "unsupported notification batch member fields: "
+                + ",".join(invalid)
+            )
+        assignments = ["status = ?", "updated_at_ms = ?"]
+        values: list[Any] = [
+            str(new_status or "").strip().lower(),
+            int(now_ms()),
+        ]
+        for key in sorted(updates):
+            assignments.append(f"{key} = ?")
+            values.append(updates[key])
+        placeholders = ",".join("?" for _ in statuses)
+        values.append(str(batch_id or "").strip())
+        values.extend(statuses)
+        with self._optional_conn(conn, commit=True) as active_conn:
+            cursor = active_conn.execute(
+                f"""
+                UPDATE trade_lifecycle_notification_outbox
+                SET {', '.join(assignments)}
+                WHERE delivery_batch_id = ?
+                  AND status IN ({placeholders})
+                """,
+                values,
+            )
+        return int(cursor.rowcount or 0)
+
     def insert_strategy_group_identity(
         self,
         identity: dict[str, Any],
@@ -2807,8 +3325,48 @@ def _notification_outbox_row(row: sqlite3.Row) -> dict[str, Any]:
         "transition_key": str(row["transition_key"]),
         "state_fingerprint": str(row["state_fingerprint"]),
         "status": str(row["status"]),
+        "delivery_batch_id": row["delivery_batch_id"],
         "payload": _json_object(row["payload_json"]),
         "payload_hash": str(row["payload_hash"]),
+        "provider_message_id": row["provider_message_id"],
+        "claim_id": row["claim_id"],
+        "claimed_at_ms": row["claimed_at_ms"],
+        "send_started_at_ms": row["send_started_at_ms"],
+        "attempt_count": int(row["attempt_count"] or 0),
+        "next_attempt_at_ms": row["next_attempt_at_ms"],
+        "last_error": row["last_error"],
+        "provider_receipt": provider_receipt,
+        "created_at_ms": int(row["created_at_ms"]),
+        "updated_at_ms": int(row["updated_at_ms"]),
+        "confirmed_at_ms": row["confirmed_at_ms"],
+    }
+
+
+def _notification_delivery_batch_row(
+    row: sqlite3.Row,
+) -> dict[str, Any]:
+    provider_receipt = (
+        _json_object(row["provider_receipt_json"])
+        if row["provider_receipt_json"]
+        else None
+    )
+    return {
+        "batch_id": str(row["batch_id"]),
+        "route_fingerprint": str(row["route_fingerprint"]),
+        "provider": str(row["provider"]),
+        "channel": str(row["channel"]),
+        "target_fingerprint": str(row["target_fingerprint"]),
+        "renderer_version": str(row["renderer_version"]),
+        "status": str(row["status"]),
+        "payload": _json_object(row["payload_json"]),
+        "payload_hash": str(row["payload_hash"]),
+        "member_count": int(row["member_count"]),
+        "first_intent_created_at_ms": int(
+            row["first_intent_created_at_ms"]
+        ),
+        "last_intent_created_at_ms": int(
+            row["last_intent_created_at_ms"]
+        ),
         "provider_message_id": row["provider_message_id"],
         "claim_id": row["claim_id"],
         "claimed_at_ms": row["claimed_at_ms"],

--- a/src/application/trades/auto_intake.py
+++ b/src/application/trades/auto_intake.py
@@ -43,6 +43,7 @@ from src.application.trades.push_listener import (
     TradeIntakeStartCancelled,
 )
 from src.application.trades.lifecycle_outbox import (
+    MAX_ATTEMPTS,
     dispatch_notifications_once,
 )
 from src.application.trades.lifecycle_runtime import (
@@ -1668,6 +1669,73 @@ def _lifecycle_delivery_status(
         str(item.get("status") or "").strip().lower() or "unknown"
         for item in notifications
     )
+    eligible_unbound_rows = [
+        item
+        for item in notifications
+        if not str(item.get("delivery_batch_id") or "").strip()
+        and str(item.get("status") or "").strip().lower()
+        in {"pending", "explicit_failed"}
+        and int(item.get("attempt_count") or 0) < MAX_ATTEMPTS
+        and (
+            item.get("next_attempt_at_ms") is None
+            or int(item.get("next_attempt_at_ms") or 0)
+            <= int(now_ms)
+        )
+    ]
+    eligible_unbound_rows.sort(
+        key=lambda item: (
+            int(item.get("created_at_ms") or 0),
+            str(item.get("outbox_id") or ""),
+        )
+    )
+    delivery_batch_ids = {
+        str(item.get("delivery_batch_id") or "").strip()
+        for item in notifications
+        if str(item.get("delivery_batch_id") or "").strip()
+    }
+    all_batches = (
+        repo.list_trade_lifecycle_notification_batches()
+        if callable(
+            getattr(
+                repo,
+                "list_trade_lifecycle_notification_batches",
+                None,
+            )
+        )
+        else []
+    )
+    delivery_batches = [
+        dict(item)
+        for item in all_batches
+        if isinstance(item, dict)
+        and str(item.get("batch_id") or "").strip()
+        in delivery_batch_ids
+    ]
+    batch_states = Counter(
+        str(item.get("status") or "").strip().lower() or "unknown"
+        for item in delivery_batches
+    )
+    unknown_batches = [
+        item
+        for item in delivery_batches
+        if str(item.get("status") or "").strip().lower()
+        == "unknown"
+    ]
+    unknown_batches.sort(
+        key=lambda item: (
+            int(item.get("created_at_ms") or 0),
+            str(item.get("batch_id") or ""),
+        )
+    )
+    messages_avoided_by_status = {
+        status: sum(
+            max(int(item.get("member_count") or 0) - 1, 0)
+            for item in delivery_batches
+            if str(item.get("status") or "").strip().lower()
+            == status
+        )
+        for status in ("confirmed", "accepted")
+    }
     unknown_rows = [
         item
         for item in notifications
@@ -1725,7 +1793,20 @@ def _lifecycle_delivery_status(
             "confirmed",
             "explicit_failed",
             "unknown",
+            "batched",
             "suppressed",
+        )
+    }
+    batch_status_counts = {
+        name: int(batch_states.get(name, 0))
+        for name in (
+            "pending",
+            "claimed",
+            "send_started",
+            "accepted",
+            "confirmed",
+            "explicit_failed",
+            "unknown",
         )
     }
     pending_cases.sort(
@@ -1741,7 +1822,7 @@ def _lifecycle_delivery_status(
         )
     )
     return {
-        "schema_version": "trade_lifecycle_delivery_status.v1",
+        "schema_version": "trade_lifecycle_delivery_status.v2",
         "status": "ok",
         "account": account_value,
         "observed_at_ms": int(now_ms),
@@ -1762,6 +1843,68 @@ def _lifecycle_delivery_status(
             if count > 1
         ),
         "outbox_status_counts": outbox_status_counts,
+        "unbound_eligible_count": len(eligible_unbound_rows),
+        "oldest_unbound_eligible": (
+            {
+                "outbox_id": eligible_unbound_rows[0].get(
+                    "outbox_id"
+                ),
+                "case_id": eligible_unbound_rows[0].get("case_id"),
+                "created_at_ms": eligible_unbound_rows[0].get(
+                    "created_at_ms"
+                ),
+                "age_ms": max(
+                    0,
+                    int(now_ms)
+                    - int(
+                        eligible_unbound_rows[0].get(
+                            "created_at_ms"
+                        )
+                        or 0
+                    ),
+                ),
+            }
+            if eligible_unbound_rows
+            else None
+        ),
+        "batch_status_counts": batch_status_counts,
+        "delivery_batch_count": len(delivery_batches),
+        "batched_member_count": len(
+            [
+                item
+                for item in notifications
+                if str(item.get("delivery_batch_id") or "").strip()
+            ]
+        ),
+        "active_batched_member_count": int(
+            outbox_states.get("batched", 0)
+        ),
+        "oldest_unknown_batch": (
+            {
+                "batch_id": unknown_batches[0].get("batch_id"),
+                "provider": unknown_batches[0].get("provider"),
+                "channel": unknown_batches[0].get("channel"),
+                "route_fingerprint": unknown_batches[0].get(
+                    "route_fingerprint"
+                ),
+                "target_fingerprint": unknown_batches[0].get(
+                    "target_fingerprint"
+                ),
+                "member_count": unknown_batches[0].get(
+                    "member_count"
+                ),
+                "created_at_ms": unknown_batches[0].get(
+                    "created_at_ms"
+                ),
+            }
+            if unknown_batches
+            else None
+        ),
+        "messages_avoided": {
+            "scope": "full_delivery_batches_touching_account",
+            **messages_avoided_by_status,
+            "total": sum(messages_avoided_by_status.values()),
+        },
         "oldest_unknown_outbox": (
             {
                 "outbox_id": unknown_rows[0].get("outbox_id"),
@@ -1801,7 +1944,7 @@ def _refresh_lifecycle_delivery_status(
         )
     except Exception as exc:
         status_state["lifecycle_delivery"] = {
-            "schema_version": "trade_lifecycle_delivery_status.v1",
+            "schema_version": "trade_lifecycle_delivery_status.v2",
             "status": "unavailable",
             "account": str(account or "").strip().lower() or None,
             "error": f"{type(exc).__name__}: {exc}",

--- a/src/application/trades/auto_intake.py
+++ b/src/application/trades/auto_intake.py
@@ -44,13 +44,18 @@ from src.application.trades.push_listener import (
 )
 from src.application.trades.lifecycle_outbox import (
     MAX_ATTEMPTS,
-    dispatch_notifications_once,
+)
+from src.application.trades.lifecycle_batch_dispatcher import (
+    LifecycleReceiptBatchDispatcher,
+    lifecycle_receipt_dispatcher_status,
+    resolve_lifecycle_receipt_dispatch_scope,
 )
 from src.application.trades.lifecycle_runtime import (
     ensure_lifecycle_timing_after_intake,
     reconcile_due_lifecycle_cases_for_source,
 )
 from src.application.trades.receipt import (
+    resolve_trade_lifecycle_notification_batch_route,
     send_trade_lifecycle_outbox_payload,
 )
 from src.application.trades.inbox import (
@@ -597,7 +602,22 @@ def main(argv: list[str] | None = None) -> int:
         else None
     )
     process_lock = threading.RLock()
+    lifecycle_receipt_dispatcher: (
+        LifecycleReceiptBatchDispatcher | None
+    ) = None
     try:
+        (
+            lifecycle_receipt_dispatcher,
+            lifecycle_dispatcher_status_fn,
+        ) = _build_lifecycle_receipt_batch_dispatcher(
+            repo=repo,
+            base=base,
+            cfg=cfg,
+            intake_cfg=intake_cfg,
+            apply_changes=apply_changes,
+        )
+        if lifecycle_receipt_dispatcher is not None:
+            lifecycle_receipt_dispatcher.start()
         if len(sources) == 1:
             return _run_listener_source_loop(
                 source=sources[0],
@@ -611,6 +631,9 @@ def main(argv: list[str] | None = None) -> int:
                 receipt_callback=receipt_callback,
                 stock_holdings_sync_callback=holdings_sync_callback,
                 process_lock=process_lock,
+                lifecycle_dispatcher_status_fn=(
+                    lifecycle_dispatcher_status_fn
+                ),
             )
 
         return _coordinate_listener_sources(
@@ -628,11 +651,18 @@ def main(argv: list[str] | None = None) -> int:
                 stock_holdings_sync_callback=holdings_sync_callback,
                 process_lock=process_lock,
                 stop_event=stop_event,
+                lifecycle_dispatcher_status_fn=(
+                    lifecycle_dispatcher_status_fn
+                ),
             ),
         )
     finally:
-        if holdings_sync_dispatcher is not None:
-            holdings_sync_dispatcher.close()
+        try:
+            if lifecycle_receipt_dispatcher is not None:
+                lifecycle_receipt_dispatcher.close()
+        finally:
+            if holdings_sync_dispatcher is not None:
+                holdings_sync_dispatcher.close()
 
 
 def _build_receipt_callback(
@@ -651,6 +681,64 @@ def _build_receipt_callback(
         }
 
     return _callback
+
+
+def _build_lifecycle_receipt_batch_dispatcher(
+    *,
+    repo: Any,
+    base: Path,
+    cfg: dict[str, Any],
+    intake_cfg: dict[str, Any],
+    apply_changes: bool,
+) -> tuple[
+    LifecycleReceiptBatchDispatcher | None,
+    Callable[[], dict[str, Any]],
+]:
+    scope = resolve_lifecycle_receipt_dispatch_scope(intake_cfg)
+    allowed_accounts = list(scope["allowed_accounts"])
+    if not apply_changes:
+        status = lifecycle_receipt_dispatcher_status(
+            status="disabled",
+            reason="dry_run",
+            allowed_accounts=allowed_accounts,
+        )
+        return None, lambda: dict(status)
+    if not allowed_accounts:
+        status = lifecycle_receipt_dispatcher_status(
+            status="disabled",
+            reason="receipt_disabled",
+        )
+        return None, lambda: dict(status)
+
+    route = resolve_trade_lifecycle_notification_batch_route(
+        config=cfg,
+    )
+    if not bool(route.get("route_available")):
+        status = lifecycle_receipt_dispatcher_status(
+            status="unavailable",
+            reason="route_unavailable",
+            allowed_accounts=allowed_accounts,
+            route=route,
+        )
+        return None, lambda: dict(status)
+
+    receipt_config = dict(scope["receipt_config"])
+    dispatcher = LifecycleReceiptBatchDispatcher(
+        repo=repo,
+        route=route,
+        allowed_accounts=allowed_accounts,
+        send_fn=lambda frozen_payload: (
+            send_trade_lifecycle_outbox_payload(
+                base=base,
+                config=cfg,
+                receipt_config=receipt_config,
+                payload=frozen_payload,
+            )
+        ),
+        poll_interval_sec=1.0,
+        log_fn=_log,
+    )
+    return dispatcher, dispatcher.snapshot
 
 
 def _build_stock_holdings_sync_dispatcher(
@@ -940,6 +1028,9 @@ def _run_listener_source_loop(
     process_lock: threading.RLock,
     stock_holdings_sync_callback: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
     stop_event: threading.Event | None = None,
+    lifecycle_dispatcher_status_fn: (
+        Callable[[], dict[str, Any]] | None
+    ) = None,
 ) -> int:
     state_path = source["state_path"]
     audit_path = source["audit_path"]
@@ -972,6 +1063,7 @@ def _run_listener_source_loop(
         status_state,
         repo=repo,
         account=str(source.get("account") or ""),
+        dispatcher_status_fn=lifecycle_dispatcher_status_fn,
     )
     stop = stop_event or threading.Event()
     settlement_gateway = build_futu_gateway(
@@ -1201,6 +1293,7 @@ def _run_listener_source_loop(
             status_state,
             repo=repo,
             account=str(source.get("account") or ""),
+            dispatcher_status_fn=lifecycle_dispatcher_status_fn,
         )
         _write_listener_status(status_path, status_state, status="listening", stage="deal_processed")
         _log(_format_result_summary(result))
@@ -1211,7 +1304,6 @@ def _run_listener_source_loop(
     last_backfill_monotonic: float | None = None
     last_heartbeat_monotonic: float | None = None
     last_inbox_retry_monotonic: float | None = None
-    last_outbox_dispatch_monotonic: float | None = None
     last_lifecycle_due_monotonic: float | None = None
     last_combo_reconciliation_monotonic: float | None = None
     backfill_cfg = dict(source.get("backfill") or intake_cfg.get("backfill") or {})
@@ -1263,55 +1355,6 @@ def _run_listener_source_loop(
                         status_state.pop("last_error", None)
                     if int(status_state["inbox"].get("pending_count") or 0) == 0:
                         status_state.pop("last_inbox_retry_error", None)
-                outbox_dispatch_due = (
-                    bool(apply_changes)
-                    and bool(
-                        (
-                            source.get("receipt")
-                            or intake_cfg.get("receipt")
-                            or {}
-                        ).get("enabled", True)
-                    )
-                    and (
-                        last_outbox_dispatch_monotonic is None
-                        or now_mono - last_outbox_dispatch_monotonic >= 5
-                    )
-                )
-                if outbox_dispatch_due:
-                    try:
-                        with process_lock:
-                            outbox_dispatch = dispatch_notifications_once(
-                                repo,
-                                send_fn=lambda frozen_payload: (
-                                    send_trade_lifecycle_outbox_payload(
-                                        base=repo_base,
-                                        config=cfg,
-                                        receipt_config=(
-                                            source.get("receipt")
-                                            or intake_cfg.get("receipt")
-                                            or {}
-                                        ),
-                                        payload=frozen_payload,
-                                    )
-                                ),
-                                now_ms=int(time.time() * 1000),
-                                account=str(
-                                    source.get("account") or ""
-                                ).strip().lower()
-                                or None,
-                            )
-                        status_state[
-                            "last_outbox_dispatch"
-                        ] = outbox_dispatch
-                        status_state.pop(
-                            "last_outbox_dispatch_error",
-                            None,
-                        )
-                    except Exception as exc:
-                        status_state[
-                            "last_outbox_dispatch_error"
-                        ] = f"{type(exc).__name__}: {exc}"
-                    last_outbox_dispatch_monotonic = now_mono
                 lifecycle_due = (
                     bool(apply_changes)
                     and (
@@ -1444,6 +1487,9 @@ def _run_listener_source_loop(
                         status_state,
                         repo=repo,
                         account=str(source.get("account") or ""),
+                        dispatcher_status_fn=(
+                            lifecycle_dispatcher_status_fn
+                        ),
                     )
                     _write_listener_status(status_path, status_state, status="listening", stage="heartbeat", restart_count=restart_count)
                     last_heartbeat_monotonic = now_mono
@@ -1933,7 +1979,24 @@ def _refresh_lifecycle_delivery_status(
     *,
     repo: Any,
     account: str,
+    dispatcher_status_fn: (
+        Callable[[], dict[str, Any]] | None
+    ) = None,
 ) -> None:
+    dispatcher_status: dict[str, Any] | None = None
+    if dispatcher_status_fn is not None:
+        try:
+            value = dispatcher_status_fn()
+            if isinstance(value, dict):
+                dispatcher_status = dict(value)
+        except Exception as exc:
+            dispatcher_status = lifecycle_receipt_dispatcher_status(
+                status="unavailable",
+                reason="status_snapshot_failed",
+            )
+            dispatcher_status["error"] = (
+                f"{type(exc).__name__}: {exc}"
+            )
     try:
         status_state["lifecycle_delivery"] = (
             _lifecycle_delivery_status(
@@ -1949,6 +2012,10 @@ def _refresh_lifecycle_delivery_status(
             "account": str(account or "").strip().lower() or None,
             "error": f"{type(exc).__name__}: {exc}",
         }
+    if dispatcher_status is not None:
+        status_state["lifecycle_delivery"]["dispatcher"] = (
+            dispatcher_status
+        )
 
 
 def _is_canonical_broker_source_key(value: str) -> bool:

--- a/src/application/trades/lifecycle_batch_dispatcher.py
+++ b/src/application/trades/lifecycle_batch_dispatcher.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import copy
+import threading
+import time
+from typing import Any, Callable
+
+from src.application.trades.lifecycle_outbox import (
+    dispatch_notification_batch_once,
+)
+
+
+DISPATCHER_STATUS_SCHEMA = "trade_lifecycle_batch_dispatcher_status.v1"
+
+
+def resolve_lifecycle_receipt_dispatch_scope(
+    intake_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve the accounts one process-level receipt owner may deliver."""
+
+    fallback_receipt = (
+        dict(intake_config.get("receipt") or {})
+        if isinstance(intake_config.get("receipt"), dict)
+        else {}
+    )
+    accounts: set[str] = set()
+    enabled_receipt_config: dict[str, Any] | None = None
+    for raw_source in intake_config.get("sources") or []:
+        if not isinstance(raw_source, dict) or not bool(
+            raw_source.get("enabled", True)
+        ):
+            continue
+        source_receipt = (
+            dict(raw_source.get("receipt") or {})
+            if isinstance(raw_source.get("receipt"), dict)
+            else fallback_receipt
+        )
+        if not bool(source_receipt.get("enabled", True)):
+            continue
+        if enabled_receipt_config is None:
+            enabled_receipt_config = source_receipt
+        account = str(raw_source.get("account") or "").strip().lower()
+        if account:
+            accounts.add(account)
+        mapping = raw_source.get("account_mapping")
+        if isinstance(mapping, dict):
+            accounts.update(
+                str(value or "").strip().lower()
+                for value in mapping.values()
+                if str(value or "").strip()
+            )
+    return {
+        "allowed_accounts": sorted(accounts),
+        "receipt_config": dict(
+            enabled_receipt_config
+            if enabled_receipt_config is not None
+            else fallback_receipt
+        ),
+    }
+
+
+def lifecycle_receipt_dispatcher_status(
+    *,
+    status: str,
+    reason: str,
+    allowed_accounts: list[str] | tuple[str, ...] | set[str] = (),
+    route: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    route_value = dict(route or {})
+    return {
+        "schema_version": DISPATCHER_STATUS_SCHEMA,
+        "status": str(status),
+        "reason": str(reason),
+        "allowed_accounts": sorted(
+            {
+                str(account or "").strip().lower()
+                for account in allowed_accounts
+                if str(account or "").strip()
+            }
+        ),
+        "provider": str(route_value.get("provider") or "") or None,
+        "channel": str(route_value.get("channel") or "") or None,
+        "target_fingerprint": (
+            str(route_value.get("target_fingerprint") or "") or None
+        ),
+        "route_fingerprint": (
+            str(route_value.get("route_fingerprint") or "") or None
+        ),
+    }
+
+
+def _batch_summary(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    keys = (
+        "batch_id",
+        "status",
+        "provider",
+        "channel",
+        "target_fingerprint",
+        "route_fingerprint",
+        "member_count",
+        "attempt_count",
+        "next_attempt_at_ms",
+        "send_started_at_ms",
+        "confirmed_at_ms",
+        "provider_message_id",
+    )
+    return {key: value.get(key) for key in keys}
+
+
+def _planning_summary(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    keys = (
+        "status",
+        "reason",
+        "candidate_count",
+        "quiet_ready_at_ms",
+        "max_wait_at_ms",
+        "next_attempt_at_ms",
+    )
+    return {key: value.get(key) for key in keys if key in value}
+
+
+def _dispatch_result_summary(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": str(result.get("status") or "unknown"),
+        "reason": result.get("reason"),
+        "planning": _planning_summary(result.get("planning")),
+        "recovery": (
+            dict(result["recovery"])
+            if isinstance(result.get("recovery"), dict)
+            else None
+        ),
+        "batch": _batch_summary(result.get("batch")),
+    }
+
+
+class LifecycleReceiptBatchDispatcher:
+    """One process-level owner for durable lifecycle receipt batches."""
+
+    def __init__(
+        self,
+        *,
+        repo: Any,
+        route: dict[str, Any],
+        allowed_accounts: list[str] | tuple[str, ...] | set[str],
+        send_fn: Callable[[dict[str, Any]], dict[str, Any]],
+        poll_interval_sec: float = 1.0,
+        now_ms_fn: Callable[[], int] | None = None,
+        log_fn: Callable[[str], None] | None = None,
+    ) -> None:
+        accounts = sorted(
+            {
+                str(account or "").strip().lower()
+                for account in allowed_accounts
+                if str(account or "").strip()
+            }
+        )
+        if not accounts:
+            raise ValueError(
+                "lifecycle receipt batch dispatcher requires allowed accounts"
+            )
+        if float(poll_interval_sec) <= 0:
+            raise ValueError("dispatcher poll_interval_sec must be > 0")
+        self._repo = repo
+        self._route = dict(route)
+        self._allowed_accounts = tuple(accounts)
+        self._send_fn = send_fn
+        self._poll_interval_sec = float(poll_interval_sec)
+        self._now_ms_fn = now_ms_fn or (
+            lambda: int(time.time() * 1000)
+        )
+        self._log_fn = log_fn
+        self._stop_event = threading.Event()
+        self._state_lock = threading.Lock()
+        self._poll_lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._state = {
+            **lifecycle_receipt_dispatcher_status(
+                status="initialized",
+                reason="ready",
+                allowed_accounts=accounts,
+                route=self._route,
+            ),
+            "poll_interval_sec": self._poll_interval_sec,
+            "poll_count": 0,
+            "provider_attempt_count": 0,
+            "last_result": None,
+            "last_error": None,
+        }
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._state_lock:
+            return copy.deepcopy(self._state)
+
+    def start(self) -> None:
+        with self._state_lock:
+            if self._thread is not None:
+                raise RuntimeError(
+                    "lifecycle receipt batch dispatcher already started"
+                )
+            if self._stop_event.is_set():
+                raise RuntimeError(
+                    "lifecycle receipt batch dispatcher already closed"
+                )
+            started_at_ms = int(self._now_ms_fn())
+            self._state.update(
+                {
+                    "status": "running",
+                    "reason": "started",
+                    "started_at_ms": started_at_ms,
+                }
+            )
+            thread = threading.Thread(
+                target=self._run,
+                name="lifecycle-receipt-batch-dispatcher",
+                daemon=True,
+            )
+            self._thread = thread
+        try:
+            thread.start()
+        except Exception:
+            with self._state_lock:
+                self._thread = None
+                self._state.update(
+                    {
+                        "status": "start_failed",
+                        "reason": "thread_start_failed",
+                    }
+                )
+            raise
+
+    def run_once(self) -> dict[str, Any]:
+        with self._poll_lock:
+            return self._run_once_locked()
+
+    def _run_once_locked(self) -> dict[str, Any]:
+        attempted_at_ms = int(self._now_ms_fn())
+        try:
+            result = dispatch_notification_batch_once(
+                self._repo,
+                route=self._route,
+                send_fn=self._send_fn,
+                now_ms=attempted_at_ms,
+                allowed_accounts=self._allowed_accounts,
+            )
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+            with self._state_lock:
+                previous_error = self._state.get("last_error")
+                self._state.update(
+                    {
+                        "poll_count": int(
+                            self._state.get("poll_count") or 0
+                        )
+                        + 1,
+                        "last_poll_at_ms": attempted_at_ms,
+                        "last_error": error,
+                    }
+                )
+            if (
+                self._log_fn is not None
+                and previous_error != error
+            ):
+                self._log_fn(
+                    "[WARN] lifecycle receipt batch dispatcher error: "
+                    + error
+                )
+            return {
+                "status": "error",
+                "error": error,
+                "batch": None,
+            }
+
+        summary = _dispatch_result_summary(result)
+        provider_attempted = summary["status"] in {
+            "confirmed",
+            "accepted",
+            "unknown",
+            "explicit_failed",
+        }
+        with self._state_lock:
+            self._state.update(
+                {
+                    "poll_count": int(
+                        self._state.get("poll_count") or 0
+                    )
+                    + 1,
+                    "provider_attempt_count": int(
+                        self._state.get("provider_attempt_count") or 0
+                    )
+                    + int(provider_attempted),
+                    "last_poll_at_ms": attempted_at_ms,
+                    "last_result": summary,
+                    "last_error": None,
+                }
+            )
+        return result
+
+    def close(self, *, timeout_sec: float | None = None) -> None:
+        self._stop_event.set()
+        with self._state_lock:
+            thread = self._thread
+            if thread is None:
+                self._state.update(
+                    {
+                        "status": "stopped",
+                        "reason": "closed_before_start",
+                        "stopped_at_ms": int(self._now_ms_fn()),
+                    }
+                )
+                return
+            if not thread.is_alive():
+                self._state.update(
+                    {
+                        "status": "stopped",
+                        "reason": "already_stopped",
+                    }
+                )
+                return
+            self._state.update(
+                {
+                    "status": "stopping",
+                    "reason": "close_requested",
+                }
+            )
+        if thread is threading.current_thread():
+            return
+        thread.join(timeout=timeout_sec)
+        if thread.is_alive():
+            with self._state_lock:
+                self._state.update(
+                    {
+                        "status": "stop_timeout",
+                        "reason": "dispatcher_thread_still_running",
+                    }
+                )
+            raise TimeoutError(
+                "lifecycle receipt batch dispatcher did not stop"
+            )
+
+    def _run(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                self.run_once()
+                if self._stop_event.wait(self._poll_interval_sec):
+                    break
+        finally:
+            with self._state_lock:
+                self._state.update(
+                    {
+                        "status": "stopped",
+                        "reason": "stop_requested",
+                        "stopped_at_ms": int(self._now_ms_fn()),
+                    }
+                )

--- a/src/application/trades/lifecycle_outbox.py
+++ b/src/application/trades/lifecycle_outbox.py
@@ -245,77 +245,6 @@ def complete_notification_attempt(
     return completed
 
 
-def dispatch_notifications_once(
-    repo: Any,
-    *,
-    send_fn: Callable[[dict[str, Any]], dict[str, Any]],
-    now_ms: int,
-    account: str | None = None,
-) -> dict[str, Any]:
-    recovery = recover_stale_notifications(repo, now_ms=now_ms)
-    claimed = claim_next_notification(
-        repo,
-        now_ms=now_ms,
-        account=account,
-    )
-    if claimed is None:
-        return {
-            "status": "idle",
-            "recovery": recovery,
-            "outbox": None,
-        }
-    outbox_id = str(claimed["outbox_id"])
-    claim_id = str(claimed["claim_id"])
-    started = mark_notification_send_started(
-        repo,
-        outbox_id=outbox_id,
-        claim_id=claim_id,
-        now_ms=now_ms,
-    )
-    try:
-        receipt = send_fn(dict(started["payload"]))
-    except Exception as exc:
-        completed = complete_notification_attempt(
-            repo,
-            outbox_id=outbox_id,
-            claim_id=claim_id,
-            outcome="unknown",
-            now_ms=now_ms,
-            error=f"{type(exc).__name__}: {exc}",
-        )
-        return {
-            "status": "unknown",
-            "recovery": recovery,
-            "outbox": completed,
-        }
-    provider_status = str(receipt.get("status") or "").strip().lower()
-    confirmed = bool(receipt.get("delivery_confirmed"))
-    explicit_failure = bool(receipt.get("explicit_pre_acceptance_failure"))
-    if confirmed or provider_status == "confirmed":
-        outcome = "confirmed"
-    elif provider_status == "accepted":
-        outcome = "accepted"
-    elif explicit_failure:
-        outcome = "explicit_failed"
-    else:
-        outcome = "unknown"
-    completed = complete_notification_attempt(
-        repo,
-        outbox_id=outbox_id,
-        claim_id=claim_id,
-        outcome=outcome,
-        now_ms=now_ms,
-        provider_message_id=receipt.get("message_id"),
-        provider_receipt=receipt,
-        error=receipt.get("send_message") or receipt.get("error"),
-    )
-    return {
-        "status": outcome,
-        "recovery": recovery,
-        "outbox": completed,
-    }
-
-
 def reconcile_unknown_notification(
     repo: Any,
     *,
@@ -1409,7 +1338,6 @@ __all__ = [
     "complete_notification_batch_attempt",
     "complete_notification_attempt",
     "dispatch_notification_batch_once",
-    "dispatch_notifications_once",
     "enqueue_notification_intent",
     "mark_notification_batch_send_started",
     "mark_notification_send_started",

--- a/src/application/trades/lifecycle_outbox.py
+++ b/src/application/trades/lifecycle_outbox.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 from src.application.ledger.api import (
     build_notification_intent,
@@ -21,11 +21,17 @@ OUTBOX_STATUSES = frozenset(
         "explicit_failed",
         "unknown",
         "suppressed",
+        "batched",
     }
 )
 CLAIM_LEASE_MS = 5 * 60 * 1000
 MAX_ATTEMPTS = 3
 RETRY_BACKOFF_MS = (30 * 1000, 5 * 60 * 1000)
+QUIET_WINDOW_MS = 10 * 1000
+MAX_BATCH_WAIT_MS = 60 * 1000
+TARGET_SEND_INTERVAL_MS = 60 * 1000
+BATCH_RETRY_BACKOFF_MS = (60 * 1000, 5 * 60 * 1000)
+BATCH_RENDERER_VERSION = "trade_lifecycle_batch.v1"
 
 
 def enqueue_notification_intent(
@@ -121,6 +127,7 @@ def claim_next_notification(
             row
             for row in sqlite_repo.list_trade_lifecycle_notifications(conn=conn)
             if str(row.get("status") or "") in {"pending", "explicit_failed"}
+            and not str(row.get("delivery_batch_id") or "").strip()
             and (
                 not account_value
                 or str(
@@ -466,17 +473,949 @@ def reconcile_unknown_notification(
     return with_sqlite_repo_transaction(repo, _run)
 
 
+def build_notification_batch_route(
+    *,
+    provider: str,
+    channel: str,
+    target: str,
+) -> dict[str, str]:
+    provider_value = str(provider or "").strip().lower()
+    channel_value = str(channel or "").strip().lower()
+    target_value = str(target or "").strip()
+    if not provider_value or not channel_value or not target_value:
+        raise ValueError("notification batch route is incomplete")
+    target_fingerprint = canonical_payload_hash(
+        {"target": target_value}
+    )
+    route_fingerprint = canonical_payload_hash(
+        {
+            "provider": provider_value,
+            "channel": channel_value,
+            "target_fingerprint": target_fingerprint,
+        }
+    )
+    return {
+        "provider": provider_value,
+        "channel": channel_value,
+        "target": target_value,
+        "target_fingerprint": target_fingerprint,
+        "route_fingerprint": route_fingerprint,
+    }
+
+
+def _normalized_accounts(values: Iterable[str] | None) -> set[str] | None:
+    if values is None:
+        return None
+    return {
+        str(value or "").strip().lower()
+        for value in values
+        if str(value or "").strip()
+    }
+
+
+def _validated_batch_route(route: dict[str, Any]) -> dict[str, str]:
+    snapshot = build_notification_batch_route(
+        provider=str(route.get("provider") or ""),
+        channel=str(route.get("channel") or ""),
+        target=str(route.get("target") or ""),
+    )
+    for key in ("target_fingerprint", "route_fingerprint"):
+        supplied = str(route.get(key) or "").strip()
+        if supplied and supplied != snapshot[key]:
+            raise ValueError("notification batch route fingerprint mismatch")
+    return snapshot
+
+
+def _batch_is_active(batch: dict[str, Any]) -> bool:
+    status = str(batch.get("status") or "").strip().lower()
+    return status in {"pending", "claimed", "send_started"} or (
+        status == "explicit_failed"
+        and int(batch.get("attempt_count") or 0) < MAX_ATTEMPTS
+    )
+
+
+def _batch_member_envelope(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "outbox_id": str(row["outbox_id"]),
+        "case_id": str(row["case_id"]),
+        "transition_type": str(row["transition_type"]),
+        "resolution_revision": int(row["resolution_revision"]),
+        "delivery_revision": int(row.get("delivery_revision") or 0),
+        "transition_key": str(row["transition_key"]),
+        "state_fingerprint": str(row["state_fingerprint"]),
+        "payload_hash": str(row["payload_hash"]),
+        "created_at_ms": int(row["created_at_ms"]),
+        "payload": dict(row.get("payload") or {}),
+    }
+
+
+def _eligible_unbound_notifications(
+    sqlite_repo: Any,
+    *,
+    conn: Any,
+    now_ms: int,
+    allowed_accounts: set[str] | None,
+) -> list[dict[str, Any]]:
+    current = int(now_ms)
+    rows = []
+    for row in sqlite_repo.list_trade_lifecycle_notifications(conn=conn):
+        status = str(row.get("status") or "").strip().lower()
+        account = str(
+            (row.get("payload") or {}).get("account") or ""
+        ).strip().lower()
+        if (
+            str(row.get("delivery_batch_id") or "").strip()
+            or status not in {"pending", "explicit_failed"}
+            or int(row.get("attempt_count") or 0) >= MAX_ATTEMPTS
+            or (
+                row.get("next_attempt_at_ms") is not None
+                and int(row.get("next_attempt_at_ms") or 0) > current
+            )
+            or (
+                allowed_accounts is not None
+                and account not in allowed_accounts
+            )
+        ):
+            continue
+        rows.append(dict(row))
+    rows.sort(
+        key=lambda item: (
+            int(item.get("created_at_ms") or 0),
+            str(item.get("outbox_id") or ""),
+        )
+    )
+    return rows
+
+
+def plan_notification_batch(
+    repo: Any,
+    *,
+    route: dict[str, Any],
+    now_ms: int,
+    allowed_accounts: Iterable[str] | None = None,
+    apply_changes: bool = True,
+) -> dict[str, Any]:
+    current = int(now_ms)
+    route_snapshot = _validated_batch_route(route)
+    account_values = _normalized_accounts(allowed_accounts)
+
+    def _run(sqlite_repo: Any, conn: Any | None) -> dict[str, Any]:
+        if conn is None:
+            raise TypeError(
+                "notification batch planning requires SQLite authority"
+            )
+        route_batches = (
+            sqlite_repo.list_trade_lifecycle_notification_batches(
+                route_fingerprint=route_snapshot["route_fingerprint"],
+                conn=conn,
+            )
+        )
+        active = next(
+            (batch for batch in route_batches if _batch_is_active(batch)),
+            None,
+        )
+        if active is not None:
+            return {
+                "status": "active_batch",
+                "reason": "route_has_active_batch",
+                "batch": active,
+            }
+        rows = _eligible_unbound_notifications(
+            sqlite_repo,
+            conn=conn,
+            now_ms=current,
+            allowed_accounts=account_values,
+        )
+        if not rows:
+            return {
+                "status": "idle",
+                "reason": "no_eligible_unbound_intents",
+                "batch": None,
+                "candidate_count": 0,
+            }
+        latest_send_started = max(
+            (
+                int(batch.get("send_started_at_ms") or 0)
+                for batch in route_batches
+            ),
+            default=0,
+        )
+        if (
+            latest_send_started > 0
+            and current - latest_send_started
+            < TARGET_SEND_INTERVAL_MS
+        ):
+            return {
+                "status": "rate_limited",
+                "reason": "route_send_interval",
+                "batch": None,
+                "candidate_count": len(rows),
+                "next_attempt_at_ms": (
+                    latest_send_started + TARGET_SEND_INTERVAL_MS
+                ),
+            }
+        oldest_created = int(rows[0]["created_at_ms"])
+        newest_created = int(rows[-1]["created_at_ms"])
+        quiet_ready = current - newest_created >= QUIET_WINDOW_MS
+        max_wait_ready = current - oldest_created >= MAX_BATCH_WAIT_MS
+        if not quiet_ready and not max_wait_ready:
+            return {
+                "status": "waiting",
+                "reason": "aggregation_window_open",
+                "batch": None,
+                "candidate_count": len(rows),
+                "quiet_ready_at_ms": newest_created + QUIET_WINDOW_MS,
+                "max_wait_at_ms": oldest_created + MAX_BATCH_WAIT_MS,
+            }
+        members = [_batch_member_envelope(row) for row in rows]
+        member_ids = [str(member["outbox_id"]) for member in members]
+        identity_hash = canonical_payload_hash(
+            {
+                "renderer_version": BATCH_RENDERER_VERSION,
+                "route_fingerprint": route_snapshot[
+                    "route_fingerprint"
+                ],
+                "member_outbox_ids": sorted(member_ids),
+            }
+        )
+        batch_id = "tlb_" + identity_hash[:32]
+        payload = {
+            "schema_version": BATCH_RENDERER_VERSION,
+            "batch_id": batch_id,
+            "route": {
+                "provider": route_snapshot["provider"],
+                "channel": route_snapshot["channel"],
+                "target_fingerprint": route_snapshot[
+                    "target_fingerprint"
+                ],
+                "route_fingerprint": route_snapshot[
+                    "route_fingerprint"
+                ],
+            },
+            "members": members,
+        }
+        batch = {
+            "batch_id": batch_id,
+            "route_fingerprint": route_snapshot["route_fingerprint"],
+            "provider": route_snapshot["provider"],
+            "channel": route_snapshot["channel"],
+            "target_fingerprint": route_snapshot[
+                "target_fingerprint"
+            ],
+            "renderer_version": BATCH_RENDERER_VERSION,
+            "status": "pending",
+            "payload": payload,
+            "payload_hash": canonical_payload_hash(payload),
+            "member_count": len(members),
+            "first_intent_created_at_ms": oldest_created,
+            "last_intent_created_at_ms": newest_created,
+            "attempt_count": max(
+                int(row.get("attempt_count") or 0) for row in rows
+            ),
+            "next_attempt_at_ms": current,
+            "created_at_ms": current,
+        }
+        if not apply_changes:
+            return {
+                "status": "ready",
+                "reason": (
+                    "max_wait_elapsed"
+                    if max_wait_ready and not quiet_ready
+                    else "quiet_window_elapsed"
+                ),
+                "batch": batch,
+                "candidate_count": len(rows),
+            }
+        created = sqlite_repo.insert_trade_lifecycle_notification_batch_once(
+            batch,
+            member_outbox_ids=member_ids,
+            conn=conn,
+        )
+        stored = sqlite_repo.get_trade_lifecycle_notification_batch(
+            batch_id,
+            conn=conn,
+        )
+        if not isinstance(stored, dict):
+            raise RuntimeError(
+                "notification delivery batch readback failed"
+            )
+        return {
+            "status": "created" if created else "existing",
+            "reason": (
+                "max_wait_elapsed"
+                if max_wait_ready and not quiet_ready
+                else "quiet_window_elapsed"
+            ),
+            "batch": stored,
+            "candidate_count": len(rows),
+        }
+
+    return with_sqlite_repo_transaction(repo, _run)
+
+
+def recover_stale_notification_batches(
+    repo: Any,
+    *,
+    now_ms: int,
+) -> dict[str, int]:
+    current = int(now_ms)
+    stale_before = current - CLAIM_LEASE_MS
+
+    def _run(sqlite_repo: Any, conn: Any | None) -> dict[str, int]:
+        if conn is None:
+            raise TypeError(
+                "notification batch recovery requires SQLite authority"
+            )
+        reclaimed = 0
+        frozen = 0
+        for batch in (
+            sqlite_repo.list_trade_lifecycle_notification_batches(
+                conn=conn
+            )
+        ):
+            status = str(batch.get("status") or "")
+            claimed_at = int(batch.get("claimed_at_ms") or 0)
+            started_at = int(batch.get("send_started_at_ms") or 0)
+            if (
+                status == "claimed"
+                and claimed_at > 0
+                and claimed_at <= stale_before
+                and started_at <= 0
+            ):
+                changed = (
+                    sqlite_repo.compare_and_set_trade_lifecycle_notification_batch(
+                        batch_id=batch["batch_id"],
+                        expected_status="claimed",
+                        new_status="pending",
+                        expected_claim_id=str(
+                            batch.get("claim_id") or ""
+                        ),
+                        fields={
+                            "claim_id": None,
+                            "claimed_at_ms": None,
+                            "next_attempt_at_ms": current,
+                            "last_error": (
+                                "stale_batch_claim_recovered_before_send"
+                            ),
+                        },
+                        conn=conn,
+                    )
+                )
+                reclaimed += int(changed)
+            elif (
+                status == "send_started"
+                and started_at > 0
+                and started_at <= stale_before
+            ):
+                changed = (
+                    sqlite_repo.compare_and_set_trade_lifecycle_notification_batch(
+                        batch_id=batch["batch_id"],
+                        expected_status="send_started",
+                        new_status="unknown",
+                        expected_claim_id=str(
+                            batch.get("claim_id") or ""
+                        ),
+                        fields={
+                            "next_attempt_at_ms": None,
+                            "last_error": (
+                                "stale_batch_send_started_delivery_unknown"
+                            ),
+                        },
+                        conn=conn,
+                    )
+                )
+                if changed:
+                    settled = (
+                        sqlite_repo.update_trade_lifecycle_notification_batch_members(
+                            batch_id=batch["batch_id"],
+                            expected_statuses=("batched",),
+                            new_status="unknown",
+                            fields={
+                                "attempt_count": int(
+                                    batch.get("attempt_count") or 0
+                                ),
+                                "next_attempt_at_ms": None,
+                                "last_error": (
+                                    "stale_batch_send_started_delivery_unknown"
+                                ),
+                            },
+                            conn=conn,
+                        )
+                    )
+                    if settled != int(batch["member_count"]):
+                        raise ValueError(
+                            "notification batch stale recovery member mismatch"
+                        )
+                frozen += int(changed)
+        return {
+            "reclaimed_claimed_count": reclaimed,
+            "frozen_unknown_count": frozen,
+        }
+
+    return with_sqlite_repo_transaction(repo, _run)
+
+
+def claim_next_notification_batch(
+    repo: Any,
+    *,
+    now_ms: int,
+    claim_id: str | None = None,
+    route_fingerprint: str | None = None,
+) -> dict[str, Any] | None:
+    current = int(now_ms)
+    claim_value = str(claim_id or uuid.uuid4().hex)
+    route_value = str(route_fingerprint or "").strip()
+
+    def _run(sqlite_repo: Any, conn: Any | None) -> dict[str, Any] | None:
+        if conn is None:
+            raise TypeError(
+                "notification batch claim requires SQLite authority"
+            )
+        batches = (
+            sqlite_repo.list_trade_lifecycle_notification_batches(
+                route_fingerprint=route_value or None,
+                conn=conn,
+            )
+        )
+        candidates = [
+            batch
+            for batch in batches
+            if str(batch.get("status") or "")
+            in {"pending", "explicit_failed"}
+            and int(batch.get("attempt_count") or 0) < MAX_ATTEMPTS
+            and (
+                batch.get("next_attempt_at_ms") is None
+                or int(batch.get("next_attempt_at_ms") or 0) <= current
+            )
+        ]
+        for batch in candidates:
+            route_batches = (
+                batches
+                if route_value
+                else sqlite_repo.list_trade_lifecycle_notification_batches(
+                    route_fingerprint=str(
+                        batch.get("route_fingerprint") or ""
+                    ),
+                    conn=conn,
+                )
+            )
+            latest_started = max(
+                (
+                    int(item.get("send_started_at_ms") or 0)
+                    for item in route_batches
+                ),
+                default=0,
+            )
+            if (
+                latest_started > 0
+                and current - latest_started
+                < TARGET_SEND_INTERVAL_MS
+            ):
+                continue
+            changed = (
+                sqlite_repo.compare_and_set_trade_lifecycle_notification_batch(
+                    batch_id=batch["batch_id"],
+                    expected_status=str(batch["status"]),
+                    new_status="claimed",
+                    claim_id=claim_value,
+                    fields={
+                        "claimed_at_ms": current,
+                        "send_started_at_ms": None,
+                        "next_attempt_at_ms": None,
+                        "last_error": None,
+                    },
+                    conn=conn,
+                )
+            )
+            if not changed:
+                continue
+            return sqlite_repo.get_trade_lifecycle_notification_batch(
+                batch["batch_id"],
+                conn=conn,
+            )
+        return None
+
+    return with_sqlite_repo_transaction(repo, _run)
+
+
+def mark_notification_batch_send_started(
+    repo: Any,
+    *,
+    batch_id: str,
+    claim_id: str,
+    now_ms: int,
+) -> dict[str, Any]:
+    def _run(sqlite_repo: Any, conn: Any | None) -> dict[str, Any]:
+        if conn is None:
+            raise TypeError(
+                "notification batch send-start requires SQLite authority"
+            )
+        current = sqlite_repo.get_trade_lifecycle_notification_batch(
+            batch_id,
+            conn=conn,
+        )
+        if not isinstance(current, dict):
+            raise ValueError("notification delivery batch not found")
+        attempts = int(current.get("attempt_count") or 0) + 1
+        if attempts > MAX_ATTEMPTS:
+            raise ValueError(
+                "notification batch attempt budget exhausted"
+            )
+        changed = (
+            sqlite_repo.compare_and_set_trade_lifecycle_notification_batch(
+                batch_id=batch_id,
+                expected_status="claimed",
+                new_status="send_started",
+                expected_claim_id=claim_id,
+                fields={
+                    "send_started_at_ms": int(now_ms),
+                    "attempt_count": attempts,
+                },
+                conn=conn,
+            )
+        )
+        if not changed:
+            raise ValueError(
+                "notification batch claim lost before send_started"
+            )
+        row = sqlite_repo.get_trade_lifecycle_notification_batch(
+            batch_id,
+            conn=conn,
+        )
+        if not isinstance(row, dict):
+            raise RuntimeError(
+                "notification delivery batch readback failed"
+            )
+        return row
+
+    return with_sqlite_repo_transaction(repo, _run)
+
+
+def complete_notification_batch_attempt(
+    repo: Any,
+    *,
+    batch_id: str,
+    claim_id: str,
+    outcome: str,
+    now_ms: int,
+    provider_message_id: str | None = None,
+    provider_receipt: dict[str, Any] | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    outcome_value = str(outcome or "").strip().lower()
+    if outcome_value not in {
+        "confirmed",
+        "accepted",
+        "explicit_failed",
+        "unknown",
+    }:
+        raise ValueError(
+            "unsupported notification batch delivery outcome"
+        )
+    current = int(now_ms)
+
+    def _run(sqlite_repo: Any, conn: Any | None) -> dict[str, Any]:
+        if conn is None:
+            raise TypeError(
+                "notification batch completion requires SQLite authority"
+            )
+        batch = sqlite_repo.get_trade_lifecycle_notification_batch(
+            batch_id,
+            conn=conn,
+        )
+        if not isinstance(batch, dict):
+            raise ValueError("notification delivery batch not found")
+        if (
+            str(batch.get("status") or "") != "send_started"
+            or str(batch.get("claim_id") or "") != str(claim_id)
+        ):
+            raise ValueError(
+                "notification batch completion compare-and-set failed"
+            )
+        attempts = int(batch.get("attempt_count") or 0)
+        retryable_failure = (
+            outcome_value == "explicit_failed"
+            and attempts < MAX_ATTEMPTS
+        )
+        next_attempt_at_ms = None
+        if retryable_failure:
+            backoff_index = min(
+                max(attempts - 1, 0),
+                len(BATCH_RETRY_BACKOFF_MS) - 1,
+            )
+            next_attempt_at_ms = (
+                current + BATCH_RETRY_BACKOFF_MS[backoff_index]
+            )
+        error_value = str(error or "").strip() or None
+        fields = {
+            "provider_message_id": (
+                str(provider_message_id or "").strip() or None
+            ),
+            "provider_receipt_json": dict(provider_receipt or {}),
+            "next_attempt_at_ms": next_attempt_at_ms,
+            "last_error": error_value,
+            "confirmed_at_ms": (
+                current if outcome_value == "confirmed" else None
+            ),
+        }
+        changed = (
+            sqlite_repo.compare_and_set_trade_lifecycle_notification_batch(
+                batch_id=batch_id,
+                expected_status="send_started",
+                new_status=outcome_value,
+                expected_claim_id=claim_id,
+                fields=fields,
+                conn=conn,
+            )
+        )
+        if not changed:
+            raise ValueError(
+                "notification batch completion compare-and-set failed"
+            )
+        if not retryable_failure:
+            settled = (
+                sqlite_repo.update_trade_lifecycle_notification_batch_members(
+                    batch_id=batch_id,
+                    expected_statuses=("batched",),
+                    new_status=outcome_value,
+                    fields={
+                        "attempt_count": attempts,
+                        "next_attempt_at_ms": None,
+                        "last_error": error_value,
+                        "confirmed_at_ms": (
+                            current
+                            if outcome_value == "confirmed"
+                            else None
+                        ),
+                    },
+                    conn=conn,
+                )
+            )
+            if settled != int(batch["member_count"]):
+                raise ValueError(
+                    "notification batch completion member mismatch"
+                )
+        completed = sqlite_repo.get_trade_lifecycle_notification_batch(
+            batch_id,
+            conn=conn,
+        )
+        if not isinstance(completed, dict):
+            raise RuntimeError(
+                "notification delivery batch readback failed"
+            )
+        return completed
+
+    return with_sqlite_repo_transaction(repo, _run)
+
+
+def dispatch_notification_batch_once(
+    repo: Any,
+    *,
+    route: dict[str, Any],
+    send_fn: Callable[[dict[str, Any]], dict[str, Any]],
+    now_ms: int,
+    allowed_accounts: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    recovery = recover_stale_notification_batches(repo, now_ms=now_ms)
+    planned = plan_notification_batch(
+        repo,
+        route=route,
+        now_ms=now_ms,
+        allowed_accounts=allowed_accounts,
+        apply_changes=True,
+    )
+    route_snapshot = _validated_batch_route(route)
+    claimed = claim_next_notification_batch(
+        repo,
+        now_ms=now_ms,
+        route_fingerprint=route_snapshot["route_fingerprint"],
+    )
+    if claimed is None:
+        return {
+            "status": "idle",
+            "reason": planned.get("reason"),
+            "planning": planned,
+            "recovery": recovery,
+            "batch": None,
+        }
+    batch_id = str(claimed["batch_id"])
+    claim_id = str(claimed["claim_id"])
+    started = mark_notification_batch_send_started(
+        repo,
+        batch_id=batch_id,
+        claim_id=claim_id,
+        now_ms=now_ms,
+    )
+    try:
+        receipt = send_fn(dict(started["payload"]))
+    except Exception as exc:
+        completed = complete_notification_batch_attempt(
+            repo,
+            batch_id=batch_id,
+            claim_id=claim_id,
+            outcome="unknown",
+            now_ms=now_ms,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        return {
+            "status": "unknown",
+            "planning": planned,
+            "recovery": recovery,
+            "batch": completed,
+        }
+    provider_status = str(
+        receipt.get("status") or ""
+    ).strip().lower()
+    if bool(receipt.get("delivery_confirmed")) or (
+        provider_status == "confirmed"
+    ):
+        outcome = "confirmed"
+    elif provider_status == "accepted":
+        outcome = "accepted"
+    elif bool(receipt.get("explicit_pre_acceptance_failure")):
+        outcome = "explicit_failed"
+    else:
+        outcome = "unknown"
+    completed = complete_notification_batch_attempt(
+        repo,
+        batch_id=batch_id,
+        claim_id=claim_id,
+        outcome=outcome,
+        now_ms=now_ms,
+        provider_message_id=receipt.get("message_id"),
+        provider_receipt=receipt,
+        error=receipt.get("send_message") or receipt.get("error"),
+    )
+    return {
+        "status": outcome,
+        "planning": planned,
+        "recovery": recovery,
+        "batch": completed,
+    }
+
+
+def reconcile_notification_batch(
+    repo: Any,
+    *,
+    batch_id: str,
+    action: str,
+    broker_ref: str,
+    note: str,
+    apply_changes: bool,
+    now_ms: int | None = None,
+) -> dict[str, Any]:
+    batch = repo.get_trade_lifecycle_notification_batch(batch_id)
+    if not isinstance(batch, dict):
+        raise ValueError("notification delivery batch not found")
+    current_status = str(batch.get("status") or "")
+    if current_status not in {"accepted", "unknown"}:
+        raise ValueError(
+            "only accepted or unknown notification batch can be reconciled"
+        )
+    reference = str(broker_ref or "").strip()
+    explanation = str(note or "").strip()
+    if not reference or not explanation:
+        raise ValueError("broker_ref and note are required")
+    normalized_action = str(action or "").strip().lower()
+    allowed_actions = (
+        {"confirmed", "unknown"}
+        if current_status == "accepted"
+        else {"confirmed", "resend"}
+    )
+    if normalized_action not in allowed_actions:
+        raise ValueError(
+            "notification batch reconciliation action is invalid"
+        )
+    preview = {
+        "batch_id": str(batch_id),
+        "action": normalized_action,
+        "current_status": current_status,
+        "member_count": int(batch.get("member_count") or 0),
+        "broker_ref": reference,
+        "note": explanation,
+        "apply_changes": bool(apply_changes),
+    }
+    if not apply_changes:
+        return preview
+    resolved_at_ms = int(
+        now_ms if now_ms is not None else utc_now_ms()
+    )
+
+    def _run(sqlite_repo: Any, conn: Any | None) -> dict[str, Any]:
+        if conn is None:
+            raise TypeError(
+                "notification batch reconcile requires SQLite authority"
+            )
+        current = sqlite_repo.get_trade_lifecycle_notification_batch(
+            batch_id,
+            conn=conn,
+        )
+        if not isinstance(current, dict):
+            raise ValueError("notification delivery batch not found")
+        if str(current.get("status") or "") != current_status:
+            raise ValueError(
+                "notification batch status changed during reconcile"
+            )
+        manual_receipt = {
+            "schema_version": "manual_notification_batch_resolution.v1",
+            "action": normalized_action,
+            "broker_ref": reference,
+            "note": explanation,
+            "resolved_at_ms": resolved_at_ms,
+            "original_provider_receipt": current.get(
+                "provider_receipt"
+            ),
+        }
+        if normalized_action in {"confirmed", "unknown"}:
+            changed = (
+                sqlite_repo.compare_and_set_trade_lifecycle_notification_batch(
+                    batch_id=batch_id,
+                    expected_status=current_status,
+                    new_status=normalized_action,
+                    fields={
+                        "confirmed_at_ms": (
+                            resolved_at_ms
+                            if normalized_action == "confirmed"
+                            else None
+                        ),
+                        "provider_receipt_json": manual_receipt,
+                    },
+                    conn=conn,
+                )
+            )
+            if not changed:
+                raise ValueError(
+                    "notification batch status changed during reconcile"
+                )
+            settled = (
+                sqlite_repo.update_trade_lifecycle_notification_batch_members(
+                    batch_id=batch_id,
+                    expected_statuses=(current_status,),
+                    new_status=normalized_action,
+                    fields={
+                        "confirmed_at_ms": (
+                            resolved_at_ms
+                            if normalized_action == "confirmed"
+                            else None
+                        )
+                    },
+                    conn=conn,
+                )
+            )
+            if settled != int(current["member_count"]):
+                raise ValueError(
+                    "notification batch reconcile member mismatch"
+                )
+            return {
+                **preview,
+                "batch": (
+                    sqlite_repo.get_trade_lifecycle_notification_batch(
+                        batch_id,
+                        conn=conn,
+                    )
+                ),
+            }
+        members = (
+            sqlite_repo.list_trade_lifecycle_notification_batch_members(
+                batch_id,
+                conn=conn,
+            )
+        )
+        compensating: list[dict[str, Any]] = []
+        seen_transition_keys: set[str] = set()
+        for member in members:
+            transition_key = str(
+                member.get("transition_key") or ""
+            ).strip()
+            if transition_key in seen_transition_keys:
+                raise ValueError(
+                    "notification batch resend has duplicate transition key"
+                )
+            seen_transition_keys.add(transition_key)
+            siblings = [
+                item
+                for item in sqlite_repo.list_trade_lifecycle_notifications(
+                    case_id=str(member["case_id"]),
+                    conn=conn,
+                )
+                if str(item.get("transition_key") or "").strip()
+                == transition_key
+            ]
+            next_delivery_revision = max(
+                int(item.get("delivery_revision") or 0)
+                for item in siblings
+            ) + 1
+            intent = build_notification_intent(
+                case_id=str(member["case_id"]),
+                transition_type=str(member["transition_type"]),
+                resolution_revision=int(member["resolution_revision"]),
+                delivery_revision=next_delivery_revision,
+                transition_key=transition_key,
+                state_fingerprint=str(member["state_fingerprint"]),
+                payload={
+                    **dict(member["payload"]),
+                    "compensates_outbox_id": member["outbox_id"],
+                    "compensates_batch_id": batch_id,
+                    "delivery_revision": next_delivery_revision,
+                    "manual_resolution": {
+                        "broker_ref": reference,
+                        "note": explanation,
+                        "resolved_at_ms": resolved_at_ms,
+                    },
+                },
+            )
+            created = (
+                sqlite_repo.insert_trade_lifecycle_notification_once(
+                    intent,
+                    conn=conn,
+                )
+            )
+            if not created:
+                raise ValueError(
+                    "notification batch compensating intent already exists"
+                )
+            stored = sqlite_repo.get_trade_lifecycle_notification(
+                intent["outbox_id"],
+                conn=conn,
+            )
+            if not isinstance(stored, dict):
+                raise RuntimeError(
+                    "notification compensating intent readback failed"
+                )
+            compensating.append(stored)
+        return {
+            **preview,
+            "compensating_intents": compensating,
+            "compensating_intent_count": len(compensating),
+        }
+
+    return with_sqlite_repo_transaction(repo, _run)
+
+
 __all__ = [
+    "BATCH_RENDERER_VERSION",
+    "BATCH_RETRY_BACKOFF_MS",
     "CLAIM_LEASE_MS",
+    "MAX_BATCH_WAIT_MS",
     "MAX_ATTEMPTS",
     "OUTBOX_STATUSES",
+    "QUIET_WINDOW_MS",
+    "TARGET_SEND_INTERVAL_MS",
+    "build_notification_batch_route",
     "build_notification_intent",
     "canonical_payload_hash",
+    "claim_next_notification_batch",
     "claim_next_notification",
+    "complete_notification_batch_attempt",
     "complete_notification_attempt",
+    "dispatch_notification_batch_once",
     "dispatch_notifications_once",
     "enqueue_notification_intent",
+    "mark_notification_batch_send_started",
     "mark_notification_send_started",
+    "plan_notification_batch",
+    "reconcile_notification_batch",
     "reconcile_unknown_notification",
+    "recover_stale_notification_batches",
     "recover_stale_notifications",
 ]

--- a/src/application/trades/receipt.py
+++ b/src/application/trades/receipt.py
@@ -13,6 +13,13 @@ from src.application.notification_delivery_adapter import (
     select_notification_delivery_adapter,
 )
 from src.application.notification_shells import render_receipt
+from src.application.trades.lifecycle_outbox import (
+    BATCH_RENDERER_VERSION,
+    build_notification_batch_route,
+)
+
+
+MAX_LIFECYCLE_BATCH_DISPLAY_ITEMS = 12
 
 
 def send_trade_intake_receipt(
@@ -189,6 +196,282 @@ def build_trade_lifecycle_notification_message(
     )
 
 
+def _batch_member_payload(member: dict[str, Any]) -> dict[str, Any]:
+    return (
+        dict(member.get("payload") or {})
+        if isinstance(member.get("payload"), dict)
+        else {}
+    )
+
+
+def _batch_member_transition(member: dict[str, Any]) -> str:
+    payload = _batch_member_payload(member)
+    return str(
+        member.get("transition_type")
+        or payload.get("transition_type")
+        or ""
+    ).strip().lower()
+
+
+def _lifecycle_transition_priority(transition: str) -> int:
+    return {
+        "conflict": 5,
+        "needs_review": 4,
+        "resolution_corrected": 3,
+        "resolution_confirmed": 2,
+        "option_leg_closed": 1,
+    }.get(str(transition or "").strip().lower(), 0)
+
+
+def _lifecycle_transition_text(transition: str) -> str:
+    return {
+        "conflict": "⚠️ 证据冲突",
+        "needs_review": "⚠️ 原因待复核",
+        "resolution_corrected": "✅ 结果已更正",
+        "resolution_confirmed": "✅ 结果已确认",
+        "option_leg_closed": "⏳ 期权腿已平仓",
+    }.get(str(transition or "").strip().lower(), "状态更新")
+
+
+def _batch_representatives(
+    members: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    selected: dict[str, dict[str, Any]] = {}
+    for index, member in enumerate(members):
+        payload = _batch_member_payload(member)
+        case_id = str(
+            member.get("case_id") or payload.get("case_id") or ""
+        ).strip()
+        group_key = case_id or str(
+            member.get("outbox_id") or f"missing-{index}"
+        )
+        transition = _batch_member_transition(member)
+        rank = (
+            int(member.get("resolution_revision") or 0),
+            int(member.get("created_at_ms") or 0),
+            _lifecycle_transition_priority(transition),
+            str(member.get("outbox_id") or ""),
+        )
+        previous = selected.get(group_key)
+        if previous is None or rank > previous["_representative_rank"]:
+            selected[group_key] = {
+                **member,
+                "_representative_rank": rank,
+                "_case_group_key": group_key,
+            }
+    representatives = list(selected.values())
+    representatives.sort(
+        key=lambda member: (
+            -_lifecycle_transition_priority(
+                _batch_member_transition(member)
+            ),
+            str(
+                _batch_member_payload(member).get("account") or ""
+            ).strip().lower(),
+            str(
+                _batch_member_payload(member).get("symbol") or ""
+            ).strip().upper(),
+            str(
+                _batch_member_payload(member).get("expiration_ymd")
+                or ""
+            ),
+            str(_batch_member_payload(member).get("strike") or ""),
+            str(member.get("_case_group_key") or ""),
+            str(member.get("outbox_id") or ""),
+        )
+    )
+    return representatives
+
+
+def build_trade_lifecycle_notification_batch_message(
+    payload: dict[str, Any],
+) -> str:
+    frozen = dict(payload or {})
+    raw_members = frozen.get("members")
+    if not isinstance(raw_members, list) or not raw_members:
+        raise ValueError("lifecycle notification batch has no members")
+    members = [
+        dict(item)
+        if isinstance(item, dict)
+        else {
+            "outbox_id": f"invalid-{index}",
+            "case_id": f"invalid-{index}",
+            "payload": {},
+        }
+        for index, item in enumerate(raw_members)
+    ]
+    representatives = _batch_representatives(members)
+    if len(representatives) == 1:
+        return build_trade_lifecycle_notification_message(
+            _batch_member_payload(representatives[0])
+        )
+    accounts = sorted(
+        {
+            str(_batch_member_payload(member).get("account") or "-")
+            .strip()
+            .lower()
+            or "-"
+            for member in representatives
+        }
+    )
+    highest_transition = (
+        _batch_member_transition(representatives[0])
+        if representatives
+        else ""
+    )
+    rows: list[str] = []
+    for index, member in enumerate(
+        representatives[:MAX_LIFECYCLE_BATCH_DISPLAY_ITEMS],
+        start=1,
+    ):
+        item = _batch_member_payload(member)
+        transition = _batch_member_transition(member)
+        contract = " ".join(
+            str(value)
+            for value in (
+                item.get("expiration_ymd"),
+                item.get("strike"),
+                _option_type_text(_optional_str(item.get("option_type"))),
+            )
+            if value not in (None, "")
+        )
+        rows.append(
+            " · ".join(
+                (
+                    f"{index}.",
+                    _lifecycle_transition_text(transition),
+                    str(item.get("account") or "-"),
+                    str(item.get("symbol") or "-"),
+                    contract or "合约待确认",
+                    f"`{str(item.get('case_id') or member.get('case_id') or '-').strip() or '-'}`",
+                )
+            )
+        )
+    remaining = max(
+        0,
+        len(representatives) - MAX_LIFECYCLE_BATCH_DISPLAY_ITEMS,
+    )
+    if remaining:
+        rows.append(f"另有 {remaining} 个案件未展开")
+    return render_receipt(
+        account=" / ".join(accounts),
+        receipt_type="期权平仓批次",
+        status=_lifecycle_transition_text(highest_transition),
+        fields=(
+            (
+                "范围",
+                f"{len(members)} 条意图 · {len(representatives)} 个案件",
+            ),
+            ("批次", f"`{str(frozen.get('batch_id') or '-').strip()}`"),
+        ),
+        sections=(("明细", rows),),
+    )
+
+
+def resolve_trade_lifecycle_notification_batch_route(
+    *,
+    config: dict[str, Any] | None,
+    route_resolver: Callable[..., dict[str, Any]] = (
+        resolve_notification_route_from_config
+    ),
+) -> dict[str, Any]:
+    route = resolve_notification_delivery_route(
+        config=config or {},
+        route_resolver=route_resolver,
+    )
+    target = str(route.get("target") or "").strip()
+    provider = str(route.get("provider") or "").strip()
+    channel = str(route.get("channel") or "").strip()
+    if not target or not provider or not channel:
+        return {**route, "route_available": False}
+    return {
+        **route,
+        **build_notification_batch_route(
+            provider=provider,
+            channel=channel,
+            target=target,
+        ),
+        "route_available": True,
+    }
+
+
+def classify_trade_lifecycle_delivery_result(
+    normalized: dict[str, Any],
+) -> dict[str, Any]:
+    result = dict(normalized or {})
+    delivery_confirmed = bool(
+        result.get("delivery_confirmed")
+        or (result.get("ok") and result.get("message_id"))
+    )
+    command_ok = bool(result.get("command_ok") or result.get("ok"))
+    ambiguous = bool(
+        result.get("ambiguous_send")
+        or result.get("duplicate_risk")
+        or (
+            result.get("fallback_used")
+            and not delivery_confirmed
+        )
+    )
+    http_status = result.get("http_status")
+    provider_code = result.get("provider_response_code")
+    if provider_code is None:
+        provider_code = result.get("feishu_code")
+    provider_rejected = bool(
+        not ambiguous
+        and isinstance(http_status, int)
+        and (
+            400 <= http_status <= 499
+            or (
+                200 <= http_status <= 299
+                and provider_code not in (None, 0, "0")
+            )
+        )
+    )
+    pre_io_failure = bool(
+        result.get("explicit_pre_acceptance_failure")
+        or (
+            result.get("local_error_code")
+            and not result.get("http_attempts")
+            and http_status is None
+        )
+    )
+    if delivery_confirmed:
+        outcome = "confirmed"
+    elif ambiguous:
+        outcome = "unknown"
+    elif provider_rejected or pre_io_failure:
+        outcome = "explicit_failed"
+    elif command_ok:
+        outcome = "accepted"
+    else:
+        outcome = "unknown"
+    return {
+        "outcome": outcome,
+        "delivery_confirmed": delivery_confirmed,
+        "command_ok": command_ok,
+        "explicit_pre_acceptance_failure": (
+            outcome == "explicit_failed"
+        ),
+        "classification_evidence": {
+            "http_status": http_status,
+            "provider_response_code": provider_code,
+            "ambiguous_send": bool(result.get("ambiguous_send")),
+            "duplicate_risk": bool(result.get("duplicate_risk")),
+            "fallback_used": bool(result.get("fallback_used")),
+            "local_error_code": result.get("local_error_code"),
+            "idempotency_key": result.get("idempotency_key"),
+            "effective_idempotency_key": result.get(
+                "effective_idempotency_key"
+            ),
+            "http_attempt_count": len(
+                result.get("http_attempts")
+                if isinstance(result.get("http_attempts"), list)
+                else []
+            ),
+        },
+    }
+
+
 def send_trade_lifecycle_outbox_payload(
     *,
     base: Path,
@@ -210,59 +493,132 @@ def send_trade_lifecycle_outbox_payload(
             "status": "explicit_failed",
             "explicit_pre_acceptance_failure": True,
             "error": "trade receipt delivery is disabled",
+            "classification_evidence": {
+                "preflight": "receipt_disabled"
+            },
         }
-    route = resolve_notification_delivery_route(
+    route = resolve_trade_lifecycle_notification_batch_route(
         config=config or {},
         route_resolver=route_resolver,
     )
     target = route.get("target")
-    if not str(target or "").strip():
+    if not bool(route.get("route_available")):
         return {
             "status": "explicit_failed",
             "explicit_pre_acceptance_failure": True,
             "error": "notification route is unavailable",
+            "classification_evidence": {
+                "preflight": "route_unavailable"
+            },
         }
+    is_batch = (
+        str(payload.get("schema_version") or "").strip()
+        == BATCH_RENDERER_VERSION
+        and isinstance(payload.get("members"), list)
+    )
+    batch_id = str(payload.get("batch_id") or "").strip()
+    if is_batch:
+        frozen_route = (
+            dict(payload.get("route") or {})
+            if isinstance(payload.get("route"), dict)
+            else {}
+        )
+        mismatch = any(
+            str(frozen_route.get(key) or "").strip()
+            != str(route.get(key) or "").strip()
+            for key in (
+                "provider",
+                "channel",
+                "target_fingerprint",
+                "route_fingerprint",
+            )
+        )
+        if not batch_id or mismatch:
+            return {
+                "status": "explicit_failed",
+                "explicit_pre_acceptance_failure": True,
+                "error": (
+                    "notification batch route changed before delivery"
+                    if mismatch
+                    else "notification batch identity is unavailable"
+                ),
+                "batch_id": batch_id or None,
+                "classification_evidence": {
+                    "preflight": (
+                        "route_fingerprint_mismatch"
+                        if mismatch
+                        else "batch_identity_unavailable"
+                    ),
+                    "resolved_route_fingerprint": route.get(
+                        "route_fingerprint"
+                    ),
+                    "frozen_route_fingerprint": frozen_route.get(
+                        "route_fingerprint"
+                    ),
+                },
+            }
     if send_fn is None or normalize_fn is None:
-        adapter = adapter_selector(route.get("provider"))
+        try:
+            adapter = adapter_selector(route.get("provider"))
+        except ValueError as exc:
+            return {
+                "status": "explicit_failed",
+                "explicit_pre_acceptance_failure": True,
+                "error": f"{type(exc).__name__}: {exc}",
+                "batch_id": batch_id or None,
+                "classification_evidence": {
+                    "preflight": "adapter_unavailable"
+                },
+            }
         resolved_send_fn = send_fn or adapter.send_fn
         resolved_normalize_fn = normalize_fn or adapter.normalize_fn
     else:
         resolved_send_fn = send_fn
         resolved_normalize_fn = normalize_fn
-    message = build_trade_lifecycle_notification_message(payload)
+    message = (
+        build_trade_lifecycle_notification_batch_message(payload)
+        if is_batch
+        else build_trade_lifecycle_notification_message(payload)
+    )
+    send_kwargs = {
+        "base": base,
+        "channel": str(route.get("channel") or ""),
+        "target": str(target),
+        "message": message,
+        "notifications": route.get("notifications") or {},
+    }
+    if is_batch:
+        send_kwargs["idempotency_key"] = batch_id
     send_result = resolved_send_fn(
-        base=base,
-        channel=str(route.get("channel") or ""),
-        target=str(target),
-        message=message,
-        notifications=route.get("notifications") or {},
+        **send_kwargs,
     )
     normalized = normalize_notification_delivery_result(
         send_result,
         normalize_fn=resolved_normalize_fn,
     )
     message_id = _optional_str(normalized.get("message_id"))
-    delivery_confirmed = bool(
-        normalized.get("delivery_confirmed")
-        or (normalized.get("ok") and message_id)
-    )
-    command_ok = bool(
-        normalized.get("command_ok") or normalized.get("ok")
-    )
+    classification = classify_trade_lifecycle_delivery_result(normalized)
+    delivery_confirmed = bool(classification["delivery_confirmed"])
+    command_ok = bool(classification["command_ok"])
+    outcome = str(classification["outcome"])
     return {
-        "status": (
-            "confirmed"
-            if delivery_confirmed
-            else "accepted"
-            if command_ok
-            else "unknown"
-        ),
+        "status": outcome,
         "delivery_confirmed": delivery_confirmed,
+        "explicit_pre_acceptance_failure": bool(
+            classification["explicit_pre_acceptance_failure"]
+        ),
         "message_id": message_id,
         "command_ok": command_ok,
         "error_code": normalized.get("error_code"),
         "send_message": _optional_str(normalized.get("message")),
         "message_len": len(message),
+        "batch_id": batch_id or None,
+        "transport_idempotency_key": (
+            batch_id if is_batch else None
+        ),
+        "classification_evidence": classification[
+            "classification_evidence"
+        ],
     }
 
 

--- a/src/interfaces/cli/option_positions.py
+++ b/src/interfaces/cli/option_positions.py
@@ -70,13 +70,16 @@ from src.application.trades.lifecycle_runtime import (
     reconcile_due_lifecycle_cases_for_source,
 )
 from src.application.trades.lifecycle_outbox import (
-    dispatch_notifications_once,
+    dispatch_notification_batch_once,
+    plan_notification_batch,
+    reconcile_notification_batch,
     reconcile_unknown_notification,
 )
 from src.application.trades.manual_lifecycle_resolution import (
     resolve_lifecycle_manually,
 )
 from src.application.trades.receipt import (
+    resolve_trade_lifecycle_notification_batch_route,
     send_trade_lifecycle_outbox_payload,
 )
 from src.application.cash_conversion import utc_now_ms
@@ -101,6 +104,62 @@ def _load_json_object(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise SystemExit(f"expected JSON object: {path}")
     return payload
+
+
+def _lifecycle_receipt_enabled_accounts(
+    intake_config: dict[str, Any],
+) -> set[str]:
+    fallback_receipt = (
+        dict(intake_config.get("receipt") or {})
+        if isinstance(intake_config.get("receipt"), dict)
+        else {}
+    )
+    accounts: set[str] = set()
+    for raw_source in intake_config.get("sources") or []:
+        if not isinstance(raw_source, dict) or not bool(
+            raw_source.get("enabled", True)
+        ):
+            continue
+        source_receipt = (
+            dict(raw_source.get("receipt") or {})
+            if isinstance(raw_source.get("receipt"), dict)
+            else fallback_receipt
+        )
+        if not bool(source_receipt.get("enabled", True)):
+            continue
+        account = str(raw_source.get("account") or "").strip().lower()
+        if account:
+            accounts.add(account)
+        mapping = raw_source.get("account_mapping")
+        if isinstance(mapping, dict):
+            accounts.update(
+                str(value or "").strip().lower()
+                for value in mapping.values()
+                if str(value or "").strip()
+            )
+    return accounts
+
+
+def _lifecycle_dispatch_write_applied(
+    result: dict[str, Any],
+) -> bool:
+    if isinstance(result.get("batch"), dict):
+        return True
+    planning = result.get("planning")
+    if isinstance(planning, dict) and str(
+        planning.get("status") or ""
+    ) == "created":
+        return True
+    recovery = result.get("recovery")
+    if not isinstance(recovery, dict):
+        return False
+    return any(
+        int(recovery.get(key) or 0) > 0
+        for key in (
+            "reclaimed_claimed_count",
+            "frozen_unknown_count",
+        )
+    )
 
 
 def _parse_json_object_arg(raw: str | None, *, name: str) -> dict[str, Any] | None:
@@ -524,17 +583,25 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_receipt_inspect = receipt_sub.add_parser(
         'inspect',
-        help='inspect one Outbox row',
+        help='inspect one Outbox row or delivery batch',
     )
     _add_runtime_root_arg(p_receipt_inspect)
-    p_receipt_inspect.add_argument('--outbox-id', required=True)
+    inspect_identity = p_receipt_inspect.add_mutually_exclusive_group(
+        required=True
+    )
+    inspect_identity.add_argument('--outbox-id')
+    inspect_identity.add_argument('--batch-id')
     p_receipt_inspect.add_argument('--format', default='json', choices=['json'])
     p_receipt_reconcile = receipt_sub.add_parser(
         'reconcile',
         help='reconcile accepted/unknown delivery or create an explicit resend',
     )
     _add_runtime_root_arg(p_receipt_reconcile)
-    p_receipt_reconcile.add_argument('--outbox-id', required=True)
+    reconcile_identity = p_receipt_reconcile.add_mutually_exclusive_group(
+        required=True
+    )
+    reconcile_identity.add_argument('--outbox-id')
+    reconcile_identity.add_argument('--batch-id')
     p_receipt_reconcile.add_argument(
         '--mark',
         '--action',
@@ -548,11 +615,15 @@ def main(argv: list[str] | None = None) -> int:
     _add_local_write_flags(p_receipt_reconcile, high_risk=True)
     p_receipt_dispatch = receipt_sub.add_parser(
         'dispatch',
-        help='dispatch at most one due Outbox row',
+        help='dispatch at most one due lifecycle delivery batch',
     )
     _add_runtime_root_arg(p_receipt_dispatch)
     p_receipt_dispatch.add_argument('--once', action='store_true', required=True)
-    p_receipt_dispatch.add_argument('--account', default=None)
+    p_receipt_dispatch.add_argument(
+        '--account',
+        default=None,
+        help='dry-run observation filter only; applied dispatch is global',
+    )
     p_receipt_dispatch.add_argument('--config', required=True)
     p_receipt_dispatch.add_argument('--format', default='json', choices=['json'])
     _add_local_write_flags(p_receipt_dispatch, high_risk=True)
@@ -1698,21 +1769,63 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
         if args.lifecycle_cmd == 'receipts':
             if args.receipt_cmd == 'inspect':
-                row = repo.get_trade_lifecycle_notification(
-                    str(args.outbox_id)
-                )
-                if not isinstance(row, dict):
-                    raise SystemExit(
-                        "notification outbox row not found: "
-                        f"{args.outbox_id}"
+                if args.batch_id:
+                    batch = (
+                        repo.get_trade_lifecycle_notification_batch(
+                            str(args.batch_id)
+                        )
                     )
+                    if not isinstance(batch, dict):
+                        raise SystemExit(
+                            "notification delivery batch not found: "
+                            f"{args.batch_id}"
+                        )
+                    members = (
+                        repo.list_trade_lifecycle_notification_batch_members(
+                            str(args.batch_id)
+                        )
+                    )
+                    inspection = {
+                        "batch": batch,
+                        "members": members,
+                        "outbox": None,
+                    }
+                else:
+                    row = repo.get_trade_lifecycle_notification(
+                        str(args.outbox_id)
+                    )
+                    if not isinstance(row, dict):
+                        raise SystemExit(
+                            "notification outbox row not found: "
+                            f"{args.outbox_id}"
+                        )
+                    batch_id = str(
+                        row.get("delivery_batch_id") or ""
+                    ).strip()
+                    inspection = {
+                        "outbox": row,
+                        "batch": (
+                            repo.get_trade_lifecycle_notification_batch(
+                                batch_id
+                            )
+                            if batch_id
+                            else None
+                        ),
+                        "members": (
+                            repo.list_trade_lifecycle_notification_batch_members(
+                                batch_id
+                            )
+                            if batch_id
+                            else []
+                        ),
+                    }
                 print(
                     json.dumps(
                         {
                             "operation": (
                                 "lifecycle_receipt_inspect"
                             ),
-                            "outbox": row,
+                            **inspection,
                             "ledger_store": ledger_store,
                         },
                         ensure_ascii=False,
@@ -1726,15 +1839,55 @@ def main(argv: list[str] | None = None) -> int:
                     "lifecycle:receipts:reconcile"
                 ]
                 dry_run = not bool(control["write_requested"])
-                result = reconcile_unknown_notification(
-                    repo,
-                    outbox_id=str(args.outbox_id),
-                    action=str(args.action),
-                    broker_ref=str(args.broker_ref),
-                    note=str(args.note),
-                    apply_changes=not dry_run,
-                    now_ms=utc_now_ms(),
-                )
+                batch_id = str(args.batch_id or "").strip()
+                if not batch_id:
+                    row = repo.get_trade_lifecycle_notification(
+                        str(args.outbox_id)
+                    )
+                    if not isinstance(row, dict):
+                        raise SystemExit(
+                            "notification outbox row not found: "
+                            f"{args.outbox_id}"
+                        )
+                    batch_id = str(
+                        row.get("delivery_batch_id") or ""
+                    ).strip()
+                    if batch_id:
+                        batch = (
+                            repo.get_trade_lifecycle_notification_batch(
+                                batch_id
+                            )
+                        )
+                        if not isinstance(batch, dict):
+                            raise SystemExit(
+                                "notification delivery batch not found: "
+                                f"{batch_id}"
+                            )
+                        if int(batch.get("member_count") or 0) != 1:
+                            raise SystemExit(
+                                "outbox row belongs to a multi-member batch; "
+                                f"re-run with --batch-id {batch_id}"
+                            )
+                if batch_id:
+                    result = reconcile_notification_batch(
+                        repo,
+                        batch_id=batch_id,
+                        action=str(args.action),
+                        broker_ref=str(args.broker_ref),
+                        note=str(args.note),
+                        apply_changes=not dry_run,
+                        now_ms=utc_now_ms(),
+                    )
+                else:
+                    result = reconcile_unknown_notification(
+                        repo,
+                        outbox_id=str(args.outbox_id),
+                        action=str(args.action),
+                        broker_ref=str(args.broker_ref),
+                        note=str(args.note),
+                        apply_changes=not dry_run,
+                        now_ms=utc_now_ms(),
+                    )
                 payload = attach_write_contract(
                     {
                         "operation": (
@@ -1768,54 +1921,70 @@ def main(argv: list[str] | None = None) -> int:
                 account_value = str(
                     args.account or ""
                 ).strip().lower()
-                if dry_run:
-                    rows = [
-                        row
-                        for row in (
-                            repo.list_trade_lifecycle_notifications()
-                        )
-                        if str(row.get("status") or "")
-                        in {"pending", "explicit_failed"}
-                        and (
-                            not account_value
-                            or str(
-                                (
-                                    row.get("payload")
-                                    or {}
-                                ).get("account")
-                                or ""
-                            ).strip().lower()
-                            == account_value
-                        )
-                    ]
+                if not dry_run and account_value:
+                    raise SystemExit(
+                        "applied lifecycle receipt dispatch is global; "
+                        "remove --account to preserve same-route batching"
+                    )
+                config_path = _resolve_path_under(
+                    str(args.config),
+                    base=base,
+                )
+                cfg = _load_json_object(config_path)
+                intake_config = resolve_trade_intake_config(cfg)
+                receipt_config = dict(
+                    intake_config.get("receipt") or {}
+                )
+                enabled_accounts = (
+                    _lifecycle_receipt_enabled_accounts(intake_config)
+                )
+                dispatch_accounts = (
+                    enabled_accounts & {account_value}
+                    if account_value
+                    else enabled_accounts
+                )
+                route = (
+                    resolve_trade_lifecycle_notification_batch_route(
+                        config=cfg
+                    )
+                    if dispatch_accounts
+                    else {}
+                )
+                if not dispatch_accounts:
+                    result = {
+                        "status": (
+                            "dry_run" if dry_run else "idle"
+                        ),
+                        "reason": (
+                            "requested_account_receipt_disabled"
+                            if account_value
+                            else "notification_receipt_disabled"
+                        ),
+                        "preview": None,
+                    }
+                elif not bool(route.get("route_available")):
+                    result = {
+                        "status": (
+                            "dry_run" if dry_run else "explicit_failed"
+                        ),
+                        "reason": "notification_route_unavailable",
+                        "preview": None,
+                    }
+                elif dry_run:
                     result = {
                         "status": "dry_run",
-                        "candidate": rows[0] if rows else None,
+                        "preview": plan_notification_batch(
+                            repo,
+                            route=route,
+                            now_ms=utc_now_ms(),
+                            allowed_accounts=dispatch_accounts,
+                            apply_changes=False,
+                        ),
                     }
                 else:
-                    config_path = _resolve_path_under(
-                        str(args.config),
-                        base=base,
-                    )
-                    cfg = _load_json_object(config_path)
-                    trade_intake = (
-                        dict(cfg.get("trade_intake") or {})
-                        if isinstance(
-                            cfg.get("trade_intake"),
-                            dict,
-                        )
-                        else {}
-                    )
-                    receipt_config = (
-                        dict(trade_intake.get("receipt") or {})
-                        if isinstance(
-                            trade_intake.get("receipt"),
-                            dict,
-                        )
-                        else {}
-                    )
-                    result = dispatch_notifications_once(
+                    result = dispatch_notification_batch_once(
                         repo,
+                        route=route,
                         send_fn=lambda frozen_payload: (
                             send_trade_lifecycle_outbox_payload(
                                 base=base,
@@ -1825,7 +1994,7 @@ def main(argv: list[str] | None = None) -> int:
                             )
                         ),
                         now_ms=utc_now_ms(),
-                        account=account_value or None,
+                        allowed_accounts=dispatch_accounts,
                     )
                 payload = attach_write_contract(
                     {
@@ -1836,7 +2005,10 @@ def main(argv: list[str] | None = None) -> int:
                         "ledger_store": ledger_store,
                     },
                     dry_run=dry_run,
-                    write_applied=not dry_run,
+                    write_applied=bool(
+                        not dry_run
+                        and _lifecycle_dispatch_write_applied(result)
+                    ),
                     rollback_hint=(
                         "delivery state is durable; unknown must be "
                         "reconciled manually and is never auto-retried"

--- a/tests/test_lifecycle_redesign_contracts.py
+++ b/tests/test_lifecycle_redesign_contracts.py
@@ -1922,6 +1922,8 @@ def test_outbox_v1_schema_upgrade_preserves_delivery_state(
     assert row["delivery_revision"] == 0
     assert row["transition_key"] == "legacy:legacy-outbox-1"
     assert row["state_fingerprint"] == "legacy-payload-hash"
+    assert row["delivery_batch_id"] is None
+    assert repo.list_trade_lifecycle_notification_batches() == []
 
 
 def test_lifecycle_delivery_status_separates_case_and_outbox_states(

--- a/tests/test_lifecycle_redesign_contracts.py
+++ b/tests/test_lifecycle_redesign_contracts.py
@@ -46,8 +46,11 @@ from src.application.positions.context_builder import (
 )
 from src.application.trades.lifecycle_outbox import (
     CLAIM_LEASE_MS,
+    QUIET_WINDOW_MS,
+    build_notification_batch_route,
     claim_next_notification,
     complete_notification_attempt,
+    dispatch_notification_batch_once,
     enqueue_notification_intent,
     mark_notification_send_started,
     reconcile_unknown_notification,
@@ -1955,8 +1958,82 @@ def test_lifecycle_delivery_status_separates_case_and_outbox_states(
         account="lx",
         now_ms=observed_at_ms + 1_000,
     )
+    assert status["schema_version"] == (
+        "trade_lifecycle_delivery_status.v2"
+    )
     assert status["reason_state_counts"]["cause_pending"] == 1
     assert status["overdue_pending_count"] == 1
     assert status["oldest_pending_case"]["case_id"] == case_id
     assert status["outbox_status_counts"]["pending"] == 1
+    assert status["unbound_eligible_count"] == 1
+    assert status["oldest_unbound_eligible"]["case_id"] == case_id
+    assert status["delivery_batch_count"] == 0
+    assert status["batched_member_count"] == 0
+    assert status["messages_avoided"]["total"] == 0
     assert status["oldest_unknown_outbox"] is None
+
+
+def test_lifecycle_delivery_status_reports_batch_scope_without_target(
+    tmp_path: Path,
+) -> None:
+    repo, case_id, _observed_at_ms = _case_with_option_anchor(
+        tmp_path
+    )
+    for revision, transition in (
+        (1, "option_leg_closed"),
+        (2, "needs_review"),
+    ):
+        intent = build_notification_intent(
+            case_id=case_id,
+            transition_type=transition,
+            resolution_revision=revision,
+            transition_key=(
+                f"lifecycle:{case_id}:{transition}:{revision}"
+            ),
+            state_fingerprint=f"batch-status-{revision}",
+            payload={
+                "account": "lx",
+                "case_id": case_id,
+                "transition_type": transition,
+            },
+        )
+        assert repo.insert_trade_lifecycle_notification_once(intent)
+    rows = repo.list_trade_lifecycle_notifications(case_id=case_id)
+    dispatch_at = max(
+        int(row["created_at_ms"]) for row in rows
+    ) + QUIET_WINDOW_MS
+    target = "sensitive-target-must-not-appear"
+    result = dispatch_notification_batch_once(
+        repo,
+        route=build_notification_batch_route(
+            provider="feishu_app",
+            channel="feishu_app",
+            target=target,
+        ),
+        send_fn=lambda _payload: {
+            "status": "confirmed",
+            "delivery_confirmed": True,
+            "message_id": "provider-message",
+        },
+        now_ms=dispatch_at,
+    )
+    assert result["status"] == "confirmed"
+
+    status = _lifecycle_delivery_status(
+        repo,
+        account="lx",
+        now_ms=dispatch_at + 1,
+    )
+
+    assert status["batch_status_counts"]["confirmed"] == 1
+    assert status["delivery_batch_count"] == 1
+    assert status["batched_member_count"] == 2
+    assert status["active_batched_member_count"] == 0
+    assert status["messages_avoided"] == {
+        "scope": "full_delivery_batches_touching_account",
+        "confirmed": 1,
+        "accepted": 0,
+        "total": 1,
+    }
+    assert status["oldest_unknown_batch"] is None
+    assert target not in str(status)

--- a/tests/test_option_positions_cli.py
+++ b/tests/test_option_positions_cli.py
@@ -2218,3 +2218,538 @@ def test_option_positions_cli_adopt_combo_identity_dry_run(
     assert payload["write_applied"] is False
     assert payload["identity_created"] is False
     assert repo.get_strategy_group_identity("combo:lx:9992") is None
+
+
+def _lifecycle_receipt_cli_context(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    receipt_enabled: bool = True,
+    sy_intake_enabled: bool = True,
+):
+    import src.interfaces.cli.option_positions as cli_mod
+
+    data_config = _write_data_config(
+        tmp_path / "data.json",
+        sqlite_path=tmp_path / "legacy" / "option_positions.sqlite3",
+    )
+    repo = ledger_repository.SQLiteOptionPositionsRepository(
+        tmp_path / "output_shared" / "state" / "option_positions.sqlite3"
+    )
+    repo.data_config_path = data_config  # type: ignore[attr-defined]
+    runtime_config = tmp_path / "runtime.json"
+    runtime_config.write_text(
+        json.dumps(
+            {
+                "accounts": ["lx", "sy"],
+                "account_settings": {
+                    "lx": {
+                        "type": "futu",
+                        "futu": {
+                            "account_id": "REAL_LX",
+                            "host": "127.0.0.1",
+                            "port": 11111,
+                        },
+                    },
+                    "sy": {
+                        "type": "futu",
+                        "trade_intake_enabled": sy_intake_enabled,
+                        "futu": {
+                            "account_id": "REAL_SY",
+                            "host": "127.0.0.1",
+                            "port": 11112,
+                        },
+                    },
+                },
+                "notifications": {
+                    "provider": "wechat_clawbot",
+                    "target": "wechat:ops",
+                },
+                "trade_intake": {
+                    "receipt": {"enabled": receipt_enabled}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "resolve_option_positions_repo",
+        lambda **_kwargs: (data_config, repo),
+    )
+    return cli_mod, data_config, runtime_config, repo
+
+
+def _enqueue_lifecycle_cli_intents(
+    repo,
+    *,
+    count: int = 2,
+    accounts: list[str] | None = None,
+) -> list[dict]:
+    from src.application.ledger.notification_outbox import (
+        build_notification_intent,
+    )
+
+    rows = []
+    for index in range(count):
+        account = (
+            accounts[index % len(accounts)]
+            if accounts
+            else "lx"
+        )
+        intent = build_notification_intent(
+            case_id=f"case-cli-{index}",
+            transition_type="needs_review",
+            resolution_revision=1,
+            transition_key=(
+                f"lifecycle:case-cli-{index}:needs_review"
+            ),
+            state_fingerprint=f"state-cli-{index}",
+            payload={
+                "account": account,
+                "case_id": f"case-cli-{index}",
+                "transition_type": "needs_review",
+                "symbol": f"SYM{index}",
+            },
+        )
+        assert repo.insert_trade_lifecycle_notification_once(intent)
+        row = repo.get_trade_lifecycle_notification(intent["outbox_id"])
+        assert row is not None
+        rows.append(row)
+    return rows
+
+
+def _create_lifecycle_cli_batch(repo, rows: list[dict]) -> dict:
+    from src.application.trades.lifecycle_outbox import (
+        QUIET_WINDOW_MS,
+        build_notification_batch_route,
+        plan_notification_batch,
+    )
+
+    result = plan_notification_batch(
+        repo,
+        route=build_notification_batch_route(
+            provider="wechat_clawbot",
+            channel="wechat_clawbot",
+            target="wechat:ops",
+        ),
+        now_ms=(
+            max(int(row["created_at_ms"]) for row in rows)
+            + QUIET_WINDOW_MS
+        ),
+    )
+    assert result["status"] == "created"
+    return result["batch"]
+
+
+def test_lifecycle_receipt_cli_inspects_batch_and_members(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    cli_mod, data_config, _runtime_config, repo = (
+        _lifecycle_receipt_cli_context(monkeypatch, tmp_path)
+    )
+    rows = _enqueue_lifecycle_cli_intents(repo)
+    batch = _create_lifecycle_cli_batch(repo, rows)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "inspect",
+            "--batch-id",
+            str(batch["batch_id"]),
+        ],
+    )
+
+    cli_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["batch"]["batch_id"] == batch["batch_id"]
+    assert len(payload["members"]) == 2
+    assert payload["outbox"] is None
+    assert "wechat:ops" not in str(payload)
+
+
+def test_lifecycle_receipt_cli_refuses_multi_member_reconcile_by_outbox(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cli_mod, data_config, _runtime_config, repo = (
+        _lifecycle_receipt_cli_context(monkeypatch, tmp_path)
+    )
+    rows = _enqueue_lifecycle_cli_intents(repo)
+    batch = _create_lifecycle_cli_batch(repo, rows)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "reconcile",
+            "--outbox-id",
+            str(rows[0]["outbox_id"]),
+            "--mark",
+            "confirmed",
+            "--broker-ref",
+            "provider-check",
+            "--note",
+            "verified",
+            "--dry-run",
+        ],
+    )
+
+    with pytest.raises(
+        SystemExit,
+        match=f"re-run with --batch-id {batch['batch_id']}",
+    ):
+        cli_mod.main()
+
+
+def test_lifecycle_receipt_cli_batch_reconcile_dry_run_is_no_write(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from src.application.trades.lifecycle_outbox import (
+        QUIET_WINDOW_MS,
+        build_notification_batch_route,
+        dispatch_notification_batch_once,
+    )
+
+    cli_mod, data_config, _runtime_config, repo = (
+        _lifecycle_receipt_cli_context(monkeypatch, tmp_path)
+    )
+    rows = _enqueue_lifecycle_cli_intents(repo)
+    result = dispatch_notification_batch_once(
+        repo,
+        route=build_notification_batch_route(
+            provider="wechat_clawbot",
+            channel="wechat_clawbot",
+            target="wechat:ops",
+        ),
+        send_fn=lambda _payload: {"status": "unknown"},
+        now_ms=(
+            max(int(row["created_at_ms"]) for row in rows)
+            + QUIET_WINDOW_MS
+        ),
+    )
+    batch_id = str(result["batch"]["batch_id"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "reconcile",
+            "--batch-id",
+            batch_id,
+            "--mark",
+            "confirmed",
+            "--broker-ref",
+            "provider-check",
+            "--note",
+            "verified",
+            "--dry-run",
+        ],
+    )
+
+    cli_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["batch_id"] == batch_id
+    assert payload["member_count"] == 2
+    assert payload["apply_changes"] is False
+    assert payload["write_applied"] is False
+    assert repo.get_trade_lifecycle_notification_batch(batch_id)[
+        "status"
+    ] == "unknown"
+
+
+def test_lifecycle_receipt_cli_dispatch_dry_run_does_not_bind_or_send(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from src.application.trades.lifecycle_outbox import QUIET_WINDOW_MS
+
+    cli_mod, data_config, runtime_config, repo = (
+        _lifecycle_receipt_cli_context(monkeypatch, tmp_path)
+    )
+    rows = _enqueue_lifecycle_cli_intents(repo)
+    monkeypatch.setattr(
+        cli_mod,
+        "utc_now_ms",
+        lambda: (
+            max(int(row["created_at_ms"]) for row in rows)
+            + QUIET_WINDOW_MS
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "dispatch",
+            "--once",
+            "--account",
+            "lx",
+            "--config",
+            str(runtime_config),
+            "--dry-run",
+        ],
+    )
+
+    cli_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["preview"]["status"] == "ready"
+    assert payload["preview"]["candidate_count"] == 2
+    assert payload["write_applied"] is False
+    assert repo.list_trade_lifecycle_notification_batches() == []
+    assert {
+        row["status"]
+        for row in repo.list_trade_lifecycle_notifications()
+    } == {"pending"}
+
+
+def test_lifecycle_receipt_cli_applied_dispatch_rejects_account_scope(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cli_mod, data_config, runtime_config, repo = (
+        _lifecycle_receipt_cli_context(monkeypatch, tmp_path)
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_guard_write",
+        lambda **_kwargs: {"ok": True},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "dispatch",
+            "--once",
+            "--account",
+            "lx",
+            "--config",
+            str(runtime_config),
+            "--apply",
+            "--confirm",
+        ],
+    )
+
+    with pytest.raises(
+        SystemExit,
+        match="applied lifecycle receipt dispatch is global",
+    ):
+        cli_mod.main()
+    assert repo.list_trade_lifecycle_notification_batches() == []
+
+
+def test_lifecycle_receipt_cli_applied_dispatch_filters_disabled_account(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from src.application.trades.lifecycle_outbox import QUIET_WINDOW_MS
+
+    cli_mod, data_config, runtime_config, repo = (
+        _lifecycle_receipt_cli_context(
+            monkeypatch,
+            tmp_path,
+            sy_intake_enabled=False,
+        )
+    )
+    rows = _enqueue_lifecycle_cli_intents(
+        repo,
+        accounts=["lx", "sy"],
+    )
+    current = (
+        max(int(row["created_at_ms"]) for row in rows)
+        + QUIET_WINDOW_MS
+    )
+    calls: list[dict] = []
+    monkeypatch.setattr(cli_mod, "utc_now_ms", lambda: current)
+    monkeypatch.setattr(
+        cli_mod,
+        "_guard_write",
+        lambda **_kwargs: {"ok": True},
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "send_trade_lifecycle_outbox_payload",
+        lambda **kwargs: calls.append(dict(kwargs))
+        or {
+            "status": "confirmed",
+            "delivery_confirmed": True,
+            "message_id": "provider-message",
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "dispatch",
+            "--once",
+            "--config",
+            str(runtime_config),
+            "--apply",
+            "--confirm",
+        ],
+    )
+
+    cli_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "confirmed"
+    assert payload["batch"]["member_count"] == 1
+    assert payload["write_applied"] is True
+    assert len(calls) == 1
+    assert {
+        member["payload"]["account"]
+        for member in calls[0]["payload"]["members"]
+    } == {"lx"}
+    stored = {
+        row["payload"]["account"]: row
+        for row in repo.list_trade_lifecycle_notifications()
+    }
+    assert stored["lx"]["status"] == "confirmed"
+    assert stored["sy"]["status"] == "pending"
+    assert stored["sy"]["delivery_batch_id"] is None
+
+
+def test_lifecycle_receipt_cli_disabled_config_is_no_write(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from src.application.trades.lifecycle_outbox import QUIET_WINDOW_MS
+
+    cli_mod, data_config, runtime_config, repo = (
+        _lifecycle_receipt_cli_context(
+            monkeypatch,
+            tmp_path,
+            receipt_enabled=False,
+        )
+    )
+    rows = _enqueue_lifecycle_cli_intents(repo)
+    current = (
+        max(int(row["created_at_ms"]) for row in rows)
+        + QUIET_WINDOW_MS
+    )
+    calls: list[dict] = []
+    monkeypatch.setattr(cli_mod, "utc_now_ms", lambda: current)
+    monkeypatch.setattr(
+        cli_mod,
+        "_guard_write",
+        lambda **_kwargs: {"ok": True},
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "send_trade_lifecycle_outbox_payload",
+        lambda **kwargs: calls.append(dict(kwargs)),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "dispatch",
+            "--once",
+            "--config",
+            str(runtime_config),
+            "--apply",
+            "--confirm",
+        ],
+    )
+
+    cli_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "idle"
+    assert payload["reason"] == "notification_receipt_disabled"
+    assert payload["write_applied"] is False
+    assert calls == []
+    assert repo.list_trade_lifecycle_notification_batches() == []
+    assert {
+        row["status"]
+        for row in repo.list_trade_lifecycle_notifications()
+    } == {"pending"}
+
+
+def test_lifecycle_receipt_cli_applied_idle_reports_no_write(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    cli_mod, data_config, runtime_config, repo = (
+        _lifecycle_receipt_cli_context(monkeypatch, tmp_path)
+    )
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        cli_mod,
+        "_guard_write",
+        lambda **_kwargs: {"ok": True},
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "send_trade_lifecycle_outbox_payload",
+        lambda **kwargs: calls.append(dict(kwargs)),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "om option-positions",
+            "--data-config",
+            str(data_config),
+            "lifecycle",
+            "receipts",
+            "dispatch",
+            "--once",
+            "--config",
+            str(runtime_config),
+            "--apply",
+            "--confirm",
+        ],
+    )
+
+    cli_mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "idle"
+    assert payload["reason"] == "no_eligible_unbound_intents"
+    assert payload["write_applied"] is False
+    assert calls == []
+    assert repo.list_trade_lifecycle_notification_batches() == []

--- a/tests/test_trades_auto_intake_cli.py
+++ b/tests/test_trades_auto_intake_cli.py
@@ -6,6 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 import tempfile
+import threading
+
+import pytest
+
 import src.application.trades.auto_intake as auto_intake
 
 from src.application.layered_config import build_layered_runtime_config_from_user_config
@@ -14,6 +18,28 @@ from src.application.runtime_config_freshness import GENERATED_KEY, build_inline
 
 BASE = Path(__file__).resolve().parents[1]
 AUTO_INTAKE_CLI_TIMEOUT_SEC = 15
+
+
+def _listener_source(tmp_path: Path, account: str, port: int) -> dict:
+    return {
+        "id": account,
+        "account": account,
+        "enabled": True,
+        "mode": "apply",
+        "host": "127.0.0.1",
+        "port": port,
+        "state_path": Path(f"state/{account}.json"),
+        "audit_path": Path(f"audit/{account}.jsonl"),
+        "status_path": Path(f"status/{account}.json"),
+        "inbox_path": Path(f"inbox/{account}.sqlite3"),
+        "backfill_checkpoint_path": Path(f"backfill/{account}.json"),
+        "reconnect_sec": 5,
+        "receipt": {"enabled": True},
+        "backfill": {"enabled": False},
+        "account_mapping": {f"REAL_{account.upper()}": account},
+        "futu_account_ids": [f"REAL_{account.upper()}"],
+        "combo_reconciliation_mode": "off",
+    }
 
 
 def _write_runtime_config(tmp_path: Path) -> Path:
@@ -228,6 +254,223 @@ def test_auto_trade_intake_once_accepts_explicit_runtime_root_over_env(tmp_path:
     assert payload["state_path"] == str((explicit_runtime_root / "output_shared" / "state" / "auto_trade_intake_state.json").resolve())
     assert payload["audit_path"] == str((explicit_runtime_root / "output_shared" / "state" / "auto_trade_intake_audit.jsonl").resolve())
     assert payload["status_path"] == str((explicit_runtime_root / "output_shared" / "state" / "auto_trade_intake_status.json").resolve())
+
+
+@pytest.mark.parametrize("source_count", (1, 2))
+def test_listener_main_owns_exactly_one_lifecycle_batch_dispatcher(
+    monkeypatch,
+    tmp_path: Path,
+    source_count: int,
+) -> None:
+    sources = [
+        _listener_source(tmp_path, account, 11111 + index)
+        for index, account in enumerate(("lx", "sy")[:source_count])
+    ]
+    intake_cfg = {
+        "enabled": True,
+        "mode": "apply",
+        "state_path": Path("state.json"),
+        "audit_path": Path("audit.jsonl"),
+        "status_path": Path("status.json"),
+        "receipt": {"enabled": True},
+        "backfill": {"enabled": False},
+        "holdings_sync": {"enabled": False},
+        "combo_reconciliation": {
+            "default_mode": "off",
+            "accounts": {},
+        },
+        "account_mapping": {
+            f"REAL_{account.upper()}": account
+            for account in ("lx", "sy")[:source_count]
+        },
+        "futu_account_ids": [
+            f"REAL_{account.upper()}"
+            for account in ("lx", "sy")[:source_count]
+        ],
+        "sources": sources,
+    }
+    instances: list[object] = []
+
+    class _Dispatcher:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.start_count = 0
+            self.close_count = 0
+            instances.append(self)
+
+        def start(self):
+            self.start_count += 1
+
+        def close(self):
+            self.close_count += 1
+
+        def snapshot(self):
+            return {
+                "schema_version": (
+                    "trade_lifecycle_batch_dispatcher_status.v1"
+                ),
+                "status": (
+                    "running" if self.start_count else "initialized"
+                ),
+            }
+
+    observed_statuses: list[dict] = []
+
+    def _run_source(**kwargs):
+        observed_statuses.append(
+            kwargs["lifecycle_dispatcher_status_fn"]()
+        )
+        return 0
+
+    def _run_sources(sources, *, run_source):
+        stop_event = threading.Event()
+        return max(run_source(source, stop_event) for source in sources)
+
+    monkeypatch.setattr(auto_intake, "load_config", lambda **_kwargs: {})
+    monkeypatch.setattr(
+        auto_intake,
+        "resolve_trade_intake_config",
+        lambda *_args, **_kwargs: intake_cfg,
+    )
+    monkeypatch.setattr(
+        auto_intake,
+        "open_position_ledger_from_runtime_config",
+        lambda **_kwargs: (None, object()),
+    )
+    monkeypatch.setattr(
+        auto_intake,
+        "resolve_trade_lifecycle_notification_batch_route",
+        lambda **_kwargs: {
+            "provider": "feishu_app",
+            "channel": "bot",
+            "target": "secret-target",
+            "target_fingerprint": "target-fingerprint",
+            "route_fingerprint": "route-fingerprint",
+            "route_available": True,
+        },
+    )
+    monkeypatch.setattr(
+        auto_intake,
+        "LifecycleReceiptBatchDispatcher",
+        _Dispatcher,
+    )
+    monkeypatch.setattr(
+        auto_intake,
+        "_run_listener_source_loop",
+        _run_source,
+    )
+    monkeypatch.setattr(
+        auto_intake,
+        "_coordinate_listener_sources",
+        _run_sources,
+    )
+
+    rc = auto_intake.main(
+        [
+            "--config",
+            str(tmp_path / "config.us.json"),
+            "--runtime-root",
+            str(tmp_path),
+            "--mode",
+            "apply",
+            "--confirm",
+        ]
+    )
+
+    assert rc == 0
+    assert len(instances) == 1
+    dispatcher = instances[0]
+    assert dispatcher.start_count == 1
+    assert dispatcher.close_count == 1
+    assert dispatcher.kwargs["allowed_accounts"] == [
+        account for account in ("lx", "sy")[:source_count]
+    ]
+    assert len(observed_statuses) == source_count
+    assert {item["status"] for item in observed_statuses} == {"running"}
+
+
+@pytest.mark.parametrize(
+    ("apply_changes", "receipt_enabled", "reason"),
+    (
+        (False, True, "dry_run"),
+        (True, False, "receipt_disabled"),
+    ),
+)
+def test_lifecycle_dispatcher_is_not_built_for_dry_run_or_disabled_receipts(
+    monkeypatch,
+    tmp_path: Path,
+    apply_changes: bool,
+    receipt_enabled: bool,
+    reason: str,
+) -> None:
+    source = _listener_source(tmp_path, "lx", 11111)
+    source["receipt"] = {"enabled": receipt_enabled}
+    monkeypatch.setattr(
+        auto_intake,
+        "resolve_trade_lifecycle_notification_batch_route",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("disabled dispatcher must not resolve a route")
+        ),
+    )
+
+    dispatcher, status_fn = (
+        auto_intake._build_lifecycle_receipt_batch_dispatcher(
+            repo=object(),
+            base=tmp_path,
+            cfg={},
+            intake_cfg={
+                "receipt": {"enabled": receipt_enabled},
+                "sources": [source],
+            },
+            apply_changes=apply_changes,
+        )
+    )
+
+    assert dispatcher is None
+    assert status_fn()["status"] == "disabled"
+    assert status_fn()["reason"] == reason
+
+
+def test_lifecycle_dispatcher_is_not_built_when_route_is_unavailable(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    source = _listener_source(tmp_path, "lx", 11111)
+    monkeypatch.setattr(
+        auto_intake,
+        "resolve_trade_lifecycle_notification_batch_route",
+        lambda **_kwargs: {
+            "provider": "feishu_app",
+            "channel": "bot",
+            "route_available": False,
+        },
+    )
+
+    dispatcher, status_fn = (
+        auto_intake._build_lifecycle_receipt_batch_dispatcher(
+            repo=object(),
+            base=tmp_path,
+            cfg={},
+            intake_cfg={
+                "receipt": {"enabled": True},
+                "sources": [source],
+            },
+            apply_changes=True,
+        )
+    )
+
+    assert dispatcher is None
+    assert status_fn()["status"] == "unavailable"
+    assert status_fn()["reason"] == "route_unavailable"
+
+
+def test_source_listener_has_no_lifecycle_provider_send_path() -> None:
+    import inspect
+
+    source = inspect.getsource(auto_intake._run_listener_source_loop)
+
+    assert "send_trade_lifecycle_outbox_payload" not in source
+    assert "dispatch_notification" not in source
 
 
 def test_reconcile_intake_sources_defaults_to_every_account(

--- a/tests/test_trades_lifecycle_batch_outbox.py
+++ b/tests/test_trades_lifecycle_batch_outbox.py
@@ -80,6 +80,12 @@ def _quiet_now(rows: list[dict]) -> int:
     return max(int(row["created_at_ms"]) for row in rows) + QUIET_WINDOW_MS
 
 
+def test_legacy_per_row_delivery_dispatcher_is_removed() -> None:
+    from src.application.trades import lifecycle_outbox
+
+    assert not hasattr(lifecycle_outbox, "dispatch_notifications_once")
+
+
 def test_twenty_four_intents_use_one_batch_and_one_receipt(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_trades_lifecycle_batch_outbox.py
+++ b/tests/test_trades_lifecycle_batch_outbox.py
@@ -1,0 +1,622 @@
+from __future__ import annotations
+
+import copy
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from src.application.ledger.notification_outbox import (
+    build_notification_intent,
+    canonical_payload_hash,
+)
+from src.application.ledger.repository import (
+    SQLiteOptionPositionsRepository,
+)
+from src.application.trades.lifecycle_outbox import (
+    BATCH_RETRY_BACKOFF_MS,
+    CLAIM_LEASE_MS,
+    MAX_BATCH_WAIT_MS,
+    QUIET_WINDOW_MS,
+    TARGET_SEND_INTERVAL_MS,
+    build_notification_batch_route,
+    claim_next_notification,
+    claim_next_notification_batch,
+    complete_notification_batch_attempt,
+    dispatch_notification_batch_once,
+    enqueue_notification_intent,
+    mark_notification_batch_send_started,
+    plan_notification_batch,
+    reconcile_notification_batch,
+    recover_stale_notification_batches,
+)
+
+
+def _repo(tmp_path: Path) -> SQLiteOptionPositionsRepository:
+    return SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+
+
+def _route(*, target: str = "ou_test_target") -> dict[str, str]:
+    return build_notification_batch_route(
+        provider="feishu_app",
+        channel="bot",
+        target=target,
+    )
+
+
+def _enqueue(
+    repo: SQLiteOptionPositionsRepository,
+    *,
+    suffix: str,
+    account: str = "lx",
+    transition_type: str = "needs_review",
+) -> dict:
+    intent = build_notification_intent(
+        case_id=f"case-{suffix}",
+        transition_type=transition_type,
+        resolution_revision=1,
+        transition_key=f"lifecycle:case-{suffix}:{transition_type}",
+        state_fingerprint=f"state-{suffix}",
+        payload={
+            "account": account,
+            "case_id": f"case-{suffix}",
+            "transition_type": transition_type,
+            "symbol": f"SYM{suffix}",
+        },
+    )
+    enqueue_notification_intent(repo, intent)
+    row = repo.get_trade_lifecycle_notification(intent["outbox_id"])
+    assert row is not None
+    return row
+
+
+def _quiet_now(rows: list[dict]) -> int:
+    return max(int(row["created_at_ms"]) for row in rows) + QUIET_WINDOW_MS
+
+
+def test_twenty_four_intents_use_one_batch_and_one_receipt(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    rows = [
+        _enqueue(
+            repo,
+            suffix=f"{index:02d}",
+            account="lx" if index < 15 else "sy",
+        )
+        for index in range(24)
+    ]
+    calls: list[dict] = []
+
+    def _send(payload: dict) -> dict:
+        calls.append(payload)
+        return {
+            "status": "confirmed",
+            "delivery_confirmed": True,
+            "message_id": "provider-message-1",
+        }
+
+    result = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_send,
+        now_ms=_quiet_now(rows),
+        allowed_accounts={"lx", "sy"},
+    )
+
+    assert result["status"] == "confirmed"
+    assert len(calls) == 1
+    assert len(calls[0]["members"]) == 24
+    batch = result["batch"]
+    assert batch["member_count"] == 24
+    assert batch["status"] == "confirmed"
+    assert batch["provider_message_id"] == "provider-message-1"
+    assert batch["batch_id"] == calls[0]["batch_id"]
+    assert "ou_test_target" not in str(batch["payload"])
+    settled = repo.list_trade_lifecycle_notification_batch_members(
+        batch["batch_id"]
+    )
+    assert len(settled) == 24
+    assert {row["status"] for row in settled} == {"confirmed"}
+    assert {
+        row["delivery_batch_id"] for row in settled
+    } == {batch["batch_id"]}
+
+
+def test_quiet_window_and_oldest_max_wait_are_both_enforced(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    first = _enqueue(repo, suffix="old")
+    second = _enqueue(repo, suffix="new")
+    base = min(int(first["created_at_ms"]), int(second["created_at_ms"]))
+    with repo._connect() as conn:
+        conn.execute(
+            """
+            UPDATE trade_lifecycle_notification_outbox
+            SET created_at_ms = ?, updated_at_ms = ?
+            WHERE outbox_id = ?
+            """,
+            (base, base, first["outbox_id"]),
+        )
+        conn.execute(
+            """
+            UPDATE trade_lifecycle_notification_outbox
+            SET created_at_ms = ?, updated_at_ms = ?
+            WHERE outbox_id = ?
+            """,
+            (
+                base + MAX_BATCH_WAIT_MS - 5_000,
+                base + MAX_BATCH_WAIT_MS - 5_000,
+                second["outbox_id"],
+            ),
+        )
+
+    waiting = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=base + MAX_BATCH_WAIT_MS - 1,
+        apply_changes=False,
+    )
+    forced = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=base + MAX_BATCH_WAIT_MS,
+        apply_changes=False,
+    )
+
+    assert waiting["status"] == "waiting"
+    assert forced["status"] == "ready"
+    assert forced["reason"] == "max_wait_elapsed"
+    assert forced["candidate_count"] == 2
+
+
+def test_batch_binding_is_atomic_and_old_claim_predicate_fails_closed(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    rows = [_enqueue(repo, suffix=str(index)) for index in range(3)]
+    planned = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=_quiet_now(rows),
+    )
+
+    assert planned["status"] == "created"
+    members = repo.list_trade_lifecycle_notification_batch_members(
+        planned["batch"]["batch_id"]
+    )
+    assert len(members) == 3
+    assert {row["status"] for row in members} == {"batched"}
+    assert claim_next_notification(
+        repo,
+        now_ms=_quiet_now(rows),
+    ) is None
+
+
+def test_concurrent_planners_create_exactly_one_batch(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    rows = [_enqueue(repo, suffix=str(index)) for index in range(5)]
+    current = _quiet_now(rows)
+
+    def _plan() -> dict:
+        return plan_notification_batch(
+            repo,
+            route=_route(),
+            now_ms=current,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _value: _plan(), range(2)))
+
+    assert {result["status"] for result in results} == {
+        "created",
+        "active_batch",
+    }
+    batches = repo.list_trade_lifecycle_notification_batches()
+    assert len(batches) == 1
+    assert batches[0]["member_count"] == 5
+
+
+def test_explicit_failure_retries_same_batch_and_stops_at_three(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    row = _enqueue(repo, suffix="retry")
+    first_at = _quiet_now([row])
+    seen_batch_ids: list[str] = []
+
+    def _reject(payload: dict) -> dict:
+        seen_batch_ids.append(str(payload["batch_id"]))
+        return {
+            "status": "explicit_failed",
+            "explicit_pre_acceptance_failure": True,
+            "error": "provider rejected before acceptance",
+        }
+
+    first = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_reject,
+        now_ms=first_at,
+    )
+    first_batch = first["batch"]
+    assert first_batch["attempt_count"] == 1
+    assert first_batch["status"] == "explicit_failed"
+    assert repo.get_trade_lifecycle_notification(
+        row["outbox_id"]
+    )["status"] == "batched"
+
+    second_at = int(first_batch["next_attempt_at_ms"])
+    second = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_reject,
+        now_ms=second_at,
+    )
+    assert second["batch"]["attempt_count"] == 2
+    assert (
+        int(second["batch"]["next_attempt_at_ms"])
+        == second_at + BATCH_RETRY_BACKOFF_MS[1]
+    )
+
+    third_at = int(second["batch"]["next_attempt_at_ms"])
+    third = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_reject,
+        now_ms=third_at,
+    )
+    assert third["batch"]["attempt_count"] == 3
+    assert third["batch"]["next_attempt_at_ms"] is None
+    terminal_member = repo.get_trade_lifecycle_notification(
+        row["outbox_id"]
+    )
+    assert terminal_member["status"] == "explicit_failed"
+    assert terminal_member["attempt_count"] == 3
+
+    fourth = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_reject,
+        now_ms=third_at + TARGET_SEND_INTERVAL_MS,
+    )
+    assert fourth["status"] == "idle"
+    assert len(seen_batch_ids) == 3
+    assert len(set(seen_batch_ids)) == 1
+
+
+def test_route_budget_holds_new_intent_for_sixty_seconds(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    first_row = _enqueue(repo, suffix="first")
+    first_at = _quiet_now([first_row])
+    calls: list[str] = []
+
+    def _confirm(payload: dict) -> dict:
+        calls.append(str(payload["batch_id"]))
+        return {
+            "status": "confirmed",
+            "delivery_confirmed": True,
+            "message_id": f"message-{len(calls)}",
+        }
+
+    first = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_confirm,
+        now_ms=first_at,
+    )
+    assert first["status"] == "confirmed"
+    second_row = _enqueue(repo, suffix="second")
+    quiet_ready = max(
+        first_at + QUIET_WINDOW_MS,
+        int(second_row["created_at_ms"]) + QUIET_WINDOW_MS,
+    )
+    held_at = min(
+        quiet_ready,
+        first_at + TARGET_SEND_INTERVAL_MS - 1,
+    )
+    held = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_confirm,
+        now_ms=held_at,
+    )
+    assert held["status"] == "idle"
+    released_at = max(
+        first_at + TARGET_SEND_INTERVAL_MS,
+        int(second_row["created_at_ms"]) + QUIET_WINDOW_MS,
+    )
+    released = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=_confirm,
+        now_ms=released_at,
+    )
+    assert released["status"] == "confirmed"
+    assert len(calls) == 2
+
+
+def test_stale_claim_recovers_but_stale_send_freezes_whole_batch(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    rows = [_enqueue(repo, suffix=str(index)) for index in range(2)]
+    planned_at = _quiet_now(rows)
+    planned = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=planned_at,
+    )
+    batch_id = planned["batch"]["batch_id"]
+    first_claim = claim_next_notification_batch(
+        repo,
+        now_ms=planned_at,
+        claim_id="claim-1",
+    )
+    assert first_claim is not None
+    recovered_at = planned_at + CLAIM_LEASE_MS + 1
+    recovered = recover_stale_notification_batches(
+        repo,
+        now_ms=recovered_at,
+    )
+    assert recovered["reclaimed_claimed_count"] == 1
+    assert repo.get_trade_lifecycle_notification_batch(
+        batch_id
+    )["status"] == "pending"
+    assert {
+        row["status"]
+        for row in repo.list_trade_lifecycle_notification_batch_members(
+            batch_id
+        )
+    } == {"batched"}
+
+    second_claim = claim_next_notification_batch(
+        repo,
+        now_ms=recovered_at,
+        claim_id="claim-2",
+    )
+    assert second_claim is not None
+    mark_notification_batch_send_started(
+        repo,
+        batch_id=batch_id,
+        claim_id="claim-2",
+        now_ms=recovered_at,
+    )
+    frozen = recover_stale_notification_batches(
+        repo,
+        now_ms=recovered_at + CLAIM_LEASE_MS + 1,
+    )
+    assert frozen["frozen_unknown_count"] == 1
+    assert repo.get_trade_lifecycle_notification_batch(
+        batch_id
+    )["status"] == "unknown"
+    assert {
+        row["status"]
+        for row in repo.list_trade_lifecycle_notification_batch_members(
+            batch_id
+        )
+    } == {"unknown"}
+
+
+def test_stale_claims_do_not_consume_provider_attempt_budget(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    row = _enqueue(repo, suffix="claim-recovery")
+    current = _quiet_now([row])
+    batch_id = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=current,
+    )["batch"]["batch_id"]
+
+    for index in range(3):
+        claimed = claim_next_notification_batch(
+            repo,
+            now_ms=current,
+            claim_id=f"claim-{index}",
+        )
+        assert claimed is not None
+        assert claimed["attempt_count"] == 0
+        current += CLAIM_LEASE_MS + 1
+        recovered = recover_stale_notification_batches(
+            repo,
+            now_ms=current,
+        )
+        assert recovered["reclaimed_claimed_count"] == 1
+        assert repo.get_trade_lifecycle_notification_batch(
+            batch_id
+        )["attempt_count"] == 0
+
+    final_claim = claim_next_notification_batch(
+        repo,
+        now_ms=current,
+        claim_id="claim-final",
+    )
+    assert final_claim is not None
+    started = mark_notification_batch_send_started(
+        repo,
+        batch_id=batch_id,
+        claim_id="claim-final",
+        now_ms=current,
+    )
+    assert started["attempt_count"] == 1
+
+
+def test_unknown_batch_resend_creates_one_compensating_intent_per_member(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    rows = [_enqueue(repo, suffix=str(index)) for index in range(2)]
+    result = dispatch_notification_batch_once(
+        repo,
+        route=_route(),
+        send_fn=lambda _payload: {"status": "unknown"},
+        now_ms=_quiet_now(rows),
+    )
+    batch_id = result["batch"]["batch_id"]
+
+    resend = reconcile_notification_batch(
+        repo,
+        batch_id=batch_id,
+        action="resend",
+        broker_ref="provider-check-1",
+        note="provider acceptance could not be proven",
+        apply_changes=True,
+        now_ms=_quiet_now(rows) + 1,
+    )
+
+    assert resend["compensating_intent_count"] == 2
+    assert repo.get_trade_lifecycle_notification_batch(
+        batch_id
+    )["status"] == "unknown"
+    compensating = resend["compensating_intents"]
+    assert {row["status"] for row in compensating} == {"pending"}
+    assert {
+        row["delivery_batch_id"] for row in compensating
+    } == {None}
+    assert {
+        row["payload"]["compensates_batch_id"]
+        for row in compensating
+    } == {batch_id}
+
+
+def test_suppressed_and_confirmed_legacy_rows_are_not_reactivated(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    suppressed = build_notification_intent(
+        case_id="case-suppressed",
+        transition_type="needs_review",
+        resolution_revision=1,
+        transition_key="lifecycle:case-suppressed:needs_review",
+        state_fingerprint="state-suppressed",
+        payload={"account": "lx", "case_id": "case-suppressed"},
+        status="suppressed",
+    )
+    assert repo.insert_trade_lifecycle_notification_once(suppressed)
+    confirmed = _enqueue(repo, suffix="confirmed")
+    assert repo.compare_and_set_trade_lifecycle_notification(
+        outbox_id=confirmed["outbox_id"],
+        expected_status="pending",
+        new_status="confirmed",
+        fields={"confirmed_at_ms": int(confirmed["created_at_ms"])},
+    )
+
+    preview = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=max(
+            int(confirmed["created_at_ms"]),
+            int(
+                repo.get_trade_lifecycle_notification(
+                    suppressed["outbox_id"]
+                )["created_at_ms"]
+            ),
+        )
+        + MAX_BATCH_WAIT_MS,
+        apply_changes=False,
+    )
+
+    assert preview["status"] == "idle"
+    for outbox_id in (suppressed["outbox_id"], confirmed["outbox_id"]):
+        assert repo.get_trade_lifecycle_notification(
+            outbox_id
+        )["delivery_batch_id"] is None
+
+
+def test_terminal_completion_rolls_back_when_member_cardinality_changes(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    row = _enqueue(repo, suffix="cardinality")
+    current = _quiet_now([row])
+    batch = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=current,
+    )["batch"]
+    claimed = claim_next_notification_batch(
+        repo,
+        now_ms=current,
+        claim_id="claim-cardinality",
+    )
+    assert claimed is not None
+    mark_notification_batch_send_started(
+        repo,
+        batch_id=batch["batch_id"],
+        claim_id="claim-cardinality",
+        now_ms=current,
+    )
+    with repo._connect() as conn:
+        conn.execute(
+            """
+            UPDATE trade_lifecycle_notification_outbox
+            SET status = 'unknown'
+            WHERE outbox_id = ?
+            """,
+            (row["outbox_id"],),
+        )
+
+    try:
+        complete_notification_batch_attempt(
+            repo,
+            batch_id=batch["batch_id"],
+            claim_id="claim-cardinality",
+            outcome="confirmed",
+            now_ms=current + 1,
+        )
+    except ValueError as exc:
+        assert "member mismatch" in str(exc)
+    else:
+        raise AssertionError("expected atomic member mismatch failure")
+    assert repo.get_trade_lifecycle_notification_batch(
+        batch["batch_id"]
+    )["status"] == "send_started"
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    ("member_id", "payload_hash", "payload"),
+)
+def test_repository_rejects_frozen_member_mismatch(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    repo = _repo(tmp_path)
+    rows = [
+        _enqueue(repo, suffix="tamper-a"),
+        _enqueue(repo, suffix="tamper-b"),
+    ]
+    preview = plan_notification_batch(
+        repo,
+        route=_route(),
+        now_ms=_quiet_now(rows),
+        apply_changes=False,
+    )
+    batch = copy.deepcopy(preview["batch"])
+    member_ids = [row["outbox_id"] for row in rows]
+    if tamper == "member_id":
+        batch["payload"]["members"][0]["outbox_id"] = "outbox_wrong"
+    elif tamper == "payload_hash":
+        batch["payload"]["members"][0]["payload_hash"] = "wrong"
+    else:
+        batch["payload"]["members"][0]["payload"]["symbol"] = "WRONG"
+    batch["payload_hash"] = canonical_payload_hash(batch["payload"])
+
+    with pytest.raises(ValueError):
+        repo.insert_trade_lifecycle_notification_batch_once(
+            batch,
+            member_outbox_ids=member_ids,
+        )
+
+    assert repo.list_trade_lifecycle_notification_batches() == []
+    for row in rows:
+        stored = repo.get_trade_lifecycle_notification(row["outbox_id"])
+        assert stored["status"] == "pending"
+        assert stored["delivery_batch_id"] is None

--- a/tests/test_trades_lifecycle_batch_outbox.py
+++ b/tests/test_trades_lifecycle_batch_outbox.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import copy
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+import threading
+import time
 
 import pytest
 
@@ -29,6 +31,10 @@ from src.application.trades.lifecycle_outbox import (
     plan_notification_batch,
     reconcile_notification_batch,
     recover_stale_notification_batches,
+)
+from src.application.trades.lifecycle_batch_dispatcher import (
+    LifecycleReceiptBatchDispatcher,
+    resolve_lifecycle_receipt_dispatch_scope,
 )
 
 
@@ -121,6 +127,239 @@ def test_twenty_four_intents_use_one_batch_and_one_receipt(
     assert {
         row["delivery_batch_id"] for row in settled
     } == {batch["batch_id"]}
+
+
+def test_process_dispatcher_batches_lx_and_sy_into_one_provider_call(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    rows = [
+        _enqueue(
+            repo,
+            suffix=f"dispatcher-{index:02d}",
+            account="lx" if index < 15 else "sy",
+        )
+        for index in range(24)
+    ]
+    calls: list[dict] = []
+    dispatcher = LifecycleReceiptBatchDispatcher(
+        repo=repo,
+        route=_route(),
+        allowed_accounts={"lx", "sy"},
+        send_fn=lambda payload: calls.append(payload)
+        or {
+            "status": "confirmed",
+            "delivery_confirmed": True,
+            "message_id": "provider-dispatcher-1",
+        },
+        now_ms_fn=lambda: _quiet_now(rows),
+    )
+
+    result = dispatcher.run_once()
+
+    assert result["status"] == "confirmed"
+    assert len(calls) == 1
+    assert len(calls[0]["members"]) == 24
+    assert result["batch"]["member_count"] == 24
+    assert {
+        row["status"]
+        for row in repo.list_trade_lifecycle_notification_batch_members(
+            result["batch"]["batch_id"]
+        )
+    } == {"confirmed"}
+    snapshot = dispatcher.snapshot()
+    assert snapshot["provider_attempt_count"] == 1
+    assert "ou_test_target" not in str(snapshot)
+
+
+def test_process_dispatcher_preserves_route_budget_for_next_intent(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    first_row = _enqueue(repo, suffix="dispatcher-first")
+    first_at = _quiet_now([first_row])
+    current = [first_at]
+    calls: list[str] = []
+    dispatcher = LifecycleReceiptBatchDispatcher(
+        repo=repo,
+        route=_route(),
+        allowed_accounts={"lx"},
+        send_fn=lambda payload: calls.append(str(payload["batch_id"]))
+        or {
+            "status": "confirmed",
+            "delivery_confirmed": True,
+            "message_id": f"message-{len(calls)}",
+        },
+        now_ms_fn=lambda: current[0],
+    )
+
+    assert dispatcher.run_once()["status"] == "confirmed"
+    second_row = _enqueue(repo, suffix="dispatcher-second")
+    current[0] = max(
+        int(second_row["created_at_ms"]) + QUIET_WINDOW_MS,
+        first_at + QUIET_WINDOW_MS,
+    )
+    if current[0] >= first_at + TARGET_SEND_INTERVAL_MS:
+        current[0] = first_at + TARGET_SEND_INTERVAL_MS - 1
+    held = dispatcher.run_once()
+    assert held["status"] == "idle"
+    assert len(calls) == 1
+
+    current[0] = max(
+        first_at + TARGET_SEND_INTERVAL_MS,
+        int(second_row["created_at_ms"]) + QUIET_WINDOW_MS,
+    )
+    assert dispatcher.run_once()["status"] == "confirmed"
+    assert len(calls) == 2
+
+
+def test_dispatch_scope_uses_source_receipt_enable_precedence() -> None:
+    scope = resolve_lifecycle_receipt_dispatch_scope(
+        {
+            "receipt": {"enabled": False},
+            "sources": [
+                {
+                    "id": "lx",
+                    "account": "lx",
+                    "enabled": True,
+                    "receipt": {"enabled": False},
+                    "account_mapping": {"REAL_LX": "lx"},
+                },
+                {
+                    "id": "sy",
+                    "account": "sy",
+                    "enabled": True,
+                    "receipt": {"enabled": True},
+                    "account_mapping": {"REAL_SY": "sy"},
+                },
+                {
+                    "id": "disabled",
+                    "account": "zz",
+                    "enabled": False,
+                    "receipt": {"enabled": True},
+                    "account_mapping": {"REAL_ZZ": "zz"},
+                },
+            ],
+        }
+    )
+
+    assert scope["allowed_accounts"] == ["sy"]
+    assert scope["receipt_config"] == {"enabled": True}
+
+
+def test_dispatcher_close_cancels_cancellable_poll_wait(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    dispatcher = LifecycleReceiptBatchDispatcher(
+        repo=repo,
+        route=_route(),
+        allowed_accounts={"lx"},
+        send_fn=lambda _payload: (_ for _ in ()).throw(
+            AssertionError("idle dispatcher must not send")
+        ),
+        poll_interval_sec=1.0,
+    )
+
+    dispatcher.start()
+    deadline = time.monotonic() + 2
+    while (
+        dispatcher.snapshot()["poll_count"] < 1
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.01)
+    started_at = time.monotonic()
+    dispatcher.close()
+
+    assert time.monotonic() - started_at < 0.5
+    assert dispatcher.snapshot()["status"] == "stopped"
+    dispatcher.close()
+    assert dispatcher.snapshot()["status"] == "stopped"
+
+
+def test_repeated_dispatcher_error_is_visible_without_log_storm(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from src.application.trades import lifecycle_batch_dispatcher
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("sqlite unavailable")
+
+    logs: list[str] = []
+    monkeypatch.setattr(
+        lifecycle_batch_dispatcher,
+        "dispatch_notification_batch_once",
+        _raise,
+    )
+    dispatcher = LifecycleReceiptBatchDispatcher(
+        repo=_repo(tmp_path),
+        route=_route(),
+        allowed_accounts={"lx"},
+        send_fn=lambda _payload: {},
+        log_fn=logs.append,
+    )
+
+    assert dispatcher.run_once()["status"] == "error"
+    assert dispatcher.run_once()["status"] == "error"
+
+    snapshot = dispatcher.snapshot()
+    assert snapshot["poll_count"] == 2
+    assert snapshot["last_error"] == "RuntimeError: sqlite unavailable"
+    assert len(logs) == 1
+
+
+def test_blocking_provider_does_not_hold_ledger_or_process_lock(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    row = _enqueue(repo, suffix="blocking", account="lx")
+    current = _quiet_now([row])
+    provider_started = threading.Event()
+    provider_release = threading.Event()
+    process_lock = threading.RLock()
+
+    def _blocking_send(_payload: dict) -> dict:
+        provider_started.set()
+        assert provider_release.wait(2)
+        return {
+            "status": "confirmed",
+            "delivery_confirmed": True,
+            "message_id": "provider-blocking-1",
+        }
+
+    dispatcher = LifecycleReceiptBatchDispatcher(
+        repo=repo,
+        route=_route(),
+        allowed_accounts={"lx"},
+        send_fn=_blocking_send,
+        poll_interval_sec=0.01,
+        now_ms_fn=lambda: current,
+    )
+    dispatcher.start()
+    try:
+        assert provider_started.wait(2)
+
+        def _independent_ledger_write() -> dict:
+            with process_lock:
+                return _enqueue(
+                    repo,
+                    suffix="while-provider-blocked",
+                    account="lx",
+                )
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            written = executor.submit(_independent_ledger_write).result(
+                timeout=0.5
+            )
+        assert written["status"] == "pending"
+    finally:
+        provider_release.set()
+        dispatcher.close()
+
+    batches = repo.list_trade_lifecycle_notification_batches()
+    assert len(batches) == 1
+    assert batches[0]["status"] == "confirmed"
 
 
 def test_quiet_window_and_oldest_max_wait_are_both_enforced(

--- a/tests/test_trades_receipt.py
+++ b/tests/test_trades_receipt.py
@@ -3,13 +3,320 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from tests.notification_format_assertions import assert_mobile_flat_markdown
 
+from src.application.trades.lifecycle_outbox import (
+    BATCH_RENDERER_VERSION,
+    build_notification_batch_route,
+)
 from src.application.trades.receipt import (
+    build_trade_lifecycle_notification_batch_message,
+    build_trade_lifecycle_notification_message,
     build_trade_intake_receipt_message,
+    classify_trade_lifecycle_delivery_result,
     decide_trade_intake_receipt,
+    send_trade_lifecycle_outbox_payload,
     send_trade_intake_receipt,
 )
+from src.application.channels.wechat_clawbot.notification import (
+    normalize_wechat_clawbot_send_output,
+)
+
+
+def _lifecycle_batch_member(
+    index: int,
+    *,
+    case_id: str | None = None,
+    resolution_revision: int = 1,
+    transition_type: str = "needs_review",
+    account: str = "lx",
+    symbol: str | None = None,
+) -> dict:
+    resolved_case_id = case_id or f"case-{index:02d}"
+    payload = {
+        "account": account,
+        "case_id": resolved_case_id,
+        "transition_type": transition_type,
+        "symbol": symbol or f"SYM{index:02d}",
+        "expiration_ymd": "2026-08-21",
+        "strike": 100 + index,
+        "option_type": "put",
+    }
+    return {
+        "outbox_id": f"outbox-{index:02d}",
+        "case_id": resolved_case_id,
+        "transition_type": transition_type,
+        "resolution_revision": resolution_revision,
+        "delivery_revision": 0,
+        "transition_key": (
+            f"lifecycle:{resolved_case_id}:{transition_type}"
+        ),
+        "state_fingerprint": f"state-{index:02d}",
+        "payload_hash": f"payload-{index:02d}",
+        "created_at_ms": 1_000 + index,
+        "payload": payload,
+    }
+
+
+def _lifecycle_batch_payload(
+    members: list[dict],
+    *,
+    target: str = "wechat:ops",
+) -> dict:
+    route = build_notification_batch_route(
+        provider="wechat_clawbot",
+        channel="wechat_clawbot",
+        target=target,
+    )
+    return {
+        "schema_version": BATCH_RENDERER_VERSION,
+        "batch_id": "tlb_0123456789abcdef0123456789abcdef",
+        "route": {
+            key: route[key]
+            for key in (
+                "provider",
+                "channel",
+                "target_fingerprint",
+                "route_fingerprint",
+            )
+        },
+        "members": members,
+    }
+
+
+def test_lifecycle_batch_single_member_preserves_existing_message() -> None:
+    member = _lifecycle_batch_member(1)
+
+    assert build_trade_lifecycle_notification_batch_message(
+        _lifecycle_batch_payload([member])
+    ) == build_trade_lifecycle_notification_message(member["payload"])
+
+
+def test_lifecycle_batch_digest_is_deterministic_and_top_twelve_only() -> None:
+    members = [
+        _lifecycle_batch_member(
+            index,
+            account="lx" if index < 15 else "sy",
+        )
+        for index in range(24)
+    ]
+
+    forward = build_trade_lifecycle_notification_batch_message(
+        _lifecycle_batch_payload(members)
+    )
+    reverse = build_trade_lifecycle_notification_batch_message(
+        _lifecycle_batch_payload(list(reversed(members)))
+    )
+
+    assert forward == reverse
+    assert "范围｜24 条意图 · 24 个案件" in forward
+    assert "另有 12 个案件未展开" in forward
+    assert forward.count("`case-") == 12
+    assert "wechat:ops" not in forward
+
+
+def test_lifecycle_batch_digest_collapses_case_to_latest_revision() -> None:
+    older = _lifecycle_batch_member(
+        1,
+        case_id="case-shared",
+        resolution_revision=1,
+        symbol="OLD",
+    )
+    newer = _lifecycle_batch_member(
+        2,
+        case_id="case-shared",
+        resolution_revision=2,
+        transition_type="conflict",
+        symbol="NEW",
+    )
+    another = _lifecycle_batch_member(3, symbol="OTHER")
+
+    message = build_trade_lifecycle_notification_batch_message(
+        _lifecycle_batch_payload([older, another, newer])
+    )
+
+    assert "范围｜3 条意图 · 2 个案件" in message
+    assert "NEW" in message
+    assert "OLD" not in message
+    assert message.index("NEW") < message.index("OTHER")
+
+
+def test_lifecycle_batch_single_representative_preserves_message() -> None:
+    older = _lifecycle_batch_member(
+        1,
+        case_id="case-shared",
+        resolution_revision=1,
+        symbol="OLD",
+    )
+    newer = _lifecycle_batch_member(
+        2,
+        case_id="case-shared",
+        resolution_revision=2,
+        transition_type="conflict",
+        symbol="NEW",
+    )
+
+    assert build_trade_lifecycle_notification_batch_message(
+        _lifecycle_batch_payload([older, newer])
+    ) == build_trade_lifecycle_notification_message(newer["payload"])
+
+
+def test_lifecycle_batch_route_mismatch_fails_before_send(
+    tmp_path: Path,
+) -> None:
+    calls: list[dict] = []
+    payload = _lifecycle_batch_payload(
+        [_lifecycle_batch_member(1)],
+        target="wechat:old",
+    )
+
+    result = send_trade_lifecycle_outbox_payload(
+        base=tmp_path,
+        config={
+            "notifications": {
+                "provider": "wechat_clawbot",
+                "target": "wechat:new",
+            }
+        },
+        receipt_config={},
+        payload=payload,
+        send_fn=lambda **kwargs: calls.append(dict(kwargs)),
+        normalize_fn=lambda send_result: send_result,
+    )
+
+    assert result["status"] == "explicit_failed"
+    assert result["explicit_pre_acceptance_failure"] is True
+    assert result["classification_evidence"]["preflight"] == (
+        "route_fingerprint_mismatch"
+    )
+    assert calls == []
+    assert "wechat:old" not in str(result)
+    assert "wechat:new" not in str(result)
+
+
+def test_lifecycle_batch_sender_reuses_batch_idempotency_key(
+    tmp_path: Path,
+) -> None:
+    calls: list[dict] = []
+    payload = _lifecycle_batch_payload(
+        [_lifecycle_batch_member(1), _lifecycle_batch_member(2)]
+    )
+
+    def _send(**kwargs):
+        calls.append(dict(kwargs))
+        return {
+            "command_ok": True,
+            "delivery_confirmed": True,
+            "message_id": f"message-{len(calls)}",
+            "idempotency_key": kwargs["idempotency_key"],
+        }
+
+    for _attempt in range(2):
+        result = send_trade_lifecycle_outbox_payload(
+            base=tmp_path,
+            config={
+                "notifications": {
+                    "provider": "wechat_clawbot",
+                    "target": "wechat:ops",
+                }
+            },
+            receipt_config={},
+            payload=payload,
+            send_fn=_send,
+            normalize_fn=lambda send_result: send_result,
+        )
+        assert result["status"] == "confirmed"
+
+    assert [call["idempotency_key"] for call in calls] == [
+        payload["batch_id"],
+        payload["batch_id"],
+    ]
+    assert all("期权平仓批次" in call["message"] for call in calls)
+
+
+@pytest.mark.parametrize(
+    ("normalized", "expected"),
+    (
+        (
+            {
+                "command_ok": False,
+                "delivery_confirmed": False,
+                "http_status": 400,
+                "provider_response_code": 230001,
+            },
+            "explicit_failed",
+        ),
+        (
+            {
+                "command_ok": True,
+                "delivery_confirmed": False,
+                "http_status": 200,
+                "provider_response_code": 230001,
+            },
+            "explicit_failed",
+        ),
+        (
+            {
+                "command_ok": False,
+                "delivery_confirmed": False,
+                "http_status": 500,
+                "provider_response_code": 999,
+            },
+            "unknown",
+        ),
+        (
+            {
+                "command_ok": False,
+                "delivery_confirmed": False,
+                "http_status": 400,
+                "ambiguous_send": True,
+            },
+            "unknown",
+        ),
+        (
+            {
+                "command_ok": True,
+                "delivery_confirmed": False,
+                "fallback_used": True,
+            },
+            "unknown",
+        ),
+        (
+            {
+                "command_ok": True,
+                "delivery_confirmed": False,
+            },
+            "accepted",
+        ),
+    ),
+)
+def test_lifecycle_delivery_classifier_is_fail_closed(
+    normalized: dict,
+    expected: str,
+) -> None:
+    assert classify_trade_lifecycle_delivery_result(normalized)[
+        "outcome"
+    ] == expected
+
+
+def test_lifecycle_classifier_retries_real_wechat_business_rejection() -> None:
+    normalized = normalize_wechat_clawbot_send_output(
+        send_result={
+            "ok": False,
+            "http_status": 200,
+            "response_json": {"code": 230001, "message": "rejected"},
+            "response_tail": '{"code":230001}',
+        }
+    )
+
+    assert normalized["command_ok"] is True
+    assert normalized["delivery_confirmed"] is False
+    assert normalized["provider_response_code"] == 230001
+    assert classify_trade_lifecycle_delivery_result(normalized)[
+        "outcome"
+    ] == "explicit_failed"
 
 
 def test_receipt_decision_defaults_send_applied() -> None:


### PR DESCRIPTION
## Summary

- preserve one immutable lifecycle notification intent per case transition while moving provider delivery to durable same-route batches
- add atomic batch membership/state transitions, deterministic digest rendering, stable transport idempotency, batch-aware CLI recovery, and delivery diagnostics
- replace per-source row delivery with one process-level dispatcher; remove the legacy per-row dispatcher
- document the complete receipt risk inventory and operator contract

## Storm acceptance evidence

- historical fixture: lx=15 + sy=9, same route
- result: exactly 1 fake sender call, 1 batch with 24 members, all 24 members atomically confirmed
- display limit: 12 representatives only; membership is never split
- next same-route batch is held until the 60-second send-start budget expires

## Validation

- focused work-unit suite: 169 passed
- related lifecycle/maintenance/multi-tick suite: 122 passed
- full suite: all 3953 non-skipped tests passed; 10 skipped
- Ruff: pass
- dependency graph: 577 production modules, 0 cycles, boundary guard pass
- git diff --check: pass
- aggregate DeepReview: pass, no findings

The full sandbox run's loopback HTTP test was blocked only by socket permissions; the same read-only test passed when rerun with local loopback permission.

## Safety boundaries

- tests use fake senders and temporary SQLite ledgers
- no real notification, production config/data write, service mutation, release, deployment, or remote upgrade
- this PR must remain Draft; merge, release, and production rollout are separate approvals

## Residual risk

- production rollout is blocked until topology proves exactly one active listener process
- in-flight provider calls rely on existing adapter timeouts; ambiguous send-started work freezes as unknown
- auto-close remains one aggregate receipt per account/run and is not a per-row storm path

## Gateflow artifacts

- plan: `docs/gateflow/lifecycle-receipt-batching/plan.md`
- receipt risk inventory: `docs/gateflow/lifecycle-receipt-batching/receipt-risk-inventory.md`
- aggregate validation: `docs/gateflow/lifecycle-receipt-batching/aggregate-validation.md`
- aggregate review: `docs/reviews/code-review-20260802-063319.md`