### PR TITLE
Manage Feishu credential service drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Improvements
+- Brought the encrypted Feishu Agent credential materializer, consumer drop-ins, and oneshot execution health under the repository service profile and drift contract, so adopted hosts preserve the credential dependency across manual and automatic upgrades.
+
 ## 1.10.12 - 2026-08-07
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ om service render \
   --output-dir /tmp/options-monitor-service
 ```
 
+Linux 主机如果已预置 `systemd-creds` 加密的 Feishu Agent 凭据，可在 render 时显式加上 `--include-feishu-agent-credential`，将 credential oneshot、materializer helper 和消费服务 drop-in 纳入 service profile 与 drift；该开关不会创建或修改凭据。
+
 平台部署、升级、回滚和服务检查见 [DEPLOY.md](DEPLOY.md)、[Linux / Mac Deployment](docs/DEPLOY_LINUX_MAC.md) 与 [RUNBOOK.md](RUNBOOK.md)。
 
 ## 文档

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 918 (`src`: 491, `domain`: 76, `scripts`: 8, `tests`: 343)
-- Internal import edges: 5847 total, 2490 production/script edges excluding tests
+- Internal import edges: 5855 total, 2490 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -45,11 +45,11 @@ flowchart LR
   scripts -->|12| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2494| application
+  tests -->|2501| application
   tests -->|440| domain
   tests -->|2| domain_services
   tests -->|150| infrastructure
-  tests -->|212| interfaces
+  tests -->|213| interfaces
   tests -->|13| scripts
   tests -->|16| storage
 ```
@@ -77,9 +77,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2494 |
+| tests | application | 2501 |
 | tests | domain | 440 |
-| tests | interfaces | 212 |
+| tests | interfaces | 213 |
 | tests | infrastructure | 150 |
 | tests | storage | 16 |
 | tests | scripts | 13 |

--- a/docs/DEPLOY_LINUX_MAC.md
+++ b/docs/DEPLOY_LINUX_MAC.md
@@ -108,6 +108,20 @@ cd "$REPO"
 
 `--include-feishu-ws` 会生成 `options-monitor-feishu-ws.service`。它通过飞书长连接接收事件，不监听本地 HTTP 端口，也不需要公网回调 URL、Nginx/Caddy 或 Cloudflare Tunnel。服务会使用 `/var/lib/options-monitor/locks/feishu-ws.lock` 防止同一个 Feishu App 启动多个长连接客户端。
 
+如果 Linux 主机已通过 `systemd-creds` 预置了加密的 Feishu Agent 凭据，可以额外传入：
+
+```bash
+--include-feishu-agent-credential
+```
+
+这是显式 opt-in，只支持 systemd。它会把以下不含明文秘密的资产纳入同一个 `service.profile.json` 和 service drift 契约：
+
+- `/etc/systemd/system/options-monitor-feishu-agent-credential.service`；
+- `/usr/local/libexec/options-monitor-materialize-feishu-agent-credential`，权限 `0755`；
+- 每个由该 profile 生成的非 OpenD options-monitor service 下的 `zzzz-feishu-agent-credential.conf` drop-in。
+
+默认读取 `/etc/credstore.encrypted/pm-feishu-agent-app-secret` 和 `/etc/credstore.encrypted/om-feishu-holdings-app-secret`，将解密结果原子写入 tmpfs 上的 `/run/credentials/options-monitor-feishu-agent.env`，权限为 `0440 root:<deploy_user>`。渲染和 drift 不会创建、修改或输出加密凭据；这两个 credential store 必须由运维事先独立配置。OpenD 不读取 Feishu 凭据，因此不会添加该 drop-in。
+
 如果要启用远端自动升级，建议 `$REPO` 使用 `/opt/options-monitor/current` 这样的 symlink 布局，并额外传：
 
 ```bash
@@ -128,7 +142,7 @@ cd "$REPO"
 
 启用 `--include-auto-upgrade` 时，渲染器会保留 `--repo-root` 传入的 symlink 字面路径，并默认把 tick / trade-intake / Feishu WS / maintenance config 指到 runtime root 下的 `config.us.json` / `config.hk.json`。这样 release 切换只移动代码，不绑定 release 目录内的生产配置。必须同时传 `--config-yaml "$RUNTIME/config.yaml"`；profile 会记录 YAML source，`update apply` 会用 `config build --source yaml` 重建 runtime config，并用 `config build-assistant --source yaml` 重建 `$RUNTIME/resolved/config.assistant.json`。缺少可用 YAML authoring source 时升级会 fail closed，不再从 legacy JSON profile 恢复。
 
-升级切换 release 后还会做一次 service drift reconcile：以当前 release 的 `service render` 结果为期望状态，对比 `$RUNTIME/service.profile.json` 和 systemd unit 文件。缺失 unit 会被写入 `/etc/systemd/system/`，缺失 timer 会执行 `systemctl enable --now`。随后升级流程会用 reconcile 后的 profile 重启长期运行的 trade-intake / Feishu WS，并执行服务 active/enabled 检查；Feishu WS 还会运行 `./om inbound feishu-ws --check`，避免长驻进程继续使用旧 release、旧 config 或不可用 env。
+升级切换 release 后还会做一次 service drift reconcile：以当前 release 的 `service render` 结果为期望状态，对比 `$RUNTIME/service.profile.json`、systemd unit 和 profile 显式声明的 helper/drop-in。缺失 unit 会被写入 `/etc/systemd/system/`，缺失 timer 和 credential oneshot 会执行 `systemctl enable --now`；credential helper 还会校验内容、`0755` 权限和 oneshot `Result=success`。随后升级流程会用 reconcile 后的 profile 重启长期运行的 trade-intake / Feishu WS，并执行服务 active/enabled 检查；Feishu WS 还会运行 `./om inbound feishu-ws --check`，避免长驻进程继续使用旧 release、旧 config 或不可用 env。
 
 如果要让远端持续积累 Strategy Lab / Shadow Replay 复盘数据，额外显式开启 recorder：
 
@@ -212,11 +226,40 @@ sudo systemctl enable --now options-monitor-trade-intake.service
 sudo systemctl enable --now options-monitor-feishu-ws.service
 ```
 
+如果 render 时传了 `--include-feishu-agent-credential`，先确认加密凭据已经存在，再安装 helper 和 drop-in：
+
+```bash
+sudo test -f /etc/credstore.encrypted/pm-feishu-agent-app-secret
+sudo test -f /etc/credstore.encrypted/om-feishu-holdings-app-secret
+sudo install -D -m 0755 \
+  /tmp/options-monitor-service/systemd/libexec/options-monitor-materialize-feishu-agent-credential \
+  /usr/local/libexec/options-monitor-materialize-feishu-agent-credential
+while IFS= read -r source; do
+  relative="${source#/tmp/options-monitor-service/systemd/}"
+  sudo install -D -m 0644 "$source" "/etc/systemd/system/$relative"
+done < <(find /tmp/options-monitor-service/systemd -type f -name zzzz-feishu-agent-credential.conf -print)
+sudo systemctl daemon-reload
+sudo systemctl enable --now options-monitor-feishu-agent-credential.service
+sudo systemctl show --property=Result --value options-monitor-feishu-agent-credential.service
+```
+
+最后一条必须输出 `success`。不要在 shell 中解密或回显 credential store 内容。
+
 如果 render 时传了 `--include-auto-upgrade`，再启用升级 timer：
 
 ```bash
 sudo systemctl enable --now options-monitor-upgrade.timer
 ```
+
+对于原先把 credential unit 放在 `/usr/lib/systemd/system/` 的存量主机，升级到首个包含此能力的 release 后需要做一次显式收编：
+
+```bash
+./om service drift --runtime-root "$RUNTIME"
+./om service drift --runtime-root "$RUNTIME" --confirm
+./om service drift --runtime-root "$RUNTIME"
+```
+
+第一条应显示 `legacy_feishu_agent_credential_inferred`；第二条会把 unit 收编到 `/etc/systemd/system/`、补齐 helper/drop-in 并把显式 opt-in 写回 profile；第三条应返回 clean。首次升级进程是由旧 release 启动的，不能依赖它自己执行新 release 才提供的收编逻辑；这一次收编完成后，后续手动和 06:10 自动升级都会从 profile 保留该意图并自动 reconcile。在仍需要回滚到不识别新 profile 字段的旧 release 期间，保留 `/usr/lib/systemd/system/` 下的 legacy unit；drift 不会自动删除它。
 
 `options-monitor-auto-close-*.timer` 每天北京时间 09:00 运行一次 `./om option-positions auto-close-expired --apply --yes --quiet`。入口会按 runtime config 的 `_generated.market` 过滤 open lots，US/HK timer 只处理各自市场标的；`grace_days=1` 的到期 +1 天 cutoff 按标的市场本地日期计算，US 使用美东时间，HK 使用香港时间。短仓期权还必须有到期后的 OpenD spot 证明已经价外才会自动写入过期平仓；价内/平值或缺少 spot 时会进入 assignment review，等待指派/行权结果。这里使用 `--yes` 是因为 systemd/launchd 属于非交互脚本，高风险写入必须显式确认并输出 `audit_id`。
 `options-monitor-projection-verify.timer` 每天北京时间 09:30 运行一次 `./om option-positions verify-projection --mode auto`，用于校验 `trade_events -> position_lots` 并复用 checkpoint。

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -297,7 +297,9 @@ VERSION="$(cat VERSION)"
 
 升级会根据 `/var/lib/options-monitor/service.profile.json` 里的 `markets` / `config_paths` 重建 runtime config。profile 必须记录 `config_authoring.source=yaml` 和 `config_authoring.config_yaml`，升级时执行 `./om config build --source yaml --config-yaml <path>` 重建对应 market 的 runtime config。旧 profile 缺少 YAML authoring source 时会 fail closed；先用 `config migrate-yaml` 完成一次性迁移，再重新 `service render --config-yaml <path>`。切换 symlink 前缺失来源或 rebuild/validate 失败时会在 `upgrade_status.json` 写入 remediation。切换 symlink 后会再用 current symlink 重建/校验一次，保证 tick 看到的 runtime config freshness 与当前代码一致。
 
-切换 symlink 后会执行 service drift reconcile：当前 release 的 `render_service_bundle()` 是期望状态，旧 profile 只提供账号、市场、env file、deploy user、Feishu WS、auto-upgrade 等部署意图。reconcile 会写入缺失的 systemd unit/profile、`daemon-reload`，并启用缺失 timer。升级流程随后会用 reconcile 后的 profile 重启长期 service，并检查 `is-active` / `is-enabled`；Feishu WS 还会额外执行 `./om inbound feishu-ws --check`。`./om service drift --runtime-root /var/lib/options-monitor` 是同一逻辑的只读检查，`--confirm` 才会应用修复。
+切换 symlink 后会执行 service drift reconcile：当前 release 的 `render_service_bundle()` 是期望状态，旧 profile 只提供账号、市场、env file、deploy user、Feishu WS、auto-upgrade 和已显式收编的 Feishu Agent credential 等部署意图。reconcile 会写入缺失的 systemd unit/profile 和 profile-owned helper/drop-in、修复 helper 模式、`daemon-reload`，并启用缺失 timer 或 credential oneshot。credential oneshot 还要求 `Result=success`。升级流程随后会用 reconcile 后的 profile 重启长期 service，并检查 `is-active` / `is-enabled`；Feishu WS 还会额外执行 `./om inbound feishu-ws --check`。`./om service drift --runtime-root /var/lib/options-monitor` 是同一逻辑的只读检查，`--confirm` 才会应用修复。
+
+存量主机如果仍使用 `/usr/lib/systemd/system/options-monitor-feishu-agent-credential.service`，首次升级到包含 repository-owned credential 资产的 release 后，必须用新 release 显式执行一次 `service drift` dry-run 和 `--confirm`。原因是升级进程由旧 release 启动，无法在同一次切换中可靠使用尚未加载的新 reconcile 逻辑。收编后 profile 会保留 `feishu_agent_credential` opt-in，后续手动升级、自动升级和回滚都按同一契约 reconcile。在旧 release 回滚窗口结束前保留 `/usr/lib` legacy unit，不由 drift 自动删除。
 
 如果 systemd unit 使用 `User=<deploy_user>` 运行自动升级，`service render` 会在 profile 中标记 trade-intake 和 Feishu WS 等长期服务重启使用 `sudo -n systemctl restart ...`。服务器需要给运行用户配置最小 sudoers 授权，例如：
 

--- a/services/systemd/options-monitor-feishu-agent-credential.service.in
+++ b/services/systemd/options-monitor-feishu-agent-credential.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=options-monitor materialize encrypted Feishu Agent credential into tmpfs
+{{BEFORE}}
+
+[Service]
+Type=oneshot
+ExecStart={{EXEC_START}}
+
+[Install]
+WantedBy=multi-user.target

--- a/services/systemd/options-monitor-materialize-feishu-agent-credential
+++ b/services/systemd/options-monitor-materialize-feishu-agent-credential
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+agent_store=""
+holdings_store=""
+runtime_env_file=""
+deploy_group="root"
+
+while (($#)); do
+  case "$1" in
+    --agent-store)
+      agent_store="${2:-}"
+      shift 2
+      ;;
+    --holdings-store)
+      holdings_store="${2:-}"
+      shift 2
+      ;;
+    --runtime-env-file)
+      runtime_env_file="${2:-}"
+      shift 2
+      ;;
+    --deploy-group)
+      deploy_group="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "unsupported argument: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+
+test -n "$agent_store"
+test -n "$holdings_store"
+test -n "$runtime_env_file"
+[[ "$runtime_env_file" = /* ]]
+[[ "$deploy_group" =~ ^[A-Za-z0-9_.-]+$ ]]
+test -f "$agent_store"
+test -f "$holdings_store"
+
+runtime_dir="$(dirname -- "$runtime_env_file")"
+stage="$runtime_dir/.options-monitor-feishu-agent.env.$$"
+
+cleanup() {
+  rm -f -- "$stage"
+}
+trap cleanup EXIT
+
+agent_secret="$(
+  /usr/bin/systemd-creds decrypt \
+    --name=pm-feishu-agent-app-secret \
+    "$agent_store" \
+    -
+)"
+holdings_secret="$(
+  /usr/bin/systemd-creds decrypt \
+    --name=om-feishu-holdings-app-secret \
+    "$holdings_store" \
+    -
+)"
+test -n "$agent_secret"
+test -n "$holdings_secret"
+[[ "$agent_secret" =~ ^[A-Za-z0-9_-]+$ ]]
+[[ "$holdings_secret" =~ ^[A-Za-z0-9_-]+$ ]]
+
+install -d -m 0755 -o root -g root "$runtime_dir"
+umask 027
+printf 'OM_FEISHU_APP_SECRET=%s\nOM_FEISHU_BOT_APP_SECRET=%s\n' \
+  "$holdings_secret" \
+  "$agent_secret" > "$stage"
+chown root:"$deploy_group" "$stage"
+chmod 0440 "$stage"
+mv -f -- "$stage" "$runtime_env_file"
+
+echo "materialized=options-monitor-feishu-agent"

--- a/services/systemd/zzzz-feishu-agent-credential.conf.in
+++ b/services/systemd/zzzz-feishu-agent-credential.conf.in
@@ -1,0 +1,6 @@
+[Unit]
+Requires=options-monitor-feishu-agent-credential.service
+After=options-monitor-feishu-agent-credential.service
+
+[Service]
+{{ENVIRONMENT_FILE}}

--- a/src/application/service_deploy.py
+++ b/src/application/service_deploy.py
@@ -51,6 +51,21 @@ QUALITY_DAY_END_SYSTEMD_CALENDARS = {
     "us": "Mon..Fri *-*-* 16:30:00 America/New_York",
     "hk": "Mon..Fri *-*-* 16:30:00 Asia/Hong_Kong",
 }
+FEISHU_AGENT_CREDENTIAL_SERVICE = "options-monitor-feishu-agent-credential.service"
+FEISHU_AGENT_CREDENTIAL_DROPIN = "zzzz-feishu-agent-credential.conf"
+DEFAULT_FEISHU_AGENT_CREDENTIAL_HELPER = Path(
+    "/usr/local/libexec/options-monitor-materialize-feishu-agent-credential"
+)
+DEFAULT_FEISHU_AGENT_CREDENTIAL_STORE = Path(
+    "/etc/credstore.encrypted/pm-feishu-agent-app-secret"
+)
+DEFAULT_FEISHU_HOLDINGS_CREDENTIAL_STORE = Path(
+    "/etc/credstore.encrypted/om-feishu-holdings-app-secret"
+)
+DEFAULT_FEISHU_AGENT_CREDENTIAL_ENV_FILE = Path(
+    "/run/credentials/options-monitor-feishu-agent.env"
+)
+SYSTEMD_SERVICE_ASSET_ROOT = Path(__file__).resolve().parents[2] / "services" / "systemd"
 
 
 @dataclass(frozen=True)
@@ -59,13 +74,16 @@ class RenderedServiceFile:
     content: str
     install_path: str
     kind: str
+    mode: int | None = None
 
     def to_dict(self, *, include_content: bool = True) -> dict[str, Any]:
-        out = {
+        out: dict[str, Any] = {
             "relative_path": self.relative_path,
             "install_path": self.install_path,
             "kind": self.kind,
         }
+        if self.mode is not None:
+            out["mode"] = self.mode
         if include_content:
             out["content"] = self.content
         return out
@@ -660,6 +678,26 @@ def _systemd_environment_file(path: Path) -> str:
     return f"EnvironmentFile={_systemd_quote_arg(path)}"
 
 
+def _read_systemd_service_asset(name: str) -> str:
+    path = SYSTEMD_SERVICE_ASSET_ROOT / name
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"systemd service asset is unavailable: {path}") from exc
+
+
+def _render_systemd_service_asset(name: str, replacements: dict[str, str]) -> str:
+    content = _read_systemd_service_asset(name)
+    for key, value in replacements.items():
+        token = "{{" + key + "}}"
+        if token not in content:
+            raise ValueError(f"systemd service asset token is missing: {name}:{key}")
+        content = content.replace(token, value)
+    if "{{" in content or "}}" in content:
+        raise ValueError(f"systemd service asset has unresolved tokens: {name}")
+    return content
+
+
 def _systemd_unit(
     *,
     description: str,
@@ -823,6 +861,7 @@ def build_service_profile(
     strategy_lab_recorder: dict[str, Any] | None = None,
     quality_monitoring: dict[str, Any] | None = None,
     position_advice_promotion: dict[str, Any] | None = None,
+    feishu_agent_credential: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     restartable_services = [
         name
@@ -904,6 +943,8 @@ def build_service_profile(
         profile["position_advice_promotion"] = dict(
             position_advice_promotion
         )
+    if feishu_agent_credential is not None:
+        profile["feishu_agent_credential"] = dict(feishu_agent_credential)
     return profile
 
 
@@ -937,11 +978,18 @@ def render_service_bundle(
     strategy_lab_recorder_max_datasets: int = DEFAULT_STRATEGY_LAB_RECORDER_MAX_DATASETS,
     strategy_lab_recorder_mark_stale_hours: int = DEFAULT_STRATEGY_LAB_RECORDER_MARK_STALE_HOURS,
     include_quality_monitoring: bool = False,
+    include_feishu_agent_credential: bool = False,
+    feishu_agent_credential_helper_path: str | Path | None = None,
+    feishu_agent_credential_store: str | Path | None = None,
+    feishu_holdings_credential_store: str | Path | None = None,
+    feishu_agent_credential_env_file: str | Path | None = None,
     include_content: bool = True,
 ) -> dict[str, Any]:
     target_key = normalize_target(target)
     if include_quality_monitoring and target_key != "systemd":
         raise ValueError("quality monitoring service rendering is currently supported only for systemd")
+    if include_feishu_agent_credential and target_key != "systemd":
+        raise ValueError("Feishu Agent credential materialization is currently supported only for systemd")
     repo = _absolute_path_preserve_symlink(repo_root or Path.cwd())
     runtime = _resolve_path(runtime_root, base=repo, default=default_runtime_root(target_key))
     env_file_path = _resolve_path(env_file, base=repo, default=Path()) if env_file else None
@@ -951,6 +999,26 @@ def render_service_bundle(
     systemd_home = default_systemd_deploy_home(systemd_user) if target_key == "systemd" and systemd_user else None
     if deploy_home is not None and str(deploy_home).strip():
         systemd_home = Path(deploy_home).expanduser()
+    credential_helper_path = _resolve_path(
+        feishu_agent_credential_helper_path,
+        base=repo,
+        default=DEFAULT_FEISHU_AGENT_CREDENTIAL_HELPER,
+    )
+    agent_credential_store = _resolve_path(
+        feishu_agent_credential_store,
+        base=repo,
+        default=DEFAULT_FEISHU_AGENT_CREDENTIAL_STORE,
+    )
+    holdings_credential_store = _resolve_path(
+        feishu_holdings_credential_store,
+        base=repo,
+        default=DEFAULT_FEISHU_HOLDINGS_CREDENTIAL_STORE,
+    )
+    credential_env_file = _resolve_path(
+        feishu_agent_credential_env_file,
+        base=repo,
+        default=DEFAULT_FEISHU_AGENT_CREDENTIAL_ENV_FILE,
+    )
     opend_executable_value = str(opend_executable or DEFAULT_OPEND_EXECUTABLE).strip() or DEFAULT_OPEND_EXECUTABLE
     account_values = normalize_accounts(accounts)
     market_values = normalize_markets(markets)
@@ -1055,9 +1123,26 @@ def render_service_bundle(
 
     files: list[RenderedServiceFile] = []
     service_names: list[str] = []
+    credential_consumers: list[str] = []
 
-    def add(relative_path: str, content: str, *, install_path: str, kind: str, service_name: str | None = None) -> None:
-        files.append(RenderedServiceFile(relative_path=relative_path, content=content, install_path=install_path, kind=kind))
+    def add(
+        relative_path: str,
+        content: str,
+        *,
+        install_path: str,
+        kind: str,
+        service_name: str | None = None,
+        mode: int | None = None,
+    ) -> None:
+        files.append(
+            RenderedServiceFile(
+                relative_path=relative_path,
+                content=content,
+                install_path=install_path,
+                kind=kind,
+                mode=mode,
+            )
+        )
         if service_name:
             service_names.append(service_name)
 
@@ -1759,6 +1844,68 @@ def render_service_bundle(
                 kind="systemd_service",
                 service_name=wechat_service,
             )
+
+        if include_feishu_agent_credential:
+            credential_consumers = sorted(
+                name
+                for name in service_names
+                if name.endswith(".service")
+                and name != FEISHU_AGENT_CREDENTIAL_SERVICE
+                and not name.startswith("options-monitor-opend")
+            )
+            deploy_group = str(systemd_user or "root")
+            credential_exec = _systemd_join_args(
+                [
+                    str(credential_helper_path),
+                    "--agent-store",
+                    str(agent_credential_store),
+                    "--holdings-store",
+                    str(holdings_credential_store),
+                    "--runtime-env-file",
+                    str(credential_env_file),
+                    "--deploy-group",
+                    deploy_group,
+                ]
+            )
+            add(
+                f"systemd/{FEISHU_AGENT_CREDENTIAL_SERVICE}",
+                _render_systemd_service_asset(
+                    "options-monitor-feishu-agent-credential.service.in",
+                    {
+                        "BEFORE": "\n".join(
+                            f"Before={consumer}"
+                            for consumer in credential_consumers
+                        ),
+                        "EXEC_START": credential_exec,
+                    },
+                ),
+                install_path=f"/etc/systemd/system/{FEISHU_AGENT_CREDENTIAL_SERVICE}",
+                kind="systemd_service",
+                service_name=FEISHU_AGENT_CREDENTIAL_SERVICE,
+            )
+            add(
+                "systemd/libexec/options-monitor-materialize-feishu-agent-credential",
+                _read_systemd_service_asset(
+                    "options-monitor-materialize-feishu-agent-credential"
+                ),
+                install_path=str(credential_helper_path),
+                kind="systemd_executable",
+                mode=0o755,
+            )
+            credential_dropin = _render_systemd_service_asset(
+                "zzzz-feishu-agent-credential.conf.in",
+                {"ENVIRONMENT_FILE": _systemd_environment_file(credential_env_file)},
+            )
+            for consumer in credential_consumers:
+                add(
+                    f"systemd/{consumer}.d/{FEISHU_AGENT_CREDENTIAL_DROPIN}",
+                    credential_dropin,
+                    install_path=(
+                        f"/etc/systemd/system/{consumer}.d/"
+                        f"{FEISHU_AGENT_CREDENTIAL_DROPIN}"
+                    ),
+                    kind="systemd_dropin",
+                )
     else:
         for market in market_values:
             label = f"com.options-monitor.tick-{market}"
@@ -2245,6 +2392,15 @@ def render_service_bundle(
             "schedule_beijing": "05:15",
             "automatic_authority_cas": False,
         },
+        feishu_agent_credential={
+            "enabled": True,
+            "service_name": FEISHU_AGENT_CREDENTIAL_SERVICE,
+            "helper_path": str(credential_helper_path),
+            "agent_store": str(agent_credential_store),
+            "holdings_store": str(holdings_credential_store),
+            "runtime_env_file": str(credential_env_file),
+            "consumer_services": credential_consumers,
+        } if include_feishu_agent_credential else None,
     )
     profile_content = json.dumps(profile, ensure_ascii=False, indent=2) + "\n"
     add(
@@ -2296,6 +2452,7 @@ def _install_commands(target: ServiceTarget, *, files: list[RenderedServiceFile]
                 or "feishu-ws" in item.install_path
                 or "wechat-clawbot" in item.install_path
                 or "quality-http" in item.install_path
+                or Path(item.install_path).name == FEISHU_AGENT_CREDENTIAL_SERVICE
             )
         ]
         return {
@@ -2329,6 +2486,9 @@ def write_service_bundle(bundle: dict[str, Any], output_dir: str | Path) -> list
         path = (root / rel).resolve()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
+        mode = item.get("mode")
+        if mode is not None:
+            path.chmod(int(mode))
         written.append(str(path))
     return written
 

--- a/src/application/service_drift.py
+++ b/src/application/service_drift.py
@@ -7,8 +7,14 @@ from pathlib import Path
 from typing import Any, Callable
 
 from src.application.service_deploy import (
+    DEFAULT_FEISHU_AGENT_CREDENTIAL_ENV_FILE,
+    DEFAULT_FEISHU_AGENT_CREDENTIAL_HELPER,
+    DEFAULT_FEISHU_AGENT_CREDENTIAL_STORE,
+    DEFAULT_FEISHU_HOLDINGS_CREDENTIAL_STORE,
     DEFAULT_ACCOUNTS,
     DEFAULT_MARKETS,
+    FEISHU_AGENT_CREDENTIAL_DROPIN,
+    FEISHU_AGENT_CREDENTIAL_SERVICE,
     load_service_profile,
     render_service_bundle,
     resolve_strategy_lab_recorder_endpoint_matches,
@@ -16,6 +22,7 @@ from src.application.service_deploy import (
 
 
 SYSTEMD_REQUIRED_MAINTENANCE_UNITS = (
+    FEISHU_AGENT_CREDENTIAL_SERVICE,
     "options-monitor-position-advice-promotion.timer",
     "options-monitor-projection-verify.timer",
 )
@@ -25,6 +32,9 @@ LAUNCHD_REQUIRED_MAINTENANCE_UNITS = (
 )
 LEGACY_STRATEGY_LAB_RECORDER_HOST = "127.0.0.1"
 LEGACY_STRATEGY_LAB_RECORDER_PORT = 11111
+LEGACY_FEISHU_AGENT_CREDENTIAL_UNIT_PATH = Path(
+    "/usr/lib/systemd/system/options-monitor-feishu-agent-credential.service"
+)
 
 
 def service_drift(
@@ -39,10 +49,10 @@ def service_drift(
 ) -> dict[str, Any]:
     """Compare current-release expected services with profile and installed unit files.
 
-    Dry-run is the default. Confirmed apply writes missing or changed unit files,
-    repairs expected timer activation, retires extra managed units, and refreshes
-    the service profile. Long-running expected services are not enabled or
-    restarted here.
+    Dry-run is the default. Confirmed apply writes missing or changed unit files
+    and profile-owned support files, repairs expected timer and credential
+    activation, retires extra managed assets, and refreshes the service profile.
+    Long-running expected services are not enabled or restarted here.
     """
 
     initial = _load_profile_and_paths(
@@ -155,6 +165,50 @@ def _load_profile_and_paths(
     }
 
 
+def _effective_profile_with_legacy_feishu_credential(
+    profile: dict[str, Any],
+    *,
+    ctx: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    if str(ctx.get("provider") or "").strip().lower() != "systemd":
+        return profile, []
+    if "feishu_agent_credential" in profile:
+        return profile, []
+
+    profile_services = set(_service_names_from_profile(profile))
+    inferred_from_profile = FEISHU_AGENT_CREDENTIAL_SERVICE in profile_services
+    unit_path = LEGACY_FEISHU_AGENT_CREDENTIAL_UNIT_PATH
+    dropin_root = Path(ctx["systemd_unit_root"])
+    legacy_dropins = sorted(
+        path
+        for path in dropin_root.glob(
+            f"options-monitor-*.service.d/{FEISHU_AGENT_CREDENTIAL_DROPIN}"
+        )
+        if path.is_file()
+    ) if dropin_root.exists() else []
+    inferred_from_legacy = unit_path.is_file() and bool(legacy_dropins)
+    if not inferred_from_profile and not inferred_from_legacy:
+        return profile, []
+
+    effective = dict(profile)
+    effective["feishu_agent_credential"] = {
+        "enabled": True,
+        "service_name": FEISHU_AGENT_CREDENTIAL_SERVICE,
+        "helper_path": str(DEFAULT_FEISHU_AGENT_CREDENTIAL_HELPER),
+        "agent_store": str(DEFAULT_FEISHU_AGENT_CREDENTIAL_STORE),
+        "holdings_store": str(DEFAULT_FEISHU_HOLDINGS_CREDENTIAL_STORE),
+        "runtime_env_file": str(DEFAULT_FEISHU_AGENT_CREDENTIAL_ENV_FILE),
+    }
+    return effective, [
+        {
+            "code": "legacy_feishu_agent_credential_inferred",
+            "source": "profile_service" if inferred_from_profile else "installed_assets",
+            "unit_path": str(unit_path),
+            "dropin_count": len(legacy_dropins),
+        }
+    ]
+
+
 def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
     profile = ctx["profile"]
     provider = str(ctx["provider"] or "").strip().lower()
@@ -188,18 +242,31 @@ def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
             "extra_profile_units": [],
             "extra_installed_units": [],
             "mismatched_units": [],
+            "expected_managed_files": [],
+            "installed_managed_files": [],
+            "missing_managed_files": [],
+            "extra_managed_files": [],
+            "mismatched_managed_files": [],
+            "mode_mismatched_managed_files": [],
             "activation_states": {},
             "active_states": {},
+            "execution_states": {},
             "activation_drift_units": [],
+            "execution_drift_units": [],
             "required_units": [],
             "missing_required_units": [],
             "profile_content_changed": False,
             "manual_actions": [],
             "summary": {"ok": True, "status": "skipped", "error_count": 0, "warning_count": 0},
         }
+    effective_profile, profile_compatibility_warnings = _effective_profile_with_legacy_feishu_credential(
+        profile,
+        ctx=ctx,
+    )
+    ctx["effective_profile"] = effective_profile
     try:
         bundle = _expected_bundle_from_profile(
-            profile,
+            effective_profile,
             provider=provider,
             repo_root=ctx["repo_root"],
             runtime_root=ctx["runtime_root"],
@@ -228,12 +295,20 @@ def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
             },
         }
     compatibility_warnings_raw = bundle.get("compatibility_warnings")
-    compatibility_warnings = (
-        [dict(item) for item in compatibility_warnings_raw if isinstance(item, dict)]
-        if isinstance(compatibility_warnings_raw, list)
-        else []
-    )
+    compatibility_warnings = list(profile_compatibility_warnings)
+    if isinstance(compatibility_warnings_raw, list):
+        compatibility_warnings.extend(
+            dict(item)
+            for item in compatibility_warnings_raw
+            if isinstance(item, dict)
+        )
     expected_files = _expected_install_files(bundle, provider=provider)
+    expected_managed_files = _expected_managed_files(bundle, provider=provider)
+    installed_managed_files = _installed_managed_files(
+        provider=provider,
+        expected_files=expected_managed_files,
+        ctx=ctx,
+    )
     expected_services = _service_names_from_profile(_bundle_profile(bundle))
     profile_services = _service_names_from_profile(profile)
     installed_units = _installed_units(provider=provider, expected_files=expected_files, ctx=ctx)
@@ -241,7 +316,19 @@ def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
     extra_profile_units = sorted(set(profile_services) - set(expected_services))
     missing_installed_units = sorted(set(expected_files) - set(installed_units))
     extra_installed_units = sorted(set(installed_units) - set(expected_files))
+    extra_managed_files = sorted(
+        set(installed_managed_files) - set(expected_managed_files)
+    )
     mismatched_units = _mismatched_units(provider=provider, expected_files=expected_files, ctx=ctx)
+    (
+        missing_managed_files,
+        mismatched_managed_files,
+        mode_mismatched_managed_files,
+    ) = _managed_file_status(
+        provider=provider,
+        expected_files=expected_managed_files,
+        ctx=ctx,
+    )
     activation_states = _activation_states(
         provider=provider,
         expected_files=expected_files,
@@ -254,11 +341,22 @@ def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
         installed_units=installed_units,
         ctx=ctx,
     )
+    execution_states = _execution_states(
+        provider=provider,
+        expected_files=expected_files,
+        installed_units=installed_units,
+        ctx=ctx,
+    )
     activation_drift_units = sorted(
         name
         for name in set(activation_states) | set(active_states)
         if activation_states.get(name) in {"disabled", "masked"}
         or active_states.get(name) in {"inactive", "failed", "deactivating"}
+    )
+    execution_drift_units = sorted(
+        name
+        for name, state in execution_states.items()
+        if state != "success"
     )
     required_units = _required_units(provider, expected_services)
     missing_required_units = sorted(
@@ -272,7 +370,12 @@ def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
         missing_installed_units=missing_installed_units,
         mismatched_units=mismatched_units,
         activation_drift_units=activation_drift_units,
+        execution_drift_units=execution_drift_units,
         extra_installed_units=extra_installed_units,
+        extra_managed_files=extra_managed_files,
+        missing_managed_files=missing_managed_files,
+        mismatched_managed_files=mismatched_managed_files,
+        mode_mismatched_managed_files=mode_mismatched_managed_files,
         profile_path=ctx["profile_path"],
     )
     summary = _drift_summary(
@@ -282,8 +385,13 @@ def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
         missing_installed_units=missing_installed_units,
         extra_profile_units=extra_profile_units,
         extra_installed_units=extra_installed_units,
+        extra_managed_files=extra_managed_files,
         mismatched_units=mismatched_units,
+        missing_managed_files=missing_managed_files,
+        mismatched_managed_files=mismatched_managed_files,
+        mode_mismatched_managed_files=mode_mismatched_managed_files,
         activation_drift_units=activation_drift_units,
+        execution_drift_units=execution_drift_units,
         profile_content_changed=profile_content_changed,
         compatibility_warning_count=len(compatibility_warnings),
     )
@@ -303,9 +411,17 @@ def _build_drift(ctx: dict[str, Any]) -> dict[str, Any]:
         "extra_profile_units": extra_profile_units,
         "extra_installed_units": extra_installed_units,
         "mismatched_units": mismatched_units,
+        "expected_managed_files": sorted(expected_managed_files),
+        "installed_managed_files": installed_managed_files,
+        "missing_managed_files": missing_managed_files,
+        "extra_managed_files": extra_managed_files,
+        "mismatched_managed_files": mismatched_managed_files,
+        "mode_mismatched_managed_files": mode_mismatched_managed_files,
         "activation_states": activation_states,
         "active_states": active_states,
+        "execution_states": execution_states,
         "activation_drift_units": activation_drift_units,
+        "execution_drift_units": execution_drift_units,
         "required_units": required_units,
         "missing_required_units": missing_required_units,
         "profile_content_changed": profile_content_changed,
@@ -334,6 +450,12 @@ def _expected_bundle_from_profile(
     strategy_lab_recorder = strategy_lab_recorder_raw if isinstance(strategy_lab_recorder_raw, dict) else {}
     quality_monitoring_raw = profile.get("quality_monitoring")
     quality_monitoring = quality_monitoring_raw if isinstance(quality_monitoring_raw, dict) else {}
+    feishu_agent_credential_raw = profile.get("feishu_agent_credential")
+    feishu_agent_credential = (
+        feishu_agent_credential_raw
+        if isinstance(feishu_agent_credential_raw, dict)
+        else {}
+    )
     services = _service_names_from_profile(profile)
     include_auto_upgrade = bool(
         isinstance(profile.get("auto_upgrade"), dict)
@@ -368,6 +490,10 @@ def _expected_bundle_from_profile(
     include_quality_monitoring = bool(
         quality_monitoring.get("enabled")
         or any(name.startswith("options-monitor-quality-") for name in services)
+    )
+    include_feishu_agent_credential = bool(
+        feishu_agent_credential.get("enabled")
+        or FEISHU_AGENT_CREDENTIAL_SERVICE in services
     )
     market_values = _profile_markets(profile)
     feishu_ws_config_key = str(feishu_ws.get("config_key") or "").strip() or None
@@ -417,6 +543,23 @@ def _expected_bundle_from_profile(
         "strategy_lab_recorder_max_datasets": int(strategy_lab_recorder.get("max_datasets") or 5),
         "strategy_lab_recorder_mark_stale_hours": int(strategy_lab_recorder.get("mark_stale_hours") or 2),
         "include_quality_monitoring": include_quality_monitoring,
+        "include_feishu_agent_credential": include_feishu_agent_credential,
+        "feishu_agent_credential_helper_path": (
+            feishu_agent_credential.get("helper_path")
+            or DEFAULT_FEISHU_AGENT_CREDENTIAL_HELPER
+        ),
+        "feishu_agent_credential_store": (
+            feishu_agent_credential.get("agent_store")
+            or DEFAULT_FEISHU_AGENT_CREDENTIAL_STORE
+        ),
+        "feishu_holdings_credential_store": (
+            feishu_agent_credential.get("holdings_store")
+            or DEFAULT_FEISHU_HOLDINGS_CREDENTIAL_STORE
+        ),
+        "feishu_agent_credential_env_file": (
+            feishu_agent_credential.get("runtime_env_file")
+            or DEFAULT_FEISHU_AGENT_CREDENTIAL_ENV_FILE
+        ),
         "include_content": True,
     }
     compatibility_warnings: list[dict[str, Any]] = []
@@ -523,6 +666,47 @@ def _expected_install_files(bundle: dict[str, Any], *, provider: str) -> dict[st
     return out
 
 
+def _expected_managed_files(bundle: dict[str, Any], *, provider: str) -> dict[str, dict[str, Any]]:
+    if provider != "systemd":
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for item in bundle.get("files", []):
+        if not isinstance(item, dict) or item.get("kind") not in {
+            "systemd_dropin",
+            "systemd_executable",
+        }:
+            continue
+        install_path = str(item.get("install_path") or "").strip()
+        if install_path:
+            out[install_path] = item
+    return out
+
+
+def _installed_managed_files(
+    *,
+    provider: str,
+    expected_files: dict[str, dict[str, Any]],
+    ctx: dict[str, Any],
+) -> list[str]:
+    if provider != "systemd":
+        return []
+    installed = {
+        key
+        for key, item in expected_files.items()
+        if _install_path(item, provider=provider, ctx=ctx).is_file()
+    }
+    root = Path(ctx["systemd_unit_root"])
+    if root.exists():
+        for path in root.glob(
+            f"options-monitor-*.service.d/{FEISHU_AGENT_CREDENTIAL_DROPIN}"
+        ):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(root)
+            installed.add(str(Path("/etc/systemd/system") / relative))
+    return sorted(installed)
+
+
 def _service_name_for_file(item: dict[str, Any], *, provider: str) -> str:
     if provider == "systemd":
         return Path(str(item.get("install_path") or item.get("relative_path") or "")).name
@@ -597,8 +781,27 @@ def _installed_units(*, provider: str, expected_files: dict[str, dict[str, Any]]
 def _install_path(item: dict[str, Any], *, provider: str, ctx: dict[str, Any]) -> Path:
     raw = Path(str(item.get("install_path") or "")).expanduser()
     if provider == "systemd":
+        if item.get("kind") == "systemd_executable":
+            return raw
+        if item.get("kind") == "systemd_dropin":
+            live_root = Path("/etc/systemd/system")
+            try:
+                relative = raw.relative_to(live_root)
+            except ValueError:
+                return raw
+            return Path(ctx["systemd_unit_root"]) / relative
         return Path(ctx["systemd_unit_root"]) / raw.name
     return raw
+
+
+def _managed_path_from_key(key: str, *, ctx: dict[str, Any]) -> Path:
+    raw = Path(key).expanduser()
+    live_root = Path("/etc/systemd/system")
+    try:
+        relative = raw.relative_to(live_root)
+    except ValueError:
+        return raw
+    return Path(ctx["systemd_unit_root"]) / relative
 
 
 def _mismatched_units(*, provider: str, expected_files: dict[str, dict[str, Any]], ctx: dict[str, Any]) -> list[str]:
@@ -616,6 +819,39 @@ def _mismatched_units(*, provider: str, expected_files: dict[str, dict[str, Any]
     return sorted(out)
 
 
+def _managed_file_status(
+    *,
+    provider: str,
+    expected_files: dict[str, dict[str, Any]],
+    ctx: dict[str, Any],
+) -> tuple[list[str], list[str], list[str]]:
+    missing: list[str] = []
+    mismatched: list[str] = []
+    mode_mismatched: list[str] = []
+    for key, item in expected_files.items():
+        path = _install_path(item, provider=provider, ctx=ctx)
+        if not path.exists() or not path.is_file():
+            missing.append(key)
+            continue
+        try:
+            actual = path.read_text(encoding="utf-8")
+        except Exception:
+            mismatched.append(key)
+            continue
+        if actual != str(item.get("content") or ""):
+            mismatched.append(key)
+        expected_mode = item.get("mode")
+        if expected_mode is not None:
+            try:
+                actual_mode = path.stat().st_mode & 0o777
+            except OSError:
+                mode_mismatched.append(key)
+            else:
+                if actual_mode != int(expected_mode):
+                    mode_mismatched.append(key)
+    return sorted(missing), sorted(mismatched), sorted(mode_mismatched)
+
+
 def _activation_states(
     *,
     provider: str,
@@ -628,7 +864,10 @@ def _activation_states(
     installed = set(installed_units)
     states: dict[str, str] = {}
     for name in sorted(expected_files):
-        if not name.endswith(".timer") or name not in installed:
+        if (
+            not name.endswith(".timer")
+            and name != FEISHU_AGENT_CREDENTIAL_SERVICE
+        ) or name not in installed:
             continue
         result = _run_systemctl(ctx, ["is-enabled", name], run_cmd=ctx.get("run_cmd") or subprocess.run)
         stdout = str(result.get("stdout") or "").strip().lower()
@@ -675,6 +914,38 @@ def _active_states(
     return states
 
 
+def _execution_states(
+    *,
+    provider: str,
+    expected_files: dict[str, dict[str, Any]],
+    installed_units: list[str],
+    ctx: dict[str, Any],
+) -> dict[str, str]:
+    if provider != "systemd" or not _live_systemctl_enabled(ctx):
+        return {}
+    installed = set(installed_units)
+    if (
+        FEISHU_AGENT_CREDENTIAL_SERVICE not in expected_files
+        or FEISHU_AGENT_CREDENTIAL_SERVICE not in installed
+    ):
+        return {}
+    result = _run_systemctl(
+        ctx,
+        [
+            "show",
+            "--property=Result",
+            "--value",
+            FEISHU_AGENT_CREDENTIAL_SERVICE,
+        ],
+        run_cmd=ctx.get("run_cmd") or subprocess.run,
+    )
+    if not result.get("ok"):
+        return {FEISHU_AGENT_CREDENTIAL_SERVICE: "query_failed"}
+    state = str(result.get("stdout") or "").strip().lower().splitlines()
+    value = state[0].strip() if state else ""
+    return {FEISHU_AGENT_CREDENTIAL_SERVICE: value or "unknown"}
+
+
 def _profile_content_changed(profile: dict[str, Any], bundle: dict[str, Any]) -> bool:
     expected = _bundle_profile(bundle)
     keys = (
@@ -695,6 +966,7 @@ def _profile_content_changed(profile: dict[str, Any], bundle: dict[str, Any]) ->
         "strategy_lab_recorder",
         "quality_monitoring",
         "position_advice_promotion",
+        "feishu_agent_credential",
         "restart",
     )
     return {key: profile.get(key) for key in keys if key in profile or key in expected} != {
@@ -722,8 +994,13 @@ def _drift_summary(
     missing_installed_units: list[str],
     extra_profile_units: list[str],
     extra_installed_units: list[str],
+    extra_managed_files: list[str],
     mismatched_units: list[str],
+    missing_managed_files: list[str],
+    mismatched_managed_files: list[str],
+    mode_mismatched_managed_files: list[str],
     activation_drift_units: list[str],
+    execution_drift_units: list[str],
     profile_content_changed: bool,
     compatibility_warning_count: int = 0,
 ) -> dict[str, Any]:
@@ -734,15 +1011,28 @@ def _drift_summary(
             missing_installed_units,
             extra_profile_units,
             extra_installed_units,
+            extra_managed_files,
             mismatched_units,
+            missing_managed_files,
+            mismatched_managed_files,
+            mode_mismatched_managed_files,
             activation_drift_units,
+            execution_drift_units,
         )
         if values
     )
     if profile_content_changed:
         warning_count += 1
     warning_count += max(0, int(compatibility_warning_count))
-    error_count = int(bool(missing_required_units)) + int(bool(activation_drift_units))
+    error_count = (
+        int(bool(missing_required_units))
+        + int(bool(activation_drift_units))
+        + int(bool(missing_managed_files))
+        + int(bool(mismatched_managed_files))
+        + int(bool(mode_mismatched_managed_files))
+        + int(bool(extra_managed_files))
+        + int(bool(execution_drift_units))
+    )
     status = "error" if error_count else ("warn" if warning_count else "ok")
     return {
         "ok": status == "ok",
@@ -755,8 +1045,18 @@ def _drift_summary(
         "missing_installed_count": len(missing_installed_units),
         "extra_profile_count": len(extra_profile_units),
         "extra_installed_count": len(extra_installed_units),
+        "extra_managed_file_count": len(extra_managed_files),
         "mismatched_count": len(mismatched_units),
+        "managed_file_drift_count": (
+            len(missing_managed_files)
+            + len(mismatched_managed_files)
+            + len(mode_mismatched_managed_files)
+        ),
+        "missing_managed_file_count": len(missing_managed_files),
+        "mismatched_managed_file_count": len(mismatched_managed_files),
+        "mode_mismatched_managed_file_count": len(mode_mismatched_managed_files),
         "activation_drift_count": len(activation_drift_units),
+        "execution_drift_count": len(execution_drift_units),
         "profile_content_changed": bool(profile_content_changed),
     }
 
@@ -776,11 +1076,26 @@ def _manual_actions(
     missing_installed_units: list[str],
     mismatched_units: list[str],
     activation_drift_units: list[str],
+    execution_drift_units: list[str],
     extra_installed_units: list[str],
+    extra_managed_files: list[str],
+    missing_managed_files: list[str],
+    mismatched_managed_files: list[str],
+    mode_mismatched_managed_files: list[str],
     profile_path: Path,
 ) -> list[str]:
     actions: list[str] = []
-    if missing_installed_units or mismatched_units or activation_drift_units or extra_installed_units:
+    if (
+        missing_installed_units
+        or mismatched_units
+        or activation_drift_units
+        or execution_drift_units
+        or extra_installed_units
+        or extra_managed_files
+        or missing_managed_files
+        or mismatched_managed_files
+        or mode_mismatched_managed_files
+    ):
         actions.append(f"./om service drift --profile-path {profile_path} --confirm")
     if provider == "systemd":
         long_running = [
@@ -791,8 +1106,22 @@ def _manual_actions(
         ]
         actions.extend(f"manual_enable_long_running_service: sudo systemctl enable --now {name}" for name in long_running)
         actions.extend(f"manual_review_unit_content: sudo systemctl cat {name}" for name in mismatched_units)
-        actions.extend(f"manual_enable_timer: sudo systemctl enable --now {name}" for name in activation_drift_units)
+        actions.extend(
+            f"manual_enable_timer: sudo systemctl enable --now {name}"
+            for name in activation_drift_units
+            if name.endswith(".timer")
+        )
+        actions.extend(
+            f"manual_enable_service: sudo systemctl enable --now {name}"
+            for name in activation_drift_units
+            if not name.endswith(".timer")
+        )
+        actions.extend(f"manual_restart_failed_oneshot: sudo systemctl start {name}" for name in execution_drift_units)
         actions.extend(f"manual_retire_unit: sudo systemctl disable --now {name}" for name in extra_installed_units)
+        actions.extend(
+            f"manual_retire_managed_file: sudo rm -- {path}"
+            for path in extra_managed_files
+        )
     return actions
 
 
@@ -809,22 +1138,36 @@ def _apply_service_drift(
             "changed": False,
             "errors": [f"confirmed service drift apply is not implemented for provider: {provider}"],
             "written_units": [],
+            "written_managed_files": [],
+            "retired_managed_files": [],
             "enabled_timers": [],
+            "enabled_services": [],
+            "started_services": [],
             "restarted_timers": [],
             "retired_units": [],
             "profile_written": False,
         }
     bundle = _expected_bundle_from_profile(
-        ctx["profile"],
+        ctx.get("effective_profile") or ctx["profile"],
         provider=provider,
         repo_root=ctx["repo_root"],
         runtime_root=ctx["runtime_root"],
     )
     expected_files = _expected_install_files(bundle, provider=provider)
+    expected_managed_files = _expected_managed_files(bundle, provider=provider)
     missing = set(before.get("missing_installed_units") or [])
     mismatched = set(before.get("mismatched_units") or [])
     units_to_write = missing | mismatched
+    missing_managed = set(before.get("missing_managed_files") or [])
+    mismatched_managed = set(before.get("mismatched_managed_files") or [])
+    mode_mismatched_managed = set(before.get("mode_mismatched_managed_files") or [])
+    managed_files_to_write = (
+        missing_managed | mismatched_managed | mode_mismatched_managed
+    )
+    extra_managed = set(before.get("extra_managed_files") or [])
     written_units: list[str] = []
+    written_managed_files: list[str] = []
+    retired_managed_files: list[str] = []
     errors: list[str] = []
     for name in sorted(units_to_write):
         item = expected_files.get(name)
@@ -843,6 +1186,39 @@ def _apply_service_drift(
             continue
         written_units.append(name)
 
+    for key in sorted(managed_files_to_write):
+        item = expected_managed_files.get(key)
+        if not item:
+            continue
+        path = _install_path(item, provider=provider, ctx=ctx)
+        write_result = _write_text_with_sudo_fallback(
+            path,
+            str(item.get("content") or ""),
+            ctx=ctx,
+            run_cmd=run_cmd,
+            mode=(int(item["mode"]) if item.get("mode") is not None else None),
+        )
+        operations.append({**write_result, "managed_file": key})
+        if not write_result.get("ok"):
+            errors.append(
+                f"write {path}: "
+                f"{write_result.get('error') or write_result.get('stderr') or write_result.get('returncode')}"
+            )
+            continue
+        written_managed_files.append(key)
+
+    for key in sorted(extra_managed):
+        path = _managed_path_from_key(key, ctx=ctx)
+        delete_result = _delete_unit_with_sudo_fallback(path, run_cmd=run_cmd)
+        operations.append({**delete_result, "managed_file": key})
+        if not delete_result.get("ok"):
+            errors.append(
+                f"delete {path}: "
+                f"{delete_result.get('error') or delete_result.get('stderr') or delete_result.get('returncode')}"
+            )
+            continue
+        retired_managed_files.append(key)
+
     profile_written = False
     if before.get("profile_content_changed"):
         try:
@@ -856,12 +1232,23 @@ def _apply_service_drift(
             operations.append({"operation": "write_profile", "path": str(ctx["profile_path"]), "ok": True})
 
     enabled_timers: list[str] = []
+    enabled_services: list[str] = []
+    started_services: list[str] = []
     restarted_timers: list[str] = []
     retired_units: list[str] = []
     activation_drift = set(before.get("activation_drift_units") or [])
+    execution_drift = set(before.get("execution_drift_units") or [])
     extra_installed = set(before.get("extra_installed_units") or [])
     live_systemctl = _live_systemctl_enabled(ctx)
-    if written_units and live_systemctl:
+    systemd_definition_changed = bool(
+        written_units
+        or any(
+            expected_managed_files.get(key, {}).get("kind") == "systemd_dropin"
+            for key in written_managed_files
+        )
+        or bool(retired_managed_files)
+    )
+    if systemd_definition_changed and live_systemctl:
         result = _run_systemctl(ctx, ["daemon-reload"], run_cmd=run_cmd)
         operations.append(result)
         if not result.get("ok"):
@@ -878,14 +1265,48 @@ def _apply_service_drift(
     for name in sorted(
         item
         for item in missing | activation_drift
-        if live_systemctl and item.endswith(".timer")
+        if live_systemctl
+        and (
+            item.endswith(".timer")
+            or item == FEISHU_AGENT_CREDENTIAL_SERVICE
+        )
     ):
         result = _run_systemctl(ctx, ["enable", "--now", name], run_cmd=run_cmd)
         operations.append(result)
         if result.get("ok"):
-            enabled_timers.append(name)
+            if name.endswith(".timer"):
+                enabled_timers.append(name)
+            else:
+                enabled_services.append(name)
         else:
             errors.append(f"enable {name}: {result.get('stderr') or result.get('stdout') or result.get('returncode')}")
+    credential_refresh_needed = bool(
+        FEISHU_AGENT_CREDENTIAL_SERVICE in mismatched
+        or FEISHU_AGENT_CREDENTIAL_SERVICE in execution_drift
+        or any(
+            expected_managed_files.get(key, {}).get("kind") == "systemd_executable"
+            for key in written_managed_files
+        )
+    )
+    if (
+        live_systemctl
+        and credential_refresh_needed
+        and FEISHU_AGENT_CREDENTIAL_SERVICE not in missing
+        and FEISHU_AGENT_CREDENTIAL_SERVICE not in activation_drift
+    ):
+        result = _run_systemctl(
+            ctx,
+            ["start", FEISHU_AGENT_CREDENTIAL_SERVICE],
+            run_cmd=run_cmd,
+        )
+        operations.append(result)
+        if result.get("ok"):
+            started_services.append(FEISHU_AGENT_CREDENTIAL_SERVICE)
+        else:
+            errors.append(
+                f"start {FEISHU_AGENT_CREDENTIAL_SERVICE}: "
+                f"{result.get('stderr') or result.get('stdout') or result.get('returncode')}"
+            )
     for name in sorted(
         item
         for item in mismatched
@@ -923,10 +1344,24 @@ def _apply_service_drift(
             errors.append(f"daemon-reload after retire: {result.get('stderr') or result.get('stdout') or result.get('returncode')}")
 
     return {
-        "changed": bool(written_units or profile_written or enabled_timers or restarted_timers or retired_units),
+        "changed": bool(
+            written_units
+            or written_managed_files
+            or retired_managed_files
+            or profile_written
+            or enabled_timers
+            or enabled_services
+            or started_services
+            or restarted_timers
+            or retired_units
+        ),
         "errors": errors,
         "written_units": written_units,
+        "written_managed_files": written_managed_files,
+        "retired_managed_files": retired_managed_files,
         "enabled_timers": enabled_timers,
+        "enabled_services": enabled_services,
+        "started_services": started_services,
         "restarted_timers": restarted_timers,
         "retired_units": retired_units,
         "profile_written": profile_written,
@@ -1025,10 +1460,13 @@ def _write_text_with_sudo_fallback(
     *,
     ctx: dict[str, Any],
     run_cmd: Callable[..., Any],
+    mode: int | None = None,
 ) -> dict[str, Any]:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
+        if mode is not None:
+            path.chmod(mode)
         return {"operation": "write_unit", "path": str(path), "ok": True, "sudo_fallback": False}
     except Exception as exc:
         first_error = f"{type(exc).__name__}: {exc}"
@@ -1054,6 +1492,18 @@ def _write_text_with_sudo_fallback(
                 "stderr": str(getattr(mkdir_proc, "stderr", "") or "")[-2000:],
             }
         write_proc = run_cmd(write_command, input=content, capture_output=True, text=True, timeout=60, check=False)
+        write_rc = int(getattr(write_proc, "returncode", 1))
+        chmod_proc = None
+        chmod_command = None
+        if write_rc == 0 and mode is not None:
+            chmod_command = ["sudo", "-n", "chmod", f"{mode:04o}", str(path)]
+            chmod_proc = run_cmd(
+                chmod_command,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
     except Exception as exc:
         return {
             "operation": "write_unit",
@@ -1063,17 +1513,30 @@ def _write_text_with_sudo_fallback(
             "sudo_fallback": True,
             "sudo_command": write_command,
         }
-    write_rc = int(getattr(write_proc, "returncode", 1))
+    chmod_rc = int(getattr(chmod_proc, "returncode", 0)) if chmod_proc is not None else 0
+    ok = write_rc == 0 and chmod_rc == 0
+    if ok:
+        error = None
+    elif write_rc != 0:
+        error = first_error
+    else:
+        error = f"chmod failed: {path}"
     return {
         "operation": "write_unit",
         "path": str(path),
-        "ok": write_rc == 0,
-        "error": None if write_rc == 0 else first_error,
+        "ok": ok,
+        "error": error,
         "sudo_fallback": True,
-        "sudo_command": write_command,
-        "returncode": write_rc,
-        "stdout": str(getattr(write_proc, "stdout", "") or "")[-2000:],
-        "stderr": str(getattr(write_proc, "stderr", "") or "")[-2000:],
+        "sudo_command": chmod_command or write_command,
+        "returncode": chmod_rc if write_rc == 0 else write_rc,
+        "stdout": str(
+            getattr(chmod_proc if chmod_proc is not None else write_proc, "stdout", "")
+            or ""
+        )[-2000:],
+        "stderr": str(
+            getattr(chmod_proc if chmod_proc is not None else write_proc, "stderr", "")
+            or ""
+        )[-2000:],
     }
 
 

--- a/src/interfaces/cli/service_ops.py
+++ b/src/interfaces/cli/service_ops.py
@@ -84,6 +84,11 @@ def add_service_update_commands(subparsers: Any) -> None:
         help="render opt-in systemd quality API, refresh, recheck, and day-end reconciliation units",
     )
     service_render.add_argument(
+        "--include-feishu-agent-credential",
+        action="store_true",
+        help="render the opt-in encrypted Feishu credential materializer and consumer drop-ins",
+    )
+    service_render.add_argument(
         "--strategy-lab-recorder-source",
         default="opend",
         choices=("local", "opend"),
@@ -256,6 +261,7 @@ def handle_service_update_command(
             strategy_lab_recorder_max_datasets=args.strategy_lab_recorder_max_datasets,
             strategy_lab_recorder_mark_stale_hours=args.strategy_lab_recorder_mark_stale_hours,
             include_quality_monitoring=bool(args.include_quality_monitoring),
+            include_feishu_agent_credential=bool(args.include_feishu_agent_credential),
             include_content=(not bool(args.no_content)) or bool(args.output_dir),
         )
         if args.output_dir:

--- a/tests/test_service_deploy.py
+++ b/tests/test_service_deploy.py
@@ -179,6 +179,127 @@ def test_render_systemd_bundle_uses_runtime_root_and_canonical_entrypoints(tmp_p
     assert "deploy_home" not in profile
 
 
+def test_render_systemd_bundle_can_own_feishu_agent_credential_assets(
+    tmp_path: Path,
+) -> None:
+    from src.application.service_deploy import (
+        FEISHU_AGENT_CREDENTIAL_DROPIN,
+        FEISHU_AGENT_CREDENTIAL_SERVICE,
+        render_service_bundle,
+        write_service_bundle,
+    )
+
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    helper = tmp_path / "installed" / "libexec" / "credential-helper"
+    agent_store = tmp_path / "credstore" / "agent"
+    holdings_store = tmp_path / "credstore" / "holdings"
+    runtime_env = tmp_path / "run" / "options-monitor-feishu-agent.env"
+    repo.mkdir()
+
+    bundle = render_service_bundle(
+        target="systemd",
+        repo_root=repo,
+        runtime_root=runtime,
+        accounts=["lx"],
+        markets=["us"],
+        include_opend=True,
+        include_feishu_agent_credential=True,
+        feishu_agent_credential_helper_path=helper,
+        feishu_agent_credential_store=agent_store,
+        feishu_holdings_credential_store=holdings_store,
+        feishu_agent_credential_env_file=runtime_env,
+        deploy_user="liuxie",
+    )
+    files = {item["relative_path"]: item for item in bundle["files"]}
+    unit = files[f"systemd/{FEISHU_AGENT_CREDENTIAL_SERVICE}"]
+    helper_item = files[
+        "systemd/libexec/options-monitor-materialize-feishu-agent-credential"
+    ]
+    profile = json.loads(files["service.profile.json"]["content"])
+    credential_profile = profile["feishu_agent_credential"]
+    dropins = [
+        item
+        for item in bundle["files"]
+        if item.get("kind") == "systemd_dropin"
+    ]
+
+    assert unit["install_path"] == f"/etc/systemd/system/{FEISHU_AGENT_CREDENTIAL_SERVICE}"
+    assert f"ExecStart={helper}" in unit["content"]
+    assert f"--agent-store {agent_store}" in unit["content"]
+    assert f"--holdings-store {holdings_store}" in unit["content"]
+    assert f"--runtime-env-file {runtime_env}" in unit["content"]
+    assert "--deploy-group liuxie" in unit["content"]
+    assert helper_item["install_path"] == str(helper)
+    assert helper_item["mode"] == 0o755
+    assert "systemd-creds decrypt" in helper_item["content"]
+    assert "OM_FEISHU_APP_SECRET=%s" in helper_item["content"]
+    assert "OM_FEISHU_BOT_APP_SECRET=%s" in helper_item["content"]
+    assert "^[A-Za-z0-9_-]+$" in helper_item["content"]
+    syntax = subprocess.run(
+        ["bash", "-n"],
+        input=helper_item["content"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+    assert credential_profile == {
+        "enabled": True,
+        "service_name": FEISHU_AGENT_CREDENTIAL_SERVICE,
+        "helper_path": str(helper),
+        "agent_store": str(agent_store),
+        "holdings_store": str(holdings_store),
+        "runtime_env_file": str(runtime_env),
+        "consumer_services": credential_profile["consumer_services"],
+    }
+    assert credential_profile["consumer_services"]
+    assert FEISHU_AGENT_CREDENTIAL_SERVICE not in credential_profile["consumer_services"]
+    assert not any(
+        name.startswith("options-monitor-opend")
+        for name in credential_profile["consumer_services"]
+    )
+    assert len(dropins) == len(credential_profile["consumer_services"])
+    assert all(
+        f"Before={consumer}" in unit["content"]
+        for consumer in credential_profile["consumer_services"]
+    )
+    assert {
+        Path(item["install_path"]).parent.name.removesuffix(".d")
+        for item in dropins
+    } == set(credential_profile["consumer_services"])
+    assert all(
+        Path(item["install_path"]).name == FEISHU_AGENT_CREDENTIAL_DROPIN
+        for item in dropins
+    )
+    assert all(
+        f"EnvironmentFile={runtime_env}" in item["content"]
+        and f"Requires={FEISHU_AGENT_CREDENTIAL_SERVICE}" in item["content"]
+        for item in dropins
+    )
+    assert (
+        f"systemctl enable --now {FEISHU_AGENT_CREDENTIAL_SERVICE}"
+        in bundle["commands"]["enable"]
+    )
+
+    output_dir = tmp_path / "rendered"
+    written = write_service_bundle(bundle, output_dir)
+    rendered_helper = output_dir / helper_item["relative_path"]
+    assert str(rendered_helper) in written
+    assert rendered_helper.stat().st_mode & 0o777 == 0o755
+
+
+def test_render_launchd_bundle_rejects_feishu_agent_credential(tmp_path: Path) -> None:
+    from src.application.service_deploy import render_service_bundle
+
+    with pytest.raises(ValueError, match="supported only for systemd"):
+        render_service_bundle(
+            target="launchd",
+            repo_root=tmp_path,
+            include_feishu_agent_credential=True,
+        )
+
+
 
 
 def test_systemd_unit_rejects_non_positive_start_timeout(tmp_path: Path) -> None:
@@ -451,6 +572,285 @@ def _write_systemd_units_from_bundle(bundle: dict, systemd_root: Path, *, skip: 
         if name in skip:
             continue
         (systemd_root / name).write_text(item["content"], encoding="utf-8")
+
+
+def test_service_drift_installs_and_repairs_feishu_agent_credential_assets(
+    tmp_path: Path,
+) -> None:
+    from src.application.service_deploy import (
+        FEISHU_AGENT_CREDENTIAL_SERVICE,
+        render_service_bundle,
+    )
+    from src.application.service_drift import service_drift
+
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    systemd_root = tmp_path / "systemd"
+    helper = tmp_path / "libexec" / "credential-helper"
+    repo.mkdir()
+    runtime.mkdir()
+    bundle = render_service_bundle(
+        target="systemd",
+        repo_root=repo,
+        runtime_root=runtime,
+        accounts=["lx"],
+        markets=["us"],
+        include_feishu_agent_credential=True,
+        feishu_agent_credential_helper_path=helper,
+        feishu_agent_credential_store=tmp_path / "credstore" / "agent",
+        feishu_holdings_credential_store=tmp_path / "credstore" / "holdings",
+        feishu_agent_credential_env_file=tmp_path / "run" / "credential.env",
+        use_default_deploy_user=False,
+    )
+    files = {item["relative_path"]: item for item in bundle["files"]}
+    profile = json.loads(files["service.profile.json"]["content"])
+    (runtime / "service.profile.json").write_text(
+        json.dumps(profile, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_systemd_units_from_bundle(
+        bundle,
+        systemd_root,
+        skip={FEISHU_AGENT_CREDENTIAL_SERVICE},
+    )
+    calls: list[list[str]] = []
+    execution_result = {"value": "success"}
+
+    def _run_cmd(command, **_kwargs):  # type: ignore[no-untyped-def]
+        command = list(command)
+        calls.append(command)
+        if "is-enabled" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="enabled\n", stderr="")
+        if "is-active" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="active\n", stderr="")
+        if "show" in command and "--property=Result" in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=f"{execution_result['value']}\n",
+                stderr="",
+            )
+        if command[-2:] == ["start", FEISHU_AGENT_CREDENTIAL_SERVICE]:
+            execution_result["value"] = "success"
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    before = service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        run_cmd=_run_cmd,
+    )
+
+    assert before["summary"]["status"] == "error"
+    assert before["missing_required_units"] == [FEISHU_AGENT_CREDENTIAL_SERVICE]
+    assert str(helper) in before["missing_managed_files"]
+    assert before["missing_managed_files"]
+
+    out = service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        confirm=True,
+        run_cmd=_run_cmd,
+    )
+
+    assert out["summary"]["status"] == "ok"
+    assert out["changed"] is True
+    assert out["missing_managed_files"] == []
+    assert out["mismatched_managed_files"] == []
+    assert out["mode_mismatched_managed_files"] == []
+    assert out["execution_states"] == {FEISHU_AGENT_CREDENTIAL_SERVICE: "success"}
+    assert (systemd_root / FEISHU_AGENT_CREDENTIAL_SERVICE).is_file()
+    assert helper.is_file()
+    assert helper.stat().st_mode & 0o777 == 0o755
+    for consumer in profile["feishu_agent_credential"]["consumer_services"]:
+        assert (
+            systemd_root
+            / f"{consumer}.d"
+            / "zzzz-feishu-agent-credential.conf"
+        ).is_file()
+    assert any(
+        command[-3:] == ["enable", "--now", FEISHU_AGENT_CREDENTIAL_SERVICE]
+        for command in calls
+    )
+
+    helper.chmod(0o644)
+    execution_result["value"] = "exit-code"
+    mode_drift = service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        run_cmd=_run_cmd,
+    )
+    assert mode_drift["mode_mismatched_managed_files"] == [str(helper)]
+    assert mode_drift["execution_drift_units"] == [
+        FEISHU_AGENT_CREDENTIAL_SERVICE
+    ]
+
+    repaired = service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        confirm=True,
+        run_cmd=_run_cmd,
+    )
+    assert repaired["summary"]["status"] == "ok"
+    assert helper.stat().st_mode & 0o777 == 0o755
+    assert repaired["applied"]["started_services"] == [
+        FEISHU_AGENT_CREDENTIAL_SERVICE
+    ]
+    assert any(
+        command[-2:] == ["start", FEISHU_AGENT_CREDENTIAL_SERVICE]
+        for command in calls
+    )
+
+    stale_dropin = (
+        systemd_root
+        / "options-monitor-retired.service.d"
+        / "zzzz-feishu-agent-credential.conf"
+    )
+    stale_dropin.parent.mkdir(parents=True)
+    stale_dropin.write_text("stale\n", encoding="utf-8")
+    stale_key = str(
+        Path("/etc/systemd/system")
+        / stale_dropin.parent.name
+        / stale_dropin.name
+    )
+    stale_drift = service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        run_cmd=_run_cmd,
+    )
+    assert stale_drift["extra_managed_files"] == [stale_key]
+
+    retired = service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        confirm=True,
+        run_cmd=_run_cmd,
+    )
+    assert retired["summary"]["status"] == "ok"
+    assert retired["applied"]["retired_managed_files"] == [stale_key]
+    assert not stale_dropin.exists()
+
+
+def test_service_drift_adopts_legacy_feishu_agent_credential_installation(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.service_drift as service_drift_module
+    from src.application.service_deploy import (
+        FEISHU_AGENT_CREDENTIAL_DROPIN,
+        FEISHU_AGENT_CREDENTIAL_SERVICE,
+        render_service_bundle,
+    )
+
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    systemd_root = tmp_path / "systemd"
+    helper = tmp_path / "libexec" / "credential-helper"
+    legacy_unit = tmp_path / "usr-lib-systemd" / FEISHU_AGENT_CREDENTIAL_SERVICE
+    repo.mkdir()
+    runtime.mkdir()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text("[Service]\nType=oneshot\n", encoding="utf-8")
+    monkeypatch.setattr(
+        service_drift_module,
+        "LEGACY_FEISHU_AGENT_CREDENTIAL_UNIT_PATH",
+        legacy_unit,
+    )
+    monkeypatch.setattr(
+        service_drift_module,
+        "DEFAULT_FEISHU_AGENT_CREDENTIAL_HELPER",
+        helper,
+    )
+    monkeypatch.setattr(
+        service_drift_module,
+        "DEFAULT_FEISHU_AGENT_CREDENTIAL_STORE",
+        tmp_path / "credstore" / "agent",
+    )
+    monkeypatch.setattr(
+        service_drift_module,
+        "DEFAULT_FEISHU_HOLDINGS_CREDENTIAL_STORE",
+        tmp_path / "credstore" / "holdings",
+    )
+    monkeypatch.setattr(
+        service_drift_module,
+        "DEFAULT_FEISHU_AGENT_CREDENTIAL_ENV_FILE",
+        tmp_path / "run" / "credential.env",
+    )
+
+    base_bundle = render_service_bundle(
+        target="systemd",
+        repo_root=repo,
+        runtime_root=runtime,
+        accounts=["lx"],
+        markets=["us"],
+        use_default_deploy_user=False,
+    )
+    files = {item["relative_path"]: item for item in base_bundle["files"]}
+    profile = json.loads(files["service.profile.json"]["content"])
+    (runtime / "service.profile.json").write_text(
+        json.dumps(profile, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_systemd_units_from_bundle(base_bundle, systemd_root)
+    legacy_dropin = (
+        systemd_root
+        / "options-monitor-tick-us.service.d"
+        / FEISHU_AGENT_CREDENTIAL_DROPIN
+    )
+    legacy_dropin.parent.mkdir(parents=True)
+    legacy_dropin.write_text("legacy\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _run_cmd(command, **_kwargs):  # type: ignore[no-untyped-def]
+        command = list(command)
+        calls.append(command)
+        if "is-enabled" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="enabled\n", stderr="")
+        if "is-active" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="active\n", stderr="")
+        if "show" in command and "--property=Result" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="success\n", stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    before = service_drift_module.service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        run_cmd=_run_cmd,
+    )
+
+    assert before["missing_profile_units"] == [FEISHU_AGENT_CREDENTIAL_SERVICE]
+    assert before["compatibility_warnings"] == [
+        {
+            "code": "legacy_feishu_agent_credential_inferred",
+            "source": "installed_assets",
+            "unit_path": str(legacy_unit),
+            "dropin_count": 1,
+        }
+    ]
+
+    adopted = service_drift_module.service_drift(
+        repo_root=repo,
+        runtime_root=runtime,
+        systemd_unit_root=systemd_root,
+        confirm=True,
+        run_cmd=_run_cmd,
+    )
+    refreshed = json.loads(
+        (runtime / "service.profile.json").read_text(encoding="utf-8")
+    )
+
+    assert adopted["summary"]["status"] == "ok"
+    assert refreshed["feishu_agent_credential"]["enabled"] is True
+    assert refreshed["feishu_agent_credential"]["helper_path"] == str(helper)
+    assert {"name": FEISHU_AGENT_CREDENTIAL_SERVICE} in refreshed["services"]
+    assert (systemd_root / FEISHU_AGENT_CREDENTIAL_SERVICE).is_file()
+    assert legacy_unit.is_file()
 
 
 def test_service_drift_detects_missing_projection_verify_timer(tmp_path: Path) -> None:
@@ -737,6 +1137,51 @@ def test_service_drift_confirm_uses_sudo_fallback_for_systemd_permission_errors(
     assert any(item.get("sudo_fallback") for item in out["operations"] if item.get("operation") == "write_unit")
     assert ["sudo", "-n", "systemctl", "daemon-reload"] in calls
     assert ["sudo", "-n", "systemctl", "enable", "--now", "options-monitor-projection-verify.timer"] in calls
+
+
+def test_service_drift_sudo_fallback_applies_managed_file_mode(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from src.application.service_drift import _write_text_with_sudo_fallback
+
+    target = tmp_path / "protected" / "credential-helper"
+    original_write_text = Path.write_text
+
+    def _write_text(path: Path, content: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if path == target:
+            raise PermissionError("permission denied")
+        return original_write_text(path, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _write_text)
+    calls: list[list[str]] = []
+
+    def _run_cmd(command, **kwargs):  # type: ignore[no-untyped-def]
+        command = list(command)
+        calls.append(command)
+        if command[:4] == ["sudo", "-n", "sh", "-c"]:
+            original_write_text(
+                Path(command[-1]),
+                str(kwargs.get("input") or ""),
+                encoding="utf-8",
+            )
+        elif command[:3] == ["sudo", "-n", "chmod"]:
+            Path(command[-1]).chmod(int(command[-2], 8))
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    out = _write_text_with_sudo_fallback(
+        target,
+        "#!/bin/sh\n",
+        ctx={"provider": "systemd"},
+        run_cmd=_run_cmd,
+        mode=0o755,
+    )
+
+    assert out["ok"] is True
+    assert out["sudo_fallback"] is True
+    assert target.read_text(encoding="utf-8") == "#!/bin/sh\n"
+    assert target.stat().st_mode & 0o777 == 0o755
+    assert ["sudo", "-n", "chmod", "0755", str(target)] in calls
 
 
 def test_service_drift_retires_installed_feishu_ws_when_profile_no_longer_declares_it(tmp_path: Path) -> None:
@@ -2632,7 +3077,12 @@ def test_service_status_from_profile_can_check_systemd_enabled_state() -> None:
     ]
 
 
-def test_service_upgrade_dry_run_and_confirm_switches_current_symlink(monkeypatch, tmp_path: Path) -> None:
+@pytest.mark.parametrize("auto", [False, True])
+def test_service_upgrade_dry_run_and_confirm_switches_current_symlink(
+    monkeypatch,
+    tmp_path: Path,
+    auto: bool,
+) -> None:
     from src.application.service_upgrade import service_upgrade
 
     monkeypatch.setenv("OM_UPGRADE_INSTALLER", "pip")
@@ -2647,14 +3097,24 @@ def test_service_upgrade_dry_run_and_confirm_switches_current_symlink(monkeypatc
     current.symlink_to(v100, target_is_directory=True)
     runtime = tmp_path / "runtime"
     runtime.mkdir()
+    credential_helper = tmp_path / "libexec" / "credential-helper"
     (runtime / "service.profile.json").write_text(
         json.dumps(
             {
                 "service_provider": "systemd",
                 "restart": {"requires_sudo": False},
+                "feishu_agent_credential": {
+                    "enabled": True,
+                    "service_name": "options-monitor-feishu-agent-credential.service",
+                    "helper_path": str(credential_helper),
+                    "agent_store": str(tmp_path / "credstore" / "agent"),
+                    "holdings_store": str(tmp_path / "credstore" / "holdings"),
+                    "runtime_env_file": str(tmp_path / "run" / "credential.env"),
+                },
                 "services": [
                     {"name": "options-monitor-tick-us.timer"},
                     {"name": "options-monitor-trade-intake.service"},
+                    {"name": "options-monitor-feishu-agent-credential.service"},
                 ],
             }
         ),
@@ -2686,17 +3146,21 @@ def test_service_upgrade_dry_run_and_confirm_switches_current_symlink(monkeypatc
         if command[:3] == [CURRENT_PYTHON, "-m", "venv"]:
             _create_fake_venv_python_at(Path(command[-1]))
             return subprocess.CompletedProcess(command, 0, stdout="venv\n", stderr="")
+        if "show" in command and "--property=Result" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="success\n", stderr="")
         return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
 
     dry = service_upgrade(
         repo_root=current,
         runtime_root=runtime,
         releases_root=releases,
+        auto=auto,
         run_cmd=_run_cmd,
     )
     assert dry["status"] == "dry_run"
     assert dry["changed"] is False
     assert dry["repo_root_is_symlink"] is True
+    assert dry["auto"] is auto
     assert dry["warnings"] == []
     assert current.resolve() == v100.resolve()
 
@@ -2705,11 +3169,13 @@ def test_service_upgrade_dry_run_and_confirm_switches_current_symlink(monkeypatc
         runtime_root=runtime,
         releases_root=releases,
         confirm=True,
+        auto=auto,
         run_cmd=_run_cmd,
     )
 
     assert out["status"] == "upgraded"
     assert out["changed"] is True
+    assert out["auto"] is auto
     assert current.resolve() == (releases / "1.0.1").resolve()
     cache_repo = install / "_cache" / "git" / "options-monitor.git"
     assert ["git", "clone", "--mirror", "https://example.invalid/repo.git", str(cache_repo)] in calls
@@ -2742,6 +3208,12 @@ def test_service_upgrade_dry_run_and_confirm_switches_current_symlink(monkeypatc
         "systemctl",
         "enable",
         "--now",
+        "options-monitor-feishu-agent-credential.service",
+    ] in calls
+    assert [
+        "systemctl",
+        "enable",
+        "--now",
         "options-monitor-position-advice-promotion.timer",
     ] in calls
     refreshed_profile = json.loads((runtime / "service.profile.json").read_text(encoding="utf-8"))
@@ -2749,10 +3221,24 @@ def test_service_upgrade_dry_run_and_confirm_switches_current_symlink(monkeypatc
     assert {
         "name": "options-monitor-position-advice-promotion.timer"
     } in refreshed_profile["services"]
+    assert refreshed_profile["feishu_agent_credential"]["enabled"] is True
+    assert refreshed_profile["feishu_agent_credential"]["helper_path"] == str(
+        credential_helper
+    )
     assert (systemd_root / "options-monitor-projection-verify.timer").exists()
     assert (
         systemd_root / "options-monitor-position-advice-promotion.timer"
     ).exists()
+    assert (
+        systemd_root / "options-monitor-feishu-agent-credential.service"
+    ).exists()
+    assert credential_helper.is_file()
+    assert credential_helper.stat().st_mode & 0o777 == 0o755
+    assert (
+        systemd_root
+        / "options-monitor-trade-intake.service.d"
+        / "zzzz-feishu-agent-credential.conf"
+    ).is_file()
     assert out["service_reconcile"]["summary"]["status"] == "ok"
     assert out["service_health"]["status"] == "ok"
     assert out["release_materialize"]["method"] == "git_cache_archive"
@@ -4954,6 +5440,53 @@ def test_cli_service_render_no_content_still_writes_files(capsys, tmp_path: Path
     payload = json.loads(capsys.readouterr().out)
     assert payload["data"]["files"][0].get("content") is None
     assert "ExecStart=" in (output_dir / "systemd" / "options-monitor-tick-us.service").read_text(encoding="utf-8")
+
+
+def test_cli_service_render_can_include_feishu_agent_credential(
+    capsys,
+    tmp_path: Path,
+) -> None:
+    from src.interfaces.cli.main import main
+
+    output_dir = tmp_path / "rendered"
+    rc = main([
+        "service",
+        "render",
+        "--target",
+        "systemd",
+        "--repo-root",
+        str(tmp_path / "repo"),
+        "--runtime-root",
+        str(tmp_path / "runtime"),
+        "--markets",
+        "us",
+        "--config-yaml",
+        str(tmp_path / "runtime" / "config.yaml"),
+        "--include-feishu-agent-credential",
+        "--output-dir",
+        str(output_dir),
+        "--no-content",
+    ])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    profile = json.loads(
+        (output_dir / "service.profile.json").read_text(encoding="utf-8")
+    )
+    helper = (
+        output_dir
+        / "systemd"
+        / "libexec"
+        / "options-monitor-materialize-feishu-agent-credential"
+    )
+    assert profile["feishu_agent_credential"]["enabled"] is True
+    assert helper.stat().st_mode & 0o777 == 0o755
+    assert (
+        output_dir
+        / "systemd"
+        / "options-monitor-feishu-agent-credential.service"
+    ).is_file()
 
 
 def test_cli_service_drift_reports_missing_units(monkeypatch, capsys, tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- add repository-owned systemd templates for the encrypted Feishu Agent credential oneshot, materializer helper, and consumer drop-ins
- persist the credential opt-in in the service profile and expose it through `om service render`
- extend service drift to reconcile unit content, helper mode, drop-ins, enablement, execution result, and legacy `/usr/lib/systemd/system` adoption
- preserve the credential contract through manual and automatic upgrade paths
- document the one-time post-release adoption sequence and rollback boundary

## Why

The production credential unit previously lived outside the repository-managed `/etc/systemd/system` drift scope. Its safety depended on avoiding cleanup rather than on an explicit repository contract, so future manual and automatic upgrades could not reliably preserve or repair it.

## Impact

Hosts opt in explicitly. The renderer and drift workflow manage service assets but do not create, modify, or expose encrypted credential stores. Existing legacy installations can be adopted with a dry-run, confirmed reconcile, and final clean dry-run after upgrading to a release that contains this change.

## Validation

- `python3.12 -m pytest -q tests/test_service_deploy.py tests/test_dependency_graph_generator.py` - 146 passed
- focused Ruff - passed
- focused BasedPyright - 0 errors
- ShellCheck and `bash -n` for the materializer - passed
- dependency graph check - current, 575 production modules, 0 cycles
- `git diff --cached --check` - passed
