### PR TITLE
fix: preserve Feishu credentials in upgrade health check

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 918 (`src`: 491, `domain`: 76, `scripts`: 8, `tests`: 343)
-- Internal import edges: 5855 total, 2490 production/script edges excluding tests
+- Internal import edges: 5858 total, 2490 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -45,11 +45,11 @@ flowchart LR
   scripts -->|12| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2501| application
+  tests -->|2503| application
   tests -->|440| domain
   tests -->|2| domain_services
   tests -->|150| infrastructure
-  tests -->|213| interfaces
+  tests -->|214| interfaces
   tests -->|13| scripts
   tests -->|16| storage
 ```
@@ -77,9 +77,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2501 |
+| tests | application | 2503 |
 | tests | domain | 440 |
-| tests | interfaces | 213 |
+| tests | interfaces | 214 |
 | tests | infrastructure | 150 |
 | tests | storage | 16 |
 | tests | scripts | 13 |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -301,6 +301,8 @@ VERSION="$(cat VERSION)"
 
 存量主机如果仍使用 `/usr/lib/systemd/system/options-monitor-feishu-agent-credential.service`，首次升级到包含 repository-owned credential 资产的 release 后，必须用新 release 显式执行一次 `service drift` dry-run 和 `--confirm`。原因是升级进程由旧 release 启动，无法在同一次切换中可靠使用尚未加载的新 reconcile 逻辑。收编后 profile 会保留 `feishu_agent_credential` opt-in，后续手动升级、自动升级和回滚都按同一契约 reconcile。在旧 release 回滚窗口结束前保留 `/usr/lib` legacy unit，不由 drift 自动删除。
 
+当 profile 已收编 Feishu Agent credential 时，升级后 Feishu WS 健康检查会在 `sudo` 进程内显式合并 profile 的基础 `env_file` 和 `feishu_agent_credential.runtime_env_file`。命令行只传文件路径，不传或输出明文凭据；这避免 `sudo` 清理父进程环境后出现假性 `missing Feishu app credentials`。
+
 如果 systemd unit 使用 `User=<deploy_user>` 运行自动升级，`service render` 会在 profile 中标记 trade-intake 和 Feishu WS 等长期服务重启使用 `sudo -n systemctl restart ...`。服务器需要给运行用户配置最小 sudoers 授权，例如：
 
 ```sudoers

--- a/src/application/inbound/feishu_ws.py
+++ b/src/application/inbound/feishu_ws.py
@@ -141,8 +141,15 @@ def build_feishu_ws_settings(
     queue_size: int | None = None,
     environ: Mapping[str, str] | None = None,
     env_file: str | Path | None = None,
+    credential_env_file: str | Path | None = None,
 ) -> FeishuWsSettings:
-    env = build_effective_env(environ=environ, env_file=env_file).values
+    effective_env = build_effective_env(environ=environ, env_file=env_file)
+    if credential_env_file is not None and str(credential_env_file).strip():
+        effective_env = build_effective_env(
+            environ=effective_env.values,
+            env_file=credential_env_file,
+        )
+    env = effective_env.values
     bot_cfg = resolve_feishu_bot_config(environ=env)
     assistant_cfg = _load_assistant_behavior_config(config_path=assistant_config_path)
     behavior_cfg = _dict(_dict(assistant_cfg.get("inbound")).get("feishu_ws"))

--- a/src/application/service_upgrade.py
+++ b/src/application/service_upgrade.py
@@ -749,9 +749,21 @@ def _feishu_ws_check_command(*, profile: dict[str, Any], repo_root: Path) -> lis
     env_file = str(profile.get("env_file") or "").strip()
     if env_file:
         command.extend(["--env-file", str(Path(env_file).expanduser())])
+    credential_env_file = _feishu_agent_credential_env_file(profile)
+    if credential_env_file:
+        command.extend(["--credential-env-file", credential_env_file])
     if _feishu_ws_check_needs_sudo_for_env_file(profile):
         return ["sudo", "-n", *command]
     return command
+
+
+def _feishu_agent_credential_env_file(profile: dict[str, Any]) -> str:
+    raw = profile.get("feishu_agent_credential")
+    credential = raw if isinstance(raw, dict) else {}
+    if not bool(credential.get("enabled")):
+        return ""
+    value = str(credential.get("runtime_env_file") or "").strip()
+    return str(Path(value).expanduser()) if value else ""
 
 
 def _wechat_clawbot_check_command(*, profile: dict[str, Any], repo_root: Path) -> list[str]:
@@ -787,11 +799,15 @@ def _wechat_clawbot_check_command(*, profile: dict[str, Any], repo_root: Path) -
 def _feishu_ws_check_needs_sudo_for_env_file(profile: dict[str, Any]) -> bool:
     if _is_root_process():
         return False
-    env_file = str(profile.get("env_file") or "").strip()
-    if not env_file:
+    env_files = [str(profile.get("env_file") or "").strip()]
+    credential_env_file = _feishu_agent_credential_env_file(profile)
+    if credential_env_file:
+        env_files.append(credential_env_file)
+    paths = [Path(value).expanduser() for value in env_files if value]
+    if not paths:
         return False
     try:
-        return not os.access(str(Path(env_file).expanduser()), os.R_OK)
+        return any(not os.access(str(path), os.R_OK) for path in paths)
     except OSError:
         return True
 
@@ -852,7 +868,11 @@ def _service_health_remediation(
     if any(item.get("check") == "feishu-ws-check" for item in failed_checks):
         env_file = str((profile or {}).get("env_file") or "").strip()
         if env_file:
-            remediation.append(f"manual_check: sudo -n ./om inbound feishu-ws --check --env-file {shlex.quote(env_file)}")
+            command = f"manual_check: sudo -n ./om inbound feishu-ws --check --env-file {shlex.quote(env_file)}"
+            credential_env_file = _feishu_agent_credential_env_file(profile or {})
+            if credential_env_file:
+                command += f" --credential-env-file {shlex.quote(credential_env_file)}"
+            remediation.append(command)
         else:
             remediation.append("manual_check: source the env file, then run ./om inbound feishu-ws --check")
     if any(item.get("check") == "wechat-clawbot-check" for item in failed_checks):

--- a/src/interfaces/cli/inbound_ops.py
+++ b/src/interfaces/cli/inbound_ops.py
@@ -46,6 +46,11 @@ def add_inbound_commands(subparsers: Any) -> None:
     inbound_ws.add_argument("--assistant-config", default=None)
     inbound_ws.add_argument("--audit-db", default=None)
     inbound_ws.add_argument("--env-file", default=None)
+    inbound_ws.add_argument(
+        "--credential-env-file",
+        default=None,
+        help="additional credential env file for --check, loaded after --env-file",
+    )
     inbound_ws.add_argument("--no-local-env-file", action="store_true")
     inbound_ws.add_argument("--no-reply", action="store_true")
     inbound_ws.add_argument("--reply-in-thread", action="store_true", default=None)
@@ -111,6 +116,11 @@ def handle_inbound_command(
         return _print(out)
 
     if args.inbound_command == "feishu-ws":
+        if args.credential_env_file and not args.check:
+            raise AgentToolError(
+                code="INPUT_ERROR",
+                message="--credential-env-file is only supported with --check",
+            )
         settings = build_feishu_ws_settings_fn(
             config_key=args.config_key,
             config_path=args.config_path,
@@ -122,6 +132,7 @@ def handle_inbound_command(
             queue_size=args.queue_size,
             environ=os.environ,
             env_file=args.env_file,
+            credential_env_file=args.credential_env_file,
         )
         if args.check:
             return _print(check_feishu_ws_settings_fn(settings))

--- a/tests/test_inbound_control.py
+++ b/tests/test_inbound_control.py
@@ -4658,6 +4658,50 @@ def test_inbound_cli_feishu_ws_check_reports_redacted_config(capsys, monkeypatch
     assert "secret_1" not in json.dumps(payload, ensure_ascii=False)
 
 
+def test_inbound_cli_feishu_ws_check_merges_credential_env_file(tmp_path: Path, capsys, monkeypatch) -> None:
+    import src.interfaces.cli.main as cli
+
+    env_file = tmp_path / "options-monitor.env"
+    credential_env_file = tmp_path / "feishu-agent.env"
+    env_file.write_text(
+        "OM_FEISHU_BOT_APP_ID=app_1\nOM_FEISHU_BOT_ALLOWED_OPEN_IDS=ou_1\n",
+        encoding="utf-8",
+    )
+    credential_env_file.write_text(
+        "OM_FEISHU_BOT_APP_SECRET=secret_credential\n",
+        encoding="utf-8",
+    )
+    for name in (
+        "OM_FEISHU_BOT_APP_ID",
+        "OM_FEISHU_BOT_APP_SECRET",
+        "OM_FEISHU_BOT_ALLOWED_OPEN_IDS",
+        "OM_ENV_FILE",
+    ):
+        monkeypatch.setenv(name, "")
+    monkeypatch.setattr("src.application.inbound.feishu_ws.is_feishu_ws_sdk_available", lambda: True)
+
+    rc = cli.main(
+        [
+            "inbound",
+            "feishu-ws",
+            "--config-key",
+            "us",
+            "--env-file",
+            str(env_file),
+            "--credential-env-file",
+            str(credential_env_file),
+            "--check",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["data"]["settings"]["app_id_configured"] is True
+    assert payload["data"]["settings"]["app_secret_configured"] is True
+    assert "secret_credential" not in json.dumps(payload, ensure_ascii=False)
+
+
 def test_inbound_cli_feishu_ws_rejects_secret_override_flags(capsys) -> None:
     import src.interfaces.cli.main as cli
 

--- a/tests/test_inbound_feishu_ws.py
+++ b/tests/test_inbound_feishu_ws.py
@@ -802,6 +802,31 @@ def test_feishu_ws_settings_can_load_bot_config_from_env_file(tmp_path: Path) ->
     assert settings.allowed_senders == "feishu:ou_file"
 
 
+def test_feishu_ws_settings_overlays_explicit_credential_env_file(tmp_path: Path) -> None:
+    env_file = tmp_path / "options-monitor.env"
+    credential_env_file = tmp_path / "feishu-agent.env"
+    env_file.write_text(
+        "OM_FEISHU_BOT_APP_ID=bot_app_file\n"
+        "OM_FEISHU_BOT_APP_SECRET=stale_base_secret\n"
+        "OM_FEISHU_BOT_ALLOWED_OPEN_IDS=ou_file\n",
+        encoding="utf-8",
+    )
+    credential_env_file.write_text(
+        "OM_FEISHU_BOT_APP_SECRET=bot_secret_credential\n",
+        encoding="utf-8",
+    )
+
+    settings = build_feishu_ws_settings(
+        environ={},
+        env_file=env_file,
+        credential_env_file=credential_env_file,
+    )
+
+    assert settings.app_id == "bot_app_file"
+    assert settings.app_secret == "bot_secret_credential"
+    assert settings.allowed_senders == "feishu:ou_file"
+
+
 def test_feishu_ws_settings_reads_behavior_from_assistant_config(tmp_path: Path) -> None:
     assistant_config_path = tmp_path / "config.assistant.json"
     assistant_config_path.write_text(

--- a/tests/test_service_deploy.py
+++ b/tests/test_service_deploy.py
@@ -3505,6 +3505,50 @@ def test_post_upgrade_feishu_ws_check_uses_sudo_when_env_file_is_not_readable(mo
     assert out["ok"] is True
 
 
+def test_post_upgrade_feishu_ws_check_passes_managed_credential_file_through_sudo(monkeypatch, tmp_path: Path) -> None:
+    from src.application import service_upgrade
+
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    env_file = tmp_path / "options-monitor.env"
+    credential_env_file = tmp_path / "run" / "feishu-agent.env"
+    repo.mkdir()
+    runtime.mkdir()
+    env_file.write_text("OM_FEISHU_BOT_APP_ID=cli_1\n", encoding="utf-8")
+    profile = {
+        "service_provider": "systemd",
+        "runtime_root": str(runtime),
+        "env_file": str(env_file),
+        "config_paths": {"us": str(tmp_path / "config.us.json")},
+        "feishu_ws": {"enabled": True, "config_key": "us"},
+        "feishu_agent_credential": {
+            "enabled": True,
+            "runtime_env_file": str(credential_env_file),
+        },
+        "services": [{"name": "options-monitor-feishu-ws.service"}],
+    }
+    monkeypatch.setattr(service_upgrade, "_is_root_process", lambda: False)
+    monkeypatch.setattr(service_upgrade.os, "access", lambda *_args, **_kwargs: False)
+
+    def _run_cmd(command, **_kwargs):  # type: ignore[no-untyped-def]
+        if list(command)[:5] == ["sudo", "-n", str(repo / "om"), "inbound", "feishu-ws"]:
+            assert "--env-file" in command
+            assert command[command.index("--env-file") + 1] == str(env_file)
+            assert "--credential-env-file" in command
+            assert command[command.index("--credential-env-file") + 1] == str(credential_env_file)
+            assert "secret" not in " ".join(command)
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    out = service_upgrade._post_upgrade_service_health(
+        profile=profile,
+        repo_root=repo,
+        run_cmd=_run_cmd,
+        operations=[],
+    )
+
+    assert out["ok"] is True
+
+
 def test_service_upgrade_restart_uses_sudo_prefix_from_deploy_profile(tmp_path: Path) -> None:
     from src.application.service_upgrade import _restart_services_from_profile
 


### PR DESCRIPTION
Summary:
- merge the managed credential env file after the base service env during Feishu WS checks
- pass both file paths through sudo without exposing secret values
- cover CLI redaction, overlay precedence, and upgrade health behavior

Validation:
- 426 focused tests passed
- Ruff passed
- dependency graph current with zero cycles