### PR TITLE
refactor: simplify required-data validation

### DIFF
--- a/src/application/opend_symbol_outputs.py
+++ b/src/application/opend_symbol_outputs.py
@@ -20,7 +20,6 @@ from src.application.required_data_coverage import (
     evaluate_required_data_frame_fetch_plan_debug,
 )
 from src.application.required_data_plan_identity import (
-    required_data_request_sha256,
     validate_required_data_expected_fetch_contract,
 )
 from src.application.position_advice_source_receipts import (
@@ -55,6 +54,10 @@ _VALIDATION_REASON_CODES = frozenset(
         "internal_contract_error",
     }
 )
+
+
+class _StaleRequiredDataError(PositionAdviceSourceError):
+    """Internal typed signal for the stale-data reason code."""
 
 
 REQUIRED_DATA_COLUMNS = [
@@ -207,9 +210,9 @@ def _validate_required_data_payload_candidate_impl(
             raise PositionAdviceSourceError(
                 "success-empty required-data RV evidence contradicts fetch contract"
             )
-        _validate_snapshot_completeness(meta=meta, rows=rows)
         discovery = contract.get("fetch_plan", {}).get("expiration_discovery")
         if empty_reason == "no_expirations":
+            _validate_snapshot_completeness(meta=meta, rows=rows)
             if not isinstance(discovery, Mapping):
                 raise PositionAdviceSourceError(
                     "success-empty required-data lacks expected discovery evidence"
@@ -235,12 +238,6 @@ def _validate_required_data_payload_candidate_impl(
                     "success-empty required-data discovery evidence mismatch"
                 )
         elif empty_reason == "no_contract_rows":
-            _validate_expected_child_request_evidence(
-                meta=meta,
-                contract=contract,
-                rows=rows,
-                canonical_realized_volatility=None,
-            )
             coverage = evaluate_required_data_frame_fetch_plan_debug(
                 pd.DataFrame(),
                 dict(contract.get("fetch_plan") or {}),
@@ -251,6 +248,11 @@ def _validate_required_data_payload_candidate_impl(
                     f"{coverage.reason_code or 'internal_contract_error'}: "
                     "required-data filtered-empty evidence is invalid"
                 )
+            _validate_child_request_bindings(
+                meta=meta,
+                contract=contract,
+                canonical_realized_volatility=None,
+            )
         else:
             raise PositionAdviceSourceError(
                 "success-empty required-data reason is invalid"
@@ -263,28 +265,32 @@ def _validate_required_data_payload_candidate_impl(
         identities = _row_identity_counter(rows)
         if any(identity[0] != expected_symbol for identity in identities):
             raise PositionAdviceSourceError("required-data row symbol mismatch")
-        _validate_snapshot_completeness(meta=meta, rows=rows)
-        canonical_realized_volatility = (
-            _validate_required_realized_volatility(meta=meta, rows=rows)
-            if require_realized_volatility
-            else None
-        )
-        _validate_expected_child_request_evidence(
-            meta=meta,
-            contract=contract,
-            rows=rows,
-            canonical_realized_volatility=canonical_realized_volatility,
-        )
         coverage = evaluate_required_data_frame_fetch_plan_debug(
             pd.DataFrame(rows),
             dict(contract.get("fetch_plan") or {}),
             option_chain_evidence=meta,
         )
         if not coverage.accepted:
+            merged_requests = (contract.get("fetch_plan") or {}).get("merged_requests")
+            subject = (
+                "child request evidence"
+                if isinstance(merged_requests, list) and len(merged_requests) > 1
+                else "payload"
+            )
             raise PositionAdviceSourceError(
                 f"{coverage.reason_code or 'internal_contract_error'}: "
-                "required-data payload does not cover expected fetch contract"
+                f"required-data {subject} does not cover expected fetch contract"
             )
+        canonical_realized_volatility = (
+            _validate_required_realized_volatility(meta=meta, rows=rows)
+            if require_realized_volatility
+            else None
+        )
+        _validate_child_request_bindings(
+            meta=meta,
+            contract=contract,
+            canonical_realized_volatility=canonical_realized_volatility,
+        )
     return meta, rows, source_outcome, contract
 
 
@@ -630,59 +636,25 @@ def _validate_timestamp_evidence(meta: Mapping[str, Any]) -> None:
         )
 
 
-def _validate_expected_child_request_evidence(
+def _validate_child_request_bindings(
     *,
     meta: Mapping[str, Any],
     contract: Mapping[str, Any],
-    rows: list[Any],
     canonical_realized_volatility: Mapping[str, float | None] | None,
 ) -> None:
     merged_requests = (contract.get("fetch_plan") or {}).get("merged_requests")
-    if not isinstance(merged_requests, list) or not merged_requests:
-        return
-    row_by_code = _required_data_rows_by_code(rows)
-    aggregate_requested = _code_set(meta.get("snapshot_requested_code_set"))
-    if len(merged_requests) == 1:
-        planned_request = merged_requests[0]
-        if not isinstance(planned_request, Mapping):
-            raise PositionAdviceSourceError(
-                "required-data planned child request is invalid"
-            )
-        aggregate_requested = _validate_child_snapshot_code_evidence(
-            meta, allow_empty=True
-        )
-        _validate_child_rows_against_planned_request(
-            planned_request=planned_request,
-            requested_codes=aggregate_requested,
-            row_by_code=row_by_code,
-            contract=contract,
-        )
+    if not isinstance(merged_requests, list) or len(merged_requests) <= 1:
         return
     requests = meta.get("requests")
-    if (
-        not isinstance(requests, list)
-        or len(requests) != len(merged_requests)
-        or any(not isinstance(item, Mapping) for item in requests)
-    ):
-        raise PositionAdviceSourceError(
-            "required-data child request evidence count mismatch"
-        )
-    request_count = meta.get("request_count")
-    if (
-        isinstance(request_count, bool)
-        or not isinstance(request_count, int)
-        or request_count != len(merged_requests)
-    ):
-        raise PositionAdviceSourceError(
-            "required-data child request evidence count mismatch"
-        )
-    discovery = (contract.get("fetch_plan") or {}).get(
-        "expiration_discovery"
-    )
+    assert isinstance(requests, list)
+    children_by_index = {
+        child["request_index"]: child
+        for child in requests
+        if isinstance(child, Mapping)
+    }
+    discovery = (contract.get("fetch_plan") or {}).get("expiration_discovery")
     discovery_identity = (
-        discovery.get("request_identity")
-        if isinstance(discovery, Mapping)
-        else None
+        discovery.get("request_identity") if isinstance(discovery, Mapping) else None
     )
     expected_underlier = (
         str(discovery_identity.get("underlier") or "").strip()
@@ -690,61 +662,16 @@ def _validate_expected_child_request_evidence(
         else ""
     )
     expected_symbol = str(contract.get("symbol") or "").strip().upper()
-    expected_by_hash: dict[str, tuple[int, Mapping[str, Any]]] = {}
     for expected_index, planned_request in enumerate(merged_requests):
-        if not isinstance(planned_request, Mapping):
-            raise PositionAdviceSourceError(
-                "required-data planned child request is invalid"
-            )
-        expected_hash = required_data_request_sha256(planned_request)
-        if expected_hash in expected_by_hash:
-            raise PositionAdviceSourceError(
-                "internal_contract_error: required-data planned child request "
-                "identity mismatch"
-            )
-        expected_by_hash[expected_hash] = (expected_index, planned_request)
-    child_by_hash: dict[str, Mapping[str, Any]] = {}
-    observed_indexes: set[int] = set()
-    for child in requests:
-        assert isinstance(child, Mapping)
-        child_hash = str(child.get("planned_request_sha256") or "").strip()
-        child_index = child.get("request_index")
+        assert isinstance(planned_request, Mapping)
+        child = children_by_index[expected_index]
         if (
-            not child_hash
-            or child_hash in child_by_hash
-            or isinstance(child_index, bool)
-            or not isinstance(child_index, int)
-            or child_index < 0
-            or child_index >= len(merged_requests)
-            or child_index in observed_indexes
-        ):
-            raise PositionAdviceSourceError(
-                "scope_identity_mismatch: required-data child request identity "
-                "mismatch"
-            )
-        child_by_hash[child_hash] = child
-        observed_indexes.add(child_index)
-    if set(child_by_hash) != set(expected_by_hash):
-        raise PositionAdviceSourceError(
-            "scope_identity_mismatch: required-data child request identity mismatch"
-        )
-    child_requested_union: set[str] = set()
-    for child_hash, (expected_index, planned_request) in expected_by_hash.items():
-        child = child_by_hash[child_hash]
-        if child.get("request_index") != expected_index:
-            raise PositionAdviceSourceError(
-                "internal_contract_error: required-data child request index "
-                "contradicts planned request identity"
-            )
-        if (
-            str(child.get("request_symbol") or "").strip().upper()
-            != expected_symbol
+            str(child.get("request_symbol") or "").strip().upper() != expected_symbol
             or str(child.get("request_underlier_code") or "").strip()
             != expected_underlier
         ):
             raise PositionAdviceSourceError(
-                "scope_identity_mismatch: required-data child request symbol "
-                "identity mismatch"
+                "scope_identity_mismatch: required-data child request symbol identity mismatch"
             )
         try:
             _validate_raw_binding(
@@ -754,8 +681,7 @@ def _validate_expected_child_request_evidence(
             )
         except PositionAdviceSourceError as exc:
             raise PositionAdviceSourceError(
-                "scope_identity_mismatch: required-data child request binding "
-                "mismatch"
+                "scope_identity_mismatch: required-data child request binding mismatch"
             ) from exc
         try:
             _validate_trading_date_binding(
@@ -764,227 +690,15 @@ def _validate_expected_child_request_evidence(
                 planned_request=planned_request,
             )
         except PositionAdviceSourceError as exc:
-            raise PositionAdviceSourceError(
-                f"scope_identity_mismatch: {exc}"
-            ) from exc
-        if str(child.get("status") or "").strip().lower() != "ok":
-            raise PositionAdviceSourceError(
-                "provider_incomplete: required-data child request outcome is not "
-                "successful"
-            )
-        child_outcome = str(child.get("source_outcome") or "").strip().lower()
-        child_reason = str(child.get("reason_code") or "").strip().lower()
-        if not (
-            (child_outcome == "success_rows" and not child_reason)
-            or (
-                child_outcome == "success_empty"
-                and child_reason == "no_contract_rows"
-            )
+            raise PositionAdviceSourceError(f"scope_identity_mismatch: {exc}") from exc
+        if canonical_realized_volatility is not None and child.get(
+            "snapshot_requested_code_set"
         ):
-            raise PositionAdviceSourceError(
-                "required-data child request outcome evidence is invalid"
-            )
-        requested_codes = _validate_child_snapshot_code_evidence(
-            child, allow_empty=True
-        )
-        if canonical_realized_volatility is not None and requested_codes:
-            child_realized_volatility = _required_realized_volatility_values(
-                child
-            )
-            if child_realized_volatility != dict(
-                canonical_realized_volatility
-            ):
+            child_realized_volatility = _required_realized_volatility_values(child)
+            if child_realized_volatility != dict(canonical_realized_volatility):
                 raise PositionAdviceSourceError(
                     "required-data child request realized volatility mismatch"
                 )
-        child_requested_union.update(requested_codes)
-        _validate_child_rows_against_planned_request(
-            planned_request=planned_request,
-            requested_codes=requested_codes,
-            row_by_code=row_by_code,
-            contract=contract,
-        )
-    if child_requested_union != set(aggregate_requested):
-        raise PositionAdviceSourceError(
-            "required-data child request code sets do not match aggregate rows"
-        )
-
-
-def _required_data_rows_by_code(
-    rows: list[Any],
-) -> dict[str, Mapping[str, Any]]:
-    row_by_code: dict[str, Mapping[str, Any]] = {}
-    for row in rows:
-        if not isinstance(row, Mapping):
-            raise PositionAdviceSourceError(
-                "required-data child request rows are invalid"
-            )
-        code = str(row.get("contract_symbol") or "").strip()
-        if not code or code in row_by_code:
-            raise PositionAdviceSourceError(
-                "required-data child request rows are invalid"
-            )
-        row_by_code[code] = row
-    return row_by_code
-
-
-def _validate_child_snapshot_code_evidence(
-    child: Mapping[str, Any],
-    *,
-    allow_empty: bool = False,
-) -> frozenset[str]:
-    requested = _code_set(child.get("snapshot_requested_code_set"))
-    returned = _code_set(child.get("snapshot_returned_code_set"))
-    missing = _code_set(child.get("snapshot_missing_code_set"))
-    unexpected = _code_set(child.get("snapshot_unexpected_code_set"))
-    declared = {
-        "requested": child.get("snapshot_requested_codes"),
-        "returned": child.get("snapshot_returned_codes"),
-        "missing": child.get("snapshot_missing_codes"),
-        "unexpected": child.get("snapshot_unexpected_codes"),
-    }
-    expected = {
-        "requested": len(requested),
-        "returned": len(returned),
-        "missing": len(missing),
-        "unexpected": len(unexpected),
-    }
-    if any(
-        isinstance(value, bool) or not isinstance(value, int)
-        for value in declared.values()
-    ) or declared != expected:
-        raise PositionAdviceSourceError(
-            "required-data child request snapshot counts mismatch"
-        )
-    if (
-        (not requested and not allow_empty)
-        or not requested.issubset(returned)
-        or missing
-        or child.get("snapshot_complete") is not True
-    ):
-        raise PositionAdviceSourceError(
-            "provider_incomplete: required-data child request snapshot "
-            "evidence is incomplete"
-        )
-    return requested
-
-
-def _validate_child_rows_against_planned_request(
-    *,
-    planned_request: Mapping[str, Any],
-    requested_codes: frozenset[str],
-    row_by_code: Mapping[str, Mapping[str, Any]],
-    contract: Mapping[str, Any],
-) -> None:
-    if any(code not in row_by_code for code in requested_codes):
-        raise PositionAdviceSourceError(
-            "invalid_row_identity: required-data child request rows do not match "
-            "requested codes"
-        )
-    option_types = planned_request.get("option_types")
-    expirations = planned_request.get("explicit_expirations")
-    windows = planned_request.get("side_strike_windows")
-    if (
-        not isinstance(option_types, list)
-        or not option_types
-        or not isinstance(expirations, list)
-        or not expirations
-        or not isinstance(windows, Mapping)
-    ):
-        raise PositionAdviceSourceError(
-            "internal_contract_error: required-data planned child request is invalid"
-        )
-    discovery = (contract.get("fetch_plan") or {}).get(
-        "expiration_discovery"
-    )
-    identity = (
-        discovery.get("request_identity")
-        if isinstance(discovery, Mapping)
-        else None
-    )
-    try:
-        trading_date = date.fromisoformat(
-            str(
-                identity.get("trading_date")
-                if isinstance(identity, Mapping)
-                else ""
-            )
-        )
-    except ValueError as exc:
-        raise PositionAdviceSourceError(
-            "required-data child request trading date is invalid"
-        ) from exc
-    allowed_option_types = set(option_types)
-    allowed_expirations = set(expirations)
-    for code in requested_codes:
-        row = row_by_code[code]
-        option_type = str(row.get("option_type") or "").strip().lower()
-        expiration = str(row.get("expiration") or "").strip()
-        window = windows.get(option_type)
-        try:
-            strike = float(row.get("strike"))
-            row_dte = float(row.get("dte"))
-            expected_dte = (
-                date.fromisoformat(expiration) - trading_date
-            ).days
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise PositionAdviceSourceError(
-                "invalid_row_identity: required-data child request row identity "
-                "is invalid"
-            ) from exc
-        if option_type not in allowed_option_types or expiration not in allowed_expirations:
-            raise PositionAdviceSourceError(
-                "scope_identity_mismatch: required-data child request rows "
-                "contradict planned request"
-            )
-        if (
-            not isinstance(window, Mapping)
-            or not math.isfinite(strike)
-            or strike <= 0
-            or not math.isfinite(row_dte)
-            or not row_dte.is_integer()
-            or int(row_dte) != expected_dte
-        ):
-            raise PositionAdviceSourceError(
-                "invalid_row_identity: required-data child request rows contradict "
-                "planned request"
-            )
-        min_strike = window.get("min_strike")
-        max_strike = window.get("max_strike")
-        try:
-            parsed_min = (
-                float(min_strike) if min_strike is not None else None
-            )
-            parsed_max = (
-                float(max_strike) if max_strike is not None else None
-            )
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise PositionAdviceSourceError(
-                "required-data child request strike window is invalid"
-            ) from exc
-        if (
-            parsed_min is not None
-            and (not math.isfinite(parsed_min) or parsed_min <= 0)
-        ) or (
-            parsed_max is not None
-            and (not math.isfinite(parsed_max) or parsed_max <= 0)
-        ) or (
-            parsed_min is not None
-            and parsed_max is not None
-            and parsed_min > parsed_max
-        ):
-            raise PositionAdviceSourceError(
-                "required-data child request strike window is invalid"
-            )
-        if (
-            parsed_min is not None and strike < parsed_min
-        ) or (
-            parsed_max is not None and strike > parsed_max
-        ):
-            raise PositionAdviceSourceError(
-                "invalid_row_identity: required-data child request rows contradict "
-                "strike window"
-            )
 
 
 def _validate_raw_underlier_binding(
@@ -1050,7 +764,7 @@ def _validate_quote_freshness(
         seconds=int(SOURCE_MAX_AGE_SECONDS["quotes"])
     )
     if now_value >= expires_at:
-        raise PositionAdviceSourceError("required-data quote observation is stale")
+        raise _StaleRequiredDataError("required-data quote observation is stale")
     return now_value
 
 
@@ -1098,11 +812,10 @@ def _validate_payload_freshness_reason_coded(
 ) -> datetime:
     try:
         return _validate_payload_freshness(meta=meta, now=now)
+    except _StaleRequiredDataError as exc:
+        raise PositionAdviceSourceError(f"stale_data: {exc}") from exc
     except PositionAdviceSourceError as exc:
-        reason_code = (
-            "stale_data" if "stale" in str(exc).lower() else "freshness_unproven"
-        )
-        raise PositionAdviceSourceError(f"{reason_code}: {exc}") from exc
+        raise PositionAdviceSourceError(f"freshness_unproven: {exc}") from exc
 
 
 def _validate_rows_persist_without_loss(rows: list[Any]) -> None:

--- a/src/application/required_data_coverage.py
+++ b/src/application/required_data_coverage.py
@@ -123,291 +123,65 @@ def required_data_frame_covers_fetch_plan(
     fetch_plan: RequiredDataFetchPlanBundle,
     option_chain_evidence: Mapping[str, Any] | None = None,
 ) -> bool:
-    if option_chain_evidence is not None:
-        return required_data_frame_covers_fetch_plan_debug(
-            df,
-            fetch_plan.to_debug_dict(),
-            option_chain_evidence=option_chain_evidence,
-        )
-    if df.empty:
-        return False
-    if not _spot_reference_matches_frame(df=df, spot_reference=fetch_plan.spot_reference):
-        return False
-    trading_date = _typed_fetch_plan_trading_date(fetch_plan)
-    if not isinstance(trading_date, date):
-        return False
-    require_realized_volatility = fetch_plan.require_realized_volatility
-    if not isinstance(require_realized_volatility, bool):
-        return False
-    if any(
-        not isinstance(spec.include_realized_volatility, bool)
-        or spec.include_realized_volatility != require_realized_volatility
-        for spec in fetch_plan.merged_specs
-    ):
-        return False
-    if require_realized_volatility and not _has_realized_volatility(df):
-        return False
-    active_side_count = 0
-    for side_plan in fetch_plan.side_plans:
-        requested_expirations = _strict_expiration_list(
-            side_plan.explicit_expirations
-        )
-        if requested_expirations is None:
-            return False
-        if not requested_expirations:
-            continue
-        active_side_count += 1
-        side_min_dte = _strict_optional_nonnegative_int_value(
-            side_plan.min_dte
-        )
-        side_max_dte = _strict_optional_nonnegative_int_value(
-            side_plan.max_dte
-        )
-        if side_min_dte is _INVALID or side_max_dte is _INVALID:
-            return False
-        if not _valid_optional_range(side_min_dte, side_max_dte):
-            return False
-        try:
-            expected_dtes = required_data_expiration_dtes(
-                trading_date=trading_date,
-                expirations=requested_expirations,
-            )
-        except ValueError:
-            return False
-        if any(
-            not _value_within_optional_range(
-                value=dte,
-                minimum=side_min_dte,
-                maximum=side_max_dte,
-            )
-            for dte in expected_dtes.values()
-        ):
-            return False
-        side_df = _filter_option_type(df, side_plan.option_type)
-        if side_df.empty or "expiration" not in side_df.columns:
-            return False
-        base_min = side_plan.strike_window.base_min_strike
-        base_max = side_plan.strike_window.base_max_strike
-        exact_strikes_by_expiration = _strict_exact_strikes_by_expiration(
-            side_plan.required_exact_strikes_by_expiration,
-            allowed_expirations=requested_expirations,
-        )
-        if exact_strikes_by_expiration is None:
-            return False
-        for expiration in requested_expirations:
-            exp_df = side_df[
-                side_df["expiration"].astype(str) == expiration
-            ].copy()
-            if exp_df.empty or not _frame_dte_matches(
-                df=exp_df,
-                expected_dte=expected_dtes[expiration],
-                minimum=side_min_dte,
-                maximum=side_max_dte,
-            ):
-                return False
-            strikes = _numeric_series(exp_df, "strike")
-            if not _strikes_cover_bounds(
-                strikes=strikes,
-                base_min=base_min,
-                base_max=base_max,
-            ):
-                return False
-            if not _strikes_cover_exact_requirements(
-                strikes=strikes,
-                required_strikes=exact_strikes_by_expiration.get(
-                    str(expiration),
-                    [],
-                ),
-            ):
-                return False
-    if active_side_count <= 0:
-        return False
-
-    active_request_count = 0
-    for spec in fetch_plan.merged_specs:
-        if spec.trading_date != trading_date.isoformat():
-            return False
-        requested_expirations = _strict_expiration_list(
-            spec.explicit_expirations
-        )
-        if requested_expirations is None:
-            return False
-        if not requested_expirations:
-            return False
-        active_request_count += 1
-        request_min_dte = _strict_optional_nonnegative_int_value(spec.min_dte)
-        request_max_dte = _strict_optional_nonnegative_int_value(spec.max_dte)
-        if request_min_dte is _INVALID or request_max_dte is _INVALID:
-            return False
-        if not _valid_optional_range(request_min_dte, request_max_dte):
-            return False
-        try:
-            expected_dtes = required_data_expiration_dtes(
-                trading_date=trading_date,
-                expirations=requested_expirations,
-            )
-        except ValueError:
-            return False
-        if any(
-            not _value_within_optional_range(
-                value=dte,
-                minimum=request_min_dte,
-                maximum=request_max_dte,
-            )
-            for dte in expected_dtes.values()
-        ):
-            return False
-
-        option_types = list(spec.option_types)
-        if (
-            not option_types
-            or any(option_type not in {"put", "call"} for option_type in option_types)
-            or len(option_types) != len(set(option_types))
-        ):
-            return False
-        nested_side_plans = {
-            side_plan.option_type: side_plan
-            for side_plan in spec.side_plans
-        }
-        if (
-            len(nested_side_plans) != len(spec.side_plans)
-            or set(nested_side_plans) != set(option_types)
-        ):
-            return False
-        for option_type in option_types:
-            side_plan = nested_side_plans[option_type]
-            side_expirations = _strict_expiration_list(
-                side_plan.explicit_expirations
-            )
-            if side_expirations != requested_expirations:
-                return False
-            side_min_dte = _strict_optional_nonnegative_int_value(
-                side_plan.min_dte
-            )
-            side_max_dte = _strict_optional_nonnegative_int_value(
-                side_plan.max_dte
-            )
-            if side_min_dte is _INVALID or side_max_dte is _INVALID:
-                return False
-            if not _valid_optional_range(side_min_dte, side_max_dte):
-                return False
-            if any(
-                not _value_within_optional_range(
-                    value=dte,
-                    minimum=side_min_dte,
-                    maximum=side_max_dte,
-                )
-                for dte in expected_dtes.values()
-            ):
-                return False
-            exact_strikes_by_expiration = (
-                _strict_exact_strikes_by_expiration(
-                    side_plan.required_exact_strikes_by_expiration,
-                    allowed_expirations=side_expirations,
-                )
-            )
-            if exact_strikes_by_expiration is None:
-                return False
-            side_df = _filter_option_type(df, option_type)
-            if "expiration" not in side_df.columns:
-                return False
-            for expiration in requested_expirations:
-                exp_df = side_df[
-                    side_df["expiration"].astype(str) == expiration
-                ].copy()
-                if exp_df.empty or not _frame_dte_matches(
-                    df=exp_df,
-                    expected_dte=expected_dtes[expiration],
-                    minimum=request_min_dte,
-                    maximum=request_max_dte,
-                ):
-                    return False
-                if not _frame_dte_matches(
-                    df=exp_df,
-                    expected_dte=expected_dtes[expiration],
-                    minimum=side_min_dte,
-                    maximum=side_max_dte,
-                ):
-                    return False
-                strikes = _numeric_series(exp_df, "strike")
-                if not _strikes_cover_bounds(
-                    strikes=strikes,
-                    base_min=side_plan.strike_window.base_min_strike,
-                    base_max=side_plan.strike_window.base_max_strike,
-                ):
-                    return False
-                if not _strikes_cover_exact_requirements(
-                    strikes=strikes,
-                    required_strikes=exact_strikes_by_expiration.get(
-                        expiration,
-                        [],
-                    ),
-                ):
-                    return False
-    if active_request_count <= 0:
-        return False
-    return True
+    return required_data_frame_covers_fetch_plan_debug(
+        df,
+        fetch_plan.to_debug_dict(),
+        option_chain_evidence=option_chain_evidence,
+    )
 
 
-def _required_data_frame_covers_fetch_plan_debug_bool(
+def _evaluate_required_data_rows(
     df: pd.DataFrame,
     fetch_plan: Mapping[str, Any],
     *,
-    option_chain_evidence: Mapping[str, Any] | None = None,
-) -> bool:
-    """Validate CSV rows against the stable ``to_debug_dict`` plan shape."""
+    scope_evidence: Mapping[tuple[int, str, str], frozenset[str]] | None,
+) -> tuple[str | None, bool]:
+    """Validate plan rows once and return ``(reason_code, is_empty)``."""
 
-    if df.empty or not isinstance(fetch_plan, Mapping):
-        return False
-    if not _spot_reference_matches_frame(
-        df=df,
-        spot_reference=fetch_plan.get("spot_reference"),
+    if not isinstance(fetch_plan, Mapping):
+        return "internal_contract_error", False
+    spot_reference = fetch_plan.get("spot_reference")
+    if spot_reference is not None:
+        normalized_spot = _strict_finite_float(spot_reference)
+        if normalized_spot is None or normalized_spot <= 0:
+            return "internal_contract_error", False
+    if not df.empty and (
+        not _spot_reference_matches_frame(
+            df=df,
+            spot_reference=spot_reference,
+        )
+        or _numeric_series(df, "strike").empty
     ):
-        return False
-    if _numeric_series(df, "strike").empty:
-        return False
+        return "invalid_row_identity", False
 
     trading_date = _fetch_plan_trading_date(fetch_plan)
     if not isinstance(trading_date, date):
-        return False
+        return "internal_contract_error", False
 
     merged_requests = fetch_plan.get("merged_requests")
-    if not isinstance(merged_requests, list):
-        return False
-    require_realized_volatility = fetch_plan.get(
-        "require_realized_volatility"
-    )
+    if not isinstance(merged_requests, list) or not merged_requests:
+        return "internal_contract_error", False
+    require_realized_volatility = fetch_plan.get("require_realized_volatility")
     if not isinstance(require_realized_volatility, bool):
-        return False
-    scope_validation = _validated_option_chain_scope_evidence(
-        df=df,
-        fetch_plan=fetch_plan,
-        evidence=option_chain_evidence,
-    )
-    scope_evidence = scope_validation.resolved
-    if scope_evidence is None and _contains_option_chain_scope_evidence(
-        option_chain_evidence
-    ):
-        return False
+        return "internal_contract_error", False
     active_request_count = 0
+    any_rows = False
     for request_index, raw_request in enumerate(merged_requests):
         if not isinstance(raw_request, Mapping):
-            return False
+            return "internal_contract_error", False
         if raw_request.get("trading_date") != trading_date.isoformat():
-            return False
+            return "internal_contract_error", False
         requested_expirations = _strict_expiration_list(
             raw_request.get("explicit_expirations")
         )
-        if requested_expirations is None:
-            return False
+        if not requested_expirations:
+            return "internal_contract_error", False
         raw_rv_flag = raw_request.get("include_realized_volatility")
         if (
             not isinstance(raw_rv_flag, bool)
             or raw_rv_flag != require_realized_volatility
         ):
-            return False
-        if not requested_expirations:
-            return False
+            return "internal_contract_error", False
 
         active_request_count += 1
         request_min_dte = _strict_optional_nonnegative_int(
@@ -419,42 +193,40 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
             "max_dte",
         )
         if request_min_dte is _INVALID or request_max_dte is _INVALID:
-            return False
+            return "internal_contract_error", False
         if not _valid_optional_range(request_min_dte, request_max_dte):
-            return False
+            return "internal_contract_error", False
 
         option_types = raw_request.get("option_types")
         if (
             not isinstance(option_types, list)
             or not option_types
             or any(
-                not isinstance(option_type, str)
-                or option_type not in {"put", "call"}
+                not isinstance(option_type, str) or option_type not in {"put", "call"}
                 for option_type in option_types
             )
             or len(option_types) != len(set(option_types))
         ):
-            return False
+            return "internal_contract_error", False
         raw_side_plans = raw_request.get("side_plans")
         if not isinstance(raw_side_plans, list):
-            return False
+            return "internal_contract_error", False
         side_plans: dict[str, Mapping[str, Any]] = {}
         for raw_side_plan in raw_side_plans:
             if not isinstance(raw_side_plan, Mapping):
-                return False
+                return "internal_contract_error", False
             option_type = raw_side_plan.get("option_type")
             if option_type not in option_types or option_type in side_plans:
-                return False
+                return "internal_contract_error", False
             side_plans[str(option_type)] = raw_side_plan
         if set(side_plans) != set(option_types):
-            return False
+            return "internal_contract_error", False
 
         raw_request_windows = raw_request.get("side_strike_windows")
-        if (
-            not isinstance(raw_request_windows, Mapping)
-            or set(raw_request_windows) != set(option_types)
-        ):
-            return False
+        if not isinstance(raw_request_windows, Mapping) or set(
+            raw_request_windows
+        ) != set(option_types):
+            return "internal_contract_error", False
 
         try:
             expected_dtes = required_data_expiration_dtes(
@@ -462,7 +234,7 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
                 expirations=requested_expirations,
             )
         except ValueError:
-            return False
+            return "internal_contract_error", False
         if any(
             not _value_within_optional_range(
                 value=dte,
@@ -471,12 +243,12 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
             )
             for dte in expected_dtes.values()
         ):
-            return False
+            return "internal_contract_error", False
 
         for option_type in option_types:
             raw_request_window = raw_request_windows.get(option_type)
             if not _valid_request_strike_window(raw_request_window):
-                return False
+                return "internal_contract_error", False
             request_scope_min = _strict_optional_positive_float(
                 raw_request_window, "min_strike"
             )
@@ -488,17 +260,13 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
                 raw_side_plan.get("explicit_expirations")
             )
             if side_expirations != requested_expirations:
-                return False
-            exact_strikes_by_expiration = (
-                _strict_exact_strikes_by_expiration(
-                    raw_side_plan.get(
-                        "required_exact_strikes_by_expiration"
-                    ),
-                    allowed_expirations=side_expirations,
-                )
+                return "internal_contract_error", False
+            exact_strikes_by_expiration = _strict_exact_strikes_by_expiration(
+                raw_side_plan.get("required_exact_strikes_by_expiration"),
+                allowed_expirations=side_expirations,
             )
             if exact_strikes_by_expiration is None:
-                return False
+                return "internal_contract_error", False
             side_min_dte = _strict_optional_nonnegative_int(
                 raw_side_plan,
                 "min_dte",
@@ -508,19 +276,19 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
                 "max_dte",
             )
             if side_min_dte is _INVALID or side_max_dte is _INVALID:
-                return False
+                return "internal_contract_error", False
             if not _valid_optional_range(side_min_dte, side_max_dte):
-                return False
+                return "internal_contract_error", False
 
             effective_bounds = _effective_side_strike_bounds(raw_side_plan)
             if effective_bounds is None:
-                return False
+                return "internal_contract_error", False
             effective_min, effective_max = effective_bounds
             side_df = _filter_option_type(df, option_type)
             if scope_evidence is None and (
                 side_df.empty or "expiration" not in side_df.columns
             ):
-                return False
+                return "invalid_row_identity", False
             for expiration in requested_expirations:
                 proven_codes = (
                     scope_evidence.get((request_index, option_type, expiration))
@@ -533,45 +301,54 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
                     minimum=side_min_dte,
                     maximum=side_max_dte,
                 ):
-                    return False
+                    return "internal_contract_error", False
                 if proven_codes is not None:
-                    exp_df = df[
-                        df["contract_symbol"].astype(str).str.strip().isin(
-                            proven_codes
-                        )
-                    ].copy()
+                    if not proven_codes:
+                        exp_df = df.iloc[0:0].copy()
+                    elif "contract_symbol" not in df.columns:
+                        return "invalid_row_identity", False
+                    else:
+                        exp_df = df[
+                            df["contract_symbol"]
+                            .astype(str)
+                            .str.strip()
+                            .isin(proven_codes)
+                        ].copy()
                 else:
                     exp_df = side_df[
                         side_df["expiration"].astype(str) == expiration
                     ].copy()
                 if exp_df.empty:
-                    if proven_codes != frozenset() or exact_strikes_by_expiration.get(expiration):
-                        return False
+                    if proven_codes != frozenset():
+                        return "invalid_row_identity", False
+                    if exact_strikes_by_expiration.get(expiration):
+                        return "required_contract_missing", False
                     continue
+                any_rows = True
                 if not _frame_dte_matches(
                     df=exp_df,
                     expected_dte=expected_dte,
                     minimum=request_min_dte,
                     maximum=request_max_dte,
                 ):
-                    return False
+                    return "invalid_row_identity", False
                 if not _frame_dte_matches(
                     df=exp_df,
                     expected_dte=expected_dte,
                     minimum=side_min_dte,
                     maximum=side_max_dte,
                 ):
-                    return False
+                    return "invalid_row_identity", False
                 strikes = _numeric_series(exp_df, "strike")
                 row_codes = _frame_contract_codes(exp_df)
                 if proven_codes is not None and row_codes != proven_codes:
-                    return False
+                    return "invalid_row_identity", False
                 if proven_codes is not None and not _strikes_within_bounds(
                     strikes=strikes,
                     minimum=request_scope_min,
                     maximum=request_scope_max,
                 ):
-                    return False
+                    return "invalid_row_identity", False
                 if not _strikes_cover_bounds(
                     strikes=strikes,
                     base_min=effective_min,
@@ -584,7 +361,7 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
                         base_max=effective_max,
                     )
                 ):
-                    return False
+                    return "invalid_row_identity", False
                 if not _strikes_cover_exact_requirements(
                     strikes=strikes,
                     required_strikes=exact_strikes_by_expiration.get(
@@ -592,13 +369,15 @@ def _required_data_frame_covers_fetch_plan_debug_bool(
                         [],
                     ),
                 ):
-                    return False
+                    return "required_contract_missing", False
 
     if active_request_count <= 0:
-        return False
+        return "internal_contract_error", False
+    if not any_rows:
+        return None, True
     if require_realized_volatility and not _has_realized_volatility(df):
-        return False
-    return True
+        return "invalid_row_identity", False
+    return None, False
 
 
 def required_data_frame_covers_fetch_plan_debug(
@@ -626,74 +405,41 @@ def evaluate_required_data_frame_fetch_plan_debug(
 
     if not isinstance(fetch_plan, Mapping):
         return _blocked_coverage("internal_contract_error")
-    exact_requirement = _fetch_plan_has_exact_strike_requirement(fetch_plan)
-    if exact_requirement is None:
-        return _blocked_coverage("internal_contract_error")
     scope_validation = _validated_option_chain_scope_evidence(
         df=df,
         fetch_plan=fetch_plan,
         evidence=option_chain_evidence,
     )
-    if (
-        scope_validation.reason_code is not None
-        and _contains_option_chain_scope_evidence(option_chain_evidence)
-    ):
+    if scope_validation.reason_code is not None:
         return _blocked_coverage(
             scope_validation.reason_code,
             warnings=scope_validation.warnings,
         )
-
-    if df.empty and scope_validation.resolved is not None:
-        if any(scope_validation.resolved.values()):
-            return _blocked_coverage("invalid_row_identity")
-        if exact_requirement:
-            return _blocked_coverage(
-                "required_contract_missing",
-                provider_coverage="complete",
-                strategy_readiness="blocked",
-            )
-        return RequiredDataCoverageResult(
-            status="success_empty",
-            reason_code=None,
-            provider_coverage="complete",
-            internal_integrity="valid",
-            freshness=_freshness_evidence_strength(option_chain_evidence),
-            strategy_readiness="empty",
-            warnings=scope_validation.warnings,
-            details={"completion_unit": "request_option_type_expiration"},
-        )
-
-    accepted = _required_data_frame_covers_fetch_plan_debug_bool(
+    reason_code, is_empty = _evaluate_required_data_rows(
         df,
         fetch_plan,
-        option_chain_evidence=option_chain_evidence,
+        scope_evidence=scope_validation.resolved,
     )
-    if not accepted:
-        if _fetch_plan_missing_exact_strike(df=df, fetch_plan=fetch_plan):
-            return _blocked_coverage(
-                "required_contract_missing",
-                provider_coverage=(
-                    "complete"
-                    if scope_validation.resolved is not None
-                    else "unproven"
-                ),
-            )
+    if reason_code is not None:
         return _blocked_coverage(
-            "invalid_row_identity",
+            reason_code,
             provider_coverage=(
-                "complete" if scope_validation.resolved is not None else "unproven"
+                "complete"
+                if scope_validation.resolved is not None
+                and reason_code != "internal_contract_error"
+                else "unproven"
             ),
             warnings=scope_validation.warnings,
         )
     return RequiredDataCoverageResult(
-        status="success",
+        status=("success_empty" if is_empty else "success"),
         reason_code=None,
         provider_coverage=(
             "complete" if scope_validation.resolved is not None else "unproven"
         ),
         internal_integrity="valid",
         freshness=_freshness_evidence_strength(option_chain_evidence),
-        strategy_readiness="ready",
+        strategy_readiness=("empty" if is_empty else "ready"),
         warnings=scope_validation.warnings,
         details={"completion_unit": "request_option_type_expiration"},
     )
@@ -743,164 +489,6 @@ def _freshness_evidence_strength(
     )
 
 
-def _fetch_plan_has_exact_strike_requirement(
-    fetch_plan: Mapping[str, Any],
-) -> bool | None:
-    trading_date = _fetch_plan_trading_date(fetch_plan)
-    if not isinstance(trading_date, date):
-        return None
-    spot_reference = fetch_plan.get("spot_reference")
-    if spot_reference is not None:
-        normalized_spot = _strict_finite_float(spot_reference)
-        if normalized_spot is None or normalized_spot <= 0:
-            return None
-    require_rv = fetch_plan.get("require_realized_volatility")
-    if not isinstance(require_rv, bool):
-        return None
-    merged_requests = fetch_plan.get("merged_requests")
-    if not isinstance(merged_requests, list) or not merged_requests:
-        return None
-    has_exact = False
-    for request in merged_requests:
-        if not isinstance(request, Mapping):
-            return None
-        if (
-            request.get("trading_date") != trading_date.isoformat()
-            or request.get("include_realized_volatility") is not require_rv
-        ):
-            return None
-        expirations = _strict_expiration_list(request.get("explicit_expirations"))
-        if not expirations:
-            return None
-        min_dte = _strict_optional_nonnegative_int(request, "min_dte")
-        max_dte = _strict_optional_nonnegative_int(request, "max_dte")
-        if (
-            min_dte is _INVALID
-            or max_dte is _INVALID
-            or not _valid_optional_range(min_dte, max_dte)
-        ):
-            return None
-        try:
-            expected_dtes = required_data_expiration_dtes(
-                trading_date=trading_date,
-                expirations=expirations,
-            )
-        except ValueError:
-            return None
-        if any(
-            not _value_within_optional_range(
-                value=dte,
-                minimum=min_dte,
-                maximum=max_dte,
-            )
-            for dte in expected_dtes.values()
-        ):
-            return None
-        option_types = request.get("option_types")
-        if (
-            not isinstance(option_types, list)
-            or not option_types
-            or any(option_type not in {"put", "call"} for option_type in option_types)
-            or len(option_types) != len(set(option_types))
-        ):
-            return None
-        windows = request.get("side_strike_windows")
-        if (
-            not isinstance(windows, Mapping)
-            or set(windows) != set(option_types)
-            or any(not _valid_request_strike_window(windows.get(option_type)) for option_type in option_types)
-        ):
-            return None
-        side_plans = request.get("side_plans")
-        if not isinstance(side_plans, list):
-            return None
-        normalized_sides: set[str] = set()
-        for side_plan in side_plans:
-            if not isinstance(side_plan, Mapping):
-                return None
-            option_type = side_plan.get("option_type")
-            if option_type not in option_types or option_type in normalized_sides:
-                return None
-            normalized_sides.add(str(option_type))
-            side_expirations = _strict_expiration_list(
-                side_plan.get("explicit_expirations")
-            )
-            if side_expirations != expirations:
-                return None
-            exact = _strict_exact_strikes_by_expiration(
-                side_plan.get("required_exact_strikes_by_expiration"),
-                allowed_expirations=side_expirations,
-            )
-            if exact is None:
-                return None
-            side_min_dte = _strict_optional_nonnegative_int(side_plan, "min_dte")
-            side_max_dte = _strict_optional_nonnegative_int(side_plan, "max_dte")
-            if (
-                side_min_dte is _INVALID
-                or side_max_dte is _INVALID
-                or not _valid_optional_range(side_min_dte, side_max_dte)
-                or any(
-                    not _value_within_optional_range(
-                        value=dte,
-                        minimum=side_min_dte,
-                        maximum=side_max_dte,
-                    )
-                    for dte in expected_dtes.values()
-                )
-            ):
-                return None
-            if _effective_side_strike_bounds(side_plan) is None:
-                return None
-            has_exact = has_exact or bool(exact)
-        if normalized_sides != set(option_types):
-            return None
-    return has_exact
-
-
-def _fetch_plan_missing_exact_strike(
-    *,
-    df: pd.DataFrame,
-    fetch_plan: Mapping[str, Any],
-) -> bool:
-    merged_requests = fetch_plan.get("merged_requests")
-    if not isinstance(merged_requests, list):
-        return False
-    for request in merged_requests:
-        if not isinstance(request, Mapping):
-            return False
-        side_plans = request.get("side_plans")
-        if not isinstance(side_plans, list):
-            return False
-        for side_plan in side_plans:
-            if not isinstance(side_plan, Mapping):
-                return False
-            option_type = str(side_plan.get("option_type") or "")
-            exact = side_plan.get("required_exact_strikes_by_expiration")
-            if not isinstance(exact, Mapping):
-                return False
-            side_df = _filter_option_type(df, option_type)
-            for expiration, raw_strikes in exact.items():
-                if not isinstance(raw_strikes, list):
-                    return False
-                if "expiration" not in side_df.columns:
-                    return bool(raw_strikes)
-                exp_df = side_df[
-                    side_df["expiration"].astype(str) == str(expiration)
-                ]
-                strikes = _numeric_series(exp_df, "strike")
-                required = [
-                    value
-                    for raw_value in raw_strikes
-                    if (value := _strict_finite_float(raw_value)) is not None
-                ]
-                if required and not _strikes_cover_exact_requirements(
-                    strikes=strikes,
-                    required_strikes=required,
-                ):
-                    return True
-    return False
-
-
 def _validated_option_chain_scope_evidence(
     *,
     df: pd.DataFrame,
@@ -911,6 +499,7 @@ def _validated_option_chain_scope_evidence(
 
     if not isinstance(evidence, Mapping):
         return _ScopeEvidenceResult(None)
+    has_scope_evidence = _contains_option_chain_scope_evidence(evidence)
     if evidence.get("stale_cache_expirations") not in (None, []):
         return _ScopeEvidenceResult(None, "stale_data")
     if (
@@ -968,11 +557,11 @@ def _validated_option_chain_scope_evidence(
                 or child_index >= len(merged_requests)
                 or child_index in observed_indexes
             ):
-                return _ScopeEvidenceResult(None, "internal_contract_error")
+                return _ScopeEvidenceResult(None, "scope_identity_mismatch")
             observed_by_hash[child_hash] = child
             observed_indexes.add(child_index)
         if set(observed_by_hash) != set(expected_by_hash):
-            return _ScopeEvidenceResult(None, "internal_contract_error")
+            return _ScopeEvidenceResult(None, "scope_identity_mismatch")
         indexed_children = [
             (request_index, request, observed_by_hash[request_hash])
             for request_hash, (request_index, request) in expected_by_hash.items()
@@ -1012,6 +601,9 @@ def _validated_option_chain_scope_evidence(
         assert child_codes is not None
         warnings.extend(child_snapshot.warnings)
         scope_payload = child.get("option_chain_scope_coverage")
+        if not has_scope_evidence:
+            child_union.update(child_codes)
+            continue
         if (
             not isinstance(scope_payload, Mapping)
             or scope_payload.get("schema_version")
@@ -1067,6 +659,11 @@ def _validated_option_chain_scope_evidence(
         child_union.update(child_codes)
     if child_union != set(aggregate_codes):
         return _ScopeEvidenceResult(None, "internal_contract_error")
+    if not has_scope_evidence:
+        return _ScopeEvidenceResult(
+            None,
+            warnings=tuple(dict.fromkeys(warnings)),
+        )
     for (request_index, option_type, expiration), codes in resolved.items():
         for code in codes:
             matches = df[df["contract_symbol"].astype(str).str.strip() == code]
@@ -1272,18 +869,6 @@ def _fetch_plan_trading_date(
     return trading_date if trading_date is not None else _INVALID
 
 
-def _typed_fetch_plan_trading_date(
-    fetch_plan: RequiredDataFetchPlanBundle,
-) -> date | object:
-    discovery = fetch_plan.expiration_discovery
-    if discovery is None or not isinstance(discovery.request_identity, Mapping):
-        return _INVALID
-    trading_date = _strict_iso_date(
-        discovery.request_identity.get("trading_date")
-    )
-    return trading_date if trading_date is not None else _INVALID
-
-
 def _strict_expiration_list(value: Any) -> list[str] | None:
     if not isinstance(value, list):
         return None
@@ -1348,12 +933,7 @@ def _strict_optional_nonnegative_int(
     mapping: Mapping[str, Any],
     key: str,
 ) -> int | None | object:
-    return _strict_optional_nonnegative_int_value(mapping.get(key))
-
-
-def _strict_optional_nonnegative_int_value(
-    value: Any,
-) -> int | None | object:
+    value = mapping.get(key)
     if value is None:
         return None
     parsed = _strict_finite_float(value)

--- a/tests/test_pipeline_fetch_read_model_boundary.py
+++ b/tests/test_pipeline_fetch_read_model_boundary.py
@@ -1017,7 +1017,7 @@ def test_ensure_required_data_rejects_direct_contract_coverage_gap(
 
     with pytest.raises(
         PositionAdviceSourceError,
-        match="child request rows contradict strike window",
+        match=r"^invalid_row_identity:",
     ):
         mod.ensure_required_data(
             py="python3",

--- a/tests/test_required_data_output_integrity.py
+++ b/tests/test_required_data_output_integrity.py
@@ -910,7 +910,7 @@ def test_receipt_rejects_duplicate_requested_contract_rows(
         output_root=tmp_path,
     )
 
-    with pytest.raises(PositionAdviceSourceError, match="duplicate snapshot codes"):
+    with pytest.raises(PositionAdviceSourceError, match=r"^invalid_row_identity:"):
         _publish(root=tmp_path, raw_path=raw_path, csv_path=csv_path)
 
     assert _receipt_paths(tmp_path) == []

--- a/tests/test_required_data_prefetch_inprocess.py
+++ b/tests/test_required_data_prefetch_inprocess.py
@@ -2270,8 +2270,6 @@ def test_prefetch_refetches_when_cached_required_data_misses_strategy_side(tmp_p
                 "rate_gate_wait_sec": 1.25,
                 "from_cache_expirations": ["2026-06-19"],
                 "fetched_expirations": ["2026-07-17"],
-                "option_codes": 12,
-                "snapshot_requested_codes": 12,
                 "snapshot_opend_call_count": 1,
                 "snapshots_rows": 12,
             },

--- a/tests/test_required_data_quote_receipts.py
+++ b/tests/test_required_data_quote_receipts.py
@@ -586,7 +586,7 @@ def test_quote_receipt_rejects_incomplete_snapshot_evidence(tmp_path: Path) -> N
     raw_path, csv_path = save_outputs(tmp_path, "NVDA", payload, output_root=tmp_path)
     fetch_plan = _fetch_plan()
 
-    with pytest.raises(PositionAdviceSourceError, match="complete snapshot evidence"):
+    with pytest.raises(PositionAdviceSourceError, match=r"^provider_incomplete:"):
         publish_required_data_quote_snapshot(
             producer_root=tmp_path,
             producer_run_id="run-1",


### PR DESCRIPTION
Unifies required-data coverage evaluation, removes duplicate output-layer validation and post-failure strike inference, and narrows stale-data handling to the typed exception boundary. Net change: 709 lines removed. Validation: full pytest suite (4531 passed, 10 skipped), focused required-data and tick regressions, Ruff, diff check, and dependency-cycle check all passed.