### PR TITLE
fix(security): provision macOS Keychain through PTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+- Fixed macOS Keychain provisioning to answer both native password prompts through a private PTY, preventing a successful `security` exit from storing an empty credential while keeping values out of argv, output, and temporary files.
+
 ## 1.12.0 - 2026-08-10
 
 ### New Features

--- a/docs/SECRET_STORAGE.md
+++ b/docs/SECRET_STORAGE.md
@@ -47,6 +47,10 @@ Facebook 等后续集成遵循同一规则：App ID 是普通配置；App Secret
 逻辑名、后端、是否改变和可能受影响的服务；不会自动重启服务。
 非交互 stdin、命令参数和管道输入都会被拒绝。
 
+macOS provider 会在私有控制终端中等待 `security` 的两次原生密码提示，再把已确认值从
+进程内存写入；值不会进入子进程 argv、stdout、stderr 或临时文件。写入成功仍需用脱敏
+`status` 和实际消费方回读验证，不能只信 `security` 的退出码。
+
 macOS 命令写入 Keychain。Linux 写入 `/etc/credstore.encrypted/<credential-id>`，必须用单独的
 root 授权运行，例如先确认目标，再执行 `sudo ./om secrets set <logical-name>`。不要把秘密放在
 命令参数、shell 变量或管道中。

--- a/src/infrastructure/secret_store/macos_keychain.py
+++ b/src/infrastructure/secret_store/macos_keychain.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import errno
+import os
+import pty
+import select
+import signal
 import subprocess
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -15,6 +21,107 @@ from src.application.secret_store.registry import require_credential_spec
 KEYCHAIN_SERVICE = "options-monitor"
 SECURITY_COMMAND = "/usr/bin/security"
 MAX_KEYCHAIN_SECRET_BYTES = 64 * 1024
+KEYCHAIN_PASSWORD_PROMPT = b"password data for new item:"
+KEYCHAIN_PASSWORD_CONFIRM_PROMPT = b"retype password for new item:"
+KEYCHAIN_PROMPT_TIMEOUT_SECONDS = 15.0
+MAX_KEYCHAIN_PROMPT_BYTES = 4 * 1024
+
+
+def _write_all(fd: int, data: bytearray) -> None:
+    offset = 0
+    while offset < len(data):
+        written = os.write(fd, data[offset:])
+        if written <= 0:
+            raise OSError("failed to write credential to macOS Keychain prompt")
+        offset += written
+
+
+def _run_security_password_prompt(
+    args: list[str],
+    value: str,
+    *,
+    timeout_seconds: float = KEYCHAIN_PROMPT_TIMEOUT_SECONDS,
+) -> int:
+    """Run ``security ... -w`` behind a PTY without putting the value in argv.
+
+    ``security add-generic-password -w`` reads from a controlling terminal. A
+    normal subprocess pipe is accepted with exit code 0 but stores an empty
+    password, so provisioning must wait for the real prompt before writing.
+    Child output is intentionally discarded and never enters an exception.
+    """
+
+    secret_input = bytearray(value.encode("utf-8"))
+    secret_input.append(ord("\n"))
+    pid = -1
+    master_fd = -1
+    child_status: int | None = None
+    expected_prompts = (KEYCHAIN_PASSWORD_PROMPT, KEYCHAIN_PASSWORD_CONFIRM_PROMPT)
+    sent_count = 0
+    prompt_window = bytearray()
+    try:
+        pid, master_fd = pty.fork()
+        if pid == 0:
+            child_env = {
+                "LANG": "C",
+                "LC_ALL": "C",
+                "PATH": "/usr/bin:/bin",
+            }
+            try:
+                os.execve(args[0], args, child_env)
+            except BaseException:
+                os._exit(127)
+
+        deadline = time.monotonic() + float(timeout_seconds)
+        while child_status is None:
+            waited_pid, wait_status = os.waitpid(pid, os.WNOHANG)
+            if waited_pid == pid:
+                child_status = wait_status
+                break
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SecretProvisioningError("macOS Keychain password prompt timed out")
+            readable, _, _ = select.select([master_fd], [], [], remaining)
+            if not readable:
+                continue
+            try:
+                chunk = os.read(master_fd, 1024)
+            except OSError as exc:
+                if exc.errno != errno.EIO:
+                    raise
+                _, child_status = os.waitpid(pid, 0)
+                break
+            if not chunk:
+                _, child_status = os.waitpid(pid, 0)
+                break
+            if sent_count < len(expected_prompts):
+                prompt_window.extend(chunk.lower())
+                if len(prompt_window) > MAX_KEYCHAIN_PROMPT_BYTES:
+                    del prompt_window[:-MAX_KEYCHAIN_PROMPT_BYTES]
+                if expected_prompts[sent_count] in prompt_window:
+                    _write_all(master_fd, secret_input)
+                    sent_count += 1
+                    prompt_window.clear()
+
+        return_code = os.waitstatus_to_exitcode(child_status)
+        if sent_count != len(expected_prompts) or return_code != 0:
+            raise SecretProvisioningError("macOS Keychain update failed")
+        return return_code
+    finally:
+        for index in range(len(secret_input)):
+            secret_input[index] = 0
+        prompt_window.clear()
+        if master_fd >= 0:
+            os.close(master_fd)
+        if pid > 0 and child_status is None:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
 
 
 class MacOSKeychain:
@@ -25,9 +132,11 @@ class MacOSKeychain:
         *,
         service: str = KEYCHAIN_SERVICE,
         run_command: Callable[..., Any] = subprocess.run,
+        run_secret_command: Callable[[list[str], str], int] = _run_security_password_prompt,
     ):
         self._service = str(service)
         self._run_command = run_command
+        self._run_secret_command = run_secret_command
 
     def _args(self, action: str, logical_name: str) -> list[str]:
         require_credential_spec(logical_name)
@@ -79,17 +188,12 @@ class MacOSKeychain:
             raise SecretProvisioningError(f"credential already exists: {logical_name}; use rotate")
         args = [*self._args("add-generic-password", logical_name), "-U", "-w"]
         try:
-            result = self._run_command(
-                args,
-                input=normalized + "\n",
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                text=True,
-                check=False,
-            )
+            return_code = self._run_secret_command(args, normalized)
+        except SecretProvisioningError:
+            raise
         except OSError as exc:
             raise SecretProvisioningError("macOS Keychain update failed") from exc
-        if int(result.returncode) != 0:
+        if int(return_code) != 0:
             raise SecretProvisioningError(f"macOS Keychain update failed for {logical_name}")
 
     def delete(self, logical_name: str) -> bool:
@@ -116,6 +220,8 @@ def _validate_secret_value(value: str) -> str:
         raise SecretProvisioningError("credential value must not be empty")
     if "\x00" in normalized:
         raise SecretProvisioningError("credential value contains an unsupported NUL byte")
+    if "\r" in normalized or "\n" in normalized:
+        raise SecretProvisioningError("credential value contains an unsupported line break")
     if len(normalized.encode("utf-8")) > MAX_KEYCHAIN_SECRET_BYTES:
         raise SecretProvisioningError("credential value is too large")
     return normalized
@@ -123,6 +229,9 @@ def _validate_secret_value(value: str) -> str:
 
 __all__ = [
     "KEYCHAIN_SERVICE",
+    "KEYCHAIN_PASSWORD_CONFIRM_PROMPT",
+    "KEYCHAIN_PASSWORD_PROMPT",
+    "KEYCHAIN_PROMPT_TIMEOUT_SECONDS",
     "MAX_KEYCHAIN_SECRET_BYTES",
     "MacOSKeychain",
     "SECURITY_COMMAND",

--- a/tests/test_secret_providers.py
+++ b/tests/test_secret_providers.py
@@ -10,12 +10,14 @@ from src.application.secret_store import (
     FEISHU_BOT_APP_SECRET,
     LLM_DEEPSEEK_API_KEY,
     SecretBackendUnavailable,
+    SecretProvisioningError,
     SnapshotSecretProvider,
     credential_specs,
 )
 from src.infrastructure.secret_store.environment import EnvSecretProvider
 from src.infrastructure.secret_store.factory import build_secret_provider
 from src.infrastructure.secret_store.macos_keychain import MacOSKeychain
+from src.infrastructure.secret_store.macos_keychain import _run_security_password_prompt
 from src.infrastructure.secret_store.memory import InMemorySecretProvider
 from src.infrastructure.secret_store.systemd_credentials import (
     SystemdCredentialProvider,
@@ -88,17 +90,53 @@ def test_snapshot_provider_identity_ignores_legacy_alias() -> None:
 def test_keychain_write_never_places_secret_in_argv() -> None:
     observed: dict[str, object] = {}
 
-    def fake_run(args, **kwargs):
+    def fake_run(args, value):
         observed["args"] = list(args)
-        observed["input"] = kwargs.get("input")
-        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        observed["value"] = value
+        return 0
 
-    keychain = MacOSKeychain(run_command=fake_run)
+    keychain = MacOSKeychain(run_secret_command=fake_run)
     keychain.set(FEISHU_BOT_APP_SECRET, "test-secret-value", replace=True)
 
     assert "test-secret-value" not in observed["args"]
     assert observed["args"][-1] == "-w"
-    assert observed["input"] == "test-secret-value\n"
+    assert observed["value"] == "test-secret-value"
+
+
+def test_keychain_write_answers_both_native_password_prompts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "must-not-reach-child")
+    prompt_helper = tmp_path / "keychain-prompt-helper"
+    prompt_helper.write_text(
+        """#!/usr/bin/env python3
+import getpass
+import os
+
+first = getpass.getpass("password data for new item: ")
+second = getpass.getpass("retype password for new item: ")
+secret_env_absent = "DEEPSEEK_API_KEY" not in os.environ
+raise SystemExit(0 if first == second == "test-secret-value" and secret_env_absent else 9)
+""",
+        encoding="utf-8",
+    )
+    prompt_helper.chmod(0o700)
+
+    assert (
+        _run_security_password_prompt(
+            [str(prompt_helper)],
+            "test-secret-value",
+            timeout_seconds=3,
+        )
+        == 0
+    )
+
+
+def test_keychain_write_rejects_multiline_values() -> None:
+    keychain = MacOSKeychain(run_secret_command=lambda _args, _value: 0)
+    with pytest.raises(SecretProvisioningError, match="line break"):
+        keychain.set(FEISHU_BOT_APP_SECRET, "first\nsecond", replace=True)
 
 
 def test_systemd_provisioner_stages_only_encrypted_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- provision macOS Keychain values through a private PTY that answers both native `security` password prompts
- keep credential values out of argv, captured output, temporary files, and the child process environment
- reject multiline values and document the native prompt boundary

## Validation

- `198 passed` across secret providers/CLI/resolver, effective settings, service deployment, and sensitive-artifact guardrails
- `tests/run_smoke.py` passed
- Ruff and repository guardrails passed
- real macOS Keychain probe stored a non-secret fixture and read it back exactly
- real local migration repaired three previously empty project entries; all three passed constant-time readback comparison and redacted CLI status

## Safety

- no credential value appears in the diff, command argv, test output, or PR text
- no service restart or legacy env cleanup is part of this PR
