### PR TITLE
fix: make lifecycle state ownership canonical

### DIFF
--- a/docs/FUTU_TRADE_HOLDINGS_SYNC.md
+++ b/docs/FUTU_TRADE_HOLDINGS_SYNC.md
@@ -103,6 +103,18 @@ audit 另外记录 `stock_holdings_sync_intent`，用于证明成交是否成功
 成交。`resolution_revision` 只随业务结论变化，通知重发只增加
 `delivery_revision`。
 
+Lifecycle discovery 只冻结到期 lot 并创建 immutable case，不刷新已有 case 的
+`status` 或 `derived_summary`。既有 case 的派生状态由 canonical lifecycle read model
+计算，并只由 account-scoped `reconcile-due` 通过 ledger 原子 transition writer 推进。
+无 option-close anchor 的 case 在 canonical deadline 后仍 fail closed 为人工复核，但不因
+legacy discovery 重放而改写 broker timing policy 口径。
+
+History backfill 只从本次查询的 Futu account IDs 与 canonical account mapping 导出
+显式账户范围，并对每个账户分别执行 discovery；不向 discovery 传
+`account=None`。任一 configured Futu account ID 缺少 mapping 时，该轮 lifecycle discovery
+整体 fail closed，不部分扫描其他账户。Legacy multi-account source 仍可用，但也必须逐账户
+隔离执行。
+
 ## 平仓原因判定
 
 按冻结的合约截止时间先分流：

--- a/docs/gateflow/lifecycle-single-source-of-truth/accepted-plan.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/accepted-plan.md
@@ -1,0 +1,45 @@
+# Gateflow Accepted Plan — Lifecycle Single Source of Truth
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `accepted plan`
+- Date: 2026-08-04
+- Plan: `docs/gateflow/lifecycle-single-source-of-truth/plan.md`
+- Initial review: `docs/reviews/plan-review-20260804-001846.md`
+- Fix artifact: `docs/gateflow/lifecycle-single-source-of-truth/plan-review-fix.md`
+- Accepted re-review: `docs/reviews/plan-review-20260804-002343.md`
+- Decision: accepted
+- Next entry point: implementation Slice S1
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/accepted-plan.md`
+
+## Accepted decisions
+
+- Ledger discovery creates cases only and never refreshes an existing case projection.
+- Canonical due reconciliation owns deadline aging and distinguishes missing evidence from evidence with unavailable effective timing.
+- The missing-evidence deadline path uses the atomic writer without a public transition, preserving the existing no-Outbox behavior.
+- Backfill derives a complete explicit account set from the current Futu IDs and mapping; every discovery call is account-scoped, including legacy multi-account sources.
+- No schema, config, public CLI argument, lifecycle state, provider rule, or notification retry workflow is added.
+
+## Finding status
+
+- PR-01: accepted, fixed, re-reviewed.
+- PR-02: accepted, fixed, re-reviewed.
+- PR-03: accepted, fixed, re-reviewed.
+- New findings: none.
+
+## Validation decision
+
+Implement and review S1 and S2 separately, then run the aggregate lifecycle/backfill/tick matrix before aggregate deepreview.
+
+## Docs decision
+
+Update `docs/FUTU_TRADE_HOLDINGS_SYNC.md` in S2 to record create-only discovery and account-scoped due ownership.
+
+## Residual risks
+
+- Production convergence and deployment verification remain assigned to a separately authorized operations step.
+- The existing at-most-60-second due cadence is accepted.
+
+## Completion status
+
+Plan gate passed with all findings fixed and classified residual risks.
+

--- a/docs/gateflow/lifecycle-single-source-of-truth/accepted-plan.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/accepted-plan.md
@@ -42,4 +42,3 @@ Update `docs/FUTU_TRADE_HOLDINGS_SYNC.md` in S2 to record create-only discovery 
 ## Completion status
 
 Plan gate passed with all findings fixed and classified residual risks.
-

--- a/docs/gateflow/lifecycle-single-source-of-truth/aggregate-code-review.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/aggregate-code-review.md
@@ -1,0 +1,32 @@
+# Gateflow Aggregate DeepReview
+
+- Gate: `aggregate deepreview`
+- Work unit: `lifecycle-single-source-of-truth`
+- Base: `origin/main@ed2531e9`
+- Accepted S2 commit: `35b5c3ba`
+- Validation artifact: `docs/gateflow/lifecycle-single-source-of-truth/aggregate-validation.md`
+- Review artifact: `docs/reviews/code-review-20260804-004625.md`
+- Decision: pass
+- Findings: none new; all prior findings fixed and re-reviewed
+- Status: accepted
+- Next gate: aggregate acceptance commit, push, and Draft PR
+
+## Coverage
+
+- Reviewed the complete work-unit diff, not only the latest slice.
+- Traced discovery, canonical read-model derivation, due selection, atomic state write, fingerprint/revision, notification Outbox, prepared option-position context, backfill source identity, account mapping, audit, and status projection as one chain.
+- Confirmed the old discovery refresh owner is removed and no replacement parallel business calculation was added.
+- Confirmed current-source account identity is never discarded to an unscoped backfill discovery call.
+
+## Validation decision
+
+- Aggregate matrix: `86 passed` with four classified pre-existing deprecation warnings.
+- Compileall, targeted Ruff, full-branch whitespace check, and explicit discovery-call search pass.
+- No real notification/provider call, production config/data write, service change, release, deployment, or upgrade occurred.
+
+## Accepted residuals
+
+- Production convergence belongs to a separately authorized deployment/operations step.
+- Create-only multi-account discovery is atomic per account and idempotently retryable rather than cross-account transactional.
+- The history checkpoint remains independent from lifecycle discovery completion.
+- Repository-local `.venv` dependency drift is recorded and not repaired in this work unit.

--- a/docs/gateflow/lifecycle-single-source-of-truth/aggregate-validation.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/aggregate-validation.md
@@ -1,0 +1,79 @@
+# Gateflow Aggregate Validation
+
+- Gate: `aggregate validation`
+- Work unit: `lifecycle-single-source-of-truth`
+- Base: `origin/main@ed2531e9`
+- Accepted S1 commit: `07934baa`
+- Accepted S2 commit: `35b5c3ba`
+- Date: 2026-08-04
+- Status: pass
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/aggregate-validation.md`
+
+## Deterministic acceptance evidence
+
+- Discovery is create-only and does not refresh existing lifecycle status or derived summary.
+- Canonical account-scoped due reconciliation owns deadline aging, including missing-evidence/no-pairing fail-closed materialization.
+- Missing-anchor apply/replay retains fingerprint/revision idempotency and creates no notification Outbox rows.
+- Evidence-present/no-effective-pairing cases use the existing typed close-reason reconciler without a broker observation call.
+- Canonical timing policy is not overwritten by the historical fixed-72-hour discovery path.
+- Backfill validates complete current Futu-ID mappings and invokes lifecycle discovery once per sorted explicit account in both phases.
+- Incomplete mapping performs zero partial discovery calls, preserves payload unresolved/audit handling, and exposes a top-level lifecycle failure.
+- Existing `lifecycle_discovery_result.v2`, audit envelope, union fields, history query, checkpoint, Inbox, CLI, unified tick, and notification-format contracts remain covered.
+
+## Aggregate test gate
+
+The repository `.venv` Python does not contain pytest (`No module named pytest`). The accepted matrix used system Python 3.12 with pytest 9.0.3 and redirected bytecode to `/tmp`.
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_aggregate_pytest python3.12 -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py \
+  tests/test_trades_auto_intake_backfill.py \
+  tests/test_trades_auto_intake_cli.py \
+  tests/test_unified_tick_entrypoint.py \
+  tests/test_multi_tick_notify_format.py
+```
+
+Result: `86 passed, 4 warnings in 5.68s`.
+
+The four warnings are existing `Legacy Tick full-message renderer is deprecated` warnings from `tests/test_multi_tick_notify_format.py`; scheduled delivery continues to use Daily Brief.
+
+## Static gates
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_aggregate_compile python3.12 \
+  -m compileall -q domain src scripts
+```
+
+Result: pass with no output.
+
+```bash
+python3.12 -m ruff check \
+  src/application/ledger/writer.py \
+  src/application/trades/close_reason_reconciliation.py \
+  src/application/trades/backfill.py \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py \
+  tests/test_trades_auto_intake_backfill.py
+```
+
+Result: `All checks passed!`.
+
+The first full-branch `git diff --check origin/main...HEAD` found only seven extra blank lines at EOF in earlier Gateflow Markdown evidence. They were removed mechanically without changing content. Final `git diff --check origin/main` and working-tree `git diff --check` both pass.
+
+Repository search confirms `src/application/trades/backfill.py` has one `discover_lifecycle_cases()` call supplied with the explicit loop `account`, and no `account=None` discovery call.
+
+## Safety evidence
+
+- Tests use temporary repositories/stores and fake or absent providers.
+- No broker request, real notification, production config mutation, ledger/business-data write, service change, release, deployment, or remote upgrade was performed.
+- Aggregate validation did not modify production runtime artifacts.
+
+## Residual risks
+
+- Existing production rows and runtime convergence require a separately authorized deployment/operations step.
+- A later account discovery failure can retain earlier idempotent create-only inserts; retry is safe and cross-account rollback is intentionally absent.
+- Lifecycle-only failure does not rewind a successful history checkpoint because lifecycle discovery reruns independently on every backfill cycle.
+- Repository-local `.venv` dependency drift remains an environment issue; no dependency files are changed.
+
+All residual risks are classified. The next gate is Aggregate DeepReview of the complete `origin/main...HEAD` work-unit diff plus this validation evidence.

--- a/docs/gateflow/lifecycle-single-source-of-truth/final-closeout.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/final-closeout.md
@@ -1,0 +1,101 @@
+# Gateflow Final Closeout
+
+- Gate: `final closeout`
+- Work unit: `lifecycle-single-source-of-truth`
+- Completion status: `final closeout pass`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/132`
+- Accepted PR-review commit: `0acf5fd1`
+- Base: `main@ed2531e9`
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/final-closeout.md`
+
+## Root cause closed
+
+The history-backfill discovery path discarded current-source account identity and independently refreshed existing lifecycle cases with a historical fixed-72-hour calculation. The canonical read model and due path used the bound broker timing policy. That dual ownership could oscillate an `lx` lifecycle projection after a notification was prepared, changing the option-position context fingerprint and blocking `lx` before provider delivery while `sy` remained deliverable.
+
+## What changed
+
+- Lifecycle discovery freezes expired lots and inserts missing immutable cases only; it no longer refreshes an existing case status or derived summary.
+- The canonical lifecycle read model remains the single calculation source for allocation, evidence, broker timing policy, deadline, and derived reason state.
+- Account-scoped due reconciliation owns deadline transitions and writes through the existing atomic generation-token/CAS/fingerprint/revision boundary.
+- Missing evidence at the canonical deadline fails closed as `needs_review` with `public_transition=None`, preserving the historical no-notification behavior.
+- Evidence present without effective timing uses the existing typed close-reason reconciler and never triggers broker observation collection.
+- History backfill derives complete sorted explicit accounts from the current Futu IDs and canonical mapping, then invokes discovery once per account in both phases; it never passes `account=None`.
+- Incomplete mapping performs zero partial discovery calls, preserves payload unresolved/audit handling, and produces an observable top-level lifecycle failure.
+- Existing v2 discovery result, audit envelope, compatibility fields, Inbox/checkpoint, CLI/tick, and notification-rendering contracts remain intact.
+
+## Verification
+
+Focused slice evidence:
+
+- S1 final: `26 passed in 1.57s`.
+- S2 final: `14 passed in 1.12s`.
+
+Aggregate command:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_aggregate_pytest python3.12 -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py \
+  tests/test_trades_auto_intake_backfill.py \
+  tests/test_trades_auto_intake_cli.py \
+  tests/test_unified_tick_entrypoint.py \
+  tests/test_multi_tick_notify_format.py
+```
+
+Result: `86 passed, 4 warnings in 5.68s`; warnings are classified pre-existing Legacy Tick renderer deprecations.
+
+Additional gates:
+
+- `PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_aggregate_compile python3.12 -m compileall -q domain src scripts`: pass.
+- Ruff across every changed Python production/test file: pass.
+- Full-branch and working-tree `git diff --check`: pass.
+- Backfill search: one discovery call with explicit loop account; no `account=None` discovery call.
+- GitHub at accepted PR-review head `0acf5fd1`: Agent Plugin, Guardrails, CodeQL actions, CodeQL Python, and CodeQL summary all passed.
+- PR #132: open, Draft, CLEAN, and mergeable at final recheck.
+
+The repository `.venv` lacks pytest, so deterministic tests used available system Python 3.12 with bytecode redirected to `/tmp`; no dependency files were changed.
+
+## Review finding status
+
+- PlanReview PR-01, PR-02, PR-03: accepted, fixed, and re-reviewed.
+- S1 DeepReview S1-01: accepted, fixed, and re-reviewed.
+- S2 DeepReview S2-01, S2-02: accepted, fixed, and re-reviewed.
+- Aggregate DeepReview: passed with no new findings.
+- PR #132 DeepReview: passed with no new findings.
+- Unclassified findings: none.
+
+## Accepted commits
+
+- `ac366c5a` — accepted plan.
+- `07934baa` — accepted S1.
+- `35b5c3ba` — accepted S2.
+- `c9cd7ce2` — accepted aggregate validation/review.
+- `0acf5fd1` — accepted PR #132 review evidence.
+
+## Documentation
+
+- `docs/FUTU_TRADE_HOLDINGS_SYNC.md` documents create-only discovery, canonical due ownership, and explicit account-scoped backfill.
+- Goal, plan, PlanReview, slice implementation/review/fix, aggregate validation/review, PR review, and this closeout are preserved under `docs/gateflow/lifecycle-single-source-of-truth/` and `docs/reviews/`.
+- No public CLI example or config schema changed.
+
+## Remaining risks and owners
+
+- Existing production rows and actual runtime convergence are not verified by source delivery. Owner: separately authorized deployment/operations step; verify deployed ancestry, service/runtime fingerprints, natural due convergence, per-account prepared context, delivery batches, provider attempts, and delivery confirmation before declaring production closure.
+- Multi-account create-only discovery is atomic per account rather than one cross-account transaction. Owner: existing idempotent retry path; any later-account failure is surfaced at the top level while earlier inserts remain safe.
+- Lifecycle-only failure does not rewind a successful history checkpoint. Owner: backfill runtime; discovery reruns independently on every interval.
+- Existing due cadence is at most 60 seconds. Owner: current runtime scheduler; accepted for this work unit.
+- Repository-local `.venv` dependency drift remains. Owner: separate environment-maintenance work; it does not block the validated source change.
+
+## Issue link status
+
+This work unit was initiated from the confirmed operator investigation and is not tied to a GitHub issue, so no issue closing keyword or closeout comment is required.
+
+## Safety boundary
+
+- Tests used temporary stores and fake or absent providers; no real notification or broker request occurred.
+- No production config, ledger, position, trade event, service, release, deployment, or remote environment was changed.
+- No merge, approval, reviewer request, Ready transition, release, deployment, or upgrade was performed.
+
+## Next entry point
+
+Draft PR #132 is ready for user review. Merge remains a separate authorization. Release and production upgrade remain later independent boundaries; production follow-up must start read-only and prove per-account convergence and delivery confirmation rather than relying on service health alone.

--- a/docs/gateflow/lifecycle-single-source-of-truth/goal-confirmation.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/goal-confirmation.md
@@ -72,4 +72,3 @@ canonical deadline 已到”的收敛分支。不引入新 repository、resolver
 ## Blocking open questions
 
 无。
-

--- a/docs/gateflow/lifecycle-single-source-of-truth/goal-confirmation.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/goal-confirmation.md
@@ -1,0 +1,75 @@
+# Gateflow Goal Confirmation — Lifecycle Single Source of Truth
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `goal confirmation`
+- Date: 2026-08-04
+- Status: confirmed by user
+- Branch: `fix/lifecycle-single-source-of-truth`
+- Base: `main@ed2531e9`
+
+## User problem
+
+2026-08-03 22:30 半点候选通知中，`sy` 账户完成投递，`lx` 账户却在通知提供商调用前因
+`option-position context fingerprint mismatch` 失败。同一批 `lx` 到期期权 case 的派生状态在两条路径间
+反复震荡：
+
+- history backfill 调用的 lifecycle discovery 用旧的固定 72 小时口径写成
+  `needs_review / settlement_evidence_deadline_elapsed`；
+- account-scoped canonical due reconciliation 根据 immutable timing policy 写回
+  `waiting_settlement_evidence / awaiting_settlement_evidence`。
+
+状态被改写后，同一轮 Position Advice 前后的 canonical fingerprint 不再一致，因此安全门禁按设计
+fail closed，造成 `lx` 无通知而 `sy` 有通知。
+
+## Confirmed goal
+
+让 lifecycle case 的派生状态只由 canonical lifecycle read model 与 account-scoped due
+reconciliation 决定并通过 ledger 原子 transition writer 落库。Discovery 只负责冻结到期 lot 并创建
+case；backfill 只能发现当前明确账户的 case，不得以 `account=None` 扫描或改写其他账户。
+
+## Motivation and direct evidence
+
+- `src/application/ledger/writer.py::discover_expired_lifecycle_cases_atomically()` 在创建 case 后又遍历
+  existing cases，直接调用 `derive_lifecycle_read_model()`；该调用没有传入 canonical
+  reservations、timing policy 或 `pending_until_ms_override`，却用结果整体覆盖
+  `derived_summary`。
+- `domain/domain/option_lifecycle.py` 的 fallback deadline 是观察起点后 72 小时，而
+  `src/application/trades/lifecycle_reconciliation.py::lifecycle_case_read_model()` 会消费 ledger 中冻结的
+  timing policy 和有效 evidence/reservation。
+- `src/application/trades/backfill.py::run_history_backfill()` 在回填前后两次用 `account=None`
+  调用 discovery，所以 `sy` 的 backfill 可刷新 `lx` case。
+- `docs/plans/option-expiry-close-reason-receipt-redesign-plan-20260730.md` 明确指定
+  `reconcile_due_lifecycle_cases()` 是无新成交消息时的状态推进 owner，且每个 runtime source
+  只能处理其明确绑定账户。
+
+## Success signals
+
+1. 对已存在的 lifecycle case 重放 discovery，不再修改 `status`、`derived_summary`、
+   `resolution_revision` 或 `state_fingerprint`。
+2. 无 pairing anchor 的 case 在 canonical deadline 之前保持 pending，到期后由 due reconciliation
+   通过 canonical read model 原子转入 `needs_review`，并且重放不重复推进 revision 或 Outbox。
+3. 已绑定 broker timing policy 的 case 即使超过旧 72 小时 deadline，discovery 也不改写
+   canonical waiting 状态和指纹。
+4. `run_history_backfill()` 强制接收非空 canonical account，回填前后的 discovery 都仅使用
+   该账户；`lx` / `sy` 互不发现、互不改写。
+5. fingerprint mismatch 安全门禁保持原样；修复不通过放宽验证恢复通知。
+6. lifecycle/backfill/tick 聚焦测试、相关广泛回归、compileall 和 `git diff --check` 通过。
+
+## Non-goals and scope boundary
+
+- 不新增 lifecycle 状态、数据库 schema、配置项、后台服务或第二套投影。
+- 不改变 broker settlement evidence 的证明标准、allocation 规则或 terminal event 写入语义。
+- 不放宽 decision-state fingerprint 或通知 fail-closed 条件。
+- 不修改生产数据、不重试真实通知、不发布、不部署、不升级远端。
+- 不在本 work unit 自动修复已被旧路径改写的历史行；代码上线后由既有 canonical due
+  tick 按当前 ledger 事实收敛。
+
+## Overdesign deliberately excluded
+
+本轮只移除一个越权的 legacy refresh loop，并补齐既有 due owner 对“无 pairing clock 但
+canonical deadline 已到”的收敛分支。不引入新 repository、resolver、scheduler、状态机或数据迁移。
+
+## Blocking open questions
+
+无。
+

--- a/docs/gateflow/lifecycle-single-source-of-truth/plan-review-fix.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/plan-review-fix.md
@@ -1,0 +1,56 @@
+# Gateflow Plan Review Fix — Lifecycle Single Source of Truth
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `plan review -> fix`
+- Date: 2026-08-04
+- Reviewed target: `docs/gateflow/lifecycle-single-source-of-truth/plan.md`
+- Review artifact: `docs/reviews/plan-review-20260804-001846.md`
+- Status: fixes applied; pending re-review
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/plan-review-fix.md`
+
+## Finding decisions and fixes
+
+### PR-01 — accepted — 已修复
+
+The plan no longer infers anchor absence from `pairing_until_ms is None`.
+
+- Canonical `lifecycle_evidence_status == missing` is required for the no-anchor materialization path.
+- Evidence-present/no-effective-pairing cases go through the existing close-reason reconciler for typed timing/evidence failure classification.
+- The plan adds an anchor-present/timing-unavailable regression.
+
+### PR-02 — accepted — 已修复
+
+The proposed required `account` argument was removed.
+
+- `run_history_backfill()` keeps its current signature.
+- Discovery accounts are derived only from the current `futu_account_ids` and canonical `account_mapping`.
+- Modern single-account and supported legacy multi-account sources are both handled with explicit per-account discovery calls; `account=None` is never passed.
+- Incomplete mapping produces a typed all-or-nothing lifecycle-discovery scope failure instead of partial scanning.
+
+### PR-03 — accepted — 已修复
+
+The no-anchor deadline materialization now uses the existing atomic state writer with `public_transition=None`.
+
+- State fingerprint, revision, and generation-token CAS remain canonical.
+- The historical no-anchor aging path does not gain a new lifecycle notification Outbox side effect.
+- Apply and replay tests must assert no Outbox rows.
+
+## Validation
+
+- Plan now specifies the distinct missing-evidence, evidence-without-effective-pairing, and effective-pairing branches.
+- S2 no longer changes a supported source signature or requires a new config field.
+- All accepted findings have concrete regression assertions and no unclassified residual risk.
+
+## Docs decision
+
+No additional public documentation beyond the already planned lifecycle ownership/account-scope clarification is required for the plan fix.
+
+## Residual risks
+
+- Existing production rows and deployment verification remain assigned to a separately authorized operations step.
+- The additive multi-account backfill diagnostics shape will be documented by implementation tests and the S2 artifact.
+
+## Completion status
+
+Plan fixes complete; next entry point is adversarial plan re-review.
+

--- a/docs/gateflow/lifecycle-single-source-of-truth/plan-review-fix.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/plan-review-fix.md
@@ -53,4 +53,3 @@ No additional public documentation beyond the already planned lifecycle ownershi
 ## Completion status
 
 Plan fixes complete; next entry point is adversarial plan re-review.
-

--- a/docs/gateflow/lifecycle-single-source-of-truth/plan.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/plan.md
@@ -1,0 +1,321 @@
+# Gateflow Implementation Plan — Lifecycle Single Source of Truth
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `plan`
+- Date: 2026-08-04
+- Status: accepted after adversarial re-review
+- Goal confirmation: `docs/gateflow/lifecycle-single-source-of-truth/goal-confirmation.md`
+- Initial review: `docs/reviews/plan-review-20260804-001846.md`
+- Accepted re-review: `docs/reviews/plan-review-20260804-002343.md`
+- Branch: `fix/lifecycle-single-source-of-truth`
+- Base: `main@ed2531e9`
+
+## 1. Goal, motivation, and completion signal
+
+消除 lifecycle case 的双重状态口径：discovery 只创建 case，canonical
+`lifecycle_case_read_model()` + account-scoped `reconcile_due_lifecycle_cases()` 是唯一派生状态
+计算/推进主链，所有状态落库继续经过带 generation-token CAS、state fingerprint、revision
+和 Outbox 幂等的 `advance_lifecycle_case_state()`。
+
+完成信号：
+
+- discovery replay 对 existing case 零写入；
+- default 72h 与 immutable broker timing policy 不再互相覆盖；
+- 无 pairing anchor 的超时 case 仍由 due owner fail closed 为 `needs_review`，且不新增历史路径
+  不会产生的通知意图；
+- `lx` / `sy` backfill 严格账户隔离；
+- 同一事实重放不推进 revision、不重复 Outbox、不改变 fingerprint；
+- 聚焦与广泛验证全部通过。
+
+## 2. Non-goals and boundaries
+
+- 不改 schema/public CLI 命令/业务状态枚举；
+- 不改 decision snapshot/fingerprint validator 或 Position Advice fail-closed 门禁；
+- 不改 settlement observation 覆盖率、terminal resolver 或 allocation 语义；
+- 不创建新 scheduler、状态表、migration 或通知重试机制；
+- 不执行真实通知、生产写入、release 或 deployment。
+
+## 3. First-principles judgment and code evidence
+
+### 3.1 Authority violation
+
+`discover_expired_lifecycle_cases_atomically()` 同时承担“冻结新 case”与“刷新旧 case
+派生状态”。后者直接调用 domain fallback model，未读取 canonical case resolution、effective
+reservations 和 immutable timing policy，违反了已建立的 ledger read-model authority。
+
+Decision：从 ledger discovery transaction 删除 existing-case refresh；保留结果字段
+`refreshed_case_ids` / `would_refresh_case_ids` 且稳定返回空数组，避免不必要的 payload/CLI 破坏。
+
+### 3.2 Fail-closed aging must not disappear
+
+直接删掉 discovery refresh 会让没有 option-close anchor 的 case 丧失旧有“deadline 后转
+`needs_review`”能力，因为当前 due selector 对 `pairing_until_ms is None` 直接 skip。这会把
+安全问题从“双重写入”变成“永不收敛”。
+
+Decision：在现有 due owner 内增加一个窄分支，但不用 `pairing_until_ms`
+猜测 anchor 身份：
+
+1. 从 canonical `lifecycle_case_read_model()` 读取 `pending_until_ms`、`reason_state`、reason codes、
+   timing hash、generation token、`lifecycle_evidence_status` 和 reservation evidence ids；
+2. `pairing_until_ms is None` 时，deadline 缺失或未到则 skip；
+3. deadline 已到且 `lifecycle_evidence_status == "missing"` 、canonical
+   `reason_state == needs_review` 时，不采集 broker observation，直接物化这个 no-anchor
+   fail-closed 结论；
+4. no-anchor 落库调用 `advance_lifecycle_case_state()`，传 read-model generation token，但使用
+   `public_transition=None`，保留 legacy deadline aging 不产生 lifecycle notification Outbox 的可见语义；
+5. evidence 已存在但 pairing 不可用时，不走 no-anchor materialization；直接调现有
+   `reconcile_lifecycle_close_reason()` 做 typed fail-closed 分类，不调 provider collector；
+6. repeated due tick 必须命中相同 fingerprint/revision，no-anchor 路径始终不产生 Outbox。
+
+有 effective pairing 的 case 完全保留现有 provider observation +
+`reconcile_lifecycle_close_reason()` 主链。新分支不尝试猜测 terminal reason，只物化 canonical read
+model 已经给出的 no-anchor `needs_review`；其他 evidence 状态继续交给现有 close-reason
+resolver。
+
+### 3.3 Account isolation
+
+`run_history_backfill()` 已拥有本次查询的 `futu_account_ids` 与 canonical `account_mapping`，
+但两次把这些身份丢失为 `account=None` 传给 discovery。同时，仓库明确保留一个
+`source.account=None` 的 legacy multi-account source，因此不能以“强制每个 source 只有一个 account”
+作为修复前提。
+
+Decision：不改 `run_history_backfill()` 签名。用现有 `futu_account_ids` 及
+`account_mapping` 导出排序、去重、lowercase 的 explicit discovery account list；每个 account
+单独调 discovery，永不传 `None`。任一 configured Futu ID 缺少 mapping 时，该 phase
+返回 typed scope failure 且零 discovery 写入，不做部分账户扫描；成交回填本身继续沿用现有
+unresolved/fail-closed 处理。
+
+## 4. Contract, schema, state-machine, and public-interface decisions
+
+### Internal account-scope contract
+
+`run_history_backfill()` 的公开/internal 函数签名不变。新的 private scope resolver 契约为：
+
+```python
+_lifecycle_discovery_accounts(
+    *,
+    futu_account_ids: list[str],
+    account_mapping: dict[str, str],
+) -> tuple[str, ...]
+```
+
+- 只消费本次 history query 的 Futu IDs，不扫描 mapping 中的其他账户；
+- 所有 configured IDs 必须存在非空 canonical mapping；否则抛出 typed scope error；
+- 返回 sorted unique lowercase labels，每个 label 各调一次 discovery。
+
+backfill phase 结果保留既有 union summary keys，并增加 additive `accounts` 和
+`account_results`，便于审计 legacy multi-account source；实际 discovery call 中不会出现
+`account=None`。
+
+### Discovery result compatibility
+
+`lifecycle_discovery_result.v2` schema 不变。保留：
+
+```json
+{
+  "refreshed_case_ids": [],
+  "would_refresh_case_ids": []
+}
+```
+
+这两个字段转为明确的 compatibility placeholders，不再代表 discovery 的写权。
+
+### State transition
+
+```text
+expired lot
+  -> discovery creates immutable lifecycle_case.v2 only
+  -> canonical read model resolves case/evidence/allocation/timing facts
+  -> account-scoped due reconciliation selects due work
+     -> no evidence + no pairing + canonical deadline elapsed: needs_review via atomic state writer, no Outbox
+     -> evidence exists but effective pairing unavailable: existing typed close-reason reconciliation, no provider poll
+     -> effective pairing present: existing provider-observation/close-reason reconciliation path
+```
+
+Schema 无变更；既有 CAS、fingerprint、revision 和 Outbox 不变。
+
+## 5. Affected files/modules
+
+- `src/application/ledger/writer.py`
+- `src/application/trades/close_reason_reconciliation.py`
+- `src/application/trades/backfill.py`
+- `tests/test_position_advice_v2_lifecycle_reconciliation.py`
+- `tests/test_settlement_observation.py`
+- `tests/test_trades_auto_intake_backfill.py`
+- `docs/FUTU_TRADE_HOLDINGS_SYNC.md`
+- Gateflow artifacts under `docs/gateflow/lifecycle-single-source-of-truth/`
+- review artifacts under `docs/reviews/`
+
+## 6. Implementation slices
+
+### Slice S1 — Canonical lifecycle state ownership
+
+- Objective: 移除 discovery 的 existing-case 写权，同时在 canonical due owner 内保留无 anchor
+  case 的 deadline fail-closed 收敛。
+- Expected outcome: discovery 只创建；due reconciliation 成为唯一 aging transition owner。
+- Allowed files:
+  - `src/application/ledger/writer.py`
+  - `src/application/trades/close_reason_reconciliation.py`
+  - `tests/test_position_advice_v2_lifecycle_reconciliation.py`
+  - `tests/test_settlement_observation.py`
+- Prerequisites: goal confirmation + accepted plan.
+- Exact allowed changes:
+  1. 删除 `discover_expired_lifecycle_cases_atomically()` 的 existing-case refresh loop 及其不再需要的
+     allocations/void-derived computation imports/locals；保留空 compatibility result keys。
+  2. 在 `reconcile_due_lifecycle_cases()` 内用一个 private helper 封装 missing-evidence/no-pairing
+     deadline materialization；输入仅为 existing lifecycle case + canonical read model + apply flag。
+  3. helper 只接受 `lifecycle_evidence_status == missing` 且 `reason_state == needs_review`，
+     构造摘要时直接复用 read model 的
+     `close_reason`、reason codes、pairing/deadline/timing hash；apply 时传 generation token 给
+     `advance_lifecycle_case_state()`，且 `public_transition=None`。
+  4. evidence 已存在但 effective pairing 缺失时，调现有
+     `reconcile_lifecycle_close_reason()` 进行 typed 分类，不调 observation collector。
+  5. dry-run 返回可观测 decision，不写 case/Outbox；apply 返回 `write_result` 和 fresh
+     lifecycle read model。
+  6. 不改 pairing-present 的既有 observation/reconciliation 分支。
+- Invariants and error handling:
+  - deadline 缺失或未到时不写；
+  - generation token 变化时依既有 CAS fail closed；
+  - no-pairing 分支不调 broker collector；是否存在 anchor 由 canonical evidence status 决定；
+  - no-anchor 重放使用同一 state fingerprint/revision 且不产生 Outbox。
+- Non-goals: 不改 resolver 业务规则、timing policy 生成、provider collector、schema。
+- Focused tests:
+
+  ```bash
+  ./.venv/bin/python -m pytest -q \
+    tests/test_position_advice_v2_lifecycle_reconciliation.py \
+    tests/test_settlement_observation.py
+  ```
+
+- Expected assertions:
+  - old 72h test 改为 discovery 不 refresh，due apply 在 deadline 物化 `needs_review`；
+  - dry-run 零写入；apply 后重放不增 revision，no-anchor apply/replay 均无 Outbox；
+  - anchor 已存在但 timing 不可用时，返回 typed timing reason，不被误当成 no-anchor
+    deadline elapsed；
+  - broker timing policy deadline 迟于 fallback deadline 时，在两者之间重放 discovery 不改
+    status/summary/fingerprint，canonical read model 仍 pending。
+- Completion signal: focused tests pass and diff contains no discovery status write.
+- Stop condition: canonical due branch cannot preserve no-anchor fail-closed semantics without changing public state/schema.
+
+### Slice S2 — Account-scoped history backfill
+
+- Objective: 让 backfill lifecycle discovery 只触及本次查询 Futu IDs 明确映射到的 account。
+- Expected outcome: `sy` backfill 不再扫描 `lx`，反之亦然。
+- Allowed files:
+  - `src/application/trades/backfill.py`
+  - `tests/test_trades_auto_intake_backfill.py`
+  - `docs/FUTU_TRADE_HOLDINGS_SYNC.md`
+- Prerequisites: accepted S1 commit.
+- Exact allowed changes:
+  1. 增加 private account-scope resolver，只从本次 `futu_account_ids` + `account_mapping` 导出
+     explicit accounts；任一 ID 缺失 mapping 则整个 discovery phase typed-fail，不部分扫描。
+  2. before/after phase 按 sorted explicit account 各调 discovery 一次，从不传 `None`。
+  3. 聚合 per-account result 的 created/would-create/discovered/skipped/compatibility keys，并保留
+     `accounts` / `account_results` 审计证据。
+  4. 添加 single-account 双 phase capture、legacy two-account 顺序与 missing-mapping no-partial-discovery
+     回归。
+  5. 文档明确 discovery=create-only，due reconciliation=account-scoped transition owner。
+- Invariants and error handling:
+  - lifecycle discovery 前验证完整 account scope；missing mapping 不阻止既有 trade payload
+    unresolved/audit 路径；
+  - 不根据成交 payload 猜 backfill owner，只使用 canonical config mapping；
+  - 现有 account mapping/futu account ID 身份校验不放宽。
+- Non-goals: 不重构 source config，不修改 history query，不将单 source 扩展为跨账户 batch。
+- Focused tests:
+
+  ```bash
+  ./.venv/bin/python -m pytest -q tests/test_trades_auto_intake_backfill.py
+  ```
+
+- Expected assertions:
+  - single-account before/after discovery 均只收到 lowercase explicit account；
+  - legacy two-account source 按稳定顺序分别调用，无 `account=None`；
+  - 任一 configured ID 缺少 mapping 时两个 phase 都零 partial discovery 并记录 typed failure；
+  - 原 backfill 幂等、checkpoint、Inbox 与 audit phase 测试不变。
+- Completion signal: focused tests pass and repository has no backfill lifecycle discovery call with `account=None`.
+- Stop condition: configured Futu IDs cannot be completely mapped to canonical accounts without changing config authority.
+
+## 7. Validation matrix
+
+After S1:
+
+```bash
+./.venv/bin/python -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py
+```
+
+After S2:
+
+```bash
+./.venv/bin/python -m pytest -q tests/test_trades_auto_intake_backfill.py
+```
+
+Aggregate before deepreview:
+
+```bash
+./.venv/bin/python -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py \
+  tests/test_trades_auto_intake_backfill.py \
+  tests/test_trades_auto_intake_cli.py \
+  tests/test_unified_tick_entrypoint.py \
+  tests/test_multi_tick_notify_format.py
+
+./.venv/bin/python -m compileall -q domain src scripts
+git diff --check
+```
+
+Expected aggregate assertions:
+
+- lifecycle discovery/read-model/due reconciliation 回归通过；
+- backfill source/account/Inbox/checkpoint 行为不变；
+- trade-intake CLI 和 unified tick 调用契约不断裂；
+- 通知 formatting 基线不受影响；
+- compileall 与 whitespace check 通过。
+
+验证不调用真实 broker provider，不发真实通知，不修改生产 config/runtime data。
+
+## 8. Docs decision
+
+更新 `docs/FUTU_TRADE_HOLDINGS_SYNC.md`，明确：
+
+- discovery 只冻结/创建 case；
+- canonical read model + account-scoped due reconciliation 拥有派生状态推进权；
+- backfill lifecycle discovery 只使用 current source account。
+
+不更改用户 CLI 示例，因为命令与参数未变。
+
+## 9. Risks, open questions, and residual-risk destinations
+
+| Risk | Classification / mitigation |
+|---|---|
+| 删除 discovery refresh 使 no-anchor case 永不收敛 | Fixed in S1 by canonical missing-evidence/no-pairing deadline branch. |
+| no-pairing 被错当成 no-anchor | Fixed in S1 by canonical evidence-status split and anchor-without-timing regression. |
+| 新 due 分支重复推进 revision 或新增通知 | Fixed in S1 with existing fingerprint/CAS, `public_transition=None`, and replay/no-Outbox tests. |
+| canonical timing 已绑定但 discovery 仍覆盖 | Fixed in S1 with create-only discovery and policy-stability regression. |
+| one account backfill 扫描 another account | Fixed in S2 by explicit mapped account set and per-account calls. |
+| required single-account contract breaks legacy multi-account source | Fixed in S2 by preserving the function signature and safely iterating the mapped accounts. |
+| production rows 已被旧路径改写 | Assigned to deployment/operations work after this PR; no data repair is authorized here. Existing canonical due path should converge current facts after upgrade, which must be verified separately. |
+| newly discovered already-due case waits until next runtime due tick | Accepted bounded behavior; existing cadence is at most 60 seconds and owned by the current runtime design. |
+| compatibility placeholder fields may look obsolete | Accepted compatibility tradeoff; documented as always-empty, removal requires a later public-contract work unit. |
+
+Blocking open questions: none.
+
+## 10. Why this is not overdesigned
+
+方案只撤销一个越权 loop，复用已有 canonical read model、due scheduler、atomic state writer、CAS、
+fingerprint 和 Outbox。唯一新逻辑是 due owner 内一个 private no-pairing deadline 分支，用于保留现有
+fail-closed 语义。没有新 layer、entity、protocol、schema、config 或 worker。
+
+## 11. Completion report format
+
+Final closeout 必须列出：
+
+- changed ownership and account boundary;
+- exact focused/aggregate validation commands and results;
+- plan/code/aggregate/PR review finding status;
+- docs update;
+- residual production repair/deployment risk and owner;
+- accepted commit hashes and Draft PR URL;
+- next entry point: user review/merge; release and upgrade remain separately authorized.

--- a/docs/gateflow/lifecycle-single-source-of-truth/pr-code-review.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/pr-code-review.md
@@ -1,0 +1,34 @@
+# Gateflow PR Code Review
+
+- Gate: `PR review`
+- Work unit: `lifecycle-single-source-of-truth`
+- Reviewed target: GitHub Draft PR `#132`
+- Base/head: `main@ed2531e9` -> `fix/lifecycle-single-source-of-truth@c9cd7ce2`
+- Review artifact: `docs/reviews/pr-132-review-20260804-005134.md`
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/pr-code-review.md`
+- Completion status: pass; no fix or re-review required
+
+## Decision
+
+The PR-level DeepReview found no actionable findings. GitHub reports the exact base and head used by the accepted aggregate review, the 24-file remote scope matches the local work unit, and the PR remains open, Draft, and mergeable.
+
+## Validation
+
+- Aggregate matrix: `86 passed` with four classified pre-existing Legacy Tick renderer warnings.
+- Compileall, changed-file Ruff, full-branch diff check, and explicit unscoped-call search passed.
+- PlanReview, S1, S2, and Aggregate DeepReview findings are all fixed and re-reviewed.
+- GitHub checks were still running at review time and are not represented as successful.
+
+## Docs decision
+
+The ownership/account-boundary operator update plus goal, plan, slice, validation, aggregate, and PR-review evidence are included. Public CLI commands and config schema did not change.
+
+## Residual risks
+
+- Existing production data and runtime convergence remain outside this PR's source-delivery authority.
+- Discovery transactions remain per account and idempotently retryable.
+- Hosted checks require a post-push recheck.
+
+## Next gate
+
+Commit and push the accepted PR-review evidence, recheck the remote Draft PR head and hosted checks, then record final closeout. Merge, Ready transition, reviewer request, release, deployment, and upgrade remain prohibited by this Gateflow run.

--- a/docs/gateflow/lifecycle-single-source-of-truth/pr-code-review.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/pr-code-review.md
@@ -17,7 +17,7 @@ The PR-level DeepReview found no actionable findings. GitHub reports the exact b
 - Aggregate matrix: `86 passed` with four classified pre-existing Legacy Tick renderer warnings.
 - Compileall, changed-file Ruff, full-branch diff check, and explicit unscoped-call search passed.
 - PlanReview, S1, S2, and Aggregate DeepReview findings are all fixed and re-reviewed.
-- GitHub checks were still running at review time and are not represented as successful.
+- GitHub checks were still running at review time; after the accepted PR-review evidence push, Agent Plugin, Guardrails, CodeQL actions, CodeQL Python, and the CodeQL summary all completed successfully.
 
 ## Docs decision
 
@@ -27,8 +27,8 @@ The ownership/account-boundary operator update plus goal, plan, slice, validatio
 
 - Existing production data and runtime convergence remain outside this PR's source-delivery authority.
 - Discovery transactions remain per account and idempotently retryable.
-- Hosted checks require a post-push recheck.
+- Hosted checks passed at accepted PR-review head `0acf5fd1`.
 
 ## Next gate
 
-Commit and push the accepted PR-review evidence, recheck the remote Draft PR head and hosted checks, then record final closeout. Merge, Ready transition, reviewer request, release, deployment, and upgrade remain prohibited by this Gateflow run.
+Record and push final closeout evidence. Merge, Ready transition, reviewer request, release, deployment, and upgrade remain prohibited by this Gateflow run.

--- a/docs/gateflow/lifecycle-single-source-of-truth/s1-implementation.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/s1-implementation.md
@@ -1,0 +1,109 @@
+# Gateflow S1 Implementation — Canonical Lifecycle State Ownership
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `implementation`
+- Slice: `S1`
+- Date: 2026-08-04
+- Status: implementation and code-review fix complete; accepted after re-review
+- Accepted plan: `docs/gateflow/lifecycle-single-source-of-truth/accepted-plan.md`
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/s1-implementation.md`
+
+## Objective and outcome
+
+Remove lifecycle projection write authority from discovery while preserving the existing fail-closed deadline behavior under the canonical account-scoped due reconciler.
+
+Outcome:
+
+- discovery now freezes/creates cases only;
+- compatibility result fields `refreshed_case_ids` and `would_refresh_case_ids` remain and are always empty;
+- canonical due reconciliation handles deadline-expired cases without effective pairing;
+- canonical evidence status distinguishes truly missing anchors from evidence whose timing is unavailable;
+- missing-anchor aging uses the atomic generation-token/fingerprint/revision writer with no notification Outbox side effect;
+- effective-pairing behavior and provider observation remain unchanged.
+
+## Changed files
+
+- `src/application/ledger/writer.py`
+- `src/application/trades/close_reason_reconciliation.py`
+- `tests/test_position_advice_v2_lifecycle_reconciliation.py`
+- `tests/test_settlement_observation.py`
+- `docs/gateflow/lifecycle-single-source-of-truth/s1-implementation.md`
+
+## Implementation decisions
+
+1. Deleted the existing-case refresh loop from `discover_expired_lifecycle_cases_atomically()` and removed its obsolete fallback read-model import/state inputs.
+2. Added a private due-reconciliation helper for cases whose canonical read model has no effective pairing timestamp after the canonical deadline.
+3. The helper uses `lifecycle_evidence_status` as authority:
+   - `missing` + canonical `needs_review`: materialize the canonical read model;
+   - any evidence-present state: delegate to `reconcile_lifecycle_close_reason()` for typed classification.
+4. Missing-anchor materialization writes through `advance_lifecycle_case_state()` with the canonical generation token and `public_transition=None`.
+5. The summary records canonical reason state/codes, close reason, pairing/deadline, timing hash, and an explicit null observation hash; the atomic writer supplies canonical allocation and fingerprint/revision fields.
+
+## State and error behavior
+
+- Deadline absent or not reached: skip.
+- Effective pairing present: unchanged existing due flow.
+- Missing evidence at elapsed canonical deadline: deterministic `needs_review`, no broker query, no Outbox.
+- Evidence present but effective pairing unavailable: existing close-reason resolver, no broker query.
+- Stale lifecycle generation: existing CAS error propagates fail closed.
+- Repeated missing-evidence apply: identical business fingerprint, unchanged revision, no Outbox.
+
+## Validation
+
+The repository `.venv` Python does not currently contain pytest (`./.venv/bin/python -m pytest` reports `No module named pytest`). The same tests were run with the available system Python 3.12 and pytest 9.0.3, with bytecode redirected to `/tmp`.
+
+Targeted new regressions:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s1 python3.12 -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py::test_discovery_is_create_only_and_due_owner_reviews_missing_evidence_at_deadline \
+  tests/test_settlement_observation.py::test_discovery_replay_does_not_override_canonical_timing_policy \
+  tests/test_settlement_observation.py::test_due_reconciliation_routes_anchor_without_effective_pairing_to_close_reason
+```
+
+Result: `3 passed in 1.31s`.
+
+Focused slice suite:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s1_full python3.12 -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py
+```
+
+Initial result: `25 passed in 1.46s`.
+
+After accepted code-review finding S1-01 was fixed:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s1_rereview python3.12 -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py
+```
+
+Result: `26 passed in 1.57s`.
+
+Static diff check:
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+## Docs decision
+
+The operator-facing lifecycle ownership documentation is intentionally deferred to approved Slice S2, where discovery account scoping is completed at the same boundary.
+
+## Residual risks and uncovered areas
+
+- Account-scoped backfill is covered by later approved Slice S2.
+- Existing production rows and deployment convergence remain assigned to a separately authorized operations step.
+- The full lifecycle/backfill/tick matrix and compileall are covered by the later aggregate validation gate.
+- Repository-local `.venv` dependency drift is an environment issue; tests are currently reproducible with system Python 3.12. No dependency files are changed in this work unit.
+
+All residual risks are classified.
+
+## Completion signal
+
+S1 implementation and accepted review fix are complete; focused tests pass and the next entry point is the accepted S1 commit.

--- a/docs/gateflow/lifecycle-single-source-of-truth/s1-review-fix.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/s1-review-fix.md
@@ -1,0 +1,48 @@
+# Gateflow S1 Review Fix — Canonical Lifecycle State Ownership
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `code review -> fix`
+- Slice: `S1`
+- Date: 2026-08-04
+- Review artifact: `docs/reviews/code-review-20260804-002940.md`
+- Status: fixed and re-reviewed
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/s1-review-fix.md`
+
+## Finding decision
+
+### S1-01 — accepted — 已修复
+
+The no-effective-pairing branch now applies the canonical reason-state allowlist before invoking any reconciliation helper.
+
+- Allowed: `cause_pending`, `partially_resolved`, `needs_review`.
+- Skipped: `resolved`, `conflict`, and any unrecognized state.
+- The effective-pairing branch reuses the same normalized `reason_state` value, preserving its existing allowlist.
+
+## Regression coverage
+
+Added a conflict/no-effective-pairing deadline test that makes both the close-reason resolver and provider collector raise if called. The due result must contain zero cases and zero results.
+
+## Validation
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s1_rereview python3.12 -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py
+```
+
+Result: `26 passed in 1.57s`.
+
+`git diff --check`: pass.
+
+## Docs decision
+
+No operator documentation change is needed for this internal absorbing-state guard.
+
+## Residual risks
+
+- S2 account isolation remains covered by the later approved slice.
+- Aggregate validation remains required.
+
+## Completion status
+
+Finding S1-01 is fixed; accepted re-review artifact: `docs/reviews/code-review-20260804-003133.md`.

--- a/docs/gateflow/lifecycle-single-source-of-truth/s2-implementation.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/s2-implementation.md
@@ -1,0 +1,106 @@
+# Gateflow S2 Implementation — Account-scoped History Backfill
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `implementation`
+- Slice: `S2`
+- Date: 2026-08-04
+- Status: implementation and code-review fixes complete; accepted after re-review
+- Accepted plan: `docs/gateflow/lifecycle-single-source-of-truth/accepted-plan.md`
+- Prerequisite commit: `07934baa`
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/s2-implementation.md`
+
+## Objective and outcome
+
+Bind history-backfill lifecycle discovery to the explicit accounts represented by the current Futu source instead of scanning all ledger accounts.
+
+Outcome:
+
+- the current `futu_account_ids` and canonical `account_mapping` are the only account-scope inputs;
+- every configured Futu account ID must have a non-empty mapping before either discovery phase runs;
+- single-account and legacy multi-account sources invoke discovery once per sorted lowercase account;
+- no backfill lifecycle-discovery call passes `account=None`;
+- incomplete scope fails both lifecycle phases without partially scanning a mapped account;
+- per-account results and union summaries remain observable in diagnostics and the durable audit event;
+- the existing `lifecycle_discovery_result.v2` schema marker remains unchanged while account evidence is additive;
+- the durable audit envelope preserves its existing `ok` / `result` / `error` shape.
+
+## Changed files
+
+- `src/application/trades/backfill.py`
+- `tests/test_trades_auto_intake_backfill.py`
+- `docs/FUTU_TRADE_HOLDINGS_SYNC.md`
+- `docs/gateflow/lifecycle-single-source-of-truth/s2-implementation.md`
+
+## Implementation decisions
+
+1. Added a private scope resolver that normalizes the current Futu IDs, validates complete canonical mappings, lowercases and deduplicates account labels, and returns stable sorted accounts.
+2. The before/after lifecycle phases receive only that validated tuple and call `discover_lifecycle_cases()` once per account.
+3. Phase results retain `lifecycle_discovery_result.v2` and add `accounts`, ordered `account_results`, and deduplicated union fields for create/discover/skip plus the empty refresh compatibility fields.
+4. Missing mapping produces `lifecycle_account_scope_incomplete`, zero account calls, and the same typed phase evidence before and after payload processing.
+5. A per-account runtime exception is captured in that account result and makes the aggregate phase fail while retaining successful account evidence for safe idempotent retry.
+6. Existing history query, payload identity, Inbox, checkpoint, and top-level history/durable-queue completion semantics are unchanged.
+
+## Validation
+
+The repository `.venv` Python does not currently contain pytest. Validation used system Python 3.12 with pytest 9.0.3 and redirected bytecode to `/tmp`.
+
+Targeted account-scope regressions:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s2_target python3.12 -m pytest -q \
+  tests/test_trades_auto_intake_backfill.py::test_backfill_lifecycle_discovery_is_scoped_to_single_mapped_account \
+  tests/test_trades_auto_intake_backfill.py::test_backfill_lifecycle_discovery_scopes_legacy_source_per_account \
+  tests/test_trades_auto_intake_backfill.py::test_backfill_lifecycle_discovery_rejects_incomplete_account_scope_without_partial_scan
+```
+
+Result: `3 passed in 1.17s`.
+
+Focused slice suite after preserving the audit envelope:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s2_compat python3.12 -m pytest -q \
+  tests/test_trades_auto_intake_backfill.py
+```
+
+Result: `14 passed in 1.21s`.
+
+After accepted review findings S2-01 and S2-02 were fixed:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s2_rereview3 python3.12 -m pytest -q \
+  tests/test_trades_auto_intake_backfill.py
+```
+
+Result: `14 passed in 1.12s`.
+
+Ruff targeted check: `All checks passed!`.
+
+Static checks:
+
+```bash
+git diff --check
+rg -n "discover_lifecycle_cases\\(" src/application/trades/backfill.py
+```
+
+Result: pass; the sole call site supplies the loop's explicit `account` value.
+
+## Docs decision
+
+`docs/FUTU_TRADE_HOLDINGS_SYNC.md` now records the ownership boundary:
+
+- discovery is create-only;
+- canonical lifecycle read model plus account-scoped due reconciliation own derived-state transitions;
+- backfill derives complete explicit account scope and never uses an unscoped discovery call.
+
+## Residual risks and uncovered areas
+
+- If a later per-account discovery raises after an earlier account has created cases, the aggregate reports failure but the earlier idempotent creates remain. Retrying is safe because discovery is create-only; cross-account rollback is intentionally not introduced.
+- Existing production rows and deployment convergence remain assigned to a separately authorized operations step.
+- The full lifecycle/backfill/tick matrix, compileall, and aggregate DeepReview remain required after the S2 review gate.
+- Repository-local `.venv` dependency drift remains an environment issue; no dependency files are changed.
+
+All residual risks are classified.
+
+## Completion signal
+
+S2 implementation and accepted review fixes are complete: focused tests pass, incomplete mappings produce zero discovery calls and an observable top-level failure, the v2 diagnostic contract is preserved, and backfill contains no lifecycle discovery call with `account=None`. The next entry point is the accepted S2 commit.

--- a/docs/gateflow/lifecycle-single-source-of-truth/s2-review-fix.md
+++ b/docs/gateflow/lifecycle-single-source-of-truth/s2-review-fix.md
@@ -1,0 +1,67 @@
+# Gateflow S2 Review Fix — Account-scoped History Backfill
+
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `code review -> fix`
+- Slice: `S2`
+- Date: 2026-08-04
+- Review artifact: `docs/reviews/code-review-20260804-003745.md`
+- Status: fixed and re-reviewed
+- Artifact path: `docs/gateflow/lifecycle-single-source-of-truth/s2-review-fix.md`
+
+## Finding decision
+
+### S2-01 — accepted — 已修复
+
+The two lifecycle-discovery phases now contribute to the top-level backfill completion contract.
+
+- `lifecycle_discovery_complete` is true only when both before and after phase results are successful.
+- The value is exposed in diagnostics and included in `out["ok"]`.
+- A lifecycle-only failure produces the stable top-level error `lifecycle_discovery_incomplete`, allowing the listener status projection to retain an observable `last_backfill_error`.
+- Existing error precedence is preserved: incomplete history and durable Inbox failures remain authoritative before lifecycle discovery failure.
+- History payload processing still runs when lifecycle account scope is incomplete; unmapped payloads retain the existing unresolved/audit path.
+
+### S2-02 — accepted — 已修复
+
+The phase result keeps the existing `lifecycle_discovery_result.v2` schema discriminator.
+
+- `accounts` and `account_results` remain additive fields.
+- Existing union summary and compatibility fields remain at the same top-level paths.
+- Durable audit events continue to wrap the phase payload under `result`.
+- The single-account regression now asserts the v2 marker before and after discovery.
+
+## Regression coverage
+
+The incomplete-scope regression now includes an unmapped history payload and asserts:
+
+- both lifecycle phases make zero discovery calls and retain typed scope evidence;
+- payload receipt and identity-review audit phases still occur;
+- the payload remains unresolved;
+- top-level `ok` is false, `error` is `lifecycle_discovery_incomplete`, and diagnostics expose incomplete lifecycle discovery.
+
+The single-account regression asserts that diagnostics and the durable audit envelope retain `lifecycle_discovery_result.v2` while exposing additive account evidence.
+
+## Validation
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s2_rereview3 python3.12 -m pytest -q \
+  tests/test_trades_auto_intake_backfill.py
+```
+
+Result: `14 passed in 1.12s`.
+
+`python3.12 -m ruff check src/application/trades/backfill.py tests/test_trades_auto_intake_backfill.py`: pass.
+
+`git diff --check`: pass.
+
+## Docs decision
+
+No additional operator documentation is required; the existing S2 docs already state the fail-closed account-scope behavior.
+
+## Residual risks
+
+- History checkpoint advancement remains tied to history-query and durable-Inbox completeness. Lifecycle discovery is an independent idempotent ledger scan on every backfill cycle, so a lifecycle-only failure does not rewind successfully processed history windows.
+- Per-account create-only discovery remains retryable without cross-account rollback.
+
+## Completion status
+
+S2-01 and S2-02 are fixed; accepted re-review artifact: `docs/reviews/code-review-20260804-004321.md`.

--- a/docs/reviews/code-review-20260804-002940.md
+++ b/docs/reviews/code-review-20260804-002940.md
@@ -1,0 +1,37 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `fix/lifecycle-single-source-of-truth`
+- Base: accepted-plan checkpoint `ac366c5a`
+- Output file: `docs/reviews/code-review-20260804-002940.md`
+- Included scope: S1 create-only discovery, no-effective-pairing due branch, atomic state transition behavior, idempotency/CAS/fingerprint/Outbox semantics, and focused regressions
+- Excluded scope: S2 account-scoped backfill, production deployment/data convergence, provider correctness, and unrelated repository code
+- Parallel review coverage: 无；scope is one bounded lifecycle state-machine slice
+
+## Findings
+
+### S1-01-未修复-中-no-pairing 分支绕过了 terminal/conflict reason-state 过滤
+- **入口/函数**: `reconcile_due_lifecycle_cases()` -> `_reconcile_deadline_without_effective_pairing()` -> `reconcile_lifecycle_close_reason()`
+- **文件(行号)**: `src/application/trades/close_reason_reconciliation.py:683-711`; `src/application/trades/close_reason_reconciliation.py:536-548`
+- **输入场景**: active v2 case 已是 `conflict` 或 terminal/resolved，其 canonical read model 因没有 effective timing 而 `pairing_until_ms=None`，且 fallback/canonical deadline 已过。
+- **实际分支**: outer due loop 在检查 `reason_state` 之前先进入 no-pairing branch；helper 只要 `lifecycle_evidence_status != missing` 就重新调用 close-reason reconciler。
+- **预期行为**: `resolved` / `conflict` 是吸收性或需要受控修复的状态；due scheduler 应与原有 effective-pairing 分支一样，只调度 `cause_pending` / `partially_resolved` / 本次明确允许的 `needs_review` 收敛。
+- **实际行为**: conflict/no-pairing case 可被重新报告为 close-reason `needs_review` decision，terminal/no-pairing case 每 60 秒重进 resolver 并可出现 `not_started` 结果；持久化状态虽通常不改，但 due result/status/CLI 与 canonical absorbing state 不一致。
+- **直接证据**: 原分支在 `close_reason_reconciliation.py:712-717` 显式要求 reason state 为 `cause_pending` 或 `partially_resolved`；新 no-pairing 分支位于该过滤之前，helper 的第一个决策只看 evidence status。`reconcile_lifecycle_close_reason()` 对 conflict resolution 的 early return 使用 `decision.status=needs_review`，所以外部返回会与 persisted `conflict` 不同。
+- **影响**: due status/CLI 对已冲突或已终结 case 给出错误调和信号，并在每次 tick 重复做不应发生的 reconciliation；后续 resolver 如增加副作用，还会扩大为状态回归。
+- **建议改法和验证点**: 在进入 no-pairing helper 前先对 canonical `reason_state` 做 allowlist：仅 `cause_pending`、`partially_resolved`、`needs_review` 可进入；`resolved` / `conflict` 等直接 skip。新增 conflict/no-pairing deadline 回归，断言 close-reason resolver 与 provider collector 都未被调用、`case_count == 0`。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- S1 focused tests use system Python 3.12 because the repository `.venv` lacks pytest; aggregate validation must record the same environment fact.
+- S2 account isolation is intentionally not covered in this slice.
+- No live provider or production state was used, which is appropriate for this deterministic state-machine fix.
+

--- a/docs/reviews/code-review-20260804-002940.md
+++ b/docs/reviews/code-review-20260804-002940.md
@@ -34,4 +34,3 @@
 - S1 focused tests use system Python 3.12 because the repository `.venv` lacks pytest; aggregate validation must record the same environment fact.
 - S2 account isolation is intentionally not covered in this slice.
 - No live provider or production state was used, which is appropriate for this deterministic state-machine fix.
-

--- a/docs/reviews/code-review-20260804-003133.md
+++ b/docs/reviews/code-review-20260804-003133.md
@@ -49,4 +49,3 @@ Result: `26 passed in 1.57s`.
 ## Conclusion
 
 Pass. S1-01 is fixed, all review findings are closed, and S1 is ready for its protected local commit.
-

--- a/docs/reviews/code-review-20260804-003133.md
+++ b/docs/reviews/code-review-20260804-003133.md
@@ -1,0 +1,52 @@
+# Code Re-review
+
+## Scope
+
+- Mode: current changes
+- Branch: `fix/lifecycle-single-source-of-truth`
+- Base: accepted-plan checkpoint `ac366c5a`
+- Output file: `docs/reviews/code-review-20260804-003133.md`
+- Included scope: S1 implementation plus the fix for S1-01; discovery ownership, no-effective-pairing state selection, CAS/fingerprint/revision/no-Outbox behavior, and focused tests
+- Excluded scope: S2 account-scoped backfill, deployment/production convergence, provider correctness, and unrelated repository code
+- Parallel review coverage: 无；bounded lifecycle state-machine slice
+
+## Findings
+
+未发现新的实质性问题。
+
+### S1-01 — 已修复
+
+- The canonical `reason_state` is normalized immediately after the read model is loaded.
+- The no-effective-pairing branch now permits only `cause_pending`, `partially_resolved`, and `needs_review` before invoking the helper.
+- `resolved`, `conflict`, and unknown states are skipped before any close-reason resolver, provider collector, state writer, or outward result is produced.
+- The existing effective-pairing branch consumes the same normalized value and retains its narrower pending-only allowlist.
+- The new conflict/no-pairing regression makes resolver/provider invocation fail the test and confirms an empty due result.
+
+Final finding status: `已修复`.
+
+## Validation
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s1_rereview python3.12 -m pytest -q \
+  tests/test_position_advice_v2_lifecycle_reconciliation.py \
+  tests/test_settlement_observation.py
+```
+
+Result: `26 passed in 1.57s`.
+
+`git diff --check`: pass.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- S2 account isolation remains intentionally uncovered until the next approved slice.
+- The repository `.venv` lacks pytest; deterministic validation used system Python 3.12 and this environment difference is recorded in the implementation artifact.
+- Aggregate lifecycle/backfill/tick validation remains required after S2.
+
+## Conclusion
+
+Pass. S1-01 is fixed, all review findings are closed, and S1 is ready for its protected local commit.
+

--- a/docs/reviews/code-review-20260804-003745.md
+++ b/docs/reviews/code-review-20260804-003745.md
@@ -1,0 +1,49 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `fix/lifecycle-single-source-of-truth`
+- Base: accepted S1 checkpoint `07934baa`
+- Output file: `docs/reviews/code-review-20260804-003745.md`
+- Included scope: S2 Futu-ID-to-account scope derivation, single/legacy multi-account discovery calls, incomplete mapping behavior, aggregate diagnostics, durable audit compatibility, checkpoint/Inbox invariants, docs, and focused regressions
+- Excluded scope: S1 implementation already accepted at `07934baa`, provider correctness, production data convergence/deployment, and unrelated repository code
+- Parallel review coverage: 无；bounded history-backfill account-scope slice
+
+## Findings
+
+### S2-01-未修复-中-lifecycle phase 失败被顶层 backfill 成功语义掩盖
+- **入口/函数**: `run_history_backfill()` -> `_lifecycle_discovery_after_backfill_phase()` -> `_update_status_from_backfill()`
+- **文件(行号)**: `src/application/trades/backfill.py:370-422,434-535`; `src/application/trades/auto_intake.py:2237-2261`
+- **输入场景**: 当前 source 的任一 `futu_account_id` 缺少 mapping，或某个 account-scoped discovery 运行时失败；history query 和 durable Inbox 均成功。
+- **实际分支**: before/after phase 正确返回 `ok=false` 与 typed reason，但顶层 `out["ok"]` 只检查 `history_query_complete && durable_queue_complete`，且不设 `out["error"]`。listener 只把顶层 `error` 投影为 `last_backfill_error`。
+- **预期行为**: typed lifecycle phase 失败可以不阻止已有 trade payload 的 unresolved/audit 流程，但该轮 backfill 完成语义必须 fail closed，并让 status/readiness 能观测到稳定错误码。
+- **实际行为**: 底层 lifecycle discovery 零执行或部分失败，顶层和 listener status 仍报成功；运维需要钻入 audit/diagnostics 才能发现。
+- **直接证据**: `backfill.py:401-404` 已保留双 phase 结果，但 `backfill.py:407-422` 的成功和 error 分支完全不消费它们；`auto_intake.py:2259-2260` 只读顶层 `result.get("error")`。新 missing-mapping 回归也只断言 phase failure，未断言顶层失败。
+- **影响**: 本次引入的账户隔离安全门在配置漂移或单账户发现异常时会被监控误报为健康，无法证明该轮 lifecycle discovery 完整执行。
+- **建议改法和验证点**: 计算 `lifecycle_discovery_complete = before.ok && after.ok`，加入 diagnostics 和顶层 `ok` 判定；在 history/Inbox 错误之后使用稳定 `lifecycle_discovery_incomplete` error。扩展 missing-mapping 回归，断言 payload 路径仍执行，但顶层 `ok=false` / error 可观测。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### S2-02-未修复-中-additive phase diagnostics 替换了既有 schema marker
+- **入口/函数**: `_lifecycle_discovery_after_backfill_phase()` -> diagnostics / durable audit `result`
+- **文件(行号)**: `src/application/trades/backfill.py:434-535`; `docs/gateflow/lifecycle-single-source-of-truth/plan.md:92-115`
+- **输入场景**: 任意 single-account 或 legacy multi-account backfill 完成 before/after lifecycle discovery，下游按已有 phase result 的 `schema_version` 识别 payload。
+- **实际分支**: 聚合 result 把既有 `lifecycle_discovery_result.v2` 替换为新 `backfill_lifecycle_discovery_result.v1`，同时添加 account evidence。
+- **预期行为**: 冻结计划要求 discovery result v2 schema 不变，backfill phase 仅增量添加 `accounts` / `account_results` 并保留 union keys。
+- **实际行为**: 内部 diagnostics 与 durable audit `result` 的 schema discriminator 发生替换，其它字段虽兼容，但按 schema 分派的消费者会拒绝或误分类。
+- **直接证据**: accepted plan 在 `plan.md:106-115` 明确写明 additive account fields 与 `lifecycle_discovery_result.v2` schema 不变；原 helper 直接 spread discovery v2 result，新 aggregate 在初始化时改写 marker。
+- **影响**: 会把账户隔离修复变成不必要的诊断合同破坏，与已接受的最小变更边界不符。
+- **建议改法和验证点**: 保留顶层 `schema_version=lifecycle_discovery_result.v2`，只增加 `accounts` / `account_results`；在 single-account 回归和 audit envelope 中断言 v2 marker 与增量账户证据同时存在。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Per-account discovery 在较后账户失败时可保留较早账户已创建的 case；create-only 幂等重试使其可恢复，本 slice 不引入跨账户事务。
+- Repository `.venv` 缺少 pytest；当前验证使用 system Python 3.12，必须在聚合证据中继续记录。
+- Aggregate lifecycle/backfill/tick validation 与 aggregate DeepReview 仍待 S2 finding 修复后执行。

--- a/docs/reviews/code-review-20260804-004321.md
+++ b/docs/reviews/code-review-20260804-004321.md
@@ -1,0 +1,69 @@
+# Code Re-review
+
+## Scope
+
+- Mode: current changes
+- Branch: `fix/lifecycle-single-source-of-truth`
+- Base: accepted S1 checkpoint `07934baa`
+- Output file: `docs/reviews/code-review-20260804-004321.md`
+- Included scope: complete S2 implementation plus fixes for S2-01 and S2-02; account scope derivation, per-account calls, failure propagation, phase/audit compatibility, payload/checkpoint/Inbox behavior, docs, and focused regressions
+- Excluded scope: accepted S1 implementation, provider correctness, production data convergence/deployment, and unrelated repository code
+- Parallel review coverage: 无；bounded history-backfill account-scope slice
+
+## Findings
+
+未发现新的实质性问题。
+
+### S2-01 — 已修复
+
+- Both lifecycle phases now contribute to `lifecycle_discovery_complete`.
+- Top-level success requires complete history, durable Inbox, and complete lifecycle discovery.
+- Lifecycle-only failure emits `lifecycle_discovery_incomplete`, which the existing listener status projection exposes as `last_backfill_error`.
+- Incomplete account scope still permits the existing history-payload unresolved/audit path; the regression proves receipt and identity-review events occur without a discovery call.
+
+Final finding status: `已修复`.
+
+### S2-02 — 已修复
+
+- Phase diagnostics retain `schema_version=lifecycle_discovery_result.v2`.
+- `accounts` and `account_results` are additive; union summary and empty refresh compatibility fields remain at their existing top-level paths.
+- Durable audit events preserve the existing envelope and keep the phase result under `result`.
+- Regressions assert both the v2 discriminator and additive account evidence.
+
+Final finding status: `已修复`.
+
+## Validation
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om_lifecycle_s2_rereview3 python3.12 -m pytest -q \
+  tests/test_trades_auto_intake_backfill.py
+```
+
+Result: `14 passed in 1.12s`.
+
+```bash
+python3.12 -m ruff check \
+  src/application/trades/backfill.py \
+  tests/test_trades_auto_intake_backfill.py
+```
+
+Result: `All checks passed!`.
+
+`git diff --check`: pass.
+
+Repository search confirms the sole backfill `discover_lifecycle_cases()` call receives the explicit loop account, and `src/application/trades/backfill.py` contains no `account=None` call.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- A later per-account create failure can leave earlier account creates committed; create-only idempotent retry makes this recoverable, and cross-account rollback remains intentionally out of scope.
+- A lifecycle-only failure does not rewind the independently successful history checkpoint; lifecycle discovery is rerun on every backfill cycle and does not depend on the history window.
+- Repository `.venv` lacks pytest; deterministic validation uses system Python 3.12, recorded in the implementation artifact.
+- Aggregate lifecycle/backfill/tick validation and aggregate DeepReview remain required before push.
+
+## Conclusion
+
+Pass. S2-01 and S2-02 are fixed, all S2 review findings are closed, and the slice is ready for its protected local commit.

--- a/docs/reviews/code-review-20260804-004625.md
+++ b/docs/reviews/code-review-20260804-004625.md
@@ -1,0 +1,75 @@
+# Aggregate Code Review
+
+## Scope
+
+- Mode: branch diff
+- Branch: `fix/lifecycle-single-source-of-truth`
+- Base: `origin/main@ed2531e9`
+- Reviewed head: accepted S2 commit `35b5c3ba` plus aggregate validation/evidence cleanup
+- Output file: `docs/reviews/code-review-20260804-004625.md`
+- Included scope: complete lifecycle single-source work unit; discovery creation authority, canonical read-model/due transition ownership, no-pairing deadline branches, CAS/fingerprint/revision/Outbox semantics, backfill account derivation and phase aggregation, top-level failure propagation, diagnostics/audit compatibility, docs, and all regressions
+- Excluded scope: live broker/provider correctness, existing production-row convergence, deployment/runtime activation, release, and unrelated repository code
+- Parallel review coverage: 无；the complete diff was reviewed as one end-to-end lifecycle state and account-scope pipeline
+
+## Findings
+
+未发现新的实质性问题。
+
+Previously recorded findings are closed:
+
+- Plan PR-01/PR-02/PR-03: fixed and accepted before implementation.
+- S1-01: fixed; conflict/resolved no-pairing cases are filtered before reconciliation.
+- S2-01: fixed; lifecycle phase failure participates in top-level backfill completion and status error projection.
+- S2-02: fixed; `lifecycle_discovery_result.v2` remains the phase schema marker and account evidence is additive.
+
+## End-to-end review evidence
+
+### State ownership
+
+- `discover_expired_lifecycle_cases_atomically()` now reads existing cases only to protect target ownership and inserts missing immutable cases; no existing-case status or summary update remains.
+- `lifecycle_case_read_model()` remains the canonical combination of case, allocation, evidence, timing policy, generation token, and current-time facts.
+- Account-scoped `reconcile_due_lifecycle_cases()` is the only scheduler path added for missing-evidence deadline materialization, and it writes through the existing atomic generation-token/fingerprint/revision owner.
+- Missing evidence is distinguished from evidence whose effective timing is unavailable; the latter delegates to the existing typed close-reason reconciler without broker collection.
+- Conflict/resolved/unknown reason states are skipped before the no-pairing helper, preserving absorbing-state behavior.
+
+### Notification and fingerprint safety
+
+- Missing-anchor deadline materialization passes `public_transition=None`; the atomic writer therefore creates no notification Outbox item.
+- Dry-run performs no write; apply/replay uses the same canonical summary and generation token, so unchanged business state keeps the same revision/fingerprint.
+- Backfill discovery replay cannot alter an existing case or its derived summary, eliminating the historical lifecycle-status oscillation that invalidated prepared option-position context fingerprints.
+- Pairing-present provider observation and reconciliation behavior is unchanged.
+
+### Account and backfill boundary
+
+- Backfill account scope is derived only from the current `futu_account_ids` and canonical mapping; values are complete, normalized, deduplicated, and sorted before discovery.
+- Each discovery call receives one explicit lowercase account. Legacy multi-account sources are preserved as stable per-account calls; no backfill call passes `account=None`.
+- An incomplete mapping produces zero partial discovery calls in both phases while existing payload identity/unresolved/audit handling continues.
+- Per-account results aggregate into existing union keys with additive account evidence, and the durable audit retains its original envelope.
+- Lifecycle-only failure is observable at the top level without changing the independent history checkpoint/Inbox contracts.
+
+## Validation
+
+- Aggregate matrix: `86 passed, 4 warnings in 5.68s`.
+- Warnings: four pre-existing Legacy Tick renderer deprecations; scheduled delivery remains Daily Brief-owned.
+- Python compileall across `domain src scripts`: pass.
+- Ruff across every changed Python production/test file: pass.
+- Full-branch and working-tree `git diff --check`: pass after mechanical removal of seven extra Markdown EOF blank lines.
+- Search: one backfill discovery call with explicit loop account; no `account=None` discovery call in backfill.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Existing production rows and runtime convergence are not verified until a separately authorized deployment/operations step.
+- Per-account create-only discovery is transactionally atomic per account, not across accounts; an earlier successful account remains safely idempotent if a later account fails.
+- Lifecycle-only failure does not rewind a successful history checkpoint because discovery reruns independently every cycle.
+- The existing at-most-60-second due cadence remains accepted.
+- Repository `.venv` lacks pytest; aggregate tests used system Python 3.12, and no dependency mutation is included.
+
+All residual risks are classified; there are no unclassified findings.
+
+## Conclusion
+
+Pass. The complete work unit is ready for the aggregate acceptance commit, then push and Draft PR creation. Merge, release, deployment, and production mutation remain outside this Gateflow run.

--- a/docs/reviews/plan-review-20260804-001846.md
+++ b/docs/reviews/plan-review-20260804-001846.md
@@ -1,0 +1,70 @@
+# Plan Review — Lifecycle Single Source of Truth
+
+- Reviewed target: `docs/gateflow/lifecycle-single-source-of-truth/plan.md`
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `plan review`
+- Review scope: state authority, no-pairing deadline behavior, account isolation, compatibility, notification side effects, slices, tests, and residual risks
+- Conclusion: `fail`
+- Artifact path: `docs/reviews/plan-review-20260804-001846.md`
+
+## Assumptions tested
+
+1. `pairing_until_ms is None` uniquely means there is no accepted option-close anchor.
+2. Every supported trade-intake runtime source has a non-empty single `source.account`.
+3. Moving legacy deadline aging to `advance_lifecycle_case_state(..., public_transition="needs_review")` preserves the current notification contract.
+4. Removing the ledger discovery refresh loop leaves all deadline paths with an accountable canonical owner.
+5. Existing CAS/fingerprint/revision primitives can be reused without a schema or state-machine expansion.
+
+Architecture, best-practice, optimal-solution, overengineering, and overcoupling lenses were applied. The overall ownership direction is correct, but three assumptions are not safe enough for implementation.
+
+## Findings
+
+### PR-01-未修复-高-`pairing_until_ms is None` 不能证明没有 option-close anchor
+- **位置**: Plan §3.2 and Slice S1 no-pairing branch.
+- **问题类型**: 状态机漏洞 / 契约缺失.
+- **当前写法**: 计划把 `pairing_until_ms is None` 解释为“没有 option-close anchor”，并直接物化 read-model `needs_review`。
+- **反例/失败场景**: case 已有 accepted zero-price anchor，但 timing policy 缺失、绑定失败或无法与 anchor 组成 effective timing。该 case 同样会得到 `pairing_until_ms=None`，但正确分类应由 close-reason reconciler 给出 `lifecycle_timing_policy_unavailable` 等 typed reason，不应被 no-anchor fallback 误当成普通 deadline elapsed。
+- **为什么有问题**: 计划仍以一个派生时间字段猜测 evidence identity，与“canonical facts 是唯一真源”的目标冲突。
+- **直接证据**: `build_lifecycle_case_read_model_from_resolved_facts()` 只在 timing policy 与 anchor facts 都存在且 effective timing 可构建时设置 `pairing_until_ms`；同一 read model 已暴露 `lifecycle_evidence_status` 和 `reservation_evidence_ids`。`reconcile_lifecycle_close_reason()` 对存在 anchor 但 timing 不可用有专门 fail-closed reason。
+- **影响**: 人工复核理由失真，可能隐藏 timing binding 故障，并让修复后仍有两套分类语义。
+- **建议改法和验证点**: 分支必须使用 canonical evidence status：`lifecycle_evidence_status == "missing"` 才允许 no-anchor deadline materialization；有 anchor/evidence 但 no pairing 时调用现有 `reconcile_lifecycle_close_reason()` 进行 typed fail-closed 分类，不调 provider collector。增加“anchor exists + timing unavailable”回归。
+- **修复风险（低/中/高）**: 中.
+- **严重程度（低/中/高/严重）**: 高.
+
+### PR-02-未修复-高-必填单 account 会破坏仓库明确保留的 legacy multi-account source
+- **位置**: Plan §3.3, internal call contract, and Slice S2.
+- **问题类型**: 架构边界 / 兼容性回归 / 非最优方案.
+- **当前写法**: `run_history_backfill()` 新增必填非空 `account`，`auto_intake` 传 `source["account"]`。
+- **反例/失败场景**: `resolve_trade_intake_sources()` 在没有 modern account sources 时显式返回 `id="legacy", account=None`，同时携带可能包含多个账户的 `account_mapping` 和 `futu_account_ids`。新契约会让这条已支持路径在 history fetch 前直接失败。
+- **为什么有问题**: 用破坏性单账户签名修复 `account=None` 过宽扫描，不如从函数已有的 canonical Futu ID -> account mapping 构造显式账户集合。
+- **直接证据**: `src/application/trades/account_mapping.py::resolve_trade_intake_sources()` legacy fallback 字面设置 `"account": None`、`"account_mapping": base_mapping`、`"futu_account_ids": base_account_ids`。`run_history_backfill()` 已接收后两项信息。
+- **影响**: legacy trade intake backfill 全面中断，且计划声称“不改 public config/contract”与实际不符。
+- **建议改法和验证点**: 不新增 required account 参数。从本次 `futu_account_ids` 及 `account_mapping` 导出去重、lowercase 的 explicit account list；对每个 account 单独调 discovery，永不传 `None`。任一 configured Futu ID 无 mapping 时记录 typed scope failure 并不执行部分 discovery。测试 single-account 与 legacy two-account 路径。
+- **修复风险（低/中/高）**: 中.
+- **严重程度（低/中/高/严重）**: 高.
+
+### PR-03-未修复-高-计划会新增真实 lifecycle `needs_review` 通知意图
+- **位置**: Plan §3.2 step 3, Slice S1 invariants, and risk table.
+- **问题类型**: 范围漂移 / 通知副作用 / 契约缺失.
+- **当前写法**: no-anchor legacy aging 在 apply 时传 `public_transition="needs_review"`，并以 Outbox 幂等作为验收点。
+- **反例/失败场景**: 当前 discovery refresh 只调 repository `update_trade_lifecycle_case_derived_status()`，不创建 notification Outbox。修复部署后，存量无 anchor 且已超时的 case 在首次 due tick 会新建 `needs_review` 通知意图，这不是用户授权的修复目标。
+- **为什么有问题**: 这是可见通知语义变更，不是单纯的计算口径收敛；也与计划 non-goal“不改通知条件”冲突。
+- **直接证据**: `advance_lifecycle_case_state_atomically()` 在 `public_transition` 非空时构造并写入 fixed-slot notification intent；旧 discovery loop 只使用 repository status update。
+- **影响**: 生产升级后可能突发用户未预期的生命周期告警，扩大本 bug-fix 范围和上线风险。
+- **建议改法和验证点**: no-anchor fallback 继续使用 canonical atomic writer 和 fingerprint/revision，但 `public_transition=None`，保持旧有“转人工复核但不自动新发 lifecycle receipt”语义。增加断言：apply/replay 均无 Outbox。如未来要新增该通知，作为独立用户可见 work unit。
+- **修复风险（低/中/高）**: 低.
+- **严重程度（低/中/高/严重）**: 高.
+
+## Open questions
+
+None after applying the concrete fixes above.
+
+## Residual risks and tracking destination
+
+- Existing production rows may already contain an old-path derived summary. This remains an operations/deployment verification risk and is not a plan blocker.
+- Multi-account legacy discovery aggregation must preserve enough diagnostics for operators; cover in S2 tests and document the shape actually retained.
+
+## Final conclusion
+
+`fail`. The root ownership direction is sound, but implementation must not begin until the plan distinguishes anchor identity from timing availability, preserves the supported legacy source shape, and avoids introducing a new notification side effect.
+

--- a/docs/reviews/plan-review-20260804-001846.md
+++ b/docs/reviews/plan-review-20260804-001846.md
@@ -67,4 +67,3 @@ None after applying the concrete fixes above.
 ## Final conclusion
 
 `fail`. The root ownership direction is sound, but implementation must not begin until the plan distinguishes anchor identity from timing availability, preserves the supported legacy source shape, and avoids introducing a new notification side effect.
-

--- a/docs/reviews/plan-review-20260804-002343.md
+++ b/docs/reviews/plan-review-20260804-002343.md
@@ -52,4 +52,3 @@ All residual risks are classified; none blocks implementation.
 ## Final conclusion
 
 `pass`. The plan is code-generation-ready, preserves supported compatibility paths, retains fail-closed behavior, avoids a notification scope expansion, and uses the smallest credible ownership fix.
-

--- a/docs/reviews/plan-review-20260804-002343.md
+++ b/docs/reviews/plan-review-20260804-002343.md
@@ -1,0 +1,55 @@
+# Plan Re-review — Lifecycle Single Source of Truth
+
+- Reviewed target: `docs/gateflow/lifecycle-single-source-of-truth/plan.md`
+- Work unit: `lifecycle-single-source-of-truth`
+- Gate: `plan re-review`
+- Prior review: `docs/reviews/plan-review-20260804-001846.md`
+- Fix artifact: `docs/gateflow/lifecycle-single-source-of-truth/plan-review-fix.md`
+- Review scope: accepted findings PR-01 through PR-03 plus architecture, sequencing, contracts, tests, and residual risks
+- Conclusion: `pass`
+- Artifact path: `docs/reviews/plan-review-20260804-002343.md`
+
+## Assumptions re-tested
+
+1. Anchor identity now comes from canonical evidence status, not from the absence of an effective pairing timestamp.
+2. Both modern per-account sources and the repository's explicit legacy multi-account fallback can be scoped without any `account=None` discovery call.
+3. No-anchor deadline aging retains fail-closed status progression without introducing a new notification intent.
+4. The existing generation-token CAS, state fingerprint, revision, and optional Outbox writer remain the only persistence boundary.
+5. Slice order prevents account-scope work from masking the state-authority regression.
+
+Architecture boundary, best-practice, optimal-solution, overengineering, and overcoupling lenses were re-applied.
+
+## Finding re-review
+
+### PR-01 — 已修复
+
+The revised plan uses `lifecycle_evidence_status == missing` for no-anchor materialization and routes evidence-present/no-effective-pairing cases through the existing close-reason reconciler. The new regression explicitly distinguishes timing failure from missing evidence.
+
+### PR-02 — 已修复
+
+The required single-account signature change was removed. The plan now derives a complete explicit account set from the current Futu IDs and canonical mapping, invokes discovery per account, and keeps legacy multi-account support without a global `account=None` call.
+
+### PR-03 — 已修复
+
+The no-anchor deadline path uses `public_transition=None`; its tests require zero Outbox rows on first apply and replay. The fix therefore preserves current user-visible notification behavior while gaining canonical revision/fingerprint persistence.
+
+## New findings
+
+None.
+
+## Open questions
+
+None.
+
+## Residual risks and tracking destination
+
+- Existing production rows may still reflect an old-path projection until a separately authorized upgrade and natural canonical reconciliation. Owner: deployment/operations verification outside this work unit.
+- Multi-account lifecycle-discovery diagnostics gain additive account evidence. The exact implemented shape is owned by S2 tests and its implementation artifact; no public CLI argument or config schema changes.
+- Newly discovered already-due cases may wait for the existing at-most-60-second due cadence. This is accepted current runtime behavior, not a new scheduler requirement.
+
+All residual risks are classified; none blocks implementation.
+
+## Final conclusion
+
+`pass`. The plan is code-generation-ready, preserves supported compatibility paths, retains fail-closed behavior, avoids a notification scope expansion, and uses the smallest credible ownership fix.
+

--- a/docs/reviews/pr-132-review-20260804-005134.md
+++ b/docs/reviews/pr-132-review-20260804-005134.md
@@ -1,0 +1,73 @@
+# Pull Request Code Review
+
+## Scope
+
+- Mode: GitHub Pull Request
+- Repository: `liuxie066/options-monitor`
+- Pull Request: `#132` — `fix: make lifecycle state ownership canonical`
+- URL: `https://github.com/liuxie066/options-monitor/pull/132`
+- Remote base: `main@ed2531e956f7ff818b3198a6dc3d918bb5328b3f`
+- Reviewed remote head: `fix/lifecycle-single-source-of-truth@c9cd7ce275d84dfecd13d174abde84019df262d1`
+- Output file: `docs/reviews/pr-132-review-20260804-005134.md`
+- Included scope: all 24 PR files and four commits; source, regressions, operator docs, Gateflow evidence, remote metadata, Draft/mergeability state, and hosted-check state
+- Excluded scope: deployment, production-row convergence, release, remote upgrade, real notification/provider execution, and unrelated repository code
+- Parallel review coverage: 无；exact remote head equals the locally accepted aggregate head
+
+## Remote integrity evidence
+
+- GitHub base OID equals current `origin/main`: `ed2531e956f7ff818b3198a6dc3d918bb5328b3f`.
+- GitHub head OID, `git ls-remote`, local `HEAD`, and accepted aggregate commit all equal `c9cd7ce275d84dfecd13d174abde84019df262d1`.
+- GitHub reports 24 changed files, 2,058 additions, 103 deletions, and the same four Gateflow commits reviewed locally.
+- `gh pr diff --name-only` exactly matches the accepted local work-unit file set.
+- PR is `OPEN`, `Draft`, and `MERGEABLE`; no reviews, comments, review requests, or review decision exist.
+
+## Findings
+
+未发现新的实质性问题。
+
+The PR-level view preserves every accepted invariant:
+
+- discovery is create-only and cannot overwrite existing lifecycle projections;
+- canonical read model plus account-scoped due reconciliation owns deadline transitions;
+- missing-anchor aging uses CAS/fingerprint/revision authority with no Outbox side effect;
+- evidence-without-effective-timing remains typed and provider-free;
+- backfill derives complete explicit current-source accounts and never uses an unscoped discovery call;
+- lifecycle phase failures are top-level observable;
+- v2 result, audit envelope, CLI/tick, Inbox/checkpoint, and notification formatting compatibility are preserved.
+
+All prior PlanReview, slice DeepReview, and Aggregate DeepReview findings remain closed in the exact remote diff.
+
+## Validation
+
+- Aggregate matrix: `86 passed, 4` classified pre-existing renderer deprecation warnings.
+- Compileall across `domain src scripts`: pass.
+- Ruff across all changed Python production/test files: pass.
+- Full-branch `git diff --check`: pass.
+- No real notification, provider call, production data/config write, service change, release, deployment, or upgrade occurred.
+
+Hosted checks at review time:
+
+- `agent-plugin`: in progress
+- `guardrails`: in progress
+- CodeQL `Analyze (actions)`: in progress
+- CodeQL `Analyze (python)`: in progress
+
+Pending checks are recorded as pending, not treated as pass. They must be rechecked after the PR-review evidence push.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Production-row convergence and runtime verification require separate deployment/operations authorization.
+- Multi-account create-only discovery remains atomic per account and idempotently retryable.
+- Lifecycle-only failure leaves the independently successful history checkpoint advanced by design.
+- Repository `.venv` dependency drift remains documented; no dependency mutation is included.
+- Hosted checks have not yet completed.
+
+All residual risks are classified; there are no unclassified findings.
+
+## Conclusion
+
+Pass. PR #132 is acceptable as an open Draft at remote head `c9cd7ce2`. Commit and push this review evidence, then recheck the exact remote head and hosted checks before final closeout. Do not merge, mark Ready, request reviewers, release, deploy, or upgrade.

--- a/src/application/ledger/writer.py
+++ b/src/application/ledger/writer.py
@@ -27,7 +27,6 @@ from domain.domain.lifecycle_allocation import (
 from domain.domain.option_position_identity import normalize_currency
 from domain.domain.option_lifecycle import (
     build_lifecycle_case,
-    derive_lifecycle_read_model,
     expiration_observation_start_ms,
 )
 from domain.domain.performance.models import canonical_decimal_text, quantize_money, to_decimal
@@ -1907,7 +1906,6 @@ def discover_expired_lifecycle_cases_atomically(
             raise TypeError("lifecycle discovery requires SQLite transaction authority")
         sqlite_repo.assert_foreign_keys_clean(conn=conn)
         position_lots = list(sqlite_repo.list_position_lots(conn=conn))
-        void_event_ids = _effective_void_target_ids(sqlite_repo, conn=conn)
         existing_cases = list(
             sqlite_repo.list_trade_lifecycle_cases(
                 account=account_value or None,
@@ -2016,81 +2014,11 @@ def discover_expired_lifecycle_cases_atomically(
                 )
                 if created:
                     created_case_ids.append(case_id)
-                    existing_cases.append(lifecycle_case)
             else:
                 would_create_case_ids.append(case_id)
 
         refreshed_case_ids: list[str] = []
         would_refresh_case_ids: list[str] = []
-        for lifecycle_case in existing_cases:
-            case_id = str(lifecycle_case.get("case_id") or "").strip()
-            if (
-                not case_id
-                or str(lifecycle_case.get("schema_version") or "").strip()
-                != "lifecycle_case.v2"
-            ):
-                continue
-            persisted_status = str(lifecycle_case.get("status") or "").strip().lower()
-            if persisted_status == "conflict":
-                continue
-            allocations = list(
-                sqlite_repo.list_trade_lifecycle_allocations(
-                    case_id=case_id,
-                    conn=conn,
-                )
-            )
-            read_model = derive_lifecycle_read_model(
-                expiration_ymd=str(lifecycle_case.get("expiration_ymd") or ""),
-                market=str(
-                    lifecycle_case.get("market")
-                    or symbol_market(lifecycle_case.get("symbol"))
-                    or ""
-                ),
-                target_contracts_by_lot=dict(
-                    lifecycle_case.get("target_contracts_by_lot") or {}
-                ),
-                allocations=allocations,
-                void_event_ids=void_event_ids,
-                now_ms=current_ms,
-            )
-            next_status = {
-                "settlement_pending": "waiting_settlement_evidence",
-                "partially_resolved": "partially_resolved",
-                "needs_review": "needs_review",
-                "assigned": "ledger_written",
-                "exercised": "ledger_written",
-                "expired_unassigned": "ledger_written",
-                "closed": "ledger_written",
-                "resolved_mixed": "ledger_written",
-                "conflict": "conflict",
-            }.get(read_model.lifecycle_state, persisted_status)
-            if next_status != persisted_status:
-                if apply_changes:
-                    sqlite_repo.update_trade_lifecycle_case_derived_status(
-                        case_id=case_id,
-                        status=next_status,
-                        derived_summary={
-                            "target_contracts_by_lot": dict(
-                                lifecycle_case.get("target_contracts_by_lot") or {}
-                            ),
-                            "resolved_contracts_by_lot": (
-                                read_model.resolved_contracts_by_lot
-                            ),
-                            "remaining_contracts_by_lot": (
-                                read_model.remaining_contracts_by_lot
-                            ),
-                            "resolved_contracts_by_terminal_type": (
-                                read_model.resolved_contracts_by_terminal_type
-                            ),
-                            "lifecycle_reason_codes": list(
-                                read_model.lifecycle_reason_codes
-                            ),
-                        },
-                        conn=conn,
-                    )
-                    refreshed_case_ids.append(case_id)
-                else:
-                    would_refresh_case_ids.append(case_id)
         sqlite_repo.assert_foreign_keys_clean(conn=conn)
         return {
             "schema_version": "lifecycle_discovery_result.v2",

--- a/src/application/trades/backfill.py
+++ b/src/application/trades/backfill.py
@@ -140,9 +140,19 @@ def run_history_backfill(
     unresolved_count = 0
     last_result: dict[str, Any] | None = None
     durable_queue_complete = True
+    try:
+        lifecycle_accounts = _lifecycle_discovery_accounts(
+            futu_account_ids=futu_account_ids,
+            account_mapping=account_mapping,
+        )
+        lifecycle_scope_error = None
+    except ValueError as exc:
+        lifecycle_accounts = ()
+        lifecycle_scope_error = f"{type(exc).__name__}: {exc}"
     lifecycle_discovery_before = _lifecycle_discovery_after_backfill_phase(
         repo=repo,
-        account=None,
+        accounts=lifecycle_accounts,
+        scope_error=lifecycle_scope_error,
         observed_at_ms=int(now.astimezone(timezone.utc).timestamp() * 1000),
         apply_changes=apply_changes,
         audit_path=audit_path,
@@ -381,7 +391,8 @@ def run_history_backfill(
     diagnostics["checkpoint_advanced"] = checkpoint_advanced
     lifecycle_discovery_after = _lifecycle_discovery_after_backfill_phase(
         repo=repo,
-        account=None,
+        accounts=lifecycle_accounts,
+        scope_error=lifecycle_scope_error,
         observed_at_ms=int(now.astimezone(timezone.utc).timestamp() * 1000),
         apply_changes=apply_changes,
         audit_path=audit_path,
@@ -391,10 +402,19 @@ def run_history_backfill(
         "before": lifecycle_discovery_before,
         "after": lifecycle_discovery_after,
     }
+    lifecycle_discovery_complete = bool(
+        lifecycle_discovery_before.get("ok")
+        and lifecycle_discovery_after.get("ok")
+    )
+    diagnostics["lifecycle_discovery_complete"] = lifecycle_discovery_complete
 
     finished_at = utc_now()
     out = {
-        "ok": bool(history_query_complete and durable_queue_complete),
+        "ok": bool(
+            history_query_complete
+            and durable_queue_complete
+            and lifecycle_discovery_complete
+        ),
         "started_at_utc": started_at,
         "finished_at_utc": finished_at,
         "deal_count": len(payloads),
@@ -409,6 +429,8 @@ def run_history_backfill(
         out["error"] = "history_query_incomplete"
     elif not durable_queue_complete:
         out["error"] = "durable_inbox_incomplete"
+    elif not lifecycle_discovery_complete:
+        out["error"] = "lifecycle_discovery_incomplete"
     append_trade_intake_audit(
         audit_path,
         {
@@ -423,45 +445,142 @@ def run_history_backfill(
 def _lifecycle_discovery_after_backfill_phase(
     *,
     repo: Any,
-    account: str | None,
+    accounts: tuple[str, ...],
+    scope_error: str | None,
     observed_at_ms: int,
     apply_changes: bool,
     audit_path: Path,
     phase: str,
 ) -> dict[str, Any]:
-    try:
-        result = discover_lifecycle_cases(
-            repo,
-            account=account,
-            observed_at_ms=observed_at_ms,
-            apply_changes=apply_changes,
-        )
-        append_trade_intake_audit(
-            audit_path,
+    aggregate: dict[str, Any] = {
+        "schema_version": "lifecycle_discovery_result.v2",
+        "observed_at_ms": int(observed_at_ms),
+        "account": accounts[0] if len(accounts) == 1 else None,
+        "accounts": list(accounts),
+        "account_results": [],
+        "apply_changes": bool(apply_changes),
+        "created_case_ids": [],
+        "would_create_case_ids": [],
+        "discovered_case_ids": [],
+        "refreshed_case_ids": [],
+        "would_refresh_case_ids": [],
+        "skipped_targeted_lot_ids": [],
+    }
+    if scope_error:
+        aggregate.update(
             {
-                "phase": phase,
-                "source": "backfill",
-                "ok": True,
-                "result": result,
-            },
+                "ok": False,
+                "reason": "lifecycle_account_scope_incomplete",
+                "error": str(scope_error),
+            }
         )
-        return {"ok": True, **result}
-    except Exception as exc:
-        error = f"{type(exc).__name__}: {exc}"
         append_trade_intake_audit(
             audit_path,
             {
                 "phase": phase,
                 "source": "backfill",
                 "ok": False,
-                "error": error,
+                "error": str(scope_error),
+                "result": aggregate,
             },
         )
-        return {
-            "ok": False,
-            "apply_changes": bool(apply_changes),
-            "error": error,
+        return aggregate
+
+    account_results: list[dict[str, Any]] = []
+    aggregate_fields = (
+        "created_case_ids",
+        "would_create_case_ids",
+        "discovered_case_ids",
+        "refreshed_case_ids",
+        "would_refresh_case_ids",
+        "skipped_targeted_lot_ids",
+    )
+    for account in accounts:
+        try:
+            result = discover_lifecycle_cases(
+                repo,
+                account=account,
+                observed_at_ms=observed_at_ms,
+                apply_changes=apply_changes,
+            )
+            account_result = {"ok": True, **result}
+        except Exception as exc:
+            account_result = {
+                "ok": False,
+                "account": account,
+                "apply_changes": bool(apply_changes),
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        account_results.append(account_result)
+
+    for field in aggregate_fields:
+        aggregate[field] = sorted(
+            {
+                str(item).strip()
+                for result in account_results
+                for item in result.get(field) or []
+                if str(item or "").strip()
+            }
+        )
+    aggregate["account_results"] = account_results
+    aggregate["ok"] = all(
+        bool(result.get("ok")) for result in account_results
+    )
+    if not aggregate["ok"]:
+        aggregate["reason"] = "lifecycle_account_discovery_failed"
+        aggregate["error"] = "one or more account discoveries failed"
+    append_trade_intake_audit(
+        audit_path,
+        {
+            "phase": phase,
+            "source": "backfill",
+            "ok": bool(aggregate["ok"]),
+            "result": aggregate,
+            **(
+                {"error": str(aggregate["error"])}
+                if aggregate.get("error")
+                else {}
+            ),
+        },
+    )
+    return aggregate
+
+
+def _lifecycle_discovery_accounts(
+    *,
+    futu_account_ids: list[str],
+    account_mapping: dict[str, str],
+) -> tuple[str, ...]:
+    configured_ids = sorted(
+        {
+            str(item or "").strip()
+            for item in futu_account_ids
+            if str(item or "").strip()
         }
+    )
+    if not configured_ids:
+        raise ValueError("backfill lifecycle account scope is empty")
+    missing_ids = [
+        futu_account_id
+        for futu_account_id in configured_ids
+        if not str(
+            account_mapping.get(futu_account_id) or ""
+        ).strip()
+    ]
+    if missing_ids:
+        raise ValueError(
+            "backfill lifecycle account scope is incomplete: "
+            + ",".join(missing_ids)
+        )
+    accounts = sorted(
+        {
+            str(account_mapping[futu_account_id]).strip().lower()
+            for futu_account_id in configured_ids
+        }
+    )
+    if not accounts:
+        raise ValueError("backfill lifecycle account scope is empty")
+    return tuple(accounts)
 
 
 def _effective_lookback_hours(

--- a/src/application/trades/close_reason_reconciliation.py
+++ b/src/application/trades/close_reason_reconciliation.py
@@ -525,6 +525,94 @@ def reconcile_lifecycle_close_reason(
     }
 
 
+def _reconcile_deadline_without_effective_pairing(
+    repo: Any,
+    *,
+    lifecycle_case: dict[str, Any],
+    read_model: dict[str, Any],
+    now_ms: int,
+    apply_changes: bool,
+) -> dict[str, Any] | None:
+    case_id = str(lifecycle_case.get("case_id") or "").strip()
+    evidence_status = str(
+        read_model.get("lifecycle_evidence_status") or ""
+    ).strip().lower()
+    if evidence_status != "missing":
+        return reconcile_lifecycle_close_reason(
+            repo,
+            case_id=case_id,
+            now_ms=int(now_ms),
+            apply_changes=apply_changes,
+        )
+    if str(read_model.get("reason_state") or "").strip().lower() != "needs_review":
+        return None
+
+    reason_codes = sorted(
+        {
+            str(item).strip()
+            for item in read_model.get("lifecycle_reason_codes") or []
+            if str(item or "").strip()
+        }
+    )
+    close_reason = str(read_model.get("close_reason") or "").strip() or None
+    preview = {
+        "schema_version": "close_reason_reconciliation_result.v1",
+        "case_id": case_id,
+        "apply_changes": bool(apply_changes),
+        "decision": {
+            "status": "needs_review",
+            "close_reason": close_reason,
+            "contracts_resolved": sum(
+                int(value or 0)
+                for value in dict(
+                    read_model.get("resolved_contracts_by_lot") or {}
+                ).values()
+            ),
+            "evidence_ids": [],
+            "reason_codes": reason_codes,
+            "public_transition": None,
+        },
+        "timing": None,
+        "timing_error": read_model.get("timing_error"),
+        "observation_id": None,
+        "lifecycle_generation_token": str(
+            read_model.get("lifecycle_generation_token") or ""
+        ),
+        "poll_settlement_results": [],
+        "lifecycle_read_model": dict(read_model),
+    }
+    if not apply_changes:
+        return preview
+
+    write_result = advance_lifecycle_case_state(
+        repo,
+        case_id=case_id,
+        status="needs_review",
+        derived_summary={
+            "reason_state": "needs_review",
+            "close_reason": close_reason,
+            "lifecycle_reason_codes": reason_codes,
+            "pairing_until_ms": read_model.get("pairing_until_ms"),
+            "settlement_deadline_ms": read_model.get("pending_until_ms"),
+            "timing_policy_hash": read_model.get("timing_policy_hash"),
+            "observation_hash": None,
+        },
+        public_transition=None,
+        expected_lifecycle_generation_token=str(
+            read_model.get("lifecycle_generation_token") or ""
+        ),
+    )
+    return {
+        **preview,
+        "write_result": write_result,
+        "lifecycle_read_model": lifecycle_case_read_model(
+            repo,
+            case_id=case_id,
+            now_ms=now_ms,
+        ),
+    }
+
+
 def reconcile_due_lifecycle_cases(
     repo: Any,
     *,
@@ -592,10 +680,47 @@ def reconcile_due_lifecycle_cases(
                 )
             )
             continue
+        reason_state = str(
+            read_model.get("reason_state") or ""
+        ).strip().lower()
+        if pairing_until_value is None:
+            if (
+                settlement_deadline_value is None
+                or int(now_ms) < settlement_deadline_value
+                or reason_state
+                not in {
+                    "cause_pending",
+                    "partially_resolved",
+                    "needs_review",
+                }
+            ):
+                continue
+            try:
+                result = _reconcile_deadline_without_effective_pairing(
+                    repo,
+                    lifecycle_case=dict(lifecycle_case),
+                    read_model=dict(read_model),
+                    now_ms=int(now_ms),
+                    apply_changes=apply_changes,
+                )
+            except LifecycleCaseDataError as exc:
+                results.append(
+                    _case_data_failure(
+                        case_id=case_id,
+                        reason_code="lifecycle_close_reason_data_invalid",
+                        stage="close_reason",
+                        field=None,
+                        apply_changes=apply_changes,
+                        error=exc,
+                    )
+                )
+                continue
+            if result is not None:
+                results.append(result)
+            continue
         if (
-            pairing_until_value is None
-            or int(now_ms) < pairing_until_value
-            or read_model.get("reason_state")
+            int(now_ms) < pairing_until_value
+            or reason_state
             not in {"cause_pending", "partially_resolved"}
         ):
             continue

--- a/tests/test_position_advice_v2_lifecycle_reconciliation.py
+++ b/tests/test_position_advice_v2_lifecycle_reconciliation.py
@@ -35,6 +35,9 @@ from src.application.trades.lifecycle_reconciliation import (
 from src.application.trades.close_reason_evidence import (
     build_lifecycle_timing_policy,
 )
+from src.application.trades.close_reason_reconciliation import (
+    reconcile_due_lifecycle_cases,
+)
 
 
 EXPIRATION_YMD = "2026-08-21"
@@ -197,7 +200,7 @@ def _record_zero_price_close_anchor(
     )
 
 
-def test_discovery_freezes_case_at_observation_start_and_deadline_only_reviews(
+def test_discovery_is_create_only_and_due_owner_reviews_missing_evidence_at_deadline(
     tmp_path: Path,
 ) -> None:
     repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
@@ -248,10 +251,67 @@ def test_discovery_freezes_case_at_observation_start_and_deadline_only_reviews(
         account="lx",
         observed_at_ms=observation_start + 72 * 60 * 60 * 1000,
     )
-    assert after_deadline["refreshed_case_ids"] == [case_id]
+    assert after_deadline["refreshed_case_ids"] == []
+    assert after_deadline["would_refresh_case_ids"] == []
+    assert repo.get_trade_lifecycle_case(case_id) == lifecycle_case
+
+    deadline_ms = observation_start + 72 * 60 * 60 * 1000
+    dry_run = reconcile_due_lifecycle_cases(
+        repo,
+        account="lx",
+        now_ms=deadline_ms,
+        apply_changes=False,
+        observation_collector=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("missing anchor must not trigger provider collection")
+        ),
+    )
+    assert dry_run["case_count"] == 1
+    assert dry_run["results"][0]["decision"] == {
+        "status": "needs_review",
+        "close_reason": None,
+        "contracts_resolved": 0,
+        "evidence_ids": [],
+        "reason_codes": ["settlement_evidence_deadline_elapsed"],
+        "public_transition": None,
+    }
+    assert repo.get_trade_lifecycle_case(case_id) == lifecycle_case
+    assert repo.list_trade_lifecycle_notifications() == []
+
+    applied = reconcile_due_lifecycle_cases(
+        repo,
+        account="lx",
+        now_ms=deadline_ms,
+        apply_changes=True,
+        observation_collector=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("missing anchor must not trigger provider collection")
+        ),
+    )
+    assert applied["case_count"] == 1
+    assert applied["results"][0]["write_result"]["status"] == "needs_review"
+    assert applied["results"][0]["write_result"]["business_state_changed"] is True
     reviewed = repo.get_trade_lifecycle_case(case_id)
     assert reviewed is not None
     assert reviewed["status"] == "needs_review"
+    assert reviewed["derived_summary"]["reason_state"] == "needs_review"
+    assert reviewed["derived_summary"]["lifecycle_reason_codes"] == [
+        "settlement_evidence_deadline_elapsed"
+    ]
+    assert repo.list_trade_lifecycle_notifications() == []
+
+    replayed = reconcile_due_lifecycle_cases(
+        repo,
+        account="lx",
+        now_ms=deadline_ms,
+        apply_changes=True,
+        observation_collector=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("missing anchor must not trigger provider collection")
+        ),
+    )
+    assert replayed["results"][0]["write_result"]["business_state_changed"] is False
+    assert replayed["results"][0]["write_result"]["resolution_revision"] == (
+        reviewed["derived_summary"]["resolution_revision"]
+    )
+    assert repo.list_trade_lifecycle_notifications() == []
     assert repo.list_trade_events() == [
         item for item in repo.list_trade_events() if item["event_type"] == "open"
     ]

--- a/tests/test_settlement_observation.py
+++ b/tests/test_settlement_observation.py
@@ -195,6 +195,171 @@ def _complete_receipt(rows: list[dict]) -> dict:
     }
 
 
+def test_discovery_replay_does_not_override_canonical_timing_policy(
+    tmp_path: Path,
+) -> None:
+    repo, lifecycle_case, policy, _anchor_ms = _repo_with_pending_case(
+        tmp_path
+    )
+    case_id = str(lifecycle_case["case_id"])
+    fallback_deadline_ms = int(lifecycle_case["pending_until_ms"])
+    canonical_deadline_ms = int(policy["settlement_deadline_ms"])
+    assert fallback_deadline_ms < canonical_deadline_ms
+
+    before = repo.get_trade_lifecycle_case(case_id)
+    assert before is not None
+    canonical_before = lifecycle_case_read_model(
+        repo,
+        case_id=case_id,
+        now_ms=fallback_deadline_ms,
+    )
+    assert canonical_before["pending_until_ms"] == canonical_deadline_ms
+    assert canonical_before["reason_state"] == "cause_pending"
+
+    replay = discover_lifecycle_cases(
+        repo,
+        account="lx",
+        observed_at_ms=fallback_deadline_ms,
+    )
+
+    assert replay["created_case_ids"] == []
+    assert replay["refreshed_case_ids"] == []
+    assert replay["would_refresh_case_ids"] == []
+    assert repo.get_trade_lifecycle_case(case_id) == before
+    canonical_after = lifecycle_case_read_model(
+        repo,
+        case_id=case_id,
+        now_ms=fallback_deadline_ms,
+    )
+    assert canonical_after == canonical_before
+
+
+def test_due_reconciliation_routes_anchor_without_effective_pairing_to_close_reason(
+    monkeypatch,
+) -> None:
+    import src.application.trades.close_reason_reconciliation as reconciliation
+
+    class _DueV2Repo:
+        def list_trade_lifecycle_cases(
+            self,
+            *,
+            account: str,
+        ) -> list[dict]:
+            assert account == "lx"
+            return [
+                {
+                    "schema_version": "lifecycle_case.v2",
+                    "case_id": "anchor-without-timing",
+                    "account": "lx",
+                    "status": "waiting_settlement_evidence",
+                    "target_contracts_by_lot": {"lot-1": 1},
+                }
+            ]
+
+    monkeypatch.setattr(
+        reconciliation,
+        "lifecycle_case_read_model",
+        lambda *_args, **_kwargs: {
+            "pairing_until_ms": None,
+            "pending_until_ms": 200,
+            "reason_state": "needs_review",
+            "lifecycle_evidence_status": "closure_observed_cause_pending",
+        },
+    )
+    calls: list[dict] = []
+
+    def _reconcile(*_args, **kwargs):
+        calls.append(dict(kwargs))
+        return {
+            "case_id": "anchor-without-timing",
+            "decision": {
+                "status": "needs_review",
+                "reason_codes": ["lifecycle_timing_policy_unavailable"],
+            },
+        }
+
+    monkeypatch.setattr(
+        reconciliation,
+        "reconcile_lifecycle_close_reason",
+        _reconcile,
+    )
+
+    result = reconcile_due_lifecycle_cases(
+        _DueV2Repo(),
+        account="lx",
+        now_ms=200,
+        apply_changes=False,
+        observation_collector=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("no effective pairing must not poll provider")
+        ),
+    )
+
+    assert result["results"][0]["decision"]["reason_codes"] == [
+        "lifecycle_timing_policy_unavailable"
+    ]
+    assert calls == [
+        {
+            "case_id": "anchor-without-timing",
+            "now_ms": 200,
+            "apply_changes": False,
+        }
+    ]
+
+
+def test_due_reconciliation_skips_conflict_without_effective_pairing(
+    monkeypatch,
+) -> None:
+    import src.application.trades.close_reason_reconciliation as reconciliation
+
+    class _ConflictRepo:
+        def list_trade_lifecycle_cases(
+            self,
+            *,
+            account: str,
+        ) -> list[dict]:
+            assert account == "lx"
+            return [
+                {
+                    "schema_version": "lifecycle_case.v2",
+                    "case_id": "conflict-without-timing",
+                    "account": "lx",
+                    "status": "conflict",
+                    "target_contracts_by_lot": {"lot-1": 1},
+                }
+            ]
+
+    monkeypatch.setattr(
+        reconciliation,
+        "lifecycle_case_read_model",
+        lambda *_args, **_kwargs: {
+            "pairing_until_ms": None,
+            "pending_until_ms": 200,
+            "reason_state": "conflict",
+            "lifecycle_evidence_status": "conflict",
+        },
+    )
+    monkeypatch.setattr(
+        reconciliation,
+        "reconcile_lifecycle_close_reason",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("conflict case is absorbing for due reconciliation")
+        ),
+    )
+
+    result = reconcile_due_lifecycle_cases(
+        _ConflictRepo(),
+        account="lx",
+        now_ms=200,
+        apply_changes=False,
+        observation_collector=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("conflict case must not poll provider")
+        ),
+    )
+
+    assert result["case_count"] == 0
+    assert result["results"] == []
+
+
 class _Gateway:
     def __init__(
         self,

--- a/tests/test_trades_auto_intake_backfill.py
+++ b/tests/test_trades_auto_intake_backfill.py
@@ -5,6 +5,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+import src.application.trades.backfill as backfill_module
 from src.application.trades.backfill import run_history_backfill
 from src.application.trades.inbox import (
     list_retryable_trade_payloads,
@@ -19,6 +22,29 @@ class _FakeRepo:
 
     def list_trade_events(self) -> list[dict[str, Any]]:
         return list(self.events)
+
+
+@pytest.fixture(autouse=True)
+def _healthy_lifecycle_discovery(monkeypatch) -> None:
+    def _discover(_repo, *, account, observed_at_ms, apply_changes):
+        return {
+            "schema_version": "lifecycle_discovery_result.v2",
+            "observed_at_ms": observed_at_ms,
+            "account": account,
+            "apply_changes": apply_changes,
+            "created_case_ids": [],
+            "would_create_case_ids": [],
+            "discovered_case_ids": [],
+            "refreshed_case_ids": [],
+            "would_refresh_case_ids": [],
+            "skipped_targeted_lot_ids": [],
+        }
+
+    monkeypatch.setattr(
+        backfill_module,
+        "discover_lifecycle_cases",
+        _discover,
+    )
 
 
 def _backfill_kwargs(tmp_path: Path) -> dict[str, Any]:
@@ -98,6 +124,188 @@ def test_run_history_backfill_processes_missing_deal_through_pipeline(tmp_path: 
         "backfill_lifecycle_reconciliation_after",
         "backfill_check_finished",
     ]
+
+
+def test_backfill_lifecycle_discovery_is_scoped_to_single_mapped_account(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[str | None] = []
+
+    def _discover(_repo, *, account, observed_at_ms, apply_changes):
+        calls.append(account)
+        return {
+            "schema_version": "lifecycle_discovery_result.v2",
+            "observed_at_ms": observed_at_ms,
+            "account": account,
+            "apply_changes": apply_changes,
+            "created_case_ids": [],
+            "would_create_case_ids": [],
+            "discovered_case_ids": [],
+            "refreshed_case_ids": [],
+            "would_refresh_case_ids": [],
+            "skipped_targeted_lot_ids": [],
+        }
+
+    monkeypatch.setattr(
+        backfill_module,
+        "discover_lifecycle_cases",
+        _discover,
+    )
+    out = run_history_backfill(
+        **_backfill_kwargs(tmp_path),
+        history_deals_fn=lambda **_kwargs: ([], {}),
+        process_payload_fn=lambda *_args, **_kwargs: {},
+    )
+
+    assert calls == ["lx", "lx"]
+    lifecycle = out["diagnostics"]["lifecycle_reconciliation"]
+    assert lifecycle["before"]["accounts"] == ["lx"]
+    assert lifecycle["after"]["accounts"] == ["lx"]
+    assert lifecycle["before"]["schema_version"] == (
+        "lifecycle_discovery_result.v2"
+    )
+    assert lifecycle["after"]["schema_version"] == (
+        "lifecycle_discovery_result.v2"
+    )
+    assert lifecycle["before"]["account_results"][0]["account"] == "lx"
+    assert lifecycle["after"]["account_results"][0]["account"] == "lx"
+    audits = _audit_events(tmp_path / "audit.jsonl")
+    lifecycle_audits = [
+        event
+        for event in audits
+        if event["phase"]
+        in {
+            "backfill_lifecycle_discovery_before",
+            "backfill_lifecycle_reconciliation_after",
+        }
+    ]
+    assert all(event["ok"] is True for event in lifecycle_audits)
+    assert all(event["result"]["accounts"] == ["lx"] for event in lifecycle_audits)
+    assert all(
+        event["result"]["schema_version"]
+        == "lifecycle_discovery_result.v2"
+        for event in lifecycle_audits
+    )
+    assert all("accounts" not in event for event in lifecycle_audits)
+
+
+def test_backfill_lifecycle_discovery_scopes_legacy_source_per_account(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[str | None] = []
+
+    def _discover(_repo, *, account, observed_at_ms, apply_changes):
+        calls.append(account)
+        return {
+            "schema_version": "lifecycle_discovery_result.v2",
+            "observed_at_ms": observed_at_ms,
+            "account": account,
+            "apply_changes": apply_changes,
+            "created_case_ids": [f"created-{account}"],
+            "would_create_case_ids": [],
+            "discovered_case_ids": [f"discovered-{account}"],
+            "refreshed_case_ids": [],
+            "would_refresh_case_ids": [],
+            "skipped_targeted_lot_ids": [f"lot-{account}"],
+        }
+
+    monkeypatch.setattr(
+        backfill_module,
+        "discover_lifecycle_cases",
+        _discover,
+    )
+    kwargs = _backfill_kwargs(tmp_path)
+    kwargs["account_mapping"] = {
+        "REAL_2": "sy",
+        "REAL_1": "LX",
+    }
+    kwargs["futu_account_ids"] = ["REAL_2", "REAL_1"]
+    out = run_history_backfill(
+        **kwargs,
+        history_deals_fn=lambda **_kwargs: ([], {}),
+        process_payload_fn=lambda *_args, **_kwargs: {},
+    )
+
+    assert calls == ["lx", "sy", "lx", "sy"]
+    before = out["diagnostics"]["lifecycle_reconciliation"]["before"]
+    assert before["ok"] is True
+    assert before["accounts"] == ["lx", "sy"]
+    assert [item["account"] for item in before["account_results"]] == [
+        "lx",
+        "sy",
+    ]
+    assert before["created_case_ids"] == ["created-lx", "created-sy"]
+    assert before["discovered_case_ids"] == [
+        "discovered-lx",
+        "discovered-sy",
+    ]
+    assert before["skipped_targeted_lot_ids"] == ["lot-lx", "lot-sy"]
+
+
+def test_backfill_lifecycle_discovery_rejects_incomplete_account_scope_without_partial_scan(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        backfill_module,
+        "discover_lifecycle_cases",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("incomplete account scope must not scan any account")
+        ),
+    )
+    kwargs = _backfill_kwargs(tmp_path)
+    kwargs["account_mapping"] = {"REAL_1": "lx"}
+    kwargs["futu_account_ids"] = ["REAL_1", "REAL_2"]
+    out = run_history_backfill(
+        **kwargs,
+        history_deals_fn=lambda **_kwargs: (
+            [
+                {
+                    "deal_id": "deal-unmapped",
+                    "futu_account_id": "REAL_2",
+                }
+            ],
+            {},
+        ),
+        process_payload_fn=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unmapped payload must remain unresolved")
+        ),
+    )
+
+    assert out["ok"] is False
+    assert out["error"] == "lifecycle_discovery_incomplete"
+    assert out["deal_count"] == 1
+    assert out["unresolved_count"] == 1
+    assert out["diagnostics"]["lifecycle_discovery_complete"] is False
+    lifecycle = out["diagnostics"]["lifecycle_reconciliation"]
+    for phase in ("before", "after"):
+        assert lifecycle[phase]["ok"] is False
+        assert lifecycle[phase]["reason"] == (
+            "lifecycle_account_scope_incomplete"
+        )
+        assert lifecycle[phase]["accounts"] == []
+        assert lifecycle[phase]["account_results"] == []
+        assert "REAL_2" in lifecycle[phase]["error"]
+    lifecycle_audits = [
+        event
+        for event in _audit_events(tmp_path / "audit.jsonl")
+        if event["phase"]
+        in {
+            "backfill_lifecycle_discovery_before",
+            "backfill_lifecycle_reconciliation_after",
+        }
+    ]
+    assert all(event["ok"] is False for event in lifecycle_audits)
+    assert all("REAL_2" in event["error"] for event in lifecycle_audits)
+    assert all(event["result"]["accounts"] == [] for event in lifecycle_audits)
+    phases = [
+        event["phase"]
+        for event in _audit_events(tmp_path / "audit.jsonl")
+    ]
+    assert "backfill_received" in phases
+    assert "backfill_identity_needs_review" in phases
 
 
 def test_run_history_backfill_skips_processed_outbox_managed_duplicate_before_pipeline(


### PR DESCRIPTION
## Summary

- make lifecycle discovery create-only so it can no longer refresh an existing case with the legacy fixed-72-hour calculation
- make the canonical account-scoped due reconciler own missing-evidence deadline aging through the existing atomic CAS/fingerprint/revision writer
- scope history-backfill discovery to the current Futu IDs' explicit canonical accounts; never pass `account=None`
- preserve `lifecycle_discovery_result.v2`, audit envelopes, compatibility fields, CLI/tick contracts, and no-Outbox behavior for missing-anchor aging

## Root cause

The history-backfill discovery path used an unscoped account and independently recalculated existing lifecycle case state with the historical fixed-72-hour fallback. The canonical read model/due path used the bound broker timing policy. Repeated runs could therefore oscillate an `lx` case between projections, changing the option-position context fingerprint after a notification had been prepared. At 22:30 this blocked `lx` before provider delivery while `sy` remained deliverable.

## Ownership after this change

1. Discovery freezes expired lots and inserts missing immutable cases only.
2. The canonical lifecycle read model derives evidence, allocation, timing, and deadline state.
3. Account-scoped due reconciliation selects due cases and advances them through the existing atomic writer.
4. Missing evidence at the canonical deadline fails closed as `needs_review` with `public_transition=None`, so it creates no notification Outbox item.
5. Backfill derives a complete sorted account set from the current Futu IDs and canonical mapping, then runs discovery once per account in both phases.

## Validation

```text
86 passed, 4 pre-existing Legacy Tick deprecation warnings
python compileall domain src scripts: pass
ruff across every changed Python production/test file: pass
full branch git diff --check: pass
```

The aggregate matrix covers lifecycle discovery/read-model/due reconciliation, backfill identity/Inbox/checkpoint behavior, trade-intake CLI, unified tick, and notification formatting.

Gateflow evidence is under `docs/gateflow/lifecycle-single-source-of-truth/`; plan, slice, and aggregate DeepReviews have no open findings.

## Safety and residual risk

- tests use temporary stores and fake or absent providers
- no real notification, broker request, production config/data write, service change, release, deployment, or upgrade occurred
- existing production-row convergence and runtime verification require a separately authorized deployment/operations step
- multi-account discovery is atomic per account and idempotently retryable, not one cross-account transaction

## Issue

Initiated from the confirmed operator investigation; no linked GitHub issue.
