### PR TITLE
Restore trade intake receipt routing

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 907 (`src`: 493, `domain`: 76, `scripts`: 8, `tests`: 330)
-- Internal import edges: 5565 total, 2463 production/script edges excluding tests
+- Python files scanned: 908 (`src`: 493, `domain`: 76, `scripts`: 8, `tests`: 331)
+- Internal import edges: 5568 total, 2464 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -45,7 +45,7 @@ flowchart LR
   scripts -->|12| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2219| application
+  tests -->|2221| application
   tests -->|481| domain
   tests -->|2| domain_services
   tests -->|133| infrastructure
@@ -77,7 +77,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2219 |
+| tests | application | 2221 |
 | tests | domain | 481 |
 | tests | interfaces | 209 |
 | tests | infrastructure | 133 |

--- a/docs/FUTU_TRADE_HOLDINGS_SYNC.md
+++ b/docs/FUTU_TRADE_HOLDINGS_SYNC.md
@@ -124,6 +124,21 @@ payload hash。任一来源不完整、日历 hash 变化、零价锚点无法�
 
 ## 通知 Outbox 与批量回执
 
+普通开仓成交保留逐 broker deal 的 intake 回执；已处理的 deal 在
+history backfill 中会于 pipeline 之前跳过，不会因回执未确认而重放交易。
+provider 命令已成功但缺少 delivery confirmation 时记为
+`unconfirmed`，后续 duplicate 不自动重发；
+`retry_unconfirmed_duplicate` 只对没有 provider acceptance 或歧义发送证据的
+缺失/`failed` 回执生效。
+
+已形成 lifecycle 状态变更的平仓及其他 lifecycle 通知不走普通
+intake 直发；写入前的普通 intake `unresolved`/`failed` 仍是成交操作回执。只有
+ledger 结果携带 `notification_outbox_id`，且同一 SQLite 仓库能立即读回
+该 outbox row 时，intake 才记录 `receipt.status=outbox_managed`，并保存
+`outbox_id` 与 `outbox_readback_confirmed=true`。声称了 ID 但读回失败，
+或已完成的 lifecycle 结果没有 outbox ID，都会 fail closed，不会
+回退成一次可能重复的直发。
+
 业务事务仍然一条状态变化写一条冻结通知意图，用于案件级审计；它不在 ledger
 事务内调用飞书。外部发送单位改为 delivery batch：同一
 provider/channel/target 的 `lx`、`sy` 等账户意图可进入同一批次，一条意图不会

--- a/docs/gateflow/lifecycle-receipt-batching/receipt-risk-inventory.md
+++ b/docs/gateflow/lifecycle-receipt-batching/receipt-risk-inventory.md
@@ -5,6 +5,11 @@
 - Evidence scope: current `src/application`, `src/interfaces`, `scripts`, tests and accepted Gateflow implementation
 - Safety: 本清单为代码与测试审计；未发送真实通知，未读取或写入生产 ledger
 
+> 2026-08-03 后续状态：本快照中“ordinary trade-intake sender 无调用者”
+> 的结论已被有边界的修复取代。普通开仓恢复 intake 回执；lifecycle
+> 通知仍由 durable outbox 拥有，且 `outbox_managed` 需要 ID 读回证据。
+> 当前契约见 `docs/FUTU_TRADE_HOLDINGS_SYNC.md`。
+
 ## 结论
 
 本次发现的高风险活动路径只有 lifecycle 数据核对回执：原实现按 source/account 每五秒逐行领取，一次核对产生 24 行时可以形成 24 次外部发送。该路径已改为同路由持久化批次，并删除可直接逐行发送的 legacy dispatcher。

--- a/src/application/trades/auto_intake.py
+++ b/src/application/trades/auto_intake.py
@@ -57,6 +57,7 @@ from src.application.trades.lifecycle_runtime import (
 from src.application.trades.receipt import (
     resolve_trade_lifecycle_notification_batch_route,
     send_trade_lifecycle_outbox_payload,
+    send_trade_intake_receipt,
 )
 from src.application.trades.inbox import (
     enqueue_trade_payload,
@@ -471,12 +472,6 @@ def main(argv: list[str] | None = None) -> int:
             "and may send receipts; use --confirm or --yes"
         )
         return 2
-    receipt_callback = _build_receipt_callback(
-        base=base,
-        cfg=cfg,
-        receipt_config=intake_cfg["receipt"],
-    )
-
     if args.deal_json:
         holdings_sync_dispatcher = _build_stock_holdings_sync_dispatcher(
             intake_cfg=intake_cfg,
@@ -509,6 +504,12 @@ def main(argv: list[str] | None = None) -> int:
                     _data_config, repo = open_position_ledger_from_runtime_config(base=runtime_root, cfg=cfg, data_config=args.data_config)
                 else:
                     repo = _ReplayRepo()
+                receipt_callback = _build_receipt_callback(
+                    base=base,
+                    cfg=cfg,
+                    receipt_config=intake_cfg["receipt"],
+                    repo=repo,
+                )
                 result = _process_payload(
                     payload,
                     repo=repo,
@@ -572,6 +573,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     _data_config, repo = open_position_ledger_from_runtime_config(base=runtime_root, cfg=cfg, data_config=args.data_config)
+    receipt_callback = _build_receipt_callback(
+        base=base,
+        cfg=cfg,
+        receipt_config=intake_cfg["receipt"],
+        repo=repo,
+    )
 
     if not bool(intake_cfg["enabled"]):
         for source in sources:
@@ -670,17 +677,196 @@ def _build_receipt_callback(
     base: Path,
     cfg: dict[str, Any],
     receipt_config: dict[str, Any],
+    repo: Any,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     def _callback(context: dict[str, Any]) -> dict[str, Any]:
-        return {
-            "enabled": bool(receipt_config.get("enabled", True)),
-            "status": "outbox_managed",
-            "reason": "transactional_outbox",
-            "delivery_confirmed": False,
-            "message_id": None,
-        }
+        result = dict(context.get("result") or {})
+        claimed_outbox_ids = _claimed_lifecycle_notification_outbox_ids(
+            result
+        )
+        if claimed_outbox_ids:
+            return _lifecycle_outbox_receipt_result(
+                repo=repo,
+                receipt_config=receipt_config,
+                outbox_ids=claimed_outbox_ids,
+            )
+
+        if _lifecycle_notification_is_outbox_owned(context):
+            status = str(result.get("status") or "").strip().lower()
+            reason = str(result.get("reason") or "").strip().lower()
+            missing_outbox_is_error = (
+                status == "applied"
+                or (status == "skipped" and reason != "duplicate_deal_id")
+            )
+            return {
+                "enabled": bool(receipt_config.get("enabled", True)),
+                "status": (
+                    "failed"
+                    if missing_outbox_is_error
+                    else "skipped"
+                ),
+                "reason": (
+                    "lifecycle_outbox_missing"
+                    if missing_outbox_is_error
+                    else (
+                        "skipped_duplicate_lifecycle_outbox_owned"
+                        if status == "skipped"
+                        and reason == "duplicate_deal_id"
+                        else "lifecycle_outbox_not_created"
+                    )
+                ),
+                "delivery_confirmed": False,
+                "message_id": None,
+                "error_code": (
+                    "LIFECYCLE_OUTBOX_MISSING"
+                    if missing_outbox_is_error
+                    else None
+                ),
+            }
+
+        return send_trade_intake_receipt(
+            base=base,
+            config=cfg,
+            receipt_config=receipt_config,
+            apply_changes=bool(context.get("apply_changes")),
+            state=(
+                context.get("state")
+                if isinstance(context.get("state"), dict)
+                else {}
+            ),
+            deal=context.get("deal"),
+            result=result,
+            payload=(
+                context.get("effective_payload")
+                if isinstance(context.get("effective_payload"), dict)
+                else {}
+            ),
+        )
 
     return _callback
+
+
+def _claimed_lifecycle_notification_outbox_ids(
+    result: dict[str, Any],
+) -> list[str]:
+    outbox_ids: list[str] = []
+
+    def _append(value: object) -> None:
+        if not isinstance(value, dict):
+            return
+        outbox_id = str(value.get("notification_outbox_id") or "").strip()
+        if outbox_id and outbox_id not in outbox_ids:
+            outbox_ids.append(outbox_id)
+
+    operations = result.get("operations")
+    if isinstance(operations, list):
+        for operation in operations:
+            if isinstance(operation, dict):
+                _append(operation.get("result"))
+
+    diagnostics = result.get("diagnostics")
+    if isinstance(diagnostics, dict):
+        lifecycle_v2 = diagnostics.get("lifecycle_v2")
+        if isinstance(lifecycle_v2, dict):
+            _append(lifecycle_v2.get("ledger_result"))
+    return outbox_ids
+
+
+def _lifecycle_notification_is_outbox_owned(
+    context: dict[str, Any],
+) -> bool:
+    result = (
+        context.get("result")
+        if isinstance(context.get("result"), dict)
+        else {}
+    )
+    diagnostics = result.get("diagnostics")
+    if (
+        isinstance(diagnostics, dict)
+        and str(diagnostics.get("notification_authority") or "").strip()
+        == "lifecycle_outbox"
+    ):
+        return True
+    deal = context.get("deal")
+    position_effect = str(
+        getattr(deal, "position_effect", "") or ""
+    ).strip().lower()
+    status = str(result.get("status") or "").strip().lower()
+    return position_effect == "close" and status in {"applied", "skipped"}
+
+
+def _lifecycle_outbox_receipt_result(
+    *,
+    repo: Any,
+    receipt_config: dict[str, Any],
+    outbox_ids: list[str],
+) -> dict[str, Any]:
+    getter = getattr(repo, "get_trade_lifecycle_notification", None)
+    if not callable(getter):
+        return {
+            "enabled": bool(receipt_config.get("enabled", True)),
+            "status": "failed",
+            "reason": "lifecycle_outbox_readback_unavailable",
+            "delivery_confirmed": False,
+            "message_id": None,
+            "error_code": "LIFECYCLE_OUTBOX_READBACK_UNAVAILABLE",
+            "claimed_outbox_ids": list(outbox_ids),
+        }
+
+    rows: list[dict[str, Any]] = []
+    missing_ids: list[str] = []
+    try:
+        for outbox_id in outbox_ids:
+            row = getter(outbox_id)
+            if (
+                isinstance(row, dict)
+                and str(row.get("outbox_id") or "").strip() == outbox_id
+            ):
+                rows.append(dict(row))
+            else:
+                missing_ids.append(outbox_id)
+    except Exception as exc:
+        return {
+            "enabled": bool(receipt_config.get("enabled", True)),
+            "status": "failed",
+            "reason": "lifecycle_outbox_readback_failed",
+            "delivery_confirmed": False,
+            "message_id": None,
+            "error_code": "LIFECYCLE_OUTBOX_READBACK_FAILED",
+            "claimed_outbox_ids": list(outbox_ids),
+            "send_message": f"{type(exc).__name__}: {exc}",
+        }
+    if missing_ids:
+        return {
+            "enabled": bool(receipt_config.get("enabled", True)),
+            "status": "failed",
+            "reason": "lifecycle_outbox_readback_missing",
+            "delivery_confirmed": False,
+            "message_id": None,
+            "error_code": "LIFECYCLE_OUTBOX_READBACK_MISSING",
+            "claimed_outbox_ids": list(outbox_ids),
+            "missing_outbox_ids": missing_ids,
+        }
+
+    delivery_confirmed = all(
+        str(row.get("status") or "").strip().lower() == "confirmed"
+        for row in rows
+    )
+    message_id = (
+        str(rows[0].get("provider_message_id") or "").strip() or None
+        if len(rows) == 1
+        else None
+    )
+    return {
+        "enabled": bool(receipt_config.get("enabled", True)),
+        "status": "outbox_managed",
+        "reason": "transactional_outbox",
+        "delivery_confirmed": delivery_confirmed,
+        "message_id": message_id,
+        "outbox_id": outbox_ids[0],
+        "outbox_ids": list(outbox_ids),
+        "outbox_readback_confirmed": True,
+    }
 
 
 def _build_lifecycle_receipt_batch_dispatcher(
@@ -2093,13 +2279,20 @@ def _result_summary(result: dict[str, Any] | None) -> dict[str, Any]:
 def _receipt_summary(receipt: object) -> dict[str, Any] | None:
     if not isinstance(receipt, dict):
         return None
-    return {
+    summary = {
         "status": receipt.get("status"),
         "reason": receipt.get("reason"),
         "delivery_confirmed": bool(receipt.get("delivery_confirmed")),
         "message_id": receipt.get("message_id"),
         "error_code": receipt.get("error_code"),
     }
+    outbox_id = str(receipt.get("outbox_id") or "").strip()
+    if outbox_id:
+        summary["outbox_id"] = outbox_id
+        summary["outbox_readback_confirmed"] = bool(
+            receipt.get("outbox_readback_confirmed")
+        )
+    return summary
 
 
 def _format_result_summary(result: dict[str, Any]) -> str:

--- a/src/application/trades/receipt.py
+++ b/src/application/trades/receipt.py
@@ -13,6 +13,7 @@ from src.application.notification_delivery_adapter import (
     select_notification_delivery_adapter,
 )
 from src.application.notification_shells import render_receipt
+from src.application.trades.deal_identity import broker_deal_key
 from src.application.trades.lifecycle_outbox import (
     BATCH_RENDERER_VERSION,
     build_notification_batch_route,
@@ -42,7 +43,10 @@ def send_trade_intake_receipt(
         receipt_config=cfg,
         apply_changes=apply_changes,
         state=state,
-        deal_id=_deal_id(deal, result, payload),
+        deal_id=(
+            str(broker_deal_key(deal) or "").strip()
+            or _deal_id(deal, result, payload)
+        ),
         result=result,
     )
     if not decision["should_send"]:
@@ -645,6 +649,11 @@ def decide_trade_intake_receipt(
             return {"should_send": False, "reason": "unresolved_disabled"}
         if _receipt_delivered(state, deal_id):
             return {"should_send": False, "reason": "skipped_unresolved_already_notified"}
+        if _receipt_delivery_is_ambiguous(state, deal_id):
+            return {
+                "should_send": False,
+                "reason": "skipped_unresolved_delivery_unknown",
+            }
         if _receipt_needs_retry(state, deal_id):
             return {"should_send": True, "reason": "unresolved_retry_unconfirmed_receipt"}
         return {"should_send": True, "reason": "unresolved"}
@@ -653,6 +662,11 @@ def decide_trade_intake_receipt(
             return {"should_send": False, "reason": "failed_disabled"}
         if _receipt_delivered(state, deal_id):
             return {"should_send": False, "reason": "skipped_failed_already_notified"}
+        if _receipt_delivery_is_ambiguous(state, deal_id):
+            return {
+                "should_send": False,
+                "reason": "skipped_failed_delivery_unknown",
+            }
         if _receipt_needs_retry(state, deal_id):
             return {"should_send": True, "reason": "failed_retry_unconfirmed_receipt"}
         return {"should_send": True, "reason": "failed"}
@@ -661,6 +675,11 @@ def decide_trade_intake_receipt(
     if status == "skipped" and reason == "duplicate_deal_id":
         if bool(cfg.get("notify_duplicate", False)):
             return {"should_send": True, "reason": "duplicate"}
+        if _receipt_delivery_is_ambiguous(state, deal_id):
+            return {
+                "should_send": False,
+                "reason": "skipped_duplicate_delivery_unknown",
+            }
         if bool(cfg.get("retry_unconfirmed_duplicate", True)) and _receipt_needs_retry(state, deal_id):
             return {"should_send": True, "reason": "duplicate_retry_unconfirmed_receipt"}
         return {"should_send": False, "reason": "skipped_duplicate"}
@@ -764,9 +783,43 @@ def _combo_yield_relation_pending(diagnostics: dict[str, Any]) -> bool:
 
 
 def _receipt_needs_retry(state: dict[str, Any] | None, deal_id: str | None) -> bool:
+    receipt = _stored_receipt(state, deal_id)
+    if receipt is None:
+        return False
+    if not receipt:
+        return True
+    if bool(receipt.get("delivery_confirmed")):
+        return False
+    status = str(receipt.get("status") or "").strip().lower()
+    if status in {"unconfirmed", "outbox_managed"}:
+        return False
+    if bool(receipt.get("ambiguous_send")):
+        return False
+    return status == "failed"
+
+
+def _receipt_delivery_is_ambiguous(
+    state: dict[str, Any] | None,
+    deal_id: str | None,
+) -> bool:
+    receipt = _stored_receipt(state, deal_id)
+    if not receipt or bool(receipt.get("delivery_confirmed")):
+        return False
+    status = str(receipt.get("status") or "").strip().lower()
+    return (
+        status in {"unconfirmed", "outbox_managed"}
+        or bool(receipt.get("command_ok"))
+        or bool(receipt.get("ambiguous_send"))
+    )
+
+
+def _stored_receipt(
+    state: dict[str, Any] | None,
+    deal_id: str | None,
+) -> dict[str, Any] | None:
     key = str(deal_id or "").strip()
     if not key or not isinstance(state, dict):
-        return False
+        return None
     for bucket_name in ("processed_deal_ids", "failed_deal_ids", "unresolved_deal_ids"):
         bucket = state.get(bucket_name)
         if not isinstance(bucket, dict):
@@ -776,25 +829,14 @@ def _receipt_needs_retry(state: dict[str, Any] | None, deal_id: str | None) -> b
             continue
         receipt = item.get("receipt")
         if not isinstance(receipt, dict):
-            return True
-        return not bool(receipt.get("delivery_confirmed"))
-    return False
+            return {}
+        return dict(receipt)
+    return None
 
 
 def _receipt_delivered(state: dict[str, Any] | None, deal_id: str | None) -> bool:
-    key = str(deal_id or "").strip()
-    if not key or not isinstance(state, dict):
-        return False
-    for bucket_name in ("processed_deal_ids", "failed_deal_ids", "unresolved_deal_ids"):
-        bucket = state.get(bucket_name)
-        if not isinstance(bucket, dict):
-            continue
-        item = bucket.get(key)
-        if not isinstance(item, dict):
-            continue
-        receipt = item.get("receipt")
-        return isinstance(receipt, dict) and bool(receipt.get("delivery_confirmed"))
-    return False
+    receipt = _stored_receipt(state, deal_id)
+    return bool(receipt and receipt.get("delivery_confirmed"))
 
 
 def _deal_id(deal: Any, result: dict[str, Any], payload: dict[str, Any] | None) -> str | None:

--- a/src/application/trades/resolver.py
+++ b/src/application/trades/resolver.py
@@ -106,7 +106,10 @@ def _from_lifecycle_resolution(deal: NormalizedTradeDeal, result: LifecycleTrade
         deal_id=deal.deal_id,
         account=deal.internal_account,
         operations=list(result.operations),
-        diagnostics=dict(result.diagnostics),
+        diagnostics={
+            **dict(result.diagnostics),
+            "notification_authority": "lifecycle_outbox",
+        },
     )
 
 

--- a/tests/test_trades_auto_intake_backfill.py
+++ b/tests/test_trades_auto_intake_backfill.py
@@ -100,12 +100,24 @@ def test_run_history_backfill_processes_missing_deal_through_pipeline(tmp_path: 
     ]
 
 
-def test_run_history_backfill_skips_state_duplicate_before_pipeline(tmp_path: Path) -> None:
+def test_run_history_backfill_skips_processed_outbox_managed_duplicate_before_pipeline(
+    tmp_path: Path,
+) -> None:
     state_path = tmp_path / "state.json"
     write_trade_intake_state(
         state_path,
         {
-            "processed_deal_ids": {"deal-1": {"status": "applied", "reason": "applied_open"}},
+            "processed_deal_ids": {
+                "deal-1": {
+                    "status": "applied",
+                    "reason": "applied_open",
+                    "receipt": {
+                        "status": "outbox_managed",
+                        "reason": "transactional_outbox",
+                        "delivery_confirmed": False,
+                    },
+                }
+            },
             "failed_deal_ids": {},
             "unresolved_deal_ids": {},
         },
@@ -119,6 +131,9 @@ def test_run_history_backfill_skips_state_duplicate_before_pipeline(tmp_path: Pa
 
     kwargs = _backfill_kwargs(tmp_path)
     kwargs["state_path"] = state_path
+    kwargs["on_result_fn"] = lambda _context: (_ for _ in ()).throw(
+        AssertionError("duplicate backfill must not invoke receipt callback")
+    )
     out = run_history_backfill(
         **kwargs,
         history_deals_fn=_history_deals_fn,

--- a/tests/test_trades_auto_intake_receipt_routing.py
+++ b/tests/test_trades_auto_intake_receipt_routing.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from src.application.trades import auto_intake
+
+
+class _OutboxRepo:
+    def __init__(self, rows: dict[str, dict[str, Any]] | None = None) -> None:
+        self.rows = dict(rows or {})
+        self.reads: list[str] = []
+
+    def get_trade_lifecycle_notification(
+        self,
+        outbox_id: str,
+    ) -> dict[str, Any] | None:
+        self.reads.append(outbox_id)
+        row = self.rows.get(outbox_id)
+        return dict(row) if isinstance(row, dict) else None
+
+
+def _context(
+    *,
+    result: dict[str, Any],
+    position_effect: str,
+) -> dict[str, Any]:
+    return {
+        "apply_changes": True,
+        "state": {},
+        "deal": SimpleNamespace(
+            deal_id="deal-1",
+            position_effect=position_effect,
+        ),
+        "result": result,
+        "effective_payload": {"deal_id": "deal-1"},
+    }
+
+
+def test_open_receipt_uses_direct_intake_sender_once(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _send_trade_intake_receipt(**kwargs: Any) -> dict[str, Any]:
+        calls.append(dict(kwargs))
+        return {
+            "status": "sent",
+            "delivery_confirmed": True,
+            "message_id": "msg-1",
+        }
+
+    monkeypatch.setattr(
+        auto_intake,
+        "send_trade_intake_receipt",
+        _send_trade_intake_receipt,
+    )
+    callback = auto_intake._build_receipt_callback(
+        base=tmp_path,
+        cfg={"notifications": {"target": "wechat:ops"}},
+        receipt_config={"enabled": True},
+        repo=_OutboxRepo(),
+    )
+
+    out = callback(
+        _context(
+            result={
+                "status": "applied",
+                "action": "open",
+                "reason": "applied_open",
+                "deal_id": "deal-1",
+                "operations": [
+                    {
+                        "action": "open",
+                        "result": {"event_id": "event-1", "created": True},
+                    }
+                ],
+            },
+            position_effect="open",
+        )
+    )
+
+    assert out["status"] == "sent"
+    assert len(calls) == 1
+    assert calls[0]["result"]["action"] == "open"
+    assert calls[0]["payload"] == {"deal_id": "deal-1"}
+
+
+def test_close_receipt_is_outbox_managed_only_after_id_readback(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _OutboxRepo(
+        {
+            "outbox-1": {
+                "outbox_id": "outbox-1",
+                "status": "pending",
+                "provider_message_id": None,
+            }
+        }
+    )
+    monkeypatch.setattr(
+        auto_intake,
+        "send_trade_intake_receipt",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("lifecycle close must not send a direct receipt")
+        ),
+    )
+    callback = auto_intake._build_receipt_callback(
+        base=tmp_path,
+        cfg={},
+        receipt_config={"enabled": True},
+        repo=repo,
+    )
+
+    out = callback(
+        _context(
+            result={
+                "status": "applied",
+                "action": "close",
+                "reason": "applied_close",
+                "operations": [
+                    {
+                        "action": "close",
+                        "result": {
+                            "notification_outbox_id": "outbox-1",
+                            "notification_outbox_created": True,
+                        },
+                    }
+                ],
+            },
+            position_effect="close",
+        )
+    )
+
+    assert out["status"] == "outbox_managed"
+    assert out["outbox_id"] == "outbox-1"
+    assert out["outbox_readback_confirmed"] is True
+    assert out["delivery_confirmed"] is False
+    assert repo.reads == ["outbox-1"]
+    assert auto_intake._receipt_summary(out) == {
+        "status": "outbox_managed",
+        "reason": "transactional_outbox",
+        "delivery_confirmed": False,
+        "message_id": None,
+        "error_code": None,
+        "outbox_id": "outbox-1",
+        "outbox_readback_confirmed": True,
+    }
+
+
+def test_claimed_outbox_id_without_readback_is_not_outbox_managed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        auto_intake,
+        "send_trade_intake_receipt",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("missing outbox readback must fail closed")
+        ),
+    )
+    callback = auto_intake._build_receipt_callback(
+        base=tmp_path,
+        cfg={},
+        receipt_config={"enabled": True},
+        repo=_OutboxRepo(),
+    )
+
+    out = callback(
+        _context(
+            result={
+                "status": "applied",
+                "action": "close",
+                "operations": [
+                    {
+                        "action": "close",
+                        "result": {
+                            "notification_outbox_id": "outbox-missing",
+                            "notification_outbox_created": True,
+                        },
+                    }
+                ],
+            },
+            position_effect="close",
+        )
+    )
+
+    assert out["status"] == "failed"
+    assert out["reason"] == "lifecycle_outbox_readback_missing"
+    assert out["missing_outbox_ids"] == ["outbox-missing"]
+
+
+def test_lifecycle_waiting_state_without_outbox_does_not_direct_send(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        auto_intake,
+        "send_trade_intake_receipt",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("lifecycle state is owned by the outbox")
+        ),
+    )
+    callback = auto_intake._build_receipt_callback(
+        base=tmp_path,
+        cfg={},
+        receipt_config={"enabled": True},
+        repo=_OutboxRepo(),
+    )
+
+    out = callback(
+        _context(
+            result={
+                "status": "unresolved",
+                "action": "lifecycle",
+                "reason": "waiting_settlement_evidence",
+                "operations": [],
+                "diagnostics": {
+                    "notification_authority": "lifecycle_outbox"
+                },
+            },
+            position_effect="close",
+        )
+    )
+
+    assert out["status"] == "skipped"
+    assert out["reason"] == "lifecycle_outbox_not_created"
+
+
+def test_duplicate_close_without_current_outbox_does_not_direct_send(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        auto_intake,
+        "send_trade_intake_receipt",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("duplicate close remains lifecycle-outbox owned")
+        ),
+    )
+    callback = auto_intake._build_receipt_callback(
+        base=tmp_path,
+        cfg={},
+        receipt_config={"enabled": True},
+        repo=_OutboxRepo(),
+    )
+
+    out = callback(
+        _context(
+            result={
+                "status": "skipped",
+                "action": None,
+                "reason": "duplicate_deal_id",
+                "operations": [],
+            },
+            position_effect="close",
+        )
+    )
+
+    assert out["status"] == "skipped"
+    assert out["reason"] == "skipped_duplicate_lifecycle_outbox_owned"

--- a/tests/test_trades_receipt.py
+++ b/tests/test_trades_receipt.py
@@ -413,7 +413,7 @@ def test_receipt_decision_skips_confirmed_duplicate_by_default() -> None:
     assert out == {"should_send": False, "reason": "skipped_duplicate"}
 
 
-def test_receipt_decision_retries_unconfirmed_duplicate() -> None:
+def test_receipt_decision_retries_explicit_failed_duplicate() -> None:
     out = decide_trade_intake_receipt(
         receipt_config={},
         apply_changes=True,
@@ -430,6 +430,96 @@ def test_receipt_decision_retries_unconfirmed_duplicate() -> None:
     )
 
     assert out == {"should_send": True, "reason": "duplicate_retry_unconfirmed_receipt"}
+
+
+def test_trade_receipt_does_not_resend_provider_unconfirmed_duplicate(
+    tmp_path: Path,
+) -> None:
+    calls: list[dict] = []
+    deal = SimpleNamespace(
+        deal_id="deal-1",
+        internal_account="lx",
+        futu_account_id="REAL_1",
+        position_effect="open",
+        side="sell",
+        symbol="NVDA",
+        option_type="put",
+        expiration_ymd="2026-06-19",
+        strike=120,
+        contracts=1,
+        price=1.23,
+        multiplier=100,
+        currency="USD",
+        trade_time_ms=1779167311000,
+    )
+
+    def _send(**kwargs):
+        calls.append(dict(kwargs))
+        return {
+            "command_ok": True,
+            "delivery_confirmed": False,
+            "message_id": None,
+            "returncode": 0,
+        }
+
+    first = send_trade_intake_receipt(
+        base=tmp_path,
+        config={
+            "notifications": {
+                "provider": "wechat_clawbot",
+                "target": "wechat:ops",
+            }
+        },
+        receipt_config={},
+        apply_changes=True,
+        state={},
+        deal=deal,
+        result={
+            "status": "applied",
+            "reason": "applied_open",
+            "deal_id": "deal-1",
+            "account": "lx",
+            "action": "open",
+        },
+        payload={},
+        send_fn=_send,
+        normalize_fn=lambda send_result: send_result,
+    )
+    assert first["status"] == "unconfirmed"
+
+    duplicate = send_trade_intake_receipt(
+        base=tmp_path,
+        config={
+            "notifications": {
+                "provider": "wechat_clawbot",
+                "target": "wechat:ops",
+            }
+        },
+        receipt_config={},
+        apply_changes=True,
+        state={
+            "processed_deal_ids": {
+                "futu:lx:REAL_1:deal-1": {
+                    "status": "applied",
+                    "receipt": first,
+                }
+            }
+        },
+        deal=deal,
+        result={
+            "status": "skipped",
+            "reason": "duplicate_deal_id",
+            "deal_id": "deal-1",
+            "account": "lx",
+        },
+        payload={},
+        send_fn=_send,
+        normalize_fn=lambda send_result: send_result,
+    )
+
+    assert duplicate["status"] == "skipped"
+    assert duplicate["reason"] == "skipped_duplicate_delivery_unknown"
+    assert len(calls) == 1
 
 
 def test_receipt_decision_skips_non_option_deal() -> None:

--- a/tests/test_trades_resolver_close.py
+++ b/tests/test_trades_resolver_close.py
@@ -395,6 +395,15 @@ def test_resolve_trade_close_apply_persists_per_lot_target_events(tmp_path) -> N
     }
     assert {item["raw_payload"]["source_deal_id"] for item in close_events} == {"deal-close-1"}
     assert all(str(item["event_id"]).startswith("futu:lx:REAL_1:deal-close-1:close:") for item in close_events)
+    outbox_ids = {
+        str(operation.result.to_dict().get("notification_outbox_id") or "")
+        for operation in result.operations
+        if operation.result is not None
+    }
+    assert len(outbox_ids) == 1
+    outbox_id = next(iter(outbox_ids))
+    assert outbox_id
+    assert repo.get_trade_lifecycle_notification(outbox_id)["outbox_id"] == outbox_id
     lots = repo.list_position_lots()
     assert all(item["fields"]["status"] == "close" for item in lots)
     assert all(item["fields"]["contracts_open"] == 0 for item in lots)


### PR DESCRIPTION
## Summary

- restore direct intake receipts for ordinary open trades
- keep lifecycle and close notifications owned by the durable outbox
- require a persisted outbox ID before reporting `outbox_managed`
- suppress blind retries for provider-unconfirmed delivery and processed backfill duplicates

## Root cause

The auto-intake callback returned `outbox_managed` for every result, including ordinary opens, without creating an outbox row or invoking the existing receipt sender.

## Validation

- full suite: 3959 passed, 10 skipped
- Ruff passed for all changed Python files
- changed source compilation passed
- dependency graph check passed
- staged diff check passed

## Safety

No trade replay, real notification, VERSION change, release, deployment, service restart, or production data write was performed.
