### PR TITLE
fix: restore HK combo capture and failure notifications

### DIFF
--- a/docs/gateflow/hk-combo-capture-failure-notification/accepted-plan.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/accepted-plan.md
@@ -1,0 +1,51 @@
+# Gateflow Accepted Plan — HK Combo Capture / Failure Notification
+
+- Gate: `accepted plan commit`
+- Work unit: `hk-combo-capture-failure-notification`
+- Artifact path: `docs/gateflow/hk-combo-capture-failure-notification/accepted-plan.md`
+- Branch: `fix/hk-combo-capture-failure-notification`
+- Base: `main@0d635e11`
+- Status: pass; ready for Slice S1 implementation
+
+## Accepted scope
+
+- S1: owner-aware capture/pair routing and independent opening, SP+LC Combo, and CC+LP snapshot status.
+- S2: prefetch-before-failure current-run portfolio receipt with owner-local exact-byte reuse and fixed-failure preparation proof.
+- Focused/integration tests and Gateflow artifacts only; public schema/config/CLI/notification policy are unchanged.
+
+## Review evidence
+
+- Goal confirmation: `docs/gateflow/hk-combo-capture-failure-notification/goal-confirmation.md`
+- Accepted plan: `docs/gateflow/hk-combo-capture-failure-notification/plan.md`
+- Initial plan review: `docs/reviews/plan-review-20260810-111309.md` — `fail`, five accepted findings.
+- Plan review fix: `docs/gateflow/hk-combo-capture-failure-notification/plan-review-fix.md`.
+- Plan re-review: `docs/reviews/plan-review-20260810-111928.md` — `pass-with-risks`, no remaining material findings.
+
+## Finding status
+
+- PR-01 fixed in plan: legacy variant-less SP+LC pairs are canonical `sp_lc`; unknown explicit variants fail closed.
+- PR-02 fixed in plan: CC+LP `not_applicable` survives the producer boundary.
+- PR-03 fixed in plan: per-symbol quote binding remains consistent across owners.
+- PR-04 fixed in plan: source owner owns idempotent locate/publish/validate/reuse; no receipt field is added to `AccountRunRequest`.
+- PR-05 fixed in plan: Daily Brief authority and no-send fixed-failure preparation tests are mandatory.
+
+## Validation
+
+- Plan artifacts checked with `git diff --check`.
+- No production code or runtime data was changed at this gate.
+- Commit preflight must stage only the six files listed in this artifact and leave all pre-existing dirty files untouched.
+
+## Docs decision
+
+The Gateflow artifacts are the only docs in scope. No public command, config, schema, notification copy, or operator workflow changed.
+
+## Residual risks
+
+- Scheduler processed-target/retry semantics: assigned to a later scheduler reliability work unit.
+- OpenD expiration lookup timeout/retry: assigned to a later required-data/OpenD reliability work unit.
+- Prepared portfolio receipt freshness during unusually long runs: covered by the existing fail-closed freshness validator; track operational evidence.
+- Release and production upgrade: require separate explicit user authorization after this Draft PR.
+
+## Next entry point
+
+`implementation` — Slice S1 owner-aware capture routing and snapshot status.

--- a/docs/gateflow/hk-combo-capture-failure-notification/aggregate-code-review.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/aggregate-code-review.md
@@ -1,0 +1,55 @@
+# Gateflow Aggregate Code Review — HK capture and failure notification
+
+- Gate: `aggregate deepreview`
+- Work unit: `hk-combo-capture-failure-notification`
+- Base: `main@0d635e11`
+- Accepted plan: `6e0d8964`
+- Accepted S1: `7241fe9a`
+- Accepted S2: `aef308a0`
+- Review artifact: `docs/reviews/code-review-20260810-120647.md`
+- Status: pass; ready for accepted aggregate-review commit
+
+## Review decision
+
+- Conclusion: pass; no aggregate material findings.
+- Slice review history: S1 passed without findings; S2 passed after fixing the
+  invalid-UTF-8 typed-boundary finding DR-S2-01.
+- Fix status: no aggregate fix or re-review loop required.
+- Dirty-worktree boundary: every pre-existing service credential, documentation,
+  service-deploy/drift, secret-store and related test change is outside the
+  reviewed commit range and remains unstaged.
+
+## Validation evidence
+
+```text
+Focused S1: 52 passed
+Broader S1 regression: 129 passed
+Focused S2 after review fix: 180 passed
+Aggregate S1+S2 suite: 265 passed, 4 warnings
+Ruff across all changed production/test Python files: pass
+compileall domain src scripts: pass
+git diff --check 0d635e11..aef308a0: pass
+```
+
+The four warnings are existing legacy notification renderer deprecations. All
+validation used temporary runtime, fake providers or no-send paths. No live
+notification, broker mutation, runtime/config/service write, release, deployment
+or remote operation was performed.
+
+## Contract and docs decision
+
+- Public snapshot/receipt schemas, CLI, configuration, scheduler payload,
+  notification wording and authority policy remain unchanged.
+- Gateflow and review artifacts are the only documentation changes in this work
+  unit. The dirty `docs/DEPENDENCY_GRAPH.md` was not touched or staged.
+
+## Residual-risk destinations
+
+| Residual risk | Destination |
+|---|---|
+| Scheduler target retry after failure | Dedicated scheduler reliability work unit |
+| OpenD expiration lookup timeout/retry | Dedicated required-data/OpenD reliability work unit |
+| Portfolio receipt freshness in unusually long runs | Existing 30-minute fail-closed validator and operational evidence |
+| Live production behavior | Separate release and remote-upgrade authorization |
+
+No residual risk is unclassified.

--- a/docs/gateflow/hk-combo-capture-failure-notification/draft-pr-readiness.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/draft-pr-readiness.md
@@ -1,0 +1,71 @@
+# Gateflow Draft PR Readiness — HK capture and failure notification
+
+- Gate: `ready-to-open-draft-PR`
+- Work unit: `hk-combo-capture-failure-notification`
+- Branch: `fix/hk-combo-capture-failure-notification`
+- Original base: `main@0d635e11` (`v1.13.0`)
+- Current PR base checked: `origin/main@f8583513` (`v1.13.2`)
+- Accepted plan: `6e0d8964`
+- Accepted S1: `7241fe9a`
+- Accepted S2: `aef308a0`
+- Accepted aggregate review: `af461f3b`
+- Status: ready to push and open Draft PR
+
+## Main-drift integration boundary
+
+`origin/main` advanced during this work unit. The current-main path set and this
+branch's committed path set do not overlap, and a three-way `git merge-tree`
+preview contains no conflict markers.
+
+To avoid touching the user's dirty worktree, the four accepted work-unit commits
+were replayed only in a detached `/tmp` worktree on `origin/main@f8583513`. The
+resulting integration head was `04a09a6d`; no branch or production/runtime state
+was changed by that validation. The PR may therefore retain its original commit
+lineage while GitHub forms the already-validated merge result against current
+main.
+
+## Intended committed diff
+
+- owner-aware opening/SP+LC/CC+LP capture routing and status reduction;
+- current-run portfolio receipt publish/validate/exact-byte reuse before the
+  required-data barrier and during recovery;
+- account-scoped typed conflict handling and fixed-failure liveness through the
+  existing Daily Brief authority;
+- focused/integration tests and Gateflow/planreview/deepreview artifacts.
+
+No VERSION, CHANGELOG, public docs, public schema/config/CLI/notification wording,
+scheduler retry, OpenD timeout policy, runtime, service or deployment file belongs
+to the work-unit diff.
+
+## Validation
+
+```text
+Original branch aggregate: 265 passed, 4 warnings
+Latest-main detached integration aggregate: 265 passed, 4 warnings
+Ruff on all changed Python production/tests: pass on both heads
+compileall domain src scripts: pass on both heads
+git diff --check: pass on both heads
+Three-way merge preview against origin/main@f8583513: no conflicts
+```
+
+The warnings are existing legacy renderer deprecations. Validation used temporary
+runtime, fake providers or no-send paths and made no live external calls.
+
+## Dirty-worktree boundary
+
+The original README/operator/security/service credential/deploy/drift/secret-store
+and service test changes remain unstaged and uncommitted. The readiness commit
+must stage only this artifact. `docs/DEPENDENCY_GRAPH.md` remains untouched by the
+work unit.
+
+## Residual risks and owners
+
+- Scheduler target retry after failure: later scheduler reliability work unit.
+- OpenD expiration timeout/retry: later required-data/OpenD reliability work unit.
+- Long-run portfolio receipt freshness: existing 30-minute fail-closed validator.
+- Live behavior: separate release and remote-upgrade authorization after human PR
+  review and merge.
+
+All approved slices and aggregate review gates are complete. Next transition:
+push the branch, open a Draft PR, then perform PR-level DeepReview. Gateflow does
+not authorize merge, release, deployment or production notification replay.

--- a/docs/gateflow/hk-combo-capture-failure-notification/final-closeout.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/final-closeout.md
@@ -1,0 +1,80 @@
+# Gateflow Final Closeout — HK capture and failure notification
+
+- Gate: `final closeout`
+- Work unit: `hk-combo-capture-failure-notification`
+- Branch: `fix/hk-combo-capture-failure-notification`
+- Pull request: <https://github.com/liuxie066/options-monitor/pull/143>
+- PR base at review: `main@47887347cac7f72be76d050ee2f8f8b532b0978e`
+- Accepted PR review commit: `2ebb8972`
+- Status: final closeout pass
+
+## What changed
+
+- Candidate capture statuses are normalized and partitioned by their owning
+  snapshot before strict scope validation. Opening consumes only `put` / `call`;
+  SP+LC and CC+LP consume their own `combo_yield` variant facts and pairs.
+- Frozen required-data failure now emits the corresponding Combo capture fact,
+  and CC+LP preserves `not_applicable` rather than collapsing it to a generic
+  no-candidate result.
+- A current-run portfolio identity receipt is published from validated prepared
+  inputs before required-data prefetch and reused byte-for-byte by the complete
+  Position Advice source graph.
+- Barrier and pipeline failures can therefore reach the existing Daily Brief
+  `fixed_failure` authority path. Invalid identity/config/receipt state remains an
+  account-scoped no-send failure.
+
+## What was verified
+
+- Slice-level implementation and review gates passed; the S2 invalid-UTF-8 typed
+  boundary finding was fixed and re-reviewed.
+- Aggregate DeepReview passed with no remaining findings.
+- PR-level DeepReview passed with no findings:
+  `docs/reviews/pr-143-review-20260810-123511.md`.
+- The five implementation/readiness commits replayed without conflict on
+  `main@47887347`; detached integration head `d8380d02` passed 265 tests.
+- Ruff, compileall, and Git diff checks passed.
+- GitHub reported 5/5 checks passing on the reviewed implementation head before
+  the docs-only PR review and closeout commits.
+
+## Documentation
+
+- Gateflow plan, review, implementation, readiness, PR review, and closeout
+  artifacts are included in PR #143.
+- No public CLI, schema, config, notification wording, or operator workflow was
+  changed.
+- The unrelated dirty `docs/DEPENDENCY_GRAPH.md` and all pre-existing
+  service-credential/deploy/drift/secret-store changes remain outside this work
+  unit and were never staged.
+
+## Finding status
+
+- Plan review: five accepted findings, all resolved in the accepted plan.
+- S1 code review: no findings.
+- S2 code review: one accepted finding, fixed and re-reviewed.
+- Aggregate DeepReview: no findings.
+- PR DeepReview: no findings.
+- Blocking findings or open questions: none.
+
+## Remaining risks and owners
+
+| Residual risk | Owner / destination |
+|---|---|
+| Scheduler target retry after operational failure | Later scheduler-reliability work unit |
+| OpenD expiration lookup timeout/retry | Later required-data/OpenD reliability work unit |
+| Receipt freshness during unusually long runs | Existing 30-minute fail-closed validator plus operational evidence |
+| Live delivery behavior | Separate release/upgrade authorization and natural-run provider-attempt/delivery-confirmed evidence |
+
+No residual risk is unclassified.
+
+## PR and issue status
+
+- Draft PR: <https://github.com/liuxie066/options-monitor/pull/143>
+- Issue link: not applicable; this work unit was initiated from the reported
+  incident and no GitHub issue number was supplied.
+- The user explicitly authorized commit, push, and merge to `main` on 2026-08-10.
+
+## Next entry point
+
+Push this closeout artifact, require the new PR head checks to pass, mark PR #143
+ready for review, and merge it into `main`. Release, deployment, remote upgrade,
+and production notification verification remain separate actions.

--- a/docs/gateflow/hk-combo-capture-failure-notification/goal-confirmation.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/goal-confirmation.md
@@ -1,0 +1,85 @@
+# Gateflow Goal Confirmation — HK Combo Capture / Failure Notification
+
+- Work unit: `hk-combo-capture-failure-notification`
+- Gate: `goal confirmation`
+- Date: 2026-08-10
+- Status: confirmed by user
+- Branch: `fix/hk-combo-capture-failure-notification`
+- Base: `main@0d635e11`
+
+## User problem
+
+2026-08-10 北京时间 09:40 和 10:00 的 HK 期权监控都没有发出消息。两次故障发生在
+通知 provider 调用之前，但是由两个不同的失败点触发：
+
+- 09:40 run `20260810T014016Z-581238` 在 required-data prefetch 期间获取
+  `0700.HK` 期权到期日超时，pipeline 未执行；
+- 10:00 run `20260810T020017Z-6a4e0b` 的 `lx` / `sy` pipeline 都因
+  `combo_yield` capture status 被送入只允许 `put` / `call` 的 opening validator，抛出
+  `ValueError: unexpected opening scan scopes` 后退出。
+
+两轮都是 `decision=none`、`message_count=0`，没有 provider attempt，也没有
+`delivery_confirmed`，因此不是飞书传输层故障。
+
+## Confirmed goal
+
+1. 修复 capture status 的 owner 路由：opening snapshot 只消费 Sell Put / Covered Call
+   状态，SP+LC Combo Yield 和 CC+LP 变体各自消费、归约并封存自己的状态与候选。
+2. 在 account/config/portfolio identity 已验证的前提下，于 required-data prefetch
+   之前发布当前 Account Run 的 portfolio source receipt，并让后续完整 source graph
+   复用同一份不可变 receipt。这使 prefetch barrier 和 pipeline nonzero 这类运行故障
+   可以在既有通知 authority 门禁下准备受限的 `fixed_failure`。
+
+## Motivation and direct evidence
+
+- `src/application/pipeline_watchlist.py::run_watchlist_pipeline_default()` 先将所有 capture
+  status 放入仅包含 `(symbol, put|call)` 的 `expected_scopes` 校验，然后才过滤
+  `combo_yield` / `variant=cc_lp`，所以合法 Combo status 必然被当成 unexpected scope。
+- `src/application/symbol_monitoring.py` 在普通 Combo success/failure 路径会发布
+  `strategy_mode=combo_yield`，但 `FrozenRequiredDataUnavailable` 分支只为 `put` / `call`
+  发布 capture status，造成 Combo 早期数据失败与扫描失败的状态语义不一致。
+- `src/application/account_run.py::run_one_account()` 在 pipeline nonzero 时立即返回；当前
+  portfolio receipt 只在其后的 `publish_account_position_advice_sources()` 中发布。
+- `src/application/tick_account_execution.py` 在 global prefetch barrier 上直接组装 terminal
+  outcomes，不进入 `run_one_account()`。但此前已经完成 account config generation 冻结、
+  prepared portfolio context 加载与 identity 校验，具备发布当前 run portfolio receipt
+  的充分事实。
+- source receipt 是 write-once，receipt bytes 包含 `completed_at`。早期与后期各发布一次
+  会存在字节冲突；正确边界是发布一次并复用同一份已验证 receipt。
+
+## Success signals
+
+1. opening snapshot 的 scope 只有 `put` / `call`；合法 `combo_yield` 不再触发
+   `unexpected opening scan scopes`。
+2. 启用 Combo 的真实 default pipeline 组装测试同时封存 opening snapshot 和对应
+   Combo/CC+LP snapshot，不用手工构造封存结果替代该路径。
+3. unknown strategy mode、unknown combo variant、unexpected scope 和 duplicate scope 仍然
+   fail closed。
+4. SP+LC Combo 与 CC+LP 的 `data_unavailable` / `partial_data` / `no_candidate` /
+   `not_applicable` 分类由各自 scope 状态决定，不互相污染。
+5. 合法 prepared portfolio identity 在 prefetch 前发布一份当前-run portfolio
+   receipt；后续 pipeline 成功时完整 source graph 复用它，不产生第二份 receipt。
+6. required-data prefetch barrier 和 pipeline nonzero 在已有合法通知计划时可准备
+   `fixed_failure`；身份、config generation、authority 或 receipt 冲突仍为 no-send。
+7. 本 work unit 聚焦测试、相关 tick/notification 回归、compileall 和
+   `git diff --check` 通过。
+
+## Non-goals and scope boundary
+
+- 不修改 scheduler processed-target / retry 语义；09:50 / 10:10 跳过的问题留给独立
+  work unit。
+- 不修改 OpenD 超时、重试、数据新鲜度或 provider 调用策略。
+- 不修改服务退出码、通知文案、fixed-failure authority 校验标准或飞书适配器。
+- 不修改 production config/runtime data，不重放、不发测试或真实通知。
+- 不修改 `VERSION`，不 release、merge、deploy 或升级远端。
+- 现有与本 work unit 无关的脏改动保持原样，不编辑、不暂存、不提交。
+
+## Overdesign deliberately excluded
+
+本轮不新增 status bus、snapshot schema、notification state、retry queue 或新服务。候选修复收敛在
+`pipeline_watchlist` 已有 capture/seal 边界；身份修复复用已有 portfolio source producer
+与 receipt validator，只调整发布时机和复用契约。
+
+## Blocking open questions
+
+无。

--- a/docs/gateflow/hk-combo-capture-failure-notification/plan-review-fix.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/plan-review-fix.md
@@ -1,0 +1,33 @@
+# Gateflow Plan Review Fix — HK Combo Capture / Failure Notification
+
+- Gate: `plan review fix`
+- Work unit: `hk-combo-capture-failure-notification`
+- Review artifact: `docs/reviews/plan-review-20260810-111309.md`
+- Status: fixed; pending adversarial re-review
+
+## Finding decisions
+
+| Finding | Decision | Plan change |
+|---|---|---|
+| PR-01 | accepted | Missing/empty pair variant is now the explicit legacy `sp_lc` compatibility case; unknown explicit variants still fail closed, and the real pair shape is a required test. |
+| PR-02 | accepted | The plan now requires CC+LP summary-to-capture mapping so `not_applicable` and its reason survive the producer boundary. |
+| PR-03 | accepted | Quote binding remains a per-symbol, cross-owner frozen-fact invariant before owner partitioning. |
+| PR-04 | accepted | Removed receipt-path threading and the proposed `AccountRunRequest` field. One source-owner helper now owns locate/publish/validate/reuse for normal and recovery paths; recovery may publish only from the immutable current-run prepared context. |
+| PR-05 | accepted | Daily Brief service and notification preparation tests are mandatory and must consume the early-owner artifact, not a manually assembled authority object. |
+
+## Preserved boundaries
+
+- No snapshot, receipt, CLI, config, notification, or scheduler schema change.
+- No relaxation of current-run identity, freshness, or fixed-failure authority checks.
+- No OpenD retry/timeout, scheduler processed-target, release, deployment, or production mutation work.
+- No edit to the existing dirty `docs/DEPENDENCY_GRAPH.md`; the existing dependency direction remains unchanged.
+
+## Re-review evidence requested
+
+The re-review must confirm that:
+
+1. legacy SP+LC pairs cannot be silently dropped;
+2. CC+LP `not_applicable` is observable before the reducer;
+3. cross-owner quote identity remains fail closed;
+4. recovery has one owner-local idempotent receipt contract without request-layer leakage;
+5. validation proves actual `fixed_failure` preparation in no-send mode.

--- a/docs/gateflow/hk-combo-capture-failure-notification/plan.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/plan.md
@@ -1,0 +1,399 @@
+# Gateflow Implementation Plan — HK Combo Capture / Failure Notification
+
+- Work unit: `hk-combo-capture-failure-notification`
+- Gate: `plan`
+- Date: 2026-08-10
+- Status: accepted after adversarial re-review
+- Goal confirmation: `docs/gateflow/hk-combo-capture-failure-notification/goal-confirmation.md`
+- Initial review: `docs/reviews/plan-review-20260810-111309.md`
+- Accepted re-review: `docs/reviews/plan-review-20260810-111928.md`
+- Branch: `fix/hk-combo-capture-failure-notification`
+- Base: `main@0d635e11`
+
+## 1. Goal and completion signal
+
+在不放宽任何身份或通知安全门禁的前提下，修复 HK tick 中的两个编排断点：
+
+- capture status 必须按 snapshot owner 分区后再做严格 scope 校验，不能让
+  `combo_yield` 进入 put/call opening validator；
+- current-run portfolio identity receipt 必须在进入可预期的 operational
+  failure boundary 前发布，且完整 source graph 必须复用这份 write-once receipt。
+
+完成信号是：默认 pipeline 端到端回归可封存 opening + SP+LC Combo 或
+opening + CC+LP；prefetch barrier 与 pipeline nonzero 能在当前-run identity
+可验证时生成受限 `fixed_failure`；unknown/duplicate/config/identity/receipt conflict
+全部继续 fail closed。
+
+### 1.1 Non-goals and scope boundary
+
+- 不改 scheduler processed-target/retry 语义、OpenD timeout/retry/freshness 策略或服务退出码。
+- 不改 notification wording/action/policy、snapshot/receipt schema、public CLI 或 runtime config。
+- 不重放、不发真实通知、不写生产 runtime/broker/Feishu 数据。
+- 不修改 `VERSION`，不 merge、release、deploy 或升级远端。
+- 不触碰、暂存或提交当前 worktree 的无关脏改动。
+
+### 1.2 Goal alignment
+
+| Plan item | Binding goal / success signal |
+|---|---|
+| S1 owner-aware status/pair routing | Goal 1; success signals 1–4: opening 不消费 Combo，默认 pipeline 双快照封存，unknown/duplicate fail closed，SP+LC/CC+LP 状态独立。 |
+| S1 frozen-data and CC+LP producer mapping | Goal 1; success signal 4: 早期数据失败、扫描失败、not-applicable 不被误降级成 no-candidate。 |
+| S2 early portfolio receipt + owner-local reuse | Goal 2; success signals 5–6: prefetch 前当前-run identity 可验证，full graph 复用同一 receipt，operational failure 可准备 fixed-failure。 |
+| S2 strict conflict/recovery tests | Success signal 6: identity/config/authority/receipt conflict 仍 no-send。 |
+| Aggregate validation and reviews | Success signal 7: 聚焦+回归+compileall+diff check 通过。 |
+
+### 1.3 First-principles judgment and direct code evidence
+
+- `pipeline_watchlist.run_watchlist_pipeline_default()` 在封存 opening 前用 put/call
+  `expected_scopes` 验证全部 capture statuses，而 Combo/CC+LP 过滤发生在 opening seal 之后；
+  因此 owner partition 必须发生在 validator 之前。
+- `symbol_monitoring` 的 normal Combo 路径发布 `strategy_mode=combo_yield`，但 frozen
+  required-data 分支缺少对应 capture，且 CC+LP result 的 `status=not_applicable` 目前被硬编码
+  `completed` 覆盖。
+- SP+LC pair sink 原样转发 dataframe rows，无 `variant`；CC+LP rows 显式带
+  `variant=cc_lp`，因此 pair router 需要窄的 legacy compatibility 而不是全部强制必填。
+- `account_run.run_one_account()` 在 pipeline nonzero 时早于完整 source publication 返回；
+  `tick_account_execution` 的 prefetch barrier 也不进入 account runner，但两者之前已有冻结并
+  验证的 prepared portfolio context。
+- Portfolio source path 由 run key + payload hash 确定，receipt 含 `completed_at` 且 write-once；
+  所以正确语义是在 source owner 内 publish-or-reuse exact bytes，而不是在早期/后期各发布一次。
+
+## 2. Authority and state-flow decision
+
+### 2.1 Capture status ownership
+
+`candidate_capture_status_sink_fn` 仍为单一内存收集面，但封存前先解析成带 owner
+的 canonical status：
+
+```text
+(symbol, strategy_mode=put|call)                 -> opening snapshot
+(symbol, strategy_mode=combo_yield, variant=sp_lc) -> combo snapshot
+(symbol, strategy_mode=combo_yield, variant=cc_lp) -> cc_lp snapshot
+anything else                                   -> fail closed
+```
+
+- `variant` 对 `combo_yield` 为必填；产生端对默认变体显式发布 `sp_lc`。
+- expected opening scopes 继续由解析后的 `sell_put.enabled` /
+  `sell_call.enabled` 决定。
+- expected combo scopes 复用现有
+  `derive_yield_enhancement_policy(resolve_yield_enhancement_cfg(resolved_item))`，由其
+  `enabled` 和 canonical `variant` 决定；不建立第二套配置解析。
+- whitelist 和 runtime profile resolution 与执行路径保持一致。
+- 每个 owner 独立校验 unexpected、duplicate 和 missing scope；一个 owner 的状态不参与
+  另一个 snapshot 的归约。
+
+### 2.2 Combo / CC+LP aggregate status contract
+
+对每个已启用 owner，将其 expected scopes 补齐 missing status 后按同一个 private reducer
+归约：
+
+1. 全部 `completed`：不显式传 `opening_status`，由该 owner 自己的 pairs 推导
+   `candidates_found` 或 `no_candidate`；
+2. 全部 `not_applicable`：`not_applicable`；
+3. 所有非 `not_applicable` scope 都是 `market_closed`：`market_closed`；
+4. 有 `completed` 且同时有 `failed` / `incomplete` / `unavailable` /
+   `not_applicable`：`partial_data`；
+5. 没有 `completed`，且只有失败/缺失/不可用：`data_unavailable`；
+6. 非法 status value 不降级成可用状态，直接 fail closed。
+
+Pairs 也按 variant 分区，但保留既有 SP+LC producer 契约：
+
+- pair 缺少/空 `variant` 规范为 legacy canonical `sp_lc`；
+- 显式 `variant=cc_lp` 路由到 CC+LP snapshot；
+- 其他显式 variant 直接 fail closed，不默认归入 SP+LC。
+
+SP+LC Combo snapshot 只接收 canonical `sp_lc` pair，CC+LP snapshot 只接收
+`cc_lp` pair。候选存在不得覆盖失败/部分数据状态；只有 owner 全部
+completed 时才由 pairs 推导 found/empty。
+
+Combo capture 产生端必须保留 CC+LP summary 的 terminal semantics：
+
+- `candidates_found` / `no_candidate` -> capture `completed`；
+- `not_applicable` -> capture `not_applicable` 并保留 reason；
+- 未知 summary status -> fail closed；
+- scan exception 和 frozen required-data unavailable -> capture `failed`。
+
+此映射只对显式 CC+LP summary status 生效；现有 SP+LC summary 不宣称该字段，
+仍按既有成功/异常路径产生 completed/failed。
+
+Quote binding 是跨 owner 的共享 required-data 事实，不随 snapshot 独立：先在全部
+canonical statuses 上按 symbol 执行现有 binding 一致性校验；同一 symbol 出现多个
+`(quote_snapshot_id, quote_receipt_relpath)` 时，将该 symbol 所有 completed status 降级为
+`incomplete/quote_binding_conflict`，再按 owner 分区归约。
+
+### 2.3 Early identity receipt lifecycle
+
+```text
+frozen account config
+  -> prepared portfolio context validates account/config/source identity
+  -> publish exactly one current-run portfolio source receipt
+  -> required-data prefetch
+     -> barrier failure: receipt remains available to fixed-failure authority
+     -> pipeline nonzero: same receipt remains available
+     -> pipeline success: full source graph revalidates and reuses same receipt
+```
+
+新的 private/internal 契约收敛在现有 account-source owner：
+
+```python
+publish_or_reuse_account_portfolio_source(...) -> dict[str, Any]
+```
+
+返回现有 `_receipt_record` 形状的 JSON-safe dict，包含 `producer_root`、
+`receipt_path`、receipt 及 canonical portfolio identity fields；不新建 dataclass/schema。它只使用
+已验证 prepared portfolio context，不重新读 broker、ledger、quotes 或 FX。
+
+helper 拥有唯一的 locate/publish/reuse 契约：
+
+1. 按现有 deterministic run key 定位
+   `position_advice_producers/portfolio/<run_key>/`；
+2. 目录不存在时使用现有 producer 发布一次；
+3. 目录存在时必须恰有一份完整 receipt/payload，然后验证并复用；空目录、
+   symlink、多 receipt 或不完整内容都 fail closed，不在同一 run 生成替代身份；
+4. same-input replay 返回原 receipt bytes/path/hash/snapshot id，不生成新 `completed_at`。
+
+复用时必须：
+
+- 路径在当前 account state root 内且不是 symlink；
+- 通过现有 receipt + payload validator；
+- `source_kind=portfolio`、account、producer account run id、broker、included markets、
+  normalized portfolio source 和 identity hash 全部与当前输入一致；
+- payload 中的 portfolio context 与当前 prepared context 的 canonical content 一致；
+- 任一不一致都抛 typed source error，不修补、不重发布、不退回新建第二份。
+
+early tick 与后续 `publish_account_run_sources()` 都调用这一 owner helper，不把
+receipt path/payload 穿透到 `AccountRunRequest`。recovery (`prefetch_done=True`) 也通过同一
+helper 复用当前 run 已有 receipt；若 receipt 缺失但原 current-run prepared context
+仍完整可验证，允许从该冻结 context 发布一次。recovery 不重读 broker，不从
+stale/cross-run facts 合成 identity；prepared context 缺失、receipt 不完整/冲突均 no-send。
+
+## 3. Public contract, schema, and compatibility decisions
+
+- 不改 CLI、scheduler payload、snapshot schema、receipt schema、notification action 或用户文案。
+- capture status 是 internal callback payload；对 `combo_yield` 将 `variant` 从 optional
+  收紧为产生端必填，但 put/call 仍无 variant。
+- `AccountRunRequest` 不新增 receipt 字段，避免把 source storage contract 泄漏到账户
+  编排 payload。
+- 当 deterministic run directory 未存在时，完整 source publisher 保持原有单次发布
+  行为，便于独立调用和现有测试兼容。
+
+## 4. Affected files and ownership
+
+### Production files
+
+- `src/application/pipeline_watchlist.py`
+- `src/application/symbol_monitoring.py`
+- `src/application/position_advice_account_sources.py`
+- `src/application/account_run.py`
+- `src/application/tick_account_execution.py`
+
+### Test files
+
+- `tests/test_pipeline_capture_status_routing.py` (new focused default-pipeline tests)
+- `tests/test_symbol_monitoring_fetch_spec_merge.py`
+- `tests/test_position_advice_account_sources.py`
+- `tests/test_account_run.py`
+- `tests/test_tick_account_execution_barrier.py`
+- `tests/test_daily_decision_brief_service.py`
+- `tests/test_daily_decision_brief_notification_flow.py`
+- 仅在上述窄契约测试仍无法证明 tick -> preparation 组合时，才允许聚焦修改
+  `tests/test_multi_account_tick.py`。
+
+### Artifacts
+
+- `docs/gateflow/hk-combo-capture-failure-notification/`
+- 本 work unit 的 planreview / deepreview artifacts under `docs/reviews/`
+
+`docs/DEPENDENCY_GRAPH.md` 当前属于用户脏改动，本 work unit 不触碰。方案仅沿用
+`tick_account_execution -> account_run -> position_advice_account_sources` 的现有依赖方向：
+tick 层通过 `account_run` 暴露的窄 helper 发布早期 receipt，不新增跨模块边。
+
+## 5. Implementation slices
+
+### Slice S1 — Owner-aware capture routing and snapshot status
+
+- Objective: 修复 10:00 pipeline crash，并让 opening、SP+LC Combo、CC+LP 独立封存。
+- Prerequisite: accepted plan commit.
+- Allowed files:
+  - `src/application/pipeline_watchlist.py`
+  - `src/application/symbol_monitoring.py`
+  - `tests/test_pipeline_capture_status_routing.py`
+  - `tests/test_symbol_monitoring_fetch_spec_merge.py`
+- Exact changes:
+  1. 在 `pipeline_watchlist` 增加 private canonicalizer/router，保留 `variant`，拒绝
+     empty/unknown mode、unknown combo variant 和 put/call 携带 variant。
+  2. 用同一次 resolved watchlist traversal构建 opening / sp_lc / cc_lp expected scopes，
+     并对每个 owner 独立执行 unexpected、duplicate、missing 校验。
+  3. pair router 将 missing/empty variant 规范为 `sp_lc`，保留现有 SP+LC producer
+     shape；显式 `cc_lp` 独立路由，其他显式 variant fail closed。
+  4. opening seal 只接收 put/call statuses。SP+LC / CC+LP 各自过滤 status 和
+     pair，然后用 §2.2 reducer 得到 explicit/derived opening status。
+  5. 对 completed status 继续校验 quote snapshot/receipt binding；先在全部 owner 上按
+     symbol 保留现有唯一 quote generation 不变式，然后分区归约。
+  6. Combo success path 将 CC+LP summary 的 `not_applicable` + reason 原样投影到
+     capture，candidates_found/no_candidate 投影为 completed，未知 status fail closed。
+  7. `FrozenRequiredDataUnavailable` 为已启用 Combo 发布
+     `strategy_mode=combo_yield,status=failed,variant=<canonical variant>`，与普通扫描
+     失败契约一致。
+- Invariants:
+  - 不改 opening snapshot 的 `put|call` schema；
+  - 不把 unknown status 当成 `data_unavailable` 吞掉；
+  - 不从 pairs 的有无推断扫描是否成功；
+  - 同一 expected scope 只能有一条 terminal capture status。
+- Focused validation:
+
+  ```bash
+  ./.venv/bin/python -m pytest -q \
+    tests/test_pipeline_capture_status_routing.py \
+    tests/test_symbol_monitoring_fetch_spec_merge.py \
+    tests/test_opening_candidate_snapshot.py \
+    tests/test_combo_yield_candidate_snapshot.py \
+    tests/test_cc_lp_candidate_snapshot.py
+  ```
+
+- Required assertions:
+  - default `run_watchlist_pipeline_default()` 收到 put/call + sp_lc 状态时同时封存
+    opening 和 combo，opening scopes 不含 combo；无 variant 的现有 SP+LC pair 被保留且
+    生成 `candidates_found`；
+  - `variant=cc_lp` 只封存 CC+LP snapshot，不污染 SP+LC snapshot；
+  - all-completed empty 是 `no_candidate`，all-failed/missing 是 `data_unavailable`，
+    success+failure 是 `partial_data`，all-not-applicable 是 `not_applicable`；
+  - CC+LP no-stock summary 产生 `not_applicable` capture/snapshot；
+  - FrozenRequiredDataUnavailable 产生带 canonical variant 的 Combo failed status；
+  - put/combo 对同一 symbol 绑定不同 quote receipt 时，所有相关 owner 都降级；
+  - unknown mode/variant、unexpected scope、duplicate scope 均抛错且不留下该 owner 的终态快照。
+- Completion signal: focused tests pass; default pipeline no longer routes combo into opening.
+- Stop condition: 要保持独立状态必须改 snapshot schema 或公开配置契约。
+
+### Slice S2 — Early current-run portfolio receipt and fixed-failure liveness
+
+- Objective: 修复 09:40 类型早期 operational failure 在 notification authority 校验前
+  缺少 current-run portfolio identity 的问题。
+- Prerequisite: accepted S1 commit.
+- Allowed files:
+  - `src/application/position_advice_account_sources.py`
+  - `src/application/account_run.py`
+  - `src/application/tick_account_execution.py`
+  - `tests/test_position_advice_account_sources.py`
+  - `tests/test_account_run.py`
+  - `tests/test_tick_account_execution_barrier.py`
+  - `tests/test_daily_decision_brief_service.py`
+  - `tests/test_daily_decision_brief_notification_flow.py`
+  - 如上述窄契约仍无法证明最终 preparation action，才允许
+    `tests/test_multi_account_tick.py`
+- Exact changes:
+  1. 在 `position_advice_account_sources` 抽出单一 idempotent portfolio identity/source
+     owner helper，复用现有 normalization/hash/producer，按 deterministic run directory 定位、
+     验证、发布或复用唯一 receipt record。
+  2. 让完整 `publish_account_run_sources` 直接调同一 helper；如果当前 run 已有
+     receipt，严格验证并复用，否则保持原有发布一次的行为。
+  3. 在 `account_run` 提供一个狭的 early-publish facade，复用
+     `_position_advice_markets()` 与既有 broker/account 解析，避免 tick 层新增直接
+     source-module 依赖。
+  4. tick 层在 account config generation 冻结、prepared portfolio context 验证且
+     prepared option authority 通过后，对仍在 scanning set 的账户发布 early receipt；
+     任一发布/验证错误转为 account-scoped config/authority error，从 prefetch scope
+     移除，不产生 partial-identity failure delivery。
+  5. 不修改 `AccountRunRequest`；pipeline 成功时 full publisher 在 account state root 内定位
+     并复用同一 receipt；pipeline nonzero 时早期返回不删除、不重写 receipt。
+  6. barrier outcomes 继续由现有决策路径组装，不绕过 notification authority；
+     本修复只提供它现有规则所需的 current-run identity evidence。
+  7. recovery 路径调用同一 owner helper：优先复用当前 run 唯一合法 receipt；
+     receipt 缺失时仅可从原 current-run prepared context 发布，不刷新 broker、不读
+     stale/cross-run source；不完整/冲突目录不得覆盖。
+  8. 串联 fixed-failure contract tests：early owner 发布 -> current-run identity reader /
+     Daily Brief authority 验证 -> no-send notification preparation 选择 `fixed_failure`，不使用手工
+     构造的 identity authority 替代新产物。
+- Invariants:
+  - 一个 account run 只有一份合法 portfolio receipt；
+  - `completed_at` 由首次发布冻结，full source graph 不重写；
+  - identity/config generation/receipt path/payload 任一冲突均 no-send；
+  - 不因为 receipt 存在就把业务空结果误判为失败或允许普通报告。
+- Focused validation:
+
+  ```bash
+  ./.venv/bin/python -m pytest -q \
+    tests/test_position_advice_account_sources.py \
+    tests/test_account_run.py \
+    tests/test_tick_account_execution_barrier.py \
+    tests/test_daily_decision_brief_service.py \
+    tests/test_daily_decision_brief_notification_flow.py \
+    tests/test_multi_account_tick.py
+  ```
+
+- Required assertions:
+  - early helper 发布的 receipt 可被 current-run identity reader 验证；
+  - full source publication 复用相同 receipt path/hash/snapshot id，portfolio receipt 目录仍只一个；
+  - tampered/stale/wrong-run/wrong-account/wrong-market/context-drift receipt 被拒绝；
+  - global prefetch barrier 在 identity 已准备时保留 `should_notify` 失败结果，且
+    Daily Brief 实际读取该 receipt 后得到 `fixed_failure_delivery_allowed=True`；
+  - pipeline nonzero 同样保留 current-run identity；typed config error 继续
+    `should_notify=False`；
+  - no-send notification preparation 对上述 blocked brief 选择 `decision=fixed_failure`，不调 provider；
+  - identity publish conflict 不进入 prefetch/provider，不产生 delivery attempt。
+- Completion signal: focused tests pass and both early operational-failure paths have identity evidence.
+- Stop condition: 需要放宽 fixed-failure authority 或从 stale/cross-run source 合成 identity 才能通过。
+
+## 6. Validation matrix
+
+After S1 and S2 focused checks, run the aggregate suite:
+
+```bash
+./.venv/bin/python -m pytest -q \
+  tests/test_pipeline_capture_status_routing.py \
+  tests/test_symbol_monitoring_fetch_spec_merge.py \
+  tests/test_opening_candidate_snapshot.py \
+  tests/test_combo_yield_candidate_snapshot.py \
+  tests/test_cc_lp_candidate_snapshot.py \
+  tests/test_position_advice_account_sources.py \
+  tests/test_position_advice_account_identity_reader.py \
+  tests/test_account_run.py \
+  tests/test_tick_account_execution_barrier.py \
+  tests/test_multi_account_tick.py \
+  tests/test_daily_decision_brief_service.py \
+  tests/test_daily_decision_brief_notification_flow.py \
+  tests/test_multi_tick_notify_format.py \
+  tests/test_unified_tick_entrypoint.py
+
+./.venv/bin/python -m compileall -q domain src scripts
+git diff --check
+```
+
+验证全部使用 tmp runtime、fake subprocess/provider 或 no-send path，不读写生产 runtime，
+不发送真实通知。
+
+## 7. Docs decision
+
+不修改用户文档：公开 CLI、配置、snapshot schema、通知文案和运维流程都未改变。
+本 work unit 的设计、审查、测试与 residual risk 记录在 Gateflow artifacts。
+
+## 8. Risks and residual-risk destinations
+
+| Risk | Decision / destination |
+|---|---|
+| scheduler 在失败后仍将 target 标记 processed，后续 10 分钟窗口不重试 | Deferred to a dedicated scheduler reliability work unit; this patch restores one bounded failure notification, not retry semantics. |
+| OpenD expiration lookup can still time out | Accepted operational failure; existing prefetch classification remains, now eligible for fixed-failure only when current-run identity is valid. |
+| early receipt consumes the prepared portfolio observation freshness window before full graph completion | Bounded by the existing 30-minute portfolio receipt max age; stale receipt fails closed. Do not refresh it silently within the same run. |
+| recovery starts without a previously published current-run portfolio receipt | The owner helper may publish once only from the immutable current-run prepared context; missing context or an incomplete/conflicting receipt directory stays fail closed/no-send. |
+| mixed SP+LC and CC+LP symbols | Covered by owner/variant partition tests; each snapshot sees only its own statuses and pairs. |
+| status stream contains duplicate, unknown, or out-of-plan scopes | Fail closed before the affected snapshot is sealed; never coerce to no-candidate. |
+| production service still runs a version containing the bug | Release and remote upgrade remain separately authorized operations after this PR. |
+
+Blocking open questions: none.
+
+## 9. Why this is not overdesigned
+
+候选侧只在已有封存边界加 owner-aware partition 和一个共享 reducer；身份侧只拆出
+已有 portfolio producer 并传递其 receipt reference。不新增 schema、state machine、service、queue、
+provider 或通知特例。
+
+## 10. Completion report format
+
+Final closeout 必须列出：
+
+- 两个 root cause 与实际修复边界；
+- 每个 slice 及 aggregate 的精确验证命令/结果；
+- plan/code/aggregate/PR review 的 finding 处置；
+- 所有 accepted Gateflow commit hashes 和 Draft PR URL；
+- 未解决的 scheduler retry、OpenD timeout 与 release/deployment 风险归属；
+- 明确说明未触碰、未暂存、未提交原有脏改动。

--- a/docs/gateflow/hk-combo-capture-failure-notification/pr-review.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/pr-review.md
@@ -1,0 +1,67 @@
+# Gateflow PR Review — HK capture and failure notification
+
+- Gate: `PR review`
+- Work unit: `hk-combo-capture-failure-notification`
+- Pull request: <https://github.com/liuxie066/options-monitor/pull/143>
+- PR base: `main@47887347cac7f72be76d050ee2f8f8b532b0978e`
+- Reviewed head: `45a7ecbb5afa18ef59d7948036163e6f9c551b90`
+- Review artifact: `docs/reviews/pr-143-review-20260810-123511.md`
+- Artifact path: `docs/gateflow/hk-combo-capture-failure-notification/pr-review.md`
+- Status: pass; no fix/re-review loop required
+
+## Decision
+
+- DeepReview conclusion: `未发现实质性问题`.
+- Accepted findings: none.
+- Rejected findings: none.
+- Findings needing more evidence: none.
+- Fix status: not applicable; the PR review produced no finding that requires a code change.
+- Blocking open questions: none.
+
+## Reviewed contract
+
+- Opening snapshots consume only `put` / `call` capture scopes.
+- SP+LC and CC+LP consume only their own `combo_yield` variant scopes and pair rows.
+- Per-symbol quote identity remains guarded across all snapshot owners.
+- The current-run portfolio source is published from already frozen prepared facts before prefetch and is reused byte-for-byte by the full source graph.
+- Malformed, stale, ambiguous, or conflicting source state fails with a typed account-scoped no-send outcome.
+- Existing Daily Brief authority, not a new policy bypass, decides whether an early operational failure may prepare `fixed_failure`.
+
+## Validation
+
+```text
+PR: #143, Draft, mergeable, 5 commits, 29 files
+Reviewed base/head: 47887347...45a7ecbb
+GitHub checks: 5 / 5 checks OK
+Latest-main detached integration head: d8380d02
+Aggregate tests: 265 passed, 4 existing warnings
+Ruff: pass
+compileall: pass
+git diff --check: pass
+```
+
+All validation used a detached `/tmp` worktree, temporary runtime, fake providers,
+or no-send paths. No production config/runtime/service, broker state, live
+notification, release, deployment, or remote upgrade was performed.
+
+## Docs decision
+
+No public command, schema, configuration, notification copy, or operator workflow
+changed. This PR review artifact and its DeepReview evidence are the only new docs
+for this gate. The unrelated dirty `docs/DEPENDENCY_GRAPH.md` remains untouched and
+unstaged.
+
+## Residual risks and destinations
+
+| Residual risk | Classification / destination |
+|---|---|
+| Scheduler target retry after failure | Assigned to later scheduler-reliability work unit |
+| OpenD expiration lookup timeout/retry | Assigned to later required-data/OpenD reliability work unit |
+| Long-run receipt freshness | Covered by existing 30-minute fail-closed validator; operational evidence owner |
+| Live delivery confirmation | Separate release/upgrade and natural-run verification authorization |
+
+No residual risk is unclassified.
+
+## Next entry point
+
+`accepted PR review commit` -> final push -> `draft-PR-pass` -> final closeout.

--- a/docs/gateflow/hk-combo-capture-failure-notification/s1-code-review.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/s1-code-review.md
@@ -1,0 +1,31 @@
+# Gateflow S1 Code Review — Owner-aware capture routing
+
+- Gate: `code review S1`
+- Work unit: `hk-combo-capture-failure-notification`
+- Review artifact: `docs/reviews/code-review-20260810-113743.md`
+- Decision: pass
+- Findings: none
+- Status: accepted; ready for accepted S1 commit
+
+## Reviewed chain
+
+`run_symbol_monitoring()` producer callbacks were traced through capture and pair
+collection, canonical owner routing, expected-scope completion, cross-owner quote
+binding and opening / SP+LC / CC+LP sealing. Tests exercise the actual default
+sealing function plus the two modified producer failure/terminal paths.
+
+## Validation evidence
+
+- Focused S1 suite: `52 passed`.
+- Broader pipeline regression suite: `129 passed`.
+- Ruff on all changed S1 Python files: pass.
+- `git diff --check`: pass.
+
+## Finding disposition
+
+No findings required a fix or re-review loop.
+
+## Next gate
+
+`accepted S1 commit`, staging only S1 production files, tests and Gateflow/review
+artifacts.

--- a/docs/gateflow/hk-combo-capture-failure-notification/s1-implementation.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/s1-implementation.md
@@ -1,0 +1,73 @@
+# Gateflow S1 Implementation — Owner-aware capture routing
+
+- Gate: `implementation S1`
+- Work unit: `hk-combo-capture-failure-notification`
+- Accepted plan commit: `6e0d8964`
+- Status: implementation complete; pending code review
+
+## Implemented scope
+
+- Canonicalized capture statuses at the snapshot-owning boundary and routed only
+  `put` / `call` to the opening snapshot, `combo_yield/variant=sp_lc` to the
+  Combo snapshot, and `combo_yield/variant=cc_lp` to the CC+LP snapshot.
+- Built expected scopes from the same resolved watchlist traversal used by the
+  pipeline, then applied unexpected, duplicate, missing, invalid-status and
+  quote-binding validation independently per owner.
+- Retained the per-symbol frozen quote identity invariant across owners before
+  reducing owner-local statuses.
+- Added a shared owner-local status reducer covering completed-empty,
+  unavailable, partial, market-closed and not-applicable outcomes.
+- Routed pairs independently by variant. Existing SP+LC rows without a variant
+  are treated as the sole legacy compatibility case; unknown explicit variants
+  fail closed.
+- Preserved the CC+LP producer's `not_applicable` status and reason instead of
+  overwriting it with `completed`; malformed CC+LP summary status/results become
+  a failed capture through the existing scan-failure path.
+- Added Combo capture evidence to `FrozenRequiredDataUnavailable`, including the
+  canonical variant and frozen quote binding.
+
+## Tests added or strengthened
+
+- The real `run_watchlist_pipeline_default()` sealing path now proves:
+  - opening + SP+LC snapshots are sealed independently;
+  - a legacy variant-less SP+LC pair survives routing;
+  - CC+LP `not_applicable` seals only the CC+LP snapshot;
+  - all-completed empty, all-failed, mixed, all-not-applicable and missing-scope
+    aggregates retain their distinct semantics;
+  - invalid modes/variants, unexpected scopes, duplicate scopes and invalid pair
+    variants fail before a terminal snapshot is written;
+  - cross-owner quote conflicts downgrade every completed owner for that symbol.
+- Symbol monitoring regressions prove CC+LP `not_applicable` survives the
+  producer callback and frozen required-data failure emits a Combo failed status
+  with `variant=sp_lc`.
+
+## Validation
+
+- `python3.12 -m pytest -q -p no:cacheprovider tests/test_pipeline_capture_status_routing.py tests/test_symbol_monitoring_fetch_spec_merge.py tests/test_opening_candidate_snapshot.py tests/test_combo_yield_candidate_snapshot.py tests/test_cc_lp_candidate_snapshot.py`: `52 passed`.
+- Broader pipeline regression command covering capture routing, watchlist,
+  runtime paths, context contracts, processor boundaries and snapshot tests:
+  `129 passed`.
+- `python -m py_compile` for both changed production modules: pass.
+- `git diff --check`: pass.
+
+The repository `.venv` does not contain `pytest`; validation therefore used the
+project's documented `python3.12 -m pytest -p no:cacheprovider` fallback.
+
+## Docs and safety decision
+
+- No public schema, CLI, config, notification wording or operator workflow
+  changed; only Gateflow artifacts are updated.
+- No runtime data, provider, broker, service, production config, notification,
+  release or deployment action was invoked.
+- Pre-existing unrelated dirty files remain untouched and unstaged.
+
+## Residual risks
+
+- S1 removes the 10:00 capture-routing crash but does not yet make 09:40-style
+  prefetch failures eligible for bounded fixed-failure delivery; that is S2.
+- Scheduler processed-target retry and OpenD timeout behavior remain explicitly
+  outside this work unit.
+
+## Next gate
+
+`code review S1` using DeepReview.

--- a/docs/gateflow/hk-combo-capture-failure-notification/s2-code-review.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/s2-code-review.md
@@ -1,0 +1,36 @@
+# Gateflow S2 Code Review — Early identity receipt and failure liveness
+
+- Gate: `code review S2`
+- Work unit: `hk-combo-capture-failure-notification`
+- Initial review: `docs/reviews/code-review-20260810-120101.md`
+- Fix artifact: `docs/gateflow/hk-combo-capture-failure-notification/s2-review-fix.md`
+- Re-review: `docs/reviews/code-review-20260810-120506.md`
+- Decision: pass after fix
+- Findings: one accepted high-severity finding, fixed; no remaining findings
+- Status: accepted; ready for accepted S2 commit
+
+## Reviewed chain
+
+The review followed frozen prepared portfolio/option authority through early
+portfolio receipt publication, deterministic reuse in the full source graph,
+fresh/recovery tick orchestration, barrier and pipeline failure outcomes,
+current-run identity reading, Daily Brief authority and no-send notification
+preparation.
+
+## Finding disposition
+
+- DR-S2-01: fixed. Invalid UTF-8 in an existing receipt or payload is translated
+  to the typed source-owner error instead of escaping the account boundary.
+
+## Validation evidence
+
+- Source-owner suite after the review fix: `18 passed`.
+- Complete focused S2 suite after the review fix: `180 passed`.
+- Ruff on all changed S2 Python files: pass.
+- Python compilation on all changed S2 Python files: pass.
+- `git diff --check`: pass.
+
+## Next gate
+
+`accepted S2 commit`, staging only S2 production files, tests and Gateflow/review
+artifacts.

--- a/docs/gateflow/hk-combo-capture-failure-notification/s2-implementation.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/s2-implementation.md
@@ -1,0 +1,93 @@
+# Gateflow S2 Implementation — Early identity receipt and failure liveness
+
+- Gate: `implementation S2`
+- Work unit: `hk-combo-capture-failure-notification`
+- Accepted S1 commit: `7241fe9a`
+- Status: implementation complete; pending code review
+
+## Implemented scope
+
+- Added one source-owner helper that locates the deterministic current-run
+  portfolio producer directory, publishes the existing receipt contract once, or
+  strictly validates and reuses the original payload and receipt bytes.
+- Reuse validates source kind, account, run, broker, markets, normalized source,
+  portfolio identity, producer policy, observation time, payload path, payload
+  content and hashes. Incomplete, ambiguous, stale, symlinked or conflicting
+  state fails closed and is never repaired by creating a second identity.
+- Routed the full Position Advice source graph through the same helper, so its
+  portfolio dependency preserves the first receipt path, snapshot id and
+  `completed_at`.
+- Added a narrow `account_run` facade that derives broker and markets from the
+  frozen account config and maps source-owner failures to the existing typed
+  account-config boundary.
+- Fresh tick execution now publishes the current-run portfolio receipt after
+  prepared portfolio and option authority validation, but before the shared
+  required-data provider barrier. A receipt conflict removes only that account
+  from prefetch and account execution.
+- Recovery validates and reloads the frozen current-run portfolio and option
+  manifests, then calls the same owner helper. It never refreshes broker data or
+  synthesizes identity from another run.
+- Pipeline-nonzero and terminal-barrier outcomes retain the early receipt, so the
+  existing Daily Brief authority can authorize only its bounded
+  `fixed_failure` path. Typed config/identity conflicts remain `should_notify`
+  false.
+
+## Tests added or strengthened
+
+- Source-owner tests prove current identity readability, exact-byte full-graph
+  reuse, a single deterministic content directory, and fail-closed behavior for
+  tampered, stale, wrong-run, wrong-account, wrong-market, context-drift and
+  incomplete-directory inputs.
+- Tick barrier tests read the real current-run identity inside the fake provider,
+  proving publication occurs before prefetch. They also cover terminal barrier
+  failure, account-scoped conflict before provider/account execution, and
+  recovery reuse without a second provider call or receipt rewrite.
+- The account runner pipeline-nonzero regression proves the receipt survives the
+  early return and the result remains notification-eligible.
+- Daily Brief service coverage now uses the owner helper instead of manually
+  invoking the low-level producer.
+- The integrated no-send regression runs the real Daily Brief assembler against
+  the owner receipt, observes `authority_identity_source=current_run_portfolio_receipt`,
+  selects `decision=fixed_failure`, records no provider call and persists no
+  delivery envelope.
+- Notification-flow authority fixtures now derive their test identity through
+  the canonical portfolio identity function instead of an unrelated test-only
+  hash shape.
+
+## Validation
+
+- Focused S2 suite covering all eight allowed S2 test modules plus
+  `tests/test_multi_account_tick.py`: `180 passed`.
+- The two direct owner-to-Daily-Brief chain regressions: `2 passed`.
+- Ruff over every changed S2 Python file: pass.
+- `python3.12 -m py_compile` over every changed S2 Python file: pass.
+- `git diff --check`: pass.
+
+After the initial S2 review, the suite count increased from 178 to 180 with
+invalid-UTF-8 and wrong-broker receipt conflicts.
+
+The repository `.venv` does not contain `pytest`; validation used
+`python3.12 -m pytest -p no:cacheprovider` with an isolated bytecode cache.
+
+## Docs and safety decision
+
+- No public schema, command, configuration, scheduler payload, notification
+  wording or authority policy changed. Gateflow and review artifacts are the only
+  docs in scope.
+- No broker refresh, live provider send, runtime write, service mutation,
+  release, deployment or remote operation was invoked.
+- Pre-existing unrelated dirty files remain untouched and unstaged, including
+  `docs/DEPENDENCY_GRAPH.md`.
+
+## Residual risks
+
+- The portfolio observation still uses the existing 30-minute freshness window;
+  unusually long runs fail closed rather than silently refreshing identity.
+- Scheduler processed-target retry and OpenD expiration timeout/retry remain
+  explicitly deferred to separate work units.
+- Production remains unchanged until separately authorized release and upgrade
+  stages.
+
+## Next gate
+
+`code review S2` using DeepReview.

--- a/docs/gateflow/hk-combo-capture-failure-notification/s2-review-fix.md
+++ b/docs/gateflow/hk-combo-capture-failure-notification/s2-review-fix.md
@@ -1,0 +1,30 @@
+# Gateflow S2 Review Fix — Typed corrupt-artifact failure
+
+- Gate: `fix S2`
+- Work unit: `hk-combo-capture-failure-notification`
+- Initial review: `docs/reviews/code-review-20260810-120101.md`
+- Status: fix complete; pending S2 re-review
+
+## Finding decision
+
+### DR-S2-01 — accepted — fixed
+
+The source-owner boundary decoded existing `receipt.json` and `payload.json`
+bytes, but its public exception translator did not include `UnicodeError`.
+Invalid UTF-8 could therefore escape `PositionAdviceAccountSourceError`, bypass
+the `account_run` typed mapping and terminate the multi-account tick instead of
+isolating the affected account.
+
+The owner helper now translates `UnicodeError` through the same
+`PositionAdviceAccountSourceError` boundary as malformed JSON, hash conflicts,
+stale data and filesystem errors. The source-owner conflict matrix now includes
+invalid UTF-8 and wrong-broker cases. The existing tick-level conflict regression
+proves any typed owner failure prevents prefetch and account execution and yields
+`should_notify=False`.
+
+## Validation target
+
+- Run the source-owner conflict matrix.
+- Re-run the complete S2 focused suite.
+- Re-run Ruff, Python compilation and `git diff --check`.
+- Perform a fresh DeepReview of the corrected S2 chain.

--- a/docs/reviews/code-review-20260810-113743.md
+++ b/docs/reviews/code-review-20260810-113743.md
@@ -1,0 +1,46 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes, Gateflow Slice S1
+- Branch or PR: `fix/hk-combo-capture-failure-notification`
+- Base: accepted plan commit `6e0d8964`
+- Output file: `docs/reviews/code-review-20260810-113743.md`
+- Included scope: owner-aware capture canonicalization, expected-scope derivation,
+  cross-owner quote binding, SP+LC / CC+LP pair routing and aggregate snapshot
+  sealing in `pipeline_watchlist`; frozen-data and CC+LP producer semantics in
+  `symbol_monitoring`; the S1 default-pipeline and producer regressions.
+- Excluded scope: S2 early portfolio receipt and fixed-failure liveness; scheduler
+  retry; OpenD timeout policy; production runtime/provider behavior; all
+  pre-existing unrelated dirty files and the already accepted plan artifacts.
+- Parallel review coverage: 无. The slice is one bounded producer-to-sealer call
+  chain and was reviewed end to end without subagents.
+
+## Findings
+
+未发现实质性问题。
+
+The review followed the real path from `run_symbol_monitoring()` capture and
+pair callbacks through `run_watchlist_pipeline_default()` normalization,
+owner-local scope completion, shared quote-binding guard and the three snapshot
+sealers. It also checked the variant configuration chain, frozen-data exception
+path, malformed/duplicate/unexpected inputs, partial-data reduction and
+write-before-failure ordering.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- S1 is proven with deterministic local pipeline/sealer tests, not a live OpenD
+  run; live service behavior remains a later release/upgrade verification step
+  requiring separate authorization.
+- A malformed pair that passes the routing contract but fails the downstream
+  snapshot schema can still fail after the opening snapshot has been sealed.
+  This write ordering predates S1 and account source publication remains blocked,
+  but same-run recovery of that malformed internal state is not covered here.
+- A Combo-only account configuration with no enabled Sell Put or Covered Call
+  remains outside this slice: `opening_candidate_snapshot.v1` requires at least
+  one opening strategy mode. S1 does not change that public schema or support
+  boundary.

--- a/docs/reviews/code-review-20260810-120101.md
+++ b/docs/reviews/code-review-20260810-120101.md
@@ -1,0 +1,70 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes, Gateflow Slice S2
+- Branch or PR: `fix/hk-combo-capture-failure-notification`
+- Base: accepted S1 commit `7241fe9a`
+- Output file: `docs/reviews/code-review-20260810-120101.md`
+- Included scope: current-run portfolio receipt publish/reuse ownership, full source
+  graph reuse, fresh and recovery tick ordering, account-scoped failure outcomes,
+  Daily Brief identity authority and no-send fixed-failure preparation, plus the
+  S2 regressions.
+- Excluded scope: accepted S1 files; scheduler retry; OpenD timeout policy;
+  production runtime/provider behavior; all pre-existing unrelated dirty files.
+- Parallel review coverage: 无. The owner-to-tick-to-notification chain was reviewed
+  end to end without subagents.
+
+## Findings
+
+### 1-未修复-高-非 UTF-8 receipt/payload 会逃出 typed account boundary 并中止整个 tick
+
+- **入口/函数**: `run_tick_account_execution()` ->
+  `publish_current_run_portfolio_source()` ->
+  `publish_or_reuse_account_portfolio_source()` ->
+  `_reuse_account_portfolio_source()`.
+- **文件(行号)**: `src/application/position_advice_account_sources.py:135-144,
+  188-190,232-234`; `src/application/account_run.py:249-263`;
+  `src/application/tick_account_execution.py:766-795`.
+- **输入场景**: deterministic current-run portfolio directory already exists,
+  but `receipt.json` or `payload.json` contains invalid UTF-8 bytes because of
+  corruption or an interrupted/external write.
+- **实际分支**: `.decode("utf-8")` raises `UnicodeDecodeError`; the public owner
+  helper catches `OSError`, `TypeError`, `ValueError`, JSON errors and
+  `PositionAdviceSourceError`, but not `UnicodeError`. The account facade only
+  translates `PositionAdviceAccountSourceError`, and the fresh tick loop only
+  catches `AccountRunConfigError`.
+- **预期行为**: every invalid or conflicting existing receipt/payload becomes
+  the typed `ACCOUNT_CONFIG_PORTFOLIO_SOURCE_INVALID` outcome for that account,
+  remains `should_notify=False`, and does not enter provider prefetch.
+- **实际行为**: the raw decode error can escape the account loop and abort the
+  whole multi-account tick, violating the accepted account-local fail-closed
+  contract and potentially suppressing unrelated accounts.
+- **直接证据**: both decode calls are outside any local decode-error handler;
+  `UnicodeDecodeError` is a `UnicodeError`, not a `ValueError`. Existing conflict
+  coverage mutates payload to valid UTF-8 JSON and therefore does not exercise
+  this path.
+- **影响**: a corrupt write-once artifact changes a bounded per-account authority
+  failure into a tick-wide exception, undermining the central S2 safety boundary.
+- **建议改法和验证点**: include `UnicodeError` in the owner helper's
+  exception translation and add an invalid-UTF-8 conflict regression. At the tick
+  level, assert zero prefetch/account/provider calls and a typed no-send outcome
+  for the affected account.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Filesystem publication uses the existing write-once receipt implementation;
+  simultaneous external mutation cannot be made transactional by this slice and
+  remains fail closed through stable-read/hash checks.
+- Fresh prepared-option authority is trusted from the in-process producer batch
+  and is revalidated at account execution; recovery performs an explicit frozen
+  manifest/payload reload. A hostile mutation between those boundaries remains
+  outside the normal same-host run model.
+- Production behavior still requires a separately authorized release and remote
+  upgrade; this review performed no live provider or runtime mutation.

--- a/docs/reviews/code-review-20260810-120506.md
+++ b/docs/reviews/code-review-20260810-120506.md
@@ -1,0 +1,46 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes, Gateflow Slice S2 re-review
+- Branch or PR: `fix/hk-combo-capture-failure-notification`
+- Base: accepted S1 commit `7241fe9a`
+- Output file: `docs/reviews/code-review-20260810-120506.md`
+- Included scope: the full S2 owner-to-tick-to-Daily-Brief chain and the fix for
+  DR-S2-01 in `docs/reviews/code-review-20260810-120101.md`.
+- Excluded scope: accepted S1 files; scheduler retry; OpenD timeout policy;
+  production runtime/provider behavior; all pre-existing unrelated dirty files.
+- Parallel review coverage: 无. The corrected bounded call chain was re-reviewed
+  end to end without subagents.
+
+## Findings
+
+未发现剩余实质性问题。
+
+The re-review traced first publication, exact-byte reuse, full source graph
+adoption, fresh tick ordering, recovery reload, typed account failure, terminal
+barrier and pipeline-nonzero outcomes, current-run identity reading, Daily Brief
+authority and no-send preparation. It also rechecked malformed bytes, malformed
+JSON, stale data, path/content ambiguity and account/run/broker/market/context
+conflicts.
+
+DR-S2-01 is fixed: `UnicodeError` is translated at the public source-owner
+boundary, so invalid UTF-8 now follows the same typed per-account no-send path as
+other receipt conflicts. The dedicated conflict test passes, and the existing
+tick-level conflict test proves typed source failures do not reach provider
+prefetch or account execution.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- The receipt intentionally consumes the prepared portfolio observation's
+  existing 30-minute freshness window. Long runs fail closed rather than refresh
+  or mint a second identity.
+- Scheduler processed-target retry and OpenD expiration timeout/retry remain
+  separate reliability work units.
+- The review used deterministic local/fake/no-send paths. No live notification,
+  broker, runtime, release, deployment or remote verification was authorized or
+  performed.

--- a/docs/reviews/code-review-20260810-120647.md
+++ b/docs/reviews/code-review-20260810-120647.md
@@ -1,0 +1,60 @@
+# Code Review
+
+## Scope
+
+- Mode: aggregate branch review
+- Branch or PR: `fix/hk-combo-capture-failure-notification`
+- Reviewed range: `0d635e11..aef308a0`
+- Output file: `docs/reviews/code-review-20260810-120647.md`
+- Included scope: accepted plan and both accepted implementation slices; Combo
+  capture producer-to-sealer routing; early current-run portfolio identity
+  publication/reuse; fresh/recovery tick orchestration; barrier/pipeline failure
+  outcomes; Daily Brief fixed-failure authority and no-send preparation; all
+  work-unit tests and artifacts.
+- Excluded scope: scheduler processed-target retry; OpenD expiration timeout and
+  retry policy; release/deployment/runtime changes; pre-existing unrelated dirty
+  files outside the committed range.
+- Parallel review coverage: 无. The two-slice integration is a single bounded
+  scheduler-to-notification path and was reviewed end to end without subagents.
+
+## Findings
+
+未发现剩余实质性问题。
+
+The aggregate review traced the 10:00 success path from Combo capture callbacks
+through independent opening/SP+LC/CC+LP snapshot sealing and then into the full
+Position Advice source graph, where the portfolio source revalidates and reuses
+the early write-once receipt. It separately traced the 09:40-style required-data
+barrier failure and pipeline-nonzero paths from the same early receipt through
+current-run identity reading, existing authority resolution and bounded
+`fixed_failure` selection.
+
+The combination preserves these boundaries:
+
+- owner routing does not mix `combo_yield` into the opening snapshot;
+- explicit unknown/duplicate/scope/variant/quote conflicts fail before the
+  affected terminal snapshot;
+- early identity is published only from frozen current-run inputs and is reused
+  without changing receipt bytes or `completed_at`;
+- corrupt/config/identity conflicts remain account-scoped, no-send and before
+  provider/account execution;
+- operational failures gain evidence only; they do not bypass or broaden Daily
+  Brief notification authority;
+- no-send preparation records `decision=fixed_failure` without provider attempt
+  or a persisted delivery envelope.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Scheduler processed-target semantics still do not provide an automatic retry
+  in the remaining target window after a failed attempt; that is deferred to a
+  scheduler reliability work unit.
+- OpenD expiration lookup can still time out; this work makes the resulting
+  bounded failure notification possible but does not change upstream retries.
+- Portfolio source freshness remains the existing 30-minute observation window;
+  a long-running or late recovery fails closed instead of refreshing identity.
+- Verification is deterministic and offline/no-send. Production remains on its
+  current version until separately authorized release and remote upgrade steps.

--- a/docs/reviews/plan-review-20260810-111309.md
+++ b/docs/reviews/plan-review-20260810-111309.md
@@ -1,0 +1,178 @@
+# Plan Review — HK Combo Capture / Failure Notification
+
+- Review target: `docs/gateflow/hk-combo-capture-failure-notification/plan.md`
+- Artifact path: `docs/reviews/plan-review-20260810-111309.md`
+- Binding goal: `docs/gateflow/hk-combo-capture-failure-notification/goal-confirmation.md`
+- Branch: `fix/hk-combo-capture-failure-notification`
+- Base: `main@0d635e11`
+- Review mode: adversarial pre-implementation review
+- Conclusion: `fail`
+
+## Scope reviewed
+
+- capture status ownership and strict scope validation;
+- SP+LC Combo / CC+LP pair and terminal-status partitioning;
+- quote-evidence consistency across snapshot owners;
+- current-run portfolio receipt publication, idempotency, recovery, and full-source reuse;
+- prefetch barrier / pipeline nonzero fixed-failure preparation evidence;
+- slice boundaries, dependency direction, and dirty-worktree constraints.
+
+## Assumptions tested
+
+1. Existing SP+LC and CC+LP pair rows both carry enough variant metadata for strict routing.
+2. Existing Combo capture statuses preserve the strategy result's terminal semantics.
+3. Owner isolation may safely replace the current cross-strategy quote-binding check.
+4. Passing an early receipt reference through `AccountRunRequest` is necessary and recovery-safe.
+5. The planned focused tests prove the binding success signal "can prepare fixed_failure", not only an intermediate `should_notify` value.
+6. The plan stays within the confirmed goal and does not require schema, notification-policy, scheduler, or deployment changes.
+
+## Findings
+
+### PR-01-未修复-高-SP+LC pair 缺少 variant，按计划严格分区会把正常候选全部丢掉
+- **位置**: Plan §2.2 "Pairs 也按 variant 分区" 与 Slice S1 Exact changes 3。
+- **问题类型**: 契约缺失 / 状态机漏洞 / 不可直接实施。
+- **当前写法**: SP+LC Combo snapshot 只接收 `variant=sp_lc` 的 pair，非法 variant
+  fail closed。
+- **反例/失败场景**: 现有 SP+LC producer 将 `recommended_pairs.to_dict("records")`
+  原样发给 sink；这些 row 没有 `variant`。按计划过滤后，status 可能是
+  completed，但所有真实 pair 被丢掉，snapshot 被误封为 `no_candidate`。
+- **为什么有问题**: 直接破坏已确认的默认 pipeline 候选封存目标，而且比
+  当前 crash 更难发现：运行成功但候选静默消失。
+- **直接证据**: `src/application/combo_yield_steps.py` 的 SP+LC 路径在 sink 处只做
+  `dict(item)`，不注入 variant；`run_cc_lp_variant()` 的 row 由 CC+LP domain 生成，明确包含
+  `variant="cc_lp"`。现有 `tests/test_combo_yield_steps.py` 也没有 SP+LC variant 契约断言。
+- **影响**: SP+LC Combo 真实候选丢失，Daily Brief/Agent 读到假 `no_candidate`。
+- **建议改法和验证点**: 在 capture boundary 明确兼容契约：对 pair 的
+  missing/empty variant 规范为 legacy canonical `sp_lc`，显式 `cc_lp` 路由到 CC+LP，其他显式
+  variant fail closed。增加使用现有 SP+LC pair shape（不带 variant）的 default-pipeline
+  回归，断言 pair 保留且 snapshot 为 `candidates_found`。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 高。
+
+### PR-02-未修复-高-CC+LP not_applicable 在产生端被改写为 completed，reducer 无法恢复真实状态
+- **位置**: Plan §2.2 aggregate status contract 和 Slice S1 Exact changes 5。
+- **问题类型**: 契约缺失 / 状态机漏洞 / 测试缺口。
+- **当前写法**: reducer 可将 all-not-applicable 归约为 `not_applicable`，但计划只要求
+  FrozenRequiredDataUnavailable 新增 Combo failed status，没有要求普通 Combo success path
+  保留 CC+LP summary status。
+- **反例/失败场景**: `variant=cc_lp` 且没有 stock context 时，
+  `run_cc_lp_variant()` 返回 `status=not_applicable, reason=stock_context_missing`。
+  `symbol_monitoring` 随后却无条件发布 `status=completed`，封存层只能看到 completed +
+  zero pairs，结果仍是错误的 `no_candidate`。
+- **为什么有问题**: reducer 不能从已丢失的上游事实恢复状态；这与 binding goal
+  要求 Combo/CC+LP failed/partial/no-candidate/not-applicable 保持区分直接冲突。
+- **直接证据**: `src/application/cc_lp_steps.py::summarize_cc_lp_result()` 输出 `status` /
+  `reason`；`src/application/symbol_monitoring.py` Combo branch 在调用后硬编码
+  `_publish_status(status="completed")` 和 `_report_capture(status="completed")`。
+- **影响**: CC+LP 无持仓场景被误报为“扫描成功但无候选”，快照和后续决策
+  失真。
+- **建议改法和验证点**: 在 `symbol_monitoring` 的 Combo branch 定义窄的
+  summary-to-capture mapping：`cc_lp.status=not_applicable` 必须发布 not_applicable +
+  reason；`candidates_found|no_candidate` 映射为 completed；未知 summary status fail closed；异常和
+  frozen required-data 继续 failed。添加产生端 capture 断言及 default-pipeline
+  `not_applicable` 封存断言。
+- **修复风险（低/中/高）**: 中。
+- **严重程度（低/中/高/严重）**: 高。
+
+### PR-03-未修复-中-按 owner 局部处理 quote binding 冲突会放宽现有跨策略证据一致性
+- **位置**: Slice S1 Exact changes 4。
+- **问题类型**: 架构边界 / 最佳实践偏离 / 状态一致性。
+- **当前写法**: 同一 symbol/owner 的 quote binding 冲突只降级该 owner，不“污染”其他
+  snapshot。
+- **反例/失败场景**: 同一 `0700.HK` 的 put status 绑定 receipt A，SP+LC status
+  绑定 receipt B。按 plan，每个 owner 内都只有一个 binding，两份 snapshot 都可封存为
+  成功，但它们对同一 run/symbol 宣称了不同的冻结行情事实。
+- **为什么有问题**: owner 状态应独立，但共享的 required-data/quote 身份不应独立。
+  这不是防止状态污染，而是在不察觉的情况下放宽已有 fail-closed 不变式。
+- **直接证据**: 现有 `pipeline_watchlist.py` 在所有 normalized statuses 上按 symbol
+  统计 quote binding，发现多个 binding 时将该 symbol 的 completed status 降级为
+  `incomplete/opening_quote_binding_conflict`。
+- **影响**: 不同策略快照可在同一 run 中消费不同 quote generation，损害决策可审计性。
+- **建议改法和验证点**: 先对全部已 canonicalize 的 status 保留现有
+  per-symbol cross-owner binding 检查；冲突时将该 symbol 所有 completed owner status 降级，
+  然后再分区归约。测试 put/combo 不同 receipt 时 opening 和 combo 都不得封为完整成功。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 中。
+
+### PR-04-未修复-中-将 receipt reference 穿透 AccountRunRequest 既冗余又没有收敛 recovery 定位契约
+- **位置**: Plan §2.3、§3 和 Slice S2 Exact changes 3–5。
+- **问题类型**: 过度耦合 / 非最优方案 / 并发恢复风险 / 不可直接实施。
+- **当前写法**: tick 层通过 account_run facade 发布 early receipt，把引用写入
+  `AccountRunRequest`；另外声明 recovery 只复用当前 run 已存 receipt，但没有指定
+  如何定位、验证并传入该引用。
+- **反例/失败场景**: `prefetch_done=True` 的 recovery 分支不执行新的 early-publish
+  block，也没有 plan 中的 receipt-reference map。若传 `None`，full publisher 按兼容规则
+  再发布，因新 `completed_at` 与 write-once receipt 冲突；若额外复制 identity reader
+  的 private locator，又引入两套唯一性规则。
+- **为什么有问题**: receipt 已有 deterministic
+  `position_advice_producers/portfolio/<run_key>/<payload_hash>/receipt.json` 归属于 source owner。
+  把路径跨 tick -> request -> account run 传递会扩大 orchestration contract，却没有解决重入时的
+  locate-or-publish 原子语义。
+- **直接证据**: `position_advice_source_producers._publish_json()` 的路径由 run key + payload hash
+  决定；`position_advice_account_identity_reader.read_current_run_portfolio_identity()` 已以当前 run key
+  定位且要求唯一 receipt。`AccountRunRequest` 目前无需知道任何 source receipt path。
+- **影响**: recovery 可因二次发布冲突，或新增冗余 locator/API 后形成长期耦合。
+- **建议改法和验证点**: 在 `position_advice_account_sources` 内实现单一
+  idempotent `publish_or_reuse_portfolio_source` owner：按 current run 定位唯一 existing receipt，
+  若存在则对当前 context/account/run/broker/markets/identity 做完整验证并返回；不存在才发布。
+  early tick 与 full source graph 调同一 helper，无需修改 `AccountRunRequest`。测试 first publish、
+  same-input replay、context drift、ambiguous receipt 和 recovery replay。
+- **修复风险（低/中/高）**: 中。
+- **严重程度（低/中/高/严重）**: 中。
+
+### PR-05-未修复-高-验证只证明中间 should_notify，没有证明新路径真正准备 fixed_failure
+- **位置**: Slice S2 Required assertions 和 §6 Validation matrix。
+- **问题类型**: 测试缺口 / 过度耦合。
+- **当前写法**: barrier test 要求保留 `should_notify` 并声称“下游可准备
+  `fixed_failure`”；`tests/test_multi_account_tick.py` 只在聚焦契约无法证明时才可选修改。
+- **反例/失败场景**: early receipt 已写入但 account state path/market/account/run 布局与
+  `daily_decision_brief_service` 读者不一致，或 receipt 被判 stale/ambiguous。tick outcome 仍然
+  `should_notify=True`，但 service 返回 `fixed_failure_delivery_allowed=False`，最终仍是
+  `decision=none`。
+- **为什么有问题**: 这正是 09:40 的实际失败面：中间调度决策存在，但
+  authority evidence 不完整导致没有 message preparation。只断言 outcome 会重复遗漏根因。
+- **直接证据**: `tests/test_daily_decision_brief_service.py` 已有“手工发布 receipt 则允许
+  fixed failure / 缺失则禁止”测试；该测试没有走拟实施的 early-publication owner。
+  `tests/test_daily_decision_brief_notification_flow.py` 也是手工组装 authority，不能证明新产物被消费。
+- **影响**: 实现可通过全部计划测试，但生产仍为 `message_count=0`。
+- **建议改法和验证点**: 把 `tests/test_daily_decision_brief_service.py` 和
+  `tests/test_daily_decision_brief_notification_flow.py` 纳入 S2 allowed/mandatory validation。至少新增一条串联回归：
+  调 early owner 在 canonical account state 发布 receipt -> 装配 blocked brief -> 断言
+  `fixed_failure_delivery_allowed=True` 且 token 引用同一 identity receipt；再把该 brief 交给
+  no-send notification preparation，断言 `decision=fixed_failure` 且无 provider call。另有 barrier/pipeline
+  测试必须证明它们实际调用了同一 early owner。
+- **修复风险（低/中/高）**: 中。
+- **严重程度（低/中/高/严重）**: 高。
+
+## Goal-bound minimal design review
+
+没有发现 schema、scheduler retry、OpenD timeout、notification policy 或 deployment 方面的 scope drift。
+PR-03 的 quote binding 一致性是保留现有安全不变式，PR-04 的 owner-local
+publish-or-reuse 是对现有方案的缩减，都属于 binding goal 的必要 correctness 条件。
+
+## Architecture / best-practice / optimal-solution review
+
+- Snapshot owner partition 是正确方向，但 status 与 pair 必须分别定义 compatibility
+  contract，不能假设它们已共享 variant schema。
+- Portfolio source receipt 的唯一性、定位、验证和 replay 应留在 source owner；缩减
+  `AccountRunRequest` 可避免 orchestration contract 泄漏。
+- 保留现有全局 quote-generation 不变式比“每 snapshot 自治”更符合冻结事实的
+  可审计性。
+
+## Open questions
+
+无。上述 finding 均可以用当前 source/test 契约收敛，不需要扩大用户授权。
+
+## Residual risks and tracking destination
+
+- scheduler processed-target/retry semantics: dedicated scheduler reliability work unit;
+- OpenD expiration timeout/retry: required-data/OpenD reliability work unit;
+- release and production upgrade: separate explicit user authorization after Draft PR;
+- current-run receipt freshness expiration during unusually long runs: existing fail-closed policy; monitor as
+  operations evidence unless a real over-30-minute run demonstrates need for a separate policy change.
+
+## Conclusion
+
+`fail` — plan 的整体边界正确，但 PR-01、PR-02 会直接导致候选/状态错误，
+PR-04 会使 recovery 契约不确定，PR-05 不足以证明用户可见成功信号。修订 plan
+并通过 adversarial re-review 前不应进入 implementation。

--- a/docs/reviews/plan-review-20260810-111928.md
+++ b/docs/reviews/plan-review-20260810-111928.md
@@ -1,0 +1,76 @@
+# Plan Re-review — HK Combo Capture / Failure Notification
+
+- Review target: `docs/gateflow/hk-combo-capture-failure-notification/plan.md`
+- Artifact path: `docs/reviews/plan-review-20260810-111928.md`
+- Binding goal: `docs/gateflow/hk-combo-capture-failure-notification/goal-confirmation.md`
+- Initial review: `docs/reviews/plan-review-20260810-111309.md`
+- Fix artifact: `docs/gateflow/hk-combo-capture-failure-notification/plan-review-fix.md`
+- Branch: `fix/hk-combo-capture-failure-notification`
+- Base: `main@0d635e11`
+- Review mode: adversarial re-review
+- Conclusion: `pass-with-risks`
+
+## Scope reviewed
+
+- all five initial findings and their plan amendments;
+- capture status and pair compatibility contracts;
+- quote evidence consistency across owners;
+- portfolio source idempotency, first publication, replay, incomplete publication, and recovery;
+- proof that the new artifact reaches Daily Brief fixed-failure preparation;
+- goal-bound scope, dependency direction, and dirty-worktree isolation.
+
+## Assumptions re-tested
+
+1. Legacy SP+LC pairs without `variant` remain valid and cannot be silently dropped.
+2. CC+LP `not_applicable` is observable at the producer boundary before aggregate reduction.
+3. Owner partition does not weaken the shared quote-generation invariant.
+4. One source-owner helper supports first publication, replay, full-graph reuse, and current-run recovery without request-layer leakage.
+5. Validation reaches no-send `fixed_failure` preparation rather than stopping at an intermediate scheduler outcome.
+6. No change requires a public schema, policy relaxation, scheduler retry change, production write, or edit to unrelated dirty files.
+
+## Initial finding disposition
+
+| Finding | Re-review result | Evidence in amended plan |
+|---|---|---|
+| PR-01 | fixed | §2.2 defines missing/empty pair variant as legacy `sp_lc`; explicit unknown variants fail closed; S1 tests the real variant-less pair shape. |
+| PR-02 | fixed | §2.2 and S1 preserve CC+LP `not_applicable` and its reason before the reducer. |
+| PR-03 | fixed | Quote binding is checked per symbol across all canonical statuses before owner partition. |
+| PR-04 | fixed | Receipt data no longer crosses `AccountRunRequest`; one deterministic source-owner helper owns locate/publish/validate/reuse, including recovery from immutable current-run context. |
+| PR-05 | fixed | Daily Brief service and notification-flow tests must consume the early-owner receipt and assert no-send `decision=fixed_failure`. |
+
+## Adversarial lens results
+
+### Goal-bound minimal design
+
+Every production change maps directly to a confirmed success signal. Scheduler retry, OpenD timeout, service exit status, notification wording, release, and deployment remain deferred. No goal drift found.
+
+### Architecture and overcoupling
+
+The plan preserves `tick_account_execution -> account_run -> position_advice_account_sources`. The source owner, not the request DTO, owns receipt storage and replay. No new schema, state machine, service, or cross-layer receipt protocol is proposed.
+
+### State, idempotency, and recovery
+
+The plan distinguishes missing run directory (publish from validated current-run context), one complete matching receipt (reuse exact bytes), and incomplete/ambiguous/conflicting content (fail closed). This prevents a second `completed_at` conflict and avoids replacing partial identity state.
+
+### Validation
+
+The matrix covers the real default pipeline, legacy pair compatibility, CC+LP producer semantics, unknown and duplicate scopes, cross-owner quote conflicts, early publish/replay/context drift, both early failure points, Daily Brief authority consumption, and no-send notification preparation. Tests remain local and invoke no real provider.
+
+## Findings
+
+No remaining material plan findings.
+
+## Open questions
+
+None.
+
+## Residual risks and tracking destination
+
+- Scheduler processed-target/retry behavior remains a separate scheduler reliability work unit.
+- OpenD expiration lookup timeout/retry remains a separate required-data/OpenD reliability work unit.
+- A current-run prepared portfolio observation may become stale during an unusually long run; the existing freshness validator must continue to fail closed.
+- Production remains affected until a separately authorized release and remote upgrade occur.
+
+## Conclusion
+
+`pass-with-risks` — the amended plan is code-generation-ready, preserves existing safety boundaries, and directly proves the two confirmed user-visible outcomes. Residual risks are explicitly deferred and do not block local implementation.

--- a/docs/reviews/pr-143-review-20260810-123511.md
+++ b/docs/reviews/pr-143-review-20260810-123511.md
@@ -1,0 +1,48 @@
+# Code Review
+
+## Scope
+
+- Mode: PR
+- Branch or PR: `liuxie066/options-monitor#143` — `fix: restore HK combo capture and failure notifications`
+- Author: `liuxie066`
+- Head: `fix/hk-combo-capture-failure-notification@45a7ecbb5afa18ef59d7948036163e6f9c551b90`
+- Base: `main@47887347cac7f72be76d050ee2f8f8b532b0978e`
+- URL: <https://github.com/liuxie066/options-monitor/pull/143>
+- Output file: `docs/reviews/pr-143-review-20260810-123511.md`
+- Included scope: all 29 PR files; capture-status owner/variant routing; Combo Yield and CC+LP status production and snapshot sealing; early current-run portfolio receipt publication and exact-byte reuse; fresh and recovery tick paths; account-scoped failure handling; Daily Brief fixed-failure authority; focused tests and Gateflow artifacts.
+- Excluded scope: unrelated dirty service-credential/deploy/drift/secret-store work; scheduler processed-target retry; OpenD timeout/retry policy; release, deployment, remote runtime, and live notification behavior.
+- Parallel review coverage: 无；the PR was reviewed as one end-to-end capture and notification-authority state machine.
+
+## Findings
+
+未发现实质性问题。
+
+The review followed both real entry paths:
+
+1. `run_symbol_monitoring()` produces opening or Combo capture facts, then `run_watchlist_pipeline_default()` normalizes, partitions, validates, applies the cross-owner quote-binding guard, and seals only the owning opening, SP+LC, or CC+LP snapshot.
+2. `run_tick_account_execution()` freezes and validates account/prepared context, calls `publish_current_run_portfolio_source()` before required-data prefetch, and later lets `publish_account_run_sources()` strictly reuse the same write-once receipt. Barrier and pipeline failures can therefore use existing Daily Brief fixed-failure authority without relaxing identity checks.
+
+Adversarial checks found that unknown modes/variants/scopes, duplicates, quote-binding conflicts, malformed or stale receipts, identity/input drift, incomplete run directories, invalid recovery artifacts, and receipt conflicts all continue to fail closed. Conflict accounts are removed before provider prefetch and account execution, and no fallback constructs notification authority from unverified input.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Scheduler processed-target retry after an operational failure is assigned to a later scheduler-reliability work unit; it is not changed by PR #143.
+- OpenD expiration lookup timeout/retry is assigned to a later required-data/OpenD reliability work unit; this PR only restores authorized failure reporting when that boundary fails.
+- Current-run portfolio receipt freshness remains governed by the existing 30-minute fail-closed validator. Unusually long runs require operational evidence rather than a weakened freshness rule.
+- Local and CI validation do not prove live provider delivery. Release, remote upgrade, and natural-run `provider attempt -> delivery_confirmed` evidence remain separately authorized operational work.
+
+## Validation
+
+- GitHub PR facts: mergeable Draft PR, 5 commits, 29 files; base/head match the hashes recorded above.
+- GitHub checks on reviewed head: `5 / 5 checks OK`.
+- Latest-main integration: replayed the five PR commits without conflict on `main@47887347`; detached integration head `d8380d02`.
+- Aggregate suite on the detached integration head: `265 passed, 4 warnings in 7.48s`.
+- The four warnings are existing legacy Tick renderer deprecations.
+- Ruff on all changed production/test Python files: pass.
+- `python3.12 -m compileall -q domain src scripts`: pass.
+- `git diff --check origin/main...HEAD`: pass.
+- Main drift since the prior readiness check touched release metadata, dependency graph, channel status, and unrelated tests only; it did not overlap this PR's production/test paths.

--- a/src/application/account_run.py
+++ b/src/application/account_run.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from time import monotonic
 from typing import Any, Callable
@@ -25,7 +26,9 @@ from src.application.config_sections import (
 from src.application.config_loader import resolve_data_config_path
 from src.application.close_advice_runner import run_close_advice
 from src.application.position_advice_account_sources import (
+    PositionAdviceAccountSourceError,
     publish_account_position_advice_sources,
+    publish_or_reuse_account_portfolio_source,
 )
 from src.application.position_advice_runner import (
     run_position_advice_v2_from_account_run,
@@ -47,6 +50,7 @@ from src.application.multi_tick.misc import (
 )
 from src.application.tick_run_workspace import (
     AccountRunConfigAuthority,
+    AccountRunConfigError,
     load_account_run_config,
     load_retained_account_run_config,
 )
@@ -223,6 +227,40 @@ def _position_advice_markets(
         }
     )
     return inferred or ["HK", "US"]
+
+
+def publish_current_run_portfolio_source(
+    *,
+    cfg: dict[str, Any],
+    account_run_id: str,
+    account: str,
+    markets_to_run: list[str],
+    account_state_dir: Path,
+    prepared_portfolio_context: dict[str, Any],
+    completed_at: datetime | str | None = None,
+) -> dict[str, Any]:
+    """Publish/reuse the current-run identity receipt from frozen inputs only."""
+
+    portfolio_cfg = (
+        cfg.get("portfolio")
+        if isinstance(cfg.get("portfolio"), dict)
+        else {}
+    )
+    try:
+        return publish_or_reuse_account_portfolio_source(
+            account_run_id=account_run_id,
+            normalized_account=str(account).strip().lower(),
+            broker=str(portfolio_cfg.get("broker") or "futu"),
+            included_markets=_position_advice_markets(cfg, markets_to_run),
+            account_state_dir=account_state_dir,
+            portfolio_context=prepared_portfolio_context,
+            completed_at=completed_at,
+        )
+    except PositionAdviceAccountSourceError as exc:
+        raise AccountRunConfigError(
+            "ACCOUNT_CONFIG_PORTFOLIO_SOURCE_INVALID",
+            str(exc),
+        ) from exc
 
 
 def build_account_runtime_config(

--- a/src/application/pipeline_watchlist.py
+++ b/src/application/pipeline_watchlist.py
@@ -60,6 +60,10 @@ LIQUIDITY_COMMON_FIELDS = (
     'max_spread_ratio',
 )
 DEFAULT_PIPELINE_SYMBOL_MAX_WORKERS = 4
+_CAPTURE_STATUSES = frozenset(
+    {"completed", "not_applicable", "failed", "incomplete", "unavailable"}
+)
+_COMBO_CAPTURE_VARIANTS = frozenset({"sp_lc", "cc_lp"})
 
 
 class SymbolProcessingTimeout(TimeoutError):
@@ -138,6 +142,192 @@ def _parse_symbols_whitelist(symbols_arg: str | None) -> set[str] | None:
         return None
     items = {normalize_symbol_read(s) for s in str(symbols_arg).split(',') if str(s).strip()}
     return items or None
+
+
+def _normalize_candidate_capture_status(
+    raw: dict[str, Any],
+) -> dict[str, Any]:
+    symbol = normalize_symbol_read(raw.get("symbol"))
+    if not symbol:
+        raise ValueError("candidate capture status symbol is missing")
+    mode = str(raw.get("strategy_mode") or "").strip().lower()
+    status = str(raw.get("status") or "").strip().lower()
+    if status not in _CAPTURE_STATUSES:
+        raise ValueError(
+            f"invalid candidate capture status: {symbol}:{mode or 'missing'}:{status or 'missing'}"
+        )
+    variant = str(raw.get("variant") or "").strip().lower()
+    if mode in {"put", "call"}:
+        if variant:
+            raise ValueError(
+                f"unexpected opening scan variant: {symbol}:{mode}:{variant}"
+            )
+        owner = "opening"
+        variant_value: str | None = None
+    elif mode == "combo_yield":
+        if variant not in _COMBO_CAPTURE_VARIANTS:
+            raise ValueError(
+                f"invalid combo yield scan variant: {symbol}:{variant or 'missing'}"
+            )
+        owner = variant
+        variant_value = variant
+    else:
+        raise ValueError(
+            f"unexpected candidate capture mode: {symbol}:{mode or 'missing'}"
+        )
+    return {
+        "symbol": symbol,
+        "strategy_mode": mode,
+        "status": status,
+        "reason": str(raw.get("reason") or "").strip(),
+        "quote_snapshot_id": (
+            str(raw.get("quote_snapshot_id") or "").strip() or None
+        ),
+        "quote_receipt_relpath": (
+            str(raw.get("quote_receipt_relpath") or "").strip() or None
+        ),
+        "variant": variant_value,
+        "owner": owner,
+    }
+
+
+def _capture_scope_error_label(owner: str) -> str:
+    return {
+        "opening": "opening",
+        "sp_lc": "combo yield",
+        "cc_lp": "cc_lp",
+    }[owner]
+
+
+def _complete_capture_owner_statuses(
+    *,
+    owner: str,
+    statuses: list[dict[str, Any]],
+    expected_scopes: set[tuple[str, str]],
+) -> list[dict[str, Any]]:
+    by_scope: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for item in statuses:
+        key = (str(item["symbol"]), str(item["strategy_mode"]))
+        by_scope.setdefault(key, []).append(item)
+    unexpected_scopes = set(by_scope) - expected_scopes
+    if unexpected_scopes:
+        unexpected = ", ".join(
+            f"{symbol}:{mode}" for symbol, mode in sorted(unexpected_scopes)
+        )
+        raise ValueError(
+            f"unexpected {_capture_scope_error_label(owner)} scan scopes: {unexpected}"
+        )
+    completed = list(statuses)
+    for symbol, mode in sorted(expected_scopes):
+        items = by_scope.get((symbol, mode), [])
+        if not items:
+            completed.append(
+                {
+                    "symbol": symbol,
+                    "strategy_mode": mode,
+                    "status": "incomplete",
+                    "reason": f"{owner}_scan_status_missing",
+                    "quote_snapshot_id": None,
+                    "quote_receipt_relpath": None,
+                    "variant": None if owner == "opening" else owner,
+                    "owner": owner,
+                }
+            )
+            continue
+        if len(items) != 1:
+            raise ValueError(
+                f"duplicate {_capture_scope_error_label(owner)} scan scope: {symbol}:{mode}"
+            )
+        item = items[0]
+        if item["status"] == "completed" and (
+            not item["quote_snapshot_id"]
+            or not item["quote_receipt_relpath"]
+        ):
+            item["status"] = "incomplete"
+            item["reason"] = f"{owner}_quote_binding_missing"
+    return sorted(
+        completed,
+        key=lambda item: (
+            str(item["symbol"]),
+            str(item["strategy_mode"]),
+        ),
+    )
+
+
+def _apply_capture_quote_binding_guard(
+    statuses_by_owner: dict[str, list[dict[str, Any]]],
+) -> None:
+    quote_bindings_by_symbol: dict[str, set[tuple[str, str]]] = {}
+    for statuses in statuses_by_owner.values():
+        for item in statuses:
+            if item["quote_snapshot_id"] and item["quote_receipt_relpath"]:
+                quote_bindings_by_symbol.setdefault(
+                    str(item["symbol"]),
+                    set(),
+                ).add(
+                    (
+                        str(item["quote_snapshot_id"]),
+                        str(item["quote_receipt_relpath"]),
+                    )
+                )
+    conflict_symbols = {
+        symbol
+        for symbol, bindings in quote_bindings_by_symbol.items()
+        if len(bindings) != 1
+    }
+    for owner, statuses in statuses_by_owner.items():
+        for item in statuses:
+            if (
+                item["symbol"] in conflict_symbols
+                and item["status"] == "completed"
+            ):
+                item["status"] = "incomplete"
+                item["reason"] = f"{owner}_quote_binding_conflict"
+
+
+def _yield_snapshot_status(
+    statuses: list[dict[str, Any]],
+) -> str | None:
+    if not statuses:
+        raise ValueError("yield enhancement capture statuses are missing")
+    observed = [
+        item for item in statuses if item["status"] != "not_applicable"
+    ]
+    if observed and all(item["reason"] == "market_closed" for item in observed):
+        return "market_closed"
+    states = {str(item["status"]) for item in statuses}
+    if states == {"completed"}:
+        return None
+    if states == {"not_applicable"}:
+        return "not_applicable"
+    if "completed" in states:
+        return "partial_data"
+    return "data_unavailable"
+
+
+def _partition_combo_pairs(
+    rows: list[dict[str, Any]],
+    *,
+    expected_scopes_by_owner: dict[str, set[tuple[str, str]]],
+) -> dict[str, list[dict[str, Any]]]:
+    out: dict[str, list[dict[str, Any]]] = {"sp_lc": [], "cc_lp": []}
+    for raw in rows:
+        item = dict(raw)
+        explicit_variant = str(item.get("variant") or "").strip().lower()
+        variant = explicit_variant or "sp_lc"
+        if variant not in _COMBO_CAPTURE_VARIANTS:
+            raise ValueError(
+                f"invalid combo yield pair variant: {variant}"
+            )
+        symbol = normalize_symbol_read(item.get("symbol"))
+        if not symbol:
+            raise ValueError("combo yield pair symbol is missing")
+        if (symbol, "combo_yield") not in expected_scopes_by_owner[variant]:
+            raise ValueError(
+                f"unexpected {_capture_scope_error_label(variant)} pair scope: {symbol}:combo_yield"
+            )
+        out[variant].append(item)
+    return out
 
 
 def _iter_watchlist(cfg: dict) -> Iterable[dict]:
@@ -716,7 +906,11 @@ def run_watchlist_pipeline_default(
 
     captured_at = datetime.now(timezone.utc)
     profiles = resolve_templates_config(cfg)
-    expected_scopes: set[tuple[str, str]] = set()
+    expected_scopes_by_owner: dict[str, set[tuple[str, str]]] = {
+        "opening": set(),
+        "sp_lc": set(),
+        "cc_lp": set(),
+    }
     for raw_item in _iter_watchlist(cfg):
         symbol = normalize_symbol_read(raw_item.get("symbol"))
         if not symbol or (whitelist is not None and symbol not in whitelist):
@@ -730,84 +924,44 @@ def run_watchlist_pipeline_default(
         except Exception:
             continue
         if bool((resolved_item.get("sell_put") or {}).get("enabled", False)):
-            expected_scopes.add((symbol, "put"))
+            expected_scopes_by_owner["opening"].add((symbol, "put"))
         if bool((resolved_item.get("sell_call") or {}).get("enabled", False)):
-            expected_scopes.add((symbol, "call"))
-
-    normalized_statuses = [
-        {
-            "symbol": normalize_symbol_read(item.get("symbol")),
-            "strategy_mode": str(item.get("strategy_mode") or "").strip(),
-            "status": str(item.get("status") or "").strip(),
-            "reason": str(item.get("reason") or "").strip(),
-            "quote_snapshot_id": (
-                str(item.get("quote_snapshot_id") or "").strip() or None
-            ),
-            "quote_receipt_relpath": (
-                str(item.get("quote_receipt_relpath") or "").strip() or None
-            ),
-        }
-        for item in capture_statuses
-    ]
-    statuses_by_scope: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    for item in normalized_statuses:
-        key = (str(item["symbol"]), str(item["strategy_mode"]))
-        statuses_by_scope.setdefault(key, []).append(item)
-    unexpected_scopes = set(statuses_by_scope) - expected_scopes
-    if unexpected_scopes:
-        unexpected = ", ".join(
-            f"{symbol}:{mode}" for symbol, mode in sorted(unexpected_scopes)
+            expected_scopes_by_owner["opening"].add((symbol, "call"))
+        yield_policy = derive_yield_enhancement_policy(
+            resolve_yield_enhancement_cfg(resolved_item)
         )
-        raise ValueError(f"unexpected opening scan scopes: {unexpected}")
-    for symbol, mode in sorted(expected_scopes):
-        items = statuses_by_scope.get((symbol, mode), [])
-        if not items:
-            normalized_statuses.append(
-                {
-                    "symbol": symbol,
-                    "strategy_mode": mode,
-                    "status": "incomplete",
-                    "reason": "opening_scan_status_missing",
-                    "quote_snapshot_id": None,
-                    "quote_receipt_relpath": None,
-                }
-            )
-            continue
-        if len(items) != 1:
-            raise ValueError(f"duplicate opening scan scope: {symbol}:{mode}")
-        item = items[0]
-        if item["status"] == "completed" and (
-            not item["quote_snapshot_id"] or not item["quote_receipt_relpath"]
-        ):
-            item["status"] = "incomplete"
-            item["reason"] = "opening_quote_binding_missing"
-    quote_bindings_by_symbol: dict[str, set[tuple[str, str]]] = {}
-    for item in normalized_statuses:
-        if item["quote_snapshot_id"] and item["quote_receipt_relpath"]:
-            quote_bindings_by_symbol.setdefault(
-                str(item["symbol"]),
-                set(),
-            ).add(
-                (
-                    str(item["quote_snapshot_id"]),
-                    str(item["quote_receipt_relpath"]),
+        if yield_policy.enabled:
+            variant = str(
+                (yield_policy.config or {}).get("variant") or "sp_lc"
+            ).strip().lower()
+            if variant not in _COMBO_CAPTURE_VARIANTS:
+                raise ValueError(
+                    f"invalid configured combo yield variant: {symbol}:{variant or 'missing'}"
                 )
+            expected_scopes_by_owner[variant].add(
+                (symbol, "combo_yield")
             )
-    quote_binding_conflict_symbols = {
-        symbol
-        for symbol, bindings in quote_bindings_by_symbol.items()
-        if len(bindings) != 1
+
+    statuses_by_owner: dict[str, list[dict[str, Any]]] = {
+        "opening": [],
+        "sp_lc": [],
+        "cc_lp": [],
     }
-    for item in normalized_statuses:
-        if (
-            item["symbol"] in quote_binding_conflict_symbols
-            and item["status"] == "completed"
-        ):
-            item["status"] = "incomplete"
-            item["reason"] = "opening_quote_binding_conflict"
-    normalized_statuses.sort(
-        key=lambda item: (str(item["symbol"]), str(item["strategy_mode"]))
+    for raw_status in capture_statuses:
+        item = _normalize_candidate_capture_status(raw_status)
+        statuses_by_owner[str(item["owner"])].append(item)
+    for owner in ("opening", "sp_lc", "cc_lp"):
+        statuses_by_owner[owner] = _complete_capture_owner_statuses(
+            owner=owner,
+            statuses=statuses_by_owner[owner],
+            expected_scopes=expected_scopes_by_owner[owner],
+        )
+    _apply_capture_quote_binding_guard(statuses_by_owner)
+    combo_pairs_by_owner = _partition_combo_pairs(
+        captured_combo_pairs,
+        expected_scopes_by_owner=expected_scopes_by_owner,
     )
+    normalized_statuses = statuses_by_owner["opening"]
     account = str(
         ((cfg.get("portfolio") or {}).get("account"))
         if isinstance(cfg.get("portfolio"), dict)
@@ -885,29 +1039,9 @@ def run_watchlist_pipeline_default(
         candidate_evaluations=captured_candidate_decisions,
         sealed_at=captured_at,
     )
-    combo_statuses = [
-        item
-        for item in capture_statuses
-        if str(item.get("strategy_mode") or "") == "combo_yield"
-    ]
-    if combo_statuses:
-        combo_completed = any(
-            str(item.get("status") or "") == "completed"
-            for item in combo_statuses
-        )
-        combo_failed = any(
-            str(item.get("status") or "") == "failed"
-            for item in combo_statuses
-        )
-        combo_opening_status: str | None = None
-        if combo_completed and not combo_failed:
-            combo_opening_status = None  # derived from pairs
-        elif combo_failed and not combo_completed:
-            combo_opening_status = "data_unavailable"
-        else:
-            combo_opening_status = "partial_data"
+    if expected_scopes_by_owner["sp_lc"]:
         ranked_combo_pairs = select_best_yield_enhancement_per_symbol(
-            captured_combo_pairs
+            combo_pairs_by_owner["sp_lc"]
         )
         seal_combo_yield_candidate_snapshot(
             base=base,
@@ -917,30 +1051,12 @@ def run_watchlist_pipeline_default(
             account_config_sha256=str(account_config_sha256 or ""),
             strategy_policy_sha256=strategy_policy_hash(cfg),
             ranked_pairs=ranked_combo_pairs,
-            opening_status=combo_opening_status,
+            opening_status=_yield_snapshot_status(
+                statuses_by_owner["sp_lc"]
+            ),
             sealed_at=captured_at,
         )
-    cc_lp_statuses = [
-        item
-        for item in capture_statuses
-        if str(item.get("variant") or "").strip().lower() == "cc_lp"
-    ]
-    if cc_lp_statuses:
-        cc_lp_pairs = [
-            dict(item)
-            for item in captured_combo_pairs
-            if str(item.get("variant") or "").strip().lower() == "cc_lp"
-        ]
-        cc_lp_status: str | None = None
-        if not cc_lp_pairs:
-            cc_lp_status = (
-                "not_applicable"
-                if any(
-                    str(item.get("status") or "") == "not_applicable"
-                    for item in cc_lp_statuses
-                )
-                else "no_candidate"
-            )
+    if expected_scopes_by_owner["cc_lp"]:
         seal_cc_lp_candidate_snapshot(
             base=base,
             run_id=account_run_id,
@@ -948,8 +1064,10 @@ def run_watchlist_pipeline_default(
             market=str(authority.get("market") or ""),
             account_config_sha256=str(account_config_sha256 or ""),
             strategy_policy_sha256=strategy_policy_hash(cfg),
-            ranked_pairs=cc_lp_pairs,
-            opening_status=cc_lp_status,
+            ranked_pairs=combo_pairs_by_owner["cc_lp"],
+            opening_status=_yield_snapshot_status(
+                statuses_by_owner["cc_lp"]
+            ),
             sealed_at=captured_at,
         )
     return result

--- a/src/application/position_advice_account_sources.py
+++ b/src/application/position_advice_account_sources.py
@@ -6,6 +6,7 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping
 
+from domain.domain.decision_state_fingerprint import canonical_sha256
 from domain.domain.position_advice_authority import (
     capacity_pool_authority_id,
     normalize_account_label,
@@ -18,6 +19,7 @@ from src.application.ledger.api import (
     open_position_ledger,
 )
 from src.application.position_advice_source_producers import (
+    PORTFOLIO_SOURCE_SCHEMA,
     publish_opening_candidate_snapshot_receipt,
     publish_cash_capacity_snapshot,
     publish_fx_source_snapshot,
@@ -27,8 +29,10 @@ from src.application.position_advice_source_producers import (
 )
 from src.application.position_advice_source_receipts import (
     PositionAdviceSourceError,
+    safe_existing_relative_path,
     sha256_bytes,
     source_dependency_from_receipt,
+    validate_source_receipt,
 )
 from src.application.opening_candidate_snapshot import (
     OpeningCandidateSnapshotError,
@@ -41,6 +45,212 @@ CASH_SCOPE_SEMANTICS_VERSION = "uncommitted_headroom.v1"
 
 class PositionAdviceAccountSourceError(RuntimeError):
     """Raised when one Account Run cannot publish coherent v2 source receipts."""
+
+
+def publish_or_reuse_account_portfolio_source(
+    *,
+    account_run_id: str,
+    normalized_account: str,
+    broker: str,
+    included_markets: Iterable[str],
+    account_state_dir: Path,
+    portfolio_context: Mapping[str, Any],
+    completed_at: datetime | str | None = None,
+) -> dict[str, Any]:
+    """Publish one current-run portfolio receipt or reuse its exact bytes.
+
+    The deterministic run directory is a write-once identity boundary.  Once it
+    exists, incomplete, ambiguous, or input-conflicting contents fail closed;
+    this helper never repairs the directory by publishing a second identity.
+    """
+
+    try:
+        account = normalize_account_label(normalized_account)
+        run_id = _required_text(account_run_id, "account_run_id")
+        broker_value = _required_text(broker, "broker")
+        markets = _markets(included_markets)
+        state_root = _existing_directory(account_state_dir, "account_state_dir")
+        context = dict(portfolio_context or {})
+        portfolio_source = normalize_portfolio_source(
+            context.get("portfolio_source_name")
+        )
+        account_identifiers = _identity_values(
+            context.get("source_account_identifiers")
+        )
+        identity_hash = portfolio_account_identity_hash(
+            normalized_portfolio_source=portfolio_source,
+            broker_account_identifiers=account_identifiers,
+        )
+        payload = {
+            "schema_version": PORTFOLIO_SOURCE_SCHEMA,
+            "normalized_portfolio_source": portfolio_source,
+            "portfolio_context": context,
+        }
+        payload_hash = canonical_sha256(payload)
+        run_key = canonical_sha256({"producer_run_id": run_id})
+        run_dir = (
+            state_root
+            / "position_advice_producers"
+            / "portfolio"
+            / run_key
+        )
+        validation_now = completed_at or datetime.now(timezone.utc)
+
+        if not run_dir.exists():
+            publish_portfolio_source_snapshot(
+                producer_root=state_root,
+                account_run_id=run_id,
+                account=account,
+                broker=broker_value,
+                normalized_portfolio_source=portfolio_source,
+                portfolio_account_identity_hash=identity_hash,
+                included_markets=markets,
+                portfolio_context=context,
+                completed_at=validation_now,
+            )
+
+        record = _reuse_account_portfolio_source(
+            state_root=state_root,
+            run_dir=run_dir,
+            payload_hash=payload_hash,
+            expected_payload=payload,
+            account=account,
+            run_id=run_id,
+            broker=broker_value,
+            markets=markets,
+            portfolio_source=portfolio_source,
+            identity_hash=identity_hash,
+            now=validation_now,
+        )
+        return {
+            **record,
+            "account_run_id": run_id,
+            "account": account,
+            "broker": broker_value,
+            "included_markets": markets,
+            "normalized_portfolio_source": portfolio_source,
+            "source_account_identifiers": account_identifiers,
+            "portfolio_account_identity_hash": identity_hash,
+        }
+    except PositionAdviceAccountSourceError:
+        raise
+    except (
+        OSError,
+        TypeError,
+        UnicodeError,
+        ValueError,
+        json.JSONDecodeError,
+        PositionAdviceSourceError,
+    ) as exc:
+        raise PositionAdviceAccountSourceError(str(exc)) from exc
+
+
+def _reuse_account_portfolio_source(
+    *,
+    state_root: Path,
+    run_dir: Path,
+    payload_hash: str,
+    expected_payload: Mapping[str, Any],
+    account: str,
+    run_id: str,
+    broker: str,
+    markets: list[str],
+    portfolio_source: str,
+    identity_hash: str,
+    now: datetime | str,
+) -> dict[str, Any]:
+    if run_dir.is_symlink() or not run_dir.is_dir():
+        raise PositionAdviceAccountSourceError(
+            "current-run portfolio source directory is invalid"
+        )
+    children = list(run_dir.iterdir())
+    if (
+        len(children) != 1
+        or children[0].is_symlink()
+        or not children[0].is_dir()
+        or children[0].name != payload_hash
+    ):
+        raise PositionAdviceAccountSourceError(
+            "current-run portfolio source directory is incomplete or ambiguous"
+        )
+    content_dir = children[0]
+    content_children = list(content_dir.iterdir())
+    if (
+        {item.name for item in content_children} != {"payload.json", "receipt.json"}
+        or any(item.is_symlink() or not item.is_file() for item in content_children)
+    ):
+        raise PositionAdviceAccountSourceError(
+            "current-run portfolio source content is incomplete or invalid"
+        )
+
+    receipt_relpath = (content_dir / "receipt.json").relative_to(
+        state_root
+    ).as_posix()
+    receipt_path = safe_existing_relative_path(state_root, receipt_relpath)
+    receipt_bytes = _stable_file_bytes(receipt_path, "portfolio receipt")
+    receipt = json.loads(receipt_bytes.decode("utf-8"))
+    if not isinstance(receipt, dict):
+        raise PositionAdviceAccountSourceError(
+            "portfolio receipt must be an object"
+        )
+    validated = validate_source_receipt(
+        receipt,
+        producer_root=state_root,
+        now=now,
+        require_fresh=True,
+        expected_source_kind="portfolio",
+        expected_account=account,
+        expected_identity_hash=identity_hash,
+        expected_producer_account_run_id=run_id,
+    )
+    expected_policy_hash = canonical_sha256(
+        {
+            "schema": PORTFOLIO_SOURCE_SCHEMA,
+            "normalized_portfolio_source": portfolio_source,
+        }
+    )
+    if (
+        receipt.get("producer_run_id") != run_id
+        or receipt.get("producer_schema_version") != PORTFOLIO_SOURCE_SCHEMA
+        or receipt.get("broker") != broker
+        or receipt.get("included_markets") != markets
+        or receipt.get("producer_policy_hash") != expected_policy_hash
+        or validated["source_observed_at"]
+        != _latest_observation(
+            [expected_payload["portfolio_context"].get("source_observed_at")]
+        )
+    ):
+        raise PositionAdviceAccountSourceError(
+            "current-run portfolio receipt conflicts with prepared inputs"
+        )
+
+    payload_path = Path(validated["payload_path"])
+    expected_payload_path = content_dir / "payload.json"
+    if payload_path != expected_payload_path.resolve():
+        raise PositionAdviceAccountSourceError(
+            "current-run portfolio payload path is invalid"
+        )
+    payload_bytes = _stable_file_bytes(payload_path, "portfolio payload")
+    published_payload = json.loads(payload_bytes.decode("utf-8"))
+    if (
+        not isinstance(published_payload, dict)
+        or published_payload != dict(expected_payload)
+        or canonical_sha256(published_payload) != payload_hash
+        or sha256_bytes(payload_bytes) != validated["payload_sha256"]
+    ):
+        raise PositionAdviceAccountSourceError(
+            "current-run portfolio payload conflicts with prepared inputs"
+        )
+    if _stable_file_bytes(receipt_path, "portfolio receipt") != receipt_bytes:
+        raise PositionAdviceAccountSourceError(
+            "portfolio receipt changed while it was being validated"
+        )
+    return _receipt_record(
+        source_kind="portfolio",
+        producer_root=state_root,
+        receipt_path=receipt_path,
+        receipt=receipt,
+    )
 
 
 def publish_account_run_sources(
@@ -74,16 +284,18 @@ def publish_account_run_sources(
             state_root / "portfolio_context.json",
             "portfolio context",
         )
-    portfolio_source = normalize_portfolio_source(
-        portfolio_context.get("portfolio_source_name")
+    portfolio_record = publish_or_reuse_account_portfolio_source(
+        account_run_id=run_id,
+        normalized_account=account,
+        broker=_required_text(broker, "broker"),
+        included_markets=markets,
+        account_state_dir=state_root,
+        portfolio_context=portfolio_context,
+        completed_at=completed_at,
     )
-    account_identifiers = _identity_values(
-        portfolio_context.get("source_account_identifiers")
-    )
-    identity_hash = portfolio_account_identity_hash(
-        normalized_portfolio_source=portfolio_source,
-        broker_account_identifiers=account_identifiers,
-    )
+    portfolio_source = str(portfolio_record["normalized_portfolio_source"])
+    account_identifiers = list(portfolio_record["source_account_identifiers"])
+    identity_hash = str(portfolio_record["portfolio_account_identity_hash"])
     capacity_authority = capacity_pool_authority_id(
         normalized_portfolio_source=portfolio_source,
         broker_account_identifiers=account_identifiers,
@@ -92,26 +304,9 @@ def publish_account_run_sources(
     decision_snapshot = dict(decision_snapshot_reader() or {})
     completed = completed_at or datetime.now(timezone.utc)
 
-    receipt_records: list[dict[str, Any]] = []
-    portfolio_path, portfolio_receipt = publish_portfolio_source_snapshot(
-        producer_root=state_root,
-        account_run_id=run_id,
-        account=account,
-        broker=_required_text(broker, "broker"),
-        normalized_portfolio_source=portfolio_source,
-        portfolio_account_identity_hash=identity_hash,
-        included_markets=markets,
-        portfolio_context=portfolio_context,
-        completed_at=completed,
-    )
-    receipt_records.append(
-        _receipt_record(
-            source_kind="portfolio",
-            producer_root=state_root,
-            receipt_path=portfolio_path,
-            receipt=portfolio_receipt,
-        )
-    )
+    receipt_records: list[dict[str, Any]] = [portfolio_record]
+    portfolio_path = Path(portfolio_record["receipt_path"])
+    portfolio_receipt = dict(portfolio_record["receipt"])
 
     ledger_path, ledger_receipt = publish_ledger_source_snapshot(
         producer_root=state_root,
@@ -645,11 +840,21 @@ def _read_json_object(path: Path, label: str) -> dict[str, Any]:
     return payload
 
 
+def _stable_file_bytes(path: Path, label: str) -> bytes:
+    first = Path(path).read_bytes()
+    second = Path(path).read_bytes()
+    if first != second:
+        raise PositionAdviceAccountSourceError(
+            f"{label} changed while it was being read"
+        )
+    return first
+
+
 def _existing_directory(path: Path, field: str) -> Path:
-    candidate = Path(path).resolve()
-    if not candidate.is_dir() or candidate.is_symlink():
+    supplied = Path(path)
+    if supplied.is_symlink() or not supplied.is_dir():
         raise PositionAdviceAccountSourceError(f"{field} is invalid")
-    return candidate
+    return supplied.resolve()
 
 
 def _identity_values(value: Any) -> list[str]:
@@ -769,5 +974,6 @@ __all__ = [
     "build_cash_capacity",
     "build_share_coverage",
     "publish_account_position_advice_sources",
+    "publish_or_reuse_account_portfolio_source",
     "publish_account_run_sources",
 ]

--- a/src/application/symbol_monitoring.py
+++ b/src/application/symbol_monitoring.py
@@ -144,6 +144,9 @@ def run_symbol_monitoring(
         symbol_cfg.pop("yield_enhancement", None)
         symbol_cfg[COMBO_YIELD_CONFIG_KEY] = yield_enhancement_cfg
     yield_enhancement_policy = derive_yield_enhancement_policy(yield_enhancement_cfg)
+    combo_variant = str(
+        (yield_enhancement_policy.config or {}).get("variant") or "sp_lc"
+    ).strip().lower()
     stock = prefilters.stock
     if want_call and isinstance(stock, dict):
         effective_min_strike = resolve_effective_sell_call_min_strike(
@@ -350,6 +353,18 @@ def run_symbol_monitoring(
                             "quote_receipt_relpath": exc.receipt_relpath,
                         }
                     )
+            if want_yield_enhancement:
+                inputs.candidate_capture_status_sink_fn(
+                    {
+                        "symbol": symbol.upper(),
+                        "strategy_mode": "combo_yield",
+                        "status": "failed",
+                        "reason": "required_data_snapshot_unavailable",
+                        "quote_snapshot_id": exc.snapshot_id,
+                        "quote_receipt_relpath": exc.receipt_relpath,
+                        "variant": combo_variant,
+                    }
+                )
         for family, enabled in (
             ("sell_put", want_put),
             ("combo_yield", want_yield_enhancement),
@@ -559,9 +574,6 @@ def run_symbol_monitoring(
 
     if want_yield_enhancement:
         try:
-            combo_variant = str(
-                (yield_enhancement_policy.config or {}).get("variant") or "sp_lc"
-            ).strip().lower()
             combo_result = deps.run_combo_yield_scan_fn(
                 base=inputs.base,
                 sym=symbol,
@@ -583,20 +595,48 @@ def run_symbol_monitoring(
                 combo_result,
             )
             combo_candidate_count = _summary_candidate_count(combo_result)
+            combo_capture_status = "completed"
+            combo_capture_reason: str | None = None
+            if combo_variant == "cc_lp":
+                if not isinstance(combo_result, dict):
+                    raise ValueError("cc_lp summary result is unavailable")
+                cc_lp_status = str(
+                    combo_result.get("status") or ""
+                ).strip().lower()
+                if cc_lp_status in {"candidates_found", "no_candidate"}:
+                    combo_capture_status = "completed"
+                elif cc_lp_status == "not_applicable":
+                    combo_capture_status = "not_applicable"
+                    combo_capture_reason = str(
+                        combo_result.get("reason") or "cc_lp_not_applicable"
+                    ).strip()
+                else:
+                    raise ValueError(
+                        "unexpected cc_lp summary status: "
+                        f"{cc_lp_status or 'missing'}"
+                    )
             _publish_status(
                 family="combo_yield",
-                status="completed",
+                status=combo_capture_status,
                 candidate_count=combo_candidate_count,
+                reason=combo_capture_reason,
                 snapshot_id=resolved_quote_snapshot_id,
                 receipt_relpath=quote_receipt_relpath,
-                **_completed_empty_evidence(combo_candidate_count),
+                **(
+                    _completed_empty_evidence(combo_candidate_count)
+                    if combo_capture_status == "completed"
+                    else {"source_outcome": None, "reason_code": None}
+                ),
             )
             _report_capture(
                 strategy_mode="combo_yield",
-                status="completed",
-                reason=_capture_reason(
-                    combo_candidate_count,
-                    None,
+                status=combo_capture_status,
+                reason=(
+                    combo_capture_reason
+                    or _capture_reason(
+                        combo_candidate_count,
+                        None,
+                    )
                 ),
                 variant=combo_variant,
             )

--- a/src/application/tick_account_execution.py
+++ b/src/application/tick_account_execution.py
@@ -18,6 +18,7 @@ from src.application.account_run import (
     AccountRunRequest,
     _resolve_account_scan_decision,
     build_account_runtime_config,
+    publish_current_run_portfolio_source,
     run_one_account,
 )
 from src.application.account_config import (
@@ -36,6 +37,7 @@ from src.application.prepared_portfolio_context import (
 from src.application.prepared_option_positions_context import (
     PREPARED_OPTION_POSITIONS_MANIFEST_NAME,
     PreparedOptionPositionsBatch,
+    PreparedOptionPositionsContextError,
     load_prepared_option_positions_context,
     prepare_option_positions_contexts,
 )
@@ -445,6 +447,8 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
     prepared_option_positions_context_unavailable_by_account: dict[
         str, str
     ] = {}
+    prepared_contexts: dict[str, dict[str, Any] | None] = {}
+    validated_prepared_option_contexts: dict[str, dict[str, Any]] = {}
     snapshot_status: str | None = None
     barrier_reason: str | None = None
     prefetch_done = bool(request.prefetch_done)
@@ -511,7 +515,6 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
                 reason="portfolio_context_preparation_failed",
                 error_type=type(exc).__name__,
             )
-        prepared_contexts: dict[str, dict[str, Any] | None] = {}
         invalid_prepared_accounts: set[str] = set()
         for account, manifest in prepared.items():
             prepared_context_metrics.append(
@@ -760,6 +763,59 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
                 if account not in invalid_prepared_option_accounts
             }
 
+        invalid_portfolio_source_accounts: set[str] = set()
+        for account in sorted(scanning_configs):
+            prepared_context = prepared_contexts.get(account)
+            if not isinstance(prepared_context, dict):
+                account_config_errors[account] = AccountRunConfigError(
+                    "ACCOUNT_CONFIG_PORTFOLIO_SOURCE_INVALID",
+                    "prepared portfolio context is unavailable",
+                )
+                invalid_portfolio_source_accounts.add(account)
+                continue
+            try:
+                portfolio_source = publish_current_run_portfolio_source(
+                    cfg=scanning_configs[account],
+                    account_run_id=request.run_id,
+                    account=account,
+                    markets_to_run=request.markets_to_run,
+                    account_state_dir=account_state_dirs[account],
+                    prepared_portfolio_context=prepared_context,
+                )
+            except AccountRunConfigError as exc:
+                account_config_errors[account] = exc
+                invalid_portfolio_source_accounts.add(account)
+                request.runlog.safe_event(
+                    "position_advice_portfolio_source",
+                    "error",
+                    error_code=exc.code,
+                    message=str(exc),
+                    data={"account": account},
+                )
+                continue
+            request.runlog.safe_event(
+                "position_advice_portfolio_source",
+                "ok",
+                data={
+                    "account": account,
+                    "snapshot_id": portfolio_source["receipt"].get(
+                        "snapshot_id"
+                    ),
+                },
+            )
+
+        if invalid_portfolio_source_accounts:
+            scanning_accounts = [
+                account
+                for account in scanning_accounts
+                if account not in invalid_portfolio_source_accounts
+            ]
+            scanning_configs = {
+                account: config
+                for account, config in scanning_configs.items()
+                if account not in invalid_portfolio_source_accounts
+            }
+
         union_cfg = build_cross_account_prefetch_config(
             base_config=request.base_cfg,
             account_configs=scanning_configs,
@@ -960,6 +1016,113 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
                 "pm_read_count": 0,
             },
         )
+        invalid_recovery_accounts: set[str] = set()
+        for account in list(scanning_accounts):
+            account_key = str(account).strip().lower()
+            config = account_configs[account_key]
+            authority = account_config_authorities[account_key]
+            account_state_dir = run_repo.get_run_account_state_dir(
+                request.base,
+                request.run_id,
+                account_key,
+            )
+            prepared = (
+                account_state_dir / "prepared_portfolio_context.v1.json"
+            ).resolve()
+            prepared_option = (
+                account_state_dir / PREPARED_OPTION_POSITIONS_MANIFEST_NAME
+            ).resolve()
+            try:
+                if not prepared.is_file():
+                    raise AccountRunConfigError(
+                        "ACCOUNT_CONFIG_PREPARED_CONTEXT_INVALID",
+                        "prepared portfolio context manifest is unavailable",
+                    )
+                prepared_digest = sha256_bytes(prepared.read_bytes())
+                prepared_context = load_prepared_portfolio_context(
+                    manifest_path=prepared,
+                    expected_base=request.base,
+                    expected_run_id=request.run_id,
+                    expected_account=account_key,
+                    expected_account_config_sha256=(
+                        authority.account_config_sha256
+                    ),
+                    expected_manifest_sha256=prepared_digest,
+                    expected_runtime_config=config,
+                )
+                if not isinstance(prepared_context, dict):
+                    raise AccountRunConfigError(
+                        "ACCOUNT_CONFIG_PREPARED_CONTEXT_INVALID",
+                        "prepared portfolio context is unavailable",
+                    )
+                if not prepared_option.is_file():
+                    raise AccountRunConfigError(
+                        "ACCOUNT_CONFIG_PREPARED_OPTION_CONTEXT_INVALID",
+                        "prepared option context manifest is unavailable",
+                    )
+                prepared_option_digest = sha256_bytes(
+                    prepared_option.read_bytes()
+                )
+                validated_prepared_option_contexts[account_key] = (
+                    load_prepared_option_positions_context(
+                        manifest_path=prepared_option,
+                        expected_base=request.base,
+                        expected_run_id=request.run_id,
+                        expected_account=account_key,
+                        expected_account_config_sha256=(
+                            authority.account_config_sha256
+                        ),
+                        expected_manifest_sha256=prepared_option_digest,
+                        expected_runtime_config=config,
+                    )
+                )
+                publish_current_run_portfolio_source(
+                    cfg=config,
+                    account_run_id=request.run_id,
+                    account=account_key,
+                    markets_to_run=request.markets_to_run,
+                    account_state_dir=account_state_dir,
+                    prepared_portfolio_context=prepared_context,
+                )
+            except PreparedPortfolioContextError as exc:
+                account_config_errors[account_key] = AccountRunConfigError(
+                    "ACCOUNT_CONFIG_PREPARED_CONTEXT_INVALID",
+                    str(exc),
+                )
+                invalid_recovery_accounts.add(account_key)
+                continue
+            except PreparedOptionPositionsContextError as exc:
+                account_config_errors[account_key] = AccountRunConfigError(
+                    "ACCOUNT_CONFIG_PREPARED_OPTION_CONTEXT_INVALID",
+                    str(exc),
+                )
+                invalid_recovery_accounts.add(account_key)
+                continue
+            except OSError as exc:
+                account_config_errors[account_key] = AccountRunConfigError(
+                    "ACCOUNT_CONFIG_PREPARED_CONTEXT_INVALID",
+                    f"prepared recovery artifact is unavailable: {exc}",
+                )
+                invalid_recovery_accounts.add(account_key)
+                continue
+            except AccountRunConfigError as exc:
+                account_config_errors[account_key] = exc
+                invalid_recovery_accounts.add(account_key)
+                continue
+            prepared_contexts[account_key] = prepared_context
+            prepared_manifest_paths[account_key] = prepared
+            prepared_manifest_sha256_by_account[account_key] = prepared_digest
+            prepared_option_manifest_paths[account_key] = prepared_option
+            prepared_option_manifest_sha256_by_account[account_key] = (
+                prepared_option_digest
+            )
+
+        if invalid_recovery_accounts:
+            scanning_accounts = [
+                account
+                for account in scanning_accounts
+                if account not in invalid_recovery_accounts
+            ]
         candidate = (
             run_repo.get_run_state_dir(request.base, request.run_id)
             / "required_data_snapshot_manifest.json"
@@ -996,41 +1159,6 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
                 )
             if snapshot_status == "failed":
                 barrier_reason = "required_data_snapshot_failed"
-            for account in scanning_accounts:
-                account_key = str(account).strip().lower()
-                prepared = (
-                    run_repo.get_run_account_state_dir(
-                        request.base,
-                        request.run_id,
-                        account_key,
-                    )
-                    / "prepared_portfolio_context.v1.json"
-                ).resolve()
-                if prepared.is_file():
-                    prepared_manifest_paths[account_key] = prepared
-                    prepared_manifest_sha256_by_account[account_key] = sha256_bytes(
-                        prepared.read_bytes()
-                    )
-                prepared_option = (
-                    run_repo.get_run_account_state_dir(
-                        request.base,
-                        request.run_id,
-                        account_key,
-                    )
-                    / PREPARED_OPTION_POSITIONS_MANIFEST_NAME
-                ).resolve()
-                if prepared_option.is_file():
-                    prepared_option_manifest_paths[account_key] = (
-                        prepared_option
-                    )
-                    prepared_option_manifest_sha256_by_account[account_key] = (
-                        sha256_bytes(prepared_option.read_bytes())
-                    )
-                else:
-                    account_config_errors[account_key] = AccountRunConfigError(
-                        "ACCOUNT_CONFIG_PREPARED_OPTION_CONTEXT_INVALID",
-                        "prepared option context manifest is unavailable",
-                    )
         except (OSError, RequiredDataSnapshotError):
             barrier_reason = "required_data_snapshot_manifest_unavailable"
             snapshot_status = "unavailable"
@@ -1044,6 +1172,12 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
             or authority is None
             or not ai_decision_advice_enabled(config)
         ):
+            continue
+        validated_context = validated_prepared_option_contexts.get(account)
+        if isinstance(validated_context, dict):
+            prepared_option_positions_context_by_account[account] = (
+                validated_context
+            )
             continue
         manifest_path = prepared_option_manifest_paths.get(account)
         manifest_sha256 = prepared_option_manifest_sha256_by_account.get(

--- a/tests/test_account_run.py
+++ b/tests/test_account_run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import replace
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -681,11 +682,37 @@ def test_run_one_account_uses_account_scan_decision_over_global_skip(monkeypatch
 
 
 def test_run_one_account_returns_failed_outcome_when_pipeline_fails(monkeypatch, tmp_path: Path) -> None:
-    from src.application.account_run import run_one_account
+    from src.application.account_run import (
+        publish_current_run_portfolio_source,
+        run_one_account,
+    )
+    from src.application.position_advice_account_identity_reader import (
+        read_current_run_portfolio_identity,
+    )
 
     request = _make_request(tmp_path, prefetch_done=True)
     env = _install_common_patches(monkeypatch, request)
     runlog = _FakeRunlog()
+    env["acct_state_dir"].mkdir(parents=True, exist_ok=True)
+    cfg = json.loads(
+        request.account_config_authority.canonical_bytes.decode("utf-8")
+    )
+    portfolio = publish_current_run_portfolio_source(
+        cfg=cfg,
+        account_run_id=request.run_id,
+        account=request.acct,
+        markets_to_run=request.markets_to_run,
+        account_state_dir=env["acct_state_dir"],
+        prepared_portfolio_context={
+            "filters": {"account": "lx"},
+            "portfolio_source_name": "futu",
+            "source_account_identifiers": ["lx"],
+            "source_observed_at": datetime.now(timezone.utc).isoformat(),
+            "source_observation_status": "trusted",
+        },
+    )
+    receipt_path = Path(portfolio["receipt_path"])
+    receipt_bytes = receipt_path.read_bytes()
 
     monkeypatch.setattr(
         env["mod"],
@@ -714,8 +741,17 @@ def test_run_one_account_returns_failed_outcome_when_pipeline_fails(monkeypatch,
 
     assert outcome.ran_pipeline is False
     assert outcome.prefetch_done is True
+    assert outcome.result.should_notify is True
     assert outcome.result.notification_text == ""
     assert outcome.result.decision_reason == "pipeline failed"
+    assert receipt_path.read_bytes() == receipt_bytes
+    assert read_current_run_portfolio_identity(
+        account_state_dir=env["acct_state_dir"],
+        account_run_id=request.run_id,
+        expected_account=request.acct,
+        expected_market="US",
+        now=datetime.now(timezone.utc),
+    )["status"] == "available"
     assert any(evt["step"] == "snapshot_batches" and evt["status"] == "error" for evt in runlog.events)
     assert any(evt["action"] == "run_pipeline_result" for evt in env["audit_events"])
 

--- a/tests/test_daily_decision_brief_notification_flow.py
+++ b/tests/test_daily_decision_brief_notification_flow.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import datetime, timezone
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
 import pytest
 
-from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.position_advice_authority import (
+    portfolio_account_identity_hash,
+)
 from src.application.position_advice_authority_service import (
     apply_authority_change,
     build_identity_binding_evidence,
@@ -50,17 +54,26 @@ class _Audit:
 
 
 def _portfolio_identity_hash(account: str) -> str:
-    return canonical_sha256(
-        {
-            "normalized_portfolio_source": "futu",
-            "normalized_account": account,
-            "broker_account_id": f"test-{account}",
-        }
+    return portfolio_account_identity_hash(
+        normalized_portfolio_source="futu",
+        broker_account_identifiers=[f"test-{account}"],
     )
 
 
 def _ensure_v1_authority(base: Path, account: str) -> None:
-    identity_hash = _portfolio_identity_hash(account)
+    _ensure_v1_authority_identity(
+        base,
+        account=account,
+        identity_hash=_portfolio_identity_hash(account),
+    )
+
+
+def _ensure_v1_authority_identity(
+    base: Path,
+    *,
+    account: str,
+    identity_hash: str,
+) -> None:
     resolution = read_authority_resolution(
         base=base,
         normalized_account=account,
@@ -593,6 +606,123 @@ def test_pipeline_failure_fixed_sends_explicit_failure_without_advancing_current
     assert envelope["delivery_kind"] == "fixed_failure"
     assert "数据异常" in envelope["rendered_message"]
     assert read_latest_daily_decision_brief(base=tmp_path, account="lx", market="US")["available"] is False
+
+
+def test_early_portfolio_receipt_drives_actual_fixed_failure_in_no_send(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.daily_decision_brief_service as service
+    import src.application.tick_notification_flow as mod
+    from src.application.daily_decision_brief_repository import (
+        read_retryable_daily_decision_brief_delivery,
+    )
+    from src.application.position_advice_account_sources import (
+        publish_or_reuse_account_portfolio_source,
+    )
+
+    run_id = "early-receipt-failure"
+    bundle = _request(
+        tmp_path,
+        run_id=run_id,
+        pipeline_ok=False,
+        no_send=True,
+    )
+    state_dir = (
+        tmp_path
+        / "output_runs"
+        / run_id
+        / "accounts"
+        / "lx"
+        / "state"
+    )
+    state_dir.mkdir(parents=True)
+    observed_at = datetime.now(timezone.utc)
+    portfolio_context = {
+        "portfolio_source_name": "futu",
+        "source_observed_at": observed_at.isoformat(),
+        "source_observation_status": "trusted",
+        "source_account_identifiers": ["test-lx"],
+        "cash_by_currency": {"USD": 1000},
+    }
+    (state_dir / "portfolio_context.json").write_text(
+        json.dumps(portfolio_context),
+        encoding="utf-8",
+    )
+    (state_dir / "option_positions_context.json").write_text(
+        json.dumps(
+            {
+                "as_of_utc": observed_at.isoformat(),
+                "cash_secured_total_by_ccy": {},
+                "cash_secured_unavailable_by_symbol": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    portfolio = publish_or_reuse_account_portfolio_source(
+        account_run_id=run_id,
+        normalized_account="lx",
+        broker="futu",
+        included_markets=["US"],
+        account_state_dir=state_dir,
+        portfolio_context=portfolio_context,
+        completed_at=observed_at,
+    )
+    _ensure_v1_authority_identity(
+        tmp_path,
+        account="lx",
+        identity_hash=portfolio["portfolio_account_identity_hash"],
+    )
+    monkeypatch.setattr(
+        service,
+        "read_position_advice_v2_from_ledger",
+        lambda **_kwargs: {
+            "availability_status": "unavailable",
+            "freshness": {"status": "fresh", "reason_codes": []},
+            "authority_mode": "v1",
+            "authority_generation": 0,
+            "authority_policy_hash": None,
+            "portfolio_plan_id": None,
+            "account_run_id": run_id,
+            "row_count": 0,
+            "actionable_count": 0,
+            "model_actionable_count": 0,
+            "model_trade_actionable_count": 0,
+            "human_review_required_count": 0,
+            "rows": [],
+        },
+    )
+    assembled: dict[str, dict] = {}
+
+    def assemble(**kwargs):
+        briefs = service.assemble_daily_decision_briefs(**kwargs)
+        assembled.update(briefs)
+        return briefs
+
+    monkeypatch.setattr(mod, "assemble_daily_decision_briefs", assemble)
+    provider_calls: list[dict] = []
+    _patch_sender(monkeypatch, calls=provider_calls)
+
+    assert mod.run_tick_notification_flow(bundle.request) == 0
+
+    authority = assembled["US"]["notification_authority"]
+    prepared = bundle.request.tick_metrics["daily_brief"]["prepared"][0]
+    retry = read_retryable_daily_decision_brief_delivery(
+        base=tmp_path,
+        account="lx",
+        market="US",
+        market_trading_date=prepared["market_trading_date"],
+    )
+    assert authority["authority_identity_source"] == (
+        "current_run_portfolio_receipt"
+    )
+    assert authority["identity_snapshot_id"] == portfolio["receipt"][
+        "snapshot_id"
+    ]
+    assert prepared["decision"] == "fixed_failure"
+    assert prepared["fixed_failure_delivery_allowed"] is True
+    assert provider_calls == []
+    assert retry["envelope"] is None
 
 
 def test_pending_fixed_failure_without_provider_attempt_upgrades_to_fixed_report(

--- a/tests/test_daily_decision_brief_service.py
+++ b/tests/test_daily_decision_brief_service.py
@@ -932,36 +932,30 @@ def test_success_empty_frozen_source_corruption_uses_fixed_failure(
 def test_missing_success_summary_blocks_normal_delivery_but_current_run_identity_allows_failure(
     tmp_path: Path,
 ) -> None:
-    from domain.domain.position_advice_authority import (
-        portfolio_account_identity_hash,
-    )
-    from src.application.position_advice_source_producers import (
-        publish_portfolio_source_snapshot,
+    from src.application.position_advice_account_sources import (
+        publish_or_reuse_account_portfolio_source,
     )
 
     account_dir = _account_dir(tmp_path)
     state_dir = account_dir / "state"
     (state_dir / "position_advice_sources.v2.json").unlink()
     identifiers = ["futu-lx-current"]
-    identity_hash = portfolio_account_identity_hash(
-        normalized_portfolio_source="futu",
-        broker_account_identifiers=identifiers,
-    )
-    publish_portfolio_source_snapshot(
-        producer_root=state_dir,
+    portfolio = publish_or_reuse_account_portfolio_source(
         account_run_id="run-1",
-        account="lx",
+        normalized_account="lx",
         broker="futu",
-        normalized_portfolio_source="futu",
-        portfolio_account_identity_hash=identity_hash,
         included_markets=["US"],
+        account_state_dir=state_dir,
         portfolio_context={
+            "portfolio_source_name": "futu",
             "source_observed_at": "2026-07-17T14:00:00+00:00",
+            "source_observation_status": "trusted",
             "source_account_identifiers": identifiers,
             "cash_by_currency": {"USD": 1000},
         },
         completed_at="2026-07-17T14:00:01+00:00",
     )
+    identity_hash = portfolio["portfolio_account_identity_hash"]
 
     brief = _assemble(tmp_path)
     authority = brief["notification_authority"]

--- a/tests/test_pipeline_capture_status_routing.py
+++ b/tests/test_pipeline_capture_status_routing.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+RUN_ID = "20260810T020017Z-test"
+ACCOUNT_CONFIG_SHA256 = "a" * 64
+
+
+def _symbol_config(
+    symbol: str,
+    *,
+    variant: str = "sp_lc",
+) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "broker": "HK",
+        "sell_put": {"enabled": True},
+        "sell_call": {"enabled": False},
+        "combo_yield": {"enabled": True, "variant": variant},
+    }
+
+
+def _status(
+    symbol: str,
+    mode: str,
+    status: str,
+    *,
+    variant: str | None = None,
+    quote: str = "quote-1",
+    reason: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "symbol": symbol,
+        "strategy_mode": mode,
+        "status": status,
+        "reason": reason,
+        "quote_snapshot_id": quote,
+        "quote_receipt_relpath": f"quotes/{quote}/receipt.json",
+    }
+    if variant is not None:
+        payload["variant"] = variant
+    return payload
+
+
+def _run_default_capture(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    symbols: list[dict[str, Any]],
+    statuses: list[dict[str, Any]],
+    pairs: list[dict[str, Any]] | None = None,
+) -> None:
+    from src.application import pipeline_watchlist as mod
+
+    required_manifest = tmp_path / "required_data_manifest.json"
+    portfolio_manifest = tmp_path / "prepared_portfolio_context.json"
+    ledger_manifest = tmp_path / "prepared_option_positions_context.json"
+    (
+        tmp_path / "output_runs" / RUN_ID / "accounts" / "lx"
+    ).mkdir(parents=True)
+    for path in (required_manifest, portfolio_manifest, ledger_manifest):
+        path.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        mod,
+        "resolve_watchlist_item_runtime_config",
+        lambda *, item, **_kwargs: dict(item),
+    )
+
+    def _fake_pipeline(**kwargs: Any) -> list[dict[str, Any]]:
+        for item in statuses:
+            kwargs["position_advice_candidate_capture_status_sink_fn"](item)
+        if pairs:
+            kwargs["combo_pairs_sink_fn"](pairs)
+        kwargs["opening_runtime_context_sink_fn"](
+            {
+                "capacity_authority": {
+                    "status": "available",
+                    "logical_account": "lx",
+                    "futu_account_id": "10001",
+                    "trd_env": "REAL",
+                    "market": "HK",
+                    "source": "opend",
+                },
+                "exchange_rates": {},
+            },
+            {"exchange_rates": {}},
+        )
+        return []
+
+    monkeypatch.setattr(mod, "run_watchlist_pipeline", _fake_pipeline)
+    mod.run_watchlist_pipeline_default(
+        py="python3",
+        base=tmp_path,
+        cfg={"portfolio": {"account": "lx"}, "symbols": symbols},
+        report_dir=tmp_path / "reports",
+        state_dir=tmp_path / "state",
+        shared_state_dir=tmp_path / "shared_state",
+        required_data_dir=tmp_path / "required_data",
+        is_scheduled=True,
+        top_n=3,
+        symbol_timeout_sec=10,
+        portfolio_timeout_sec=10,
+        want_scan=True,
+        no_context=False,
+        symbols_arg=None,
+        log=lambda _message: None,
+        want_fn=lambda name: name == "scan",
+        position_advice_account_run_id=RUN_ID,
+        required_data_snapshot_manifest=required_manifest,
+        prepared_portfolio_context_manifest=portfolio_manifest,
+        prepared_option_positions_context_manifest=ledger_manifest,
+        account_config_sha256=ACCOUNT_CONFIG_SHA256,
+    )
+
+
+def test_default_pipeline_routes_opening_and_legacy_sp_lc_capture_separately(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.application.cc_lp_candidate_snapshot import (
+        CC_LP_CANDIDATE_SNAPSHOT_FILE,
+    )
+    from src.application.combo_yield_candidate_snapshot import (
+        load_combo_yield_candidate_snapshot,
+    )
+    from src.application.opening_candidate_snapshot import (
+        load_opening_candidate_snapshot,
+    )
+
+    symbol = "0700.HK"
+    _run_default_capture(
+        monkeypatch,
+        tmp_path,
+        symbols=[_symbol_config(symbol)],
+        statuses=[
+            _status(symbol, "put", "completed"),
+            _status(symbol, "combo_yield", "completed", variant="sp_lc"),
+        ],
+        pairs=[
+            {
+                "candidate_pair_id": "combo_yield:0700.HK:P:C",
+                "symbol": symbol,
+            }
+        ],
+    )
+
+    opening = load_opening_candidate_snapshot(
+        base=tmp_path,
+        run_id=RUN_ID,
+        account="lx",
+    )
+    assert opening["strategy_modes"] == ["put"]
+    assert {
+        (row["symbol"], row["strategy_mode"])
+        for row in opening["scope_results"]
+        if row["scope"] == "strategy"
+    } == {(symbol, "put")}
+
+    combo = load_combo_yield_candidate_snapshot(
+        base=tmp_path,
+        run_id=RUN_ID,
+        account="lx",
+    )
+    assert combo["opening_status"] == "candidates_found"
+    assert [row["candidate_pair_id"] for row in combo["ranked_pairs"]] == [
+        "combo_yield:0700.HK:P:C"
+    ]
+    assert not (
+        tmp_path
+        / "output_runs"
+        / RUN_ID
+        / "accounts"
+        / "lx"
+        / "state"
+        / CC_LP_CANDIDATE_SNAPSHOT_FILE
+    ).exists()
+
+
+def test_default_pipeline_preserves_cc_lp_not_applicable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.application.cc_lp_candidate_snapshot import (
+        load_cc_lp_candidate_snapshot,
+    )
+    from src.application.combo_yield_candidate_snapshot import (
+        COMBO_YIELD_CANDIDATE_SNAPSHOT_FILE,
+    )
+
+    symbol = "0700.HK"
+    _run_default_capture(
+        monkeypatch,
+        tmp_path,
+        symbols=[_symbol_config(symbol, variant="cc_lp")],
+        statuses=[
+            _status(symbol, "put", "completed"),
+            _status(
+                symbol,
+                "combo_yield",
+                "not_applicable",
+                variant="cc_lp",
+                reason="no_covered_stock",
+            ),
+        ],
+    )
+
+    snapshot = load_cc_lp_candidate_snapshot(
+        base=tmp_path,
+        run_id=RUN_ID,
+        account="lx",
+    )
+    assert snapshot["opening_status"] == "not_applicable"
+    assert snapshot["ranked_pairs"] == []
+    assert not (
+        tmp_path
+        / "output_runs"
+        / RUN_ID
+        / "accounts"
+        / "lx"
+        / "state"
+        / COMBO_YIELD_CANDIDATE_SNAPSHOT_FILE
+    ).exists()
+
+
+@pytest.mark.parametrize(
+    ("combo_states", "expected_status"),
+    [
+        (["completed", "completed"], "no_candidate"),
+        (["failed", "failed"], "data_unavailable"),
+        (["completed", "failed"], "partial_data"),
+        (["not_applicable", "not_applicable"], "not_applicable"),
+        (["completed", None], "partial_data"),
+    ],
+)
+def test_default_pipeline_aggregates_sp_lc_capture_statuses(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    combo_states: list[str | None],
+    expected_status: str,
+) -> None:
+    from src.application.combo_yield_candidate_snapshot import (
+        load_combo_yield_candidate_snapshot,
+    )
+
+    symbols = ["0700.HK", "9992.HK"]
+    statuses = [_status(symbol, "put", "completed") for symbol in symbols]
+    statuses.extend(
+        _status(
+            symbol,
+            "combo_yield",
+            state,
+            variant="sp_lc",
+            reason=("no_covered_stock" if state == "not_applicable" else None),
+        )
+        for symbol, state in zip(symbols, combo_states, strict=True)
+        if state is not None
+    )
+
+    _run_default_capture(
+        monkeypatch,
+        tmp_path,
+        symbols=[_symbol_config(symbol) for symbol in symbols],
+        statuses=statuses,
+    )
+
+    snapshot = load_combo_yield_candidate_snapshot(
+        base=tmp_path,
+        run_id=RUN_ID,
+        account="lx",
+    )
+    assert snapshot["opening_status"] == expected_status
+
+
+@pytest.mark.parametrize(
+    ("statuses", "pairs", "error"),
+    [
+        (
+            [_status("0700.HK", "combo", "completed")],
+            [],
+            "unexpected candidate capture mode",
+        ),
+        (
+            [
+                _status("0700.HK", "combo_yield", "completed", variant="sp_lc"),
+                _status("0700.HK", "combo_yield", "completed", variant="sp_lc"),
+            ],
+            [],
+            "duplicate combo yield scan scope",
+        ),
+        (
+            [_status("9992.HK", "combo_yield", "completed", variant="sp_lc")],
+            [],
+            "unexpected combo yield scan scopes",
+        ),
+        (
+            [_status("0700.HK", "combo_yield", "completed", variant="other")],
+            [],
+            "invalid combo yield scan variant",
+        ),
+        (
+            [_status("0700.HK", "combo_yield", "completed", variant="sp_lc")],
+            [
+                {
+                    "candidate_pair_id": "combo_yield:0700.HK:P:C",
+                    "symbol": "0700.HK",
+                    "variant": "other",
+                }
+            ],
+            "invalid combo yield pair variant",
+        ),
+    ],
+)
+def test_default_pipeline_rejects_invalid_capture_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    statuses: list[dict[str, Any]],
+    pairs: list[dict[str, Any]],
+    error: str,
+) -> None:
+    all_statuses = [_status("0700.HK", "put", "completed"), *statuses]
+    with pytest.raises(ValueError, match=error):
+        _run_default_capture(
+            monkeypatch,
+            tmp_path,
+            symbols=[_symbol_config("0700.HK")],
+            statuses=all_statuses,
+            pairs=pairs,
+        )
+
+    assert not (
+        tmp_path
+        / "output_runs"
+        / RUN_ID
+        / "accounts"
+        / "lx"
+        / "state"
+        / "opening_candidate_snapshot.json"
+    ).exists()
+
+
+def test_default_pipeline_rejects_cross_owner_quote_binding_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.application.combo_yield_candidate_snapshot import (
+        load_combo_yield_candidate_snapshot,
+    )
+    from src.application.opening_candidate_snapshot import (
+        load_opening_candidate_snapshot,
+    )
+
+    symbol = "0700.HK"
+    _run_default_capture(
+        monkeypatch,
+        tmp_path,
+        symbols=[_symbol_config(symbol)],
+        statuses=[
+            _status(symbol, "put", "completed", quote="quote-opening"),
+            _status(
+                symbol,
+                "combo_yield",
+                "completed",
+                variant="sp_lc",
+                quote="quote-combo",
+            ),
+        ],
+    )
+
+    opening = load_opening_candidate_snapshot(
+        base=tmp_path,
+        run_id=RUN_ID,
+        account="lx",
+    )
+    assert opening["opening_status"] == "data_unavailable"
+    strategy_scope = next(
+        row for row in opening["scope_results"] if row["scope"] == "strategy"
+    )
+    assert strategy_scope["status"] == "incomplete"
+    assert strategy_scope["reason_code"] == "opening_quote_binding_conflict"
+
+    combo = load_combo_yield_candidate_snapshot(
+        base=tmp_path,
+        run_id=RUN_ID,
+        account="lx",
+    )
+    assert combo["opening_status"] == "data_unavailable"

--- a/tests/test_position_advice_account_sources.py
+++ b/tests/test_position_advice_account_sources.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from domain.domain.decision_state_fingerprint import canonical_sha256
 from src.application.opening_candidate_snapshot import (
     dependency_from_hash,
     seal_opening_candidate_snapshot,
@@ -15,7 +16,11 @@ from src.application.position_advice_account_sources import (
     build_cash_capacity,
     build_share_coverage,
     publish_account_position_advice_sources,
+    publish_or_reuse_account_portfolio_source,
     publish_account_run_sources,
+)
+from src.application.position_advice_account_identity_reader import (
+    read_current_run_portfolio_identity,
 )
 from src.application.position_advice_source_receipts import (
     publish_source_receipt,
@@ -318,6 +323,147 @@ def test_account_run_publishes_complete_receipt_dependency_graph(
         ]
         == quote["snapshot_id"]
     )
+
+
+def test_early_portfolio_source_is_reused_by_full_graph_without_rewrite(
+    tmp_path: Path,
+) -> None:
+    state, quotes, _quote, snapshot = _account_run_inputs(tmp_path)
+    context = json.loads((state / "portfolio_context.json").read_text())
+    first = publish_or_reuse_account_portfolio_source(
+        account_run_id="run-1",
+        normalized_account="lx",
+        broker="futu",
+        included_markets=["US"],
+        account_state_dir=state,
+        portfolio_context=context,
+        completed_at=NOW + timedelta(seconds=1),
+    )
+    first_path = Path(first["receipt_path"])
+    first_bytes = first_path.read_bytes()
+
+    identity = read_current_run_portfolio_identity(
+        account_state_dir=state,
+        account_run_id="run-1",
+        expected_account="lx",
+        expected_market="US",
+        now=NOW + timedelta(seconds=2),
+    )
+    result = publish_account_run_sources(
+        account_run_id="run-1",
+        normalized_account="lx",
+        broker="futu",
+        included_markets=["US"],
+        account_state_dir=state,
+        required_data_root=quotes,
+        decision_snapshot_reader=lambda: snapshot,
+        portfolio_context_override=context,
+        completed_at=NOW + timedelta(seconds=3),
+    )
+    portfolio = next(
+        item for item in result["receipts"] if item["source_kind"] == "portfolio"
+    )
+
+    assert Path(portfolio["receipt_path"]) == first_path
+    assert first_path.read_bytes() == first_bytes
+    assert portfolio["receipt"]["snapshot_id"] == identity["snapshot_id"]
+    assert portfolio["receipt"]["completed_at"] == first["receipt"]["completed_at"]
+    assert len(list(first_path.parent.parent.iterdir())) == 1
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [
+        "tampered",
+        "invalid_utf8",
+        "stale",
+        "wrong_run",
+        "wrong_account",
+        "wrong_broker",
+        "wrong_market",
+        "context_drift",
+    ],
+)
+def test_existing_portfolio_source_conflicts_fail_closed(
+    tmp_path: Path,
+    conflict: str,
+) -> None:
+    state, _quotes, _quote, _snapshot = _account_run_inputs(tmp_path)
+    context = json.loads((state / "portfolio_context.json").read_text())
+    first = publish_or_reuse_account_portfolio_source(
+        account_run_id="run-1",
+        normalized_account="lx",
+        broker="futu",
+        included_markets=["US"],
+        account_state_dir=state,
+        portfolio_context=context,
+        completed_at=NOW + timedelta(seconds=1),
+    )
+    kwargs = {
+        "account_run_id": "run-1",
+        "normalized_account": "lx",
+        "broker": "futu",
+        "included_markets": ["US"],
+        "account_state_dir": state,
+        "portfolio_context": context,
+        "completed_at": NOW + timedelta(seconds=2),
+    }
+    if conflict == "tampered":
+        Path(first["receipt_path"]).with_name("payload.json").write_text(
+            "{}\n",
+            encoding="utf-8",
+        )
+    elif conflict == "invalid_utf8":
+        Path(first["receipt_path"]).write_bytes(b"\xff\xfe")
+    elif conflict == "stale":
+        kwargs["completed_at"] = NOW + timedelta(seconds=1800)
+    elif conflict == "wrong_run":
+        current_run_dir = Path(first["receipt_path"]).parent.parent
+        wrong_run_dir = current_run_dir.parent / canonical_sha256(
+            {"producer_run_id": "run-2"}
+        )
+        current_run_dir.rename(wrong_run_dir)
+        kwargs["account_run_id"] = "run-2"
+    elif conflict == "wrong_account":
+        kwargs["normalized_account"] = "sy"
+    elif conflict == "wrong_broker":
+        kwargs["broker"] = "other"
+    elif conflict == "wrong_market":
+        kwargs["included_markets"] = ["HK"]
+    elif conflict == "context_drift":
+        kwargs["portfolio_context"] = {
+            **context,
+            "cash_by_currency": {"CNY": 9999},
+        }
+
+    with pytest.raises(PositionAdviceAccountSourceError):
+        publish_or_reuse_account_portfolio_source(**kwargs)
+
+
+def test_incomplete_portfolio_run_directory_is_not_repaired(
+    tmp_path: Path,
+) -> None:
+    state, _quotes, _quote, _snapshot = _account_run_inputs(tmp_path)
+    context = json.loads((state / "portfolio_context.json").read_text())
+    run_dir = (
+        state
+        / "position_advice_producers"
+        / "portfolio"
+        / canonical_sha256({"producer_run_id": "run-1"})
+    )
+    run_dir.mkdir(parents=True)
+
+    with pytest.raises(PositionAdviceAccountSourceError):
+        publish_or_reuse_account_portfolio_source(
+            account_run_id="run-1",
+            normalized_account="lx",
+            broker="futu",
+            included_markets=["US"],
+            account_state_dir=state,
+            portfolio_context=context,
+            completed_at=NOW + timedelta(seconds=1),
+        )
+    assert list(run_dir.iterdir()) == []
 
 
 def test_account_run_accepts_prepared_portfolio_context_without_legacy_filename(

--- a/tests/test_symbol_monitoring_fetch_spec_merge.py
+++ b/tests/test_symbol_monitoring_fetch_spec_merge.py
@@ -286,7 +286,10 @@ def test_frozen_symbol_failure_emits_typed_artifacts_and_capture_status(
         run_sell_call_scan_fn=lambda **_kwargs: {},
         empty_sell_call_summary_fn=lambda symbol, symbol_cfg: {},
         run_combo_yield_scan_fn=lambda **_kwargs: None,
-        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {},
+        empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {
+            "symbol": symbol,
+            "strategy": "combo_yield",
+        },
         materialize_empty_combo_yield_artifacts_fn=lambda **_kwargs: None,
     )
 
@@ -297,6 +300,7 @@ def test_frozen_symbol_failure_emits_typed_artifacts_and_capture_status(
             symbol_cfg={
                 "symbol": "NVDA",
                 "sell_put": {"enabled": True},
+                "combo_yield": {"enabled": True, "variant": "sp_lc"},
                 "sell_call": {"enabled": False},
             },
             top_n=3,
@@ -324,7 +328,13 @@ def test_frozen_symbol_failure_emits_typed_artifacts_and_capture_status(
             "strategy": "sell_put",
             "candidate_count": 0,
             "note": "行情快照不可用",
-        }
+        },
+        {
+            "symbol": "NVDA",
+            "strategy": "combo_yield",
+            "candidate_count": 0,
+            "note": "行情快照不可用",
+        },
     ]
     assert capture_statuses == [
         {
@@ -334,7 +344,16 @@ def test_frozen_symbol_failure_emits_typed_artifacts_and_capture_status(
             "reason": "required_data_snapshot_unavailable",
             "quote_snapshot_id": "snapshot-failed",
             "quote_receipt_relpath": "quotes/receipt.json",
-        }
+        },
+        {
+            "symbol": "NVDA",
+            "strategy_mode": "combo_yield",
+            "status": "failed",
+            "reason": "required_data_snapshot_unavailable",
+            "quote_snapshot_id": "snapshot-failed",
+            "quote_receipt_relpath": "quotes/receipt.json",
+            "variant": "sp_lc",
+        },
     ]
     status = json.loads(
         (report_dir / "nvda_sell_put_scan_status.json").read_text(
@@ -1037,7 +1056,7 @@ def test_combo_yield_runs_when_sell_put_is_disabled(monkeypatch, tmp_path: Path)
     assert [row["strategy"] for row in out] == ["sell_put", "combo_yield", "sell_call"]
 
 
-def test_combo_yield_capture_status_carries_cc_lp_variant(monkeypatch, tmp_path: Path) -> None:
+def test_combo_yield_capture_preserves_cc_lp_not_applicable(monkeypatch, tmp_path: Path) -> None:
     import src.application.symbol_monitoring as mod
 
     capture_statuses: list[dict] = []
@@ -1079,8 +1098,8 @@ def test_combo_yield_capture_status_carries_cc_lp_variant(monkeypatch, tmp_path:
             "variant": "cc_lp",
             "symbol": "NVDA",
             "candidate_count": 0,
-            "status": "no_candidate",
-            "reason": "",
+            "status": "not_applicable",
+            "reason": "no_covered_stock",
         },
         empty_combo_yield_summary_fn=lambda symbol, symbol_cfg: {
             "strategy": "combo_yield",
@@ -1118,6 +1137,8 @@ def test_combo_yield_capture_status_carries_cc_lp_variant(monkeypatch, tmp_path:
     ]
     assert len(combo_statuses) == 1
     assert combo_statuses[0]["variant"] == "cc_lp"
+    assert combo_statuses[0]["status"] == "not_applicable"
+    assert combo_statuses[0]["reason"] == "no_covered_stock"
 
 
 def test_combo_yield_runs_after_sell_put_failure_without_touching_historical_put_artifacts(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_tick_account_execution_barrier.py
+++ b/tests/test_tick_account_execution_barrier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,6 +22,19 @@ class _Audit:
 
     def fail_schema_validation(self, **_kwargs):
         return None
+
+
+def _portfolio_context(account: str) -> dict:
+    return {
+        "filters": {"account": account},
+        "portfolio_source_name": "futu",
+        "source_account_identifiers": [account],
+        "source_observed_at": datetime.now(timezone.utc).isoformat(),
+        "source_observation_status": "trusted",
+        "stocks_by_symbol": {
+            "NVDA": {"avg_cost": 100, "shares": 100, "account": account}
+        },
+    }
 
 
 def _request(tmp_path: Path, *, accounts: list[str], workers: int, force: bool):
@@ -91,13 +105,7 @@ def _fake_prepare(**kwargs):
         assert authority.compatibility_path.read_bytes() == authority.canonical_bytes
         state_dir = Path(state_dir)
         state_dir.mkdir(parents=True, exist_ok=True)
-        context = {
-            "filters": {"account": account},
-            "portfolio_source_name": "futu",
-            "stocks_by_symbol": {
-                "NVDA": {"avg_cost": 100, "shares": 100, "account": account}
-            }
-        }
+        context = _portfolio_context(account)
         context_path = state_dir / "portfolio_context.json"
         atomic_write_json(context_path, context)
         manifest_path = state_dir / "prepared_portfolio_context.v1.json"
@@ -178,6 +186,23 @@ def _stub_prepared_option_context(monkeypatch):
         "prepare_option_positions_contexts",
         _fake_prepare_options,
     )
+    monkeypatch.setattr(
+        mod,
+        "load_prepared_option_positions_context",
+        lambda **kwargs: {
+            "prepared_authority": {
+                "run_id": kwargs["expected_run_id"],
+                "account": kwargs["expected_account"],
+            },
+            "filters": {
+                "account": kwargs["expected_account"],
+                "broker": "futu",
+            },
+            "context_status": "available",
+            "decision_snapshot_status": "trusted",
+            "open_positions_min": [],
+        },
+    )
 
 
 @pytest.mark.parametrize("workers", [1, 2])
@@ -193,12 +218,33 @@ def test_barrier_prefetches_once_and_seals_before_account_submission(
     snapshot_status: str,
 ) -> None:
     from src.application import tick_account_execution as mod
+    from src.application.position_advice_account_identity_reader import (
+        read_current_run_portfolio_identity,
+    )
     from src.infrastructure.io_utils import atomic_write_json
 
     prefetch_calls: list[dict] = []
+    identities_at_prefetch: dict[str, dict] = {}
     account_requests = []
 
     def fake_prefetch(**kwargs):
+        for account in accounts:
+            identities_at_prefetch[account] = (
+                read_current_run_portfolio_identity(
+                    account_state_dir=(
+                        tmp_path
+                        / "output_runs"
+                        / "run-1"
+                        / "accounts"
+                        / account
+                        / "state"
+                    ),
+                    account_run_id="run-1",
+                    expected_account=account,
+                    expected_market="US",
+                    now=datetime.now(timezone.utc),
+                )
+            )
         prefetch_calls.append(kwargs)
         return {
             "schema_version": "1.0",
@@ -253,6 +299,11 @@ def test_barrier_prefetches_once_and_seals_before_account_submission(
     )
 
     assert len(prefetch_calls) == 1
+    assert set(identities_at_prefetch) == set(accounts)
+    assert all(
+        item["status"] == "available"
+        for item in identities_at_prefetch.values()
+    )
     assert prefetch_calls[0]["force_refresh"] is force
     assert {item.acct for item in account_requests} == set(accounts)
     assert all(item.required_data_snapshot_manifest for item in account_requests)
@@ -667,6 +718,10 @@ def test_pm_recovery_corrupt_artifact_is_soft_and_never_refetches(
     account_state = request.run_dir / "accounts" / "lx" / "state"
     account_state.mkdir(parents=True)
     atomic_write_json(
+        account_state / "prepared_portfolio_context.v1.json",
+        {"schema_version": "prepared_portfolio_context.v1"},
+    )
+    atomic_write_json(
         account_state / "prepared_option_positions_context.v1.json",
         {
             "schema_version": "prepared_option_positions_context.v1",
@@ -683,6 +738,11 @@ def test_pm_recovery_corrupt_artifact_is_soft_and_never_refetches(
         mod,
         "load_required_data_snapshot_manifest",
         lambda **_kwargs: (snapshot, request.shared_required.resolve()),
+    )
+    monkeypatch.setattr(
+        mod,
+        "load_prepared_portfolio_context",
+        lambda **_kwargs: _portfolio_context("lx"),
     )
     monkeypatch.setattr(
         mod,
@@ -966,6 +1026,10 @@ def test_reentry_restores_manifest_bound_close_advice_plan_without_replanning(
     )
     option_manifest_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_json(
+        option_manifest_path.parent / "prepared_portfolio_context.v1.json",
+        {"schema_version": "prepared_portfolio_context.v1"},
+    )
+    atomic_write_json(
         option_manifest_path,
         {
             "schema_version": "prepared_option_positions_context.v1",
@@ -979,6 +1043,11 @@ def test_reentry_restores_manifest_bound_close_advice_plan_without_replanning(
         mod,
         "load_required_data_snapshot_manifest",
         lambda **_kwargs: (manifest, request.shared_required.resolve()),
+    )
+    monkeypatch.setattr(
+        mod,
+        "load_prepared_portfolio_context",
+        lambda **_kwargs: _portfolio_context("lx"),
     )
     monkeypatch.setattr(
         mod,
@@ -1059,6 +1128,9 @@ def test_terminal_barrier_failure_returns_typed_account_outcomes_without_pipelin
     prefetch_done: bool,
 ) -> None:
     from src.application import tick_account_execution as mod
+    from src.application.position_advice_account_identity_reader import (
+        read_current_run_portfolio_identity,
+    )
     from src.infrastructure.io_utils import atomic_write_json
 
     monkeypatch.setattr(mod, "prepare_portfolio_contexts", _fake_prepare)
@@ -1111,12 +1183,168 @@ def test_terminal_barrier_failure_returns_typed_account_outcomes_without_pipelin
     assert outcome.ran_pipeline_accounts == []
     assert outcome.prefetch_done is prefetch_done
     assert [item.decision_reason for item in outcome.results] == [reason, reason]
+    assert all(item.should_notify is True for item in outcome.results)
+    for account in ("lx", "sy"):
+        assert read_current_run_portfolio_identity(
+            account_state_dir=(
+                tmp_path
+                / "output_runs"
+                / "run-1"
+                / "accounts"
+                / account
+                / "state"
+            ),
+            account_run_id="run-1",
+            expected_account=account,
+            expected_market="US",
+            now=datetime.now(timezone.utc),
+        )["status"] == "available"
     assert set(outcome.scheduled_scan_targets_by_account) == {"lx", "sy"}
     assert all(
         item["ran_pipeline"] is False
         and item["snapshot_status"] in {"failed", "unavailable"}
         for item in outcome.account_metrics
     )
+
+
+def test_portfolio_receipt_conflict_blocks_prefetch_and_account_execution(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from domain.domain.decision_state_fingerprint import canonical_sha256
+    from src.application import tick_account_execution as mod
+
+    state_dir = (
+        tmp_path
+        / "output_runs"
+        / "run-1"
+        / "accounts"
+        / "lx"
+        / "state"
+    )
+    run_dir = (
+        state_dir
+        / "position_advice_producers"
+        / "portfolio"
+        / canonical_sha256({"producer_run_id": "run-1"})
+    )
+    run_dir.mkdir(parents=True)
+    provider_calls: list[str] = []
+    account_calls: list[str] = []
+    monkeypatch.setattr(mod, "prepare_portfolio_contexts", _fake_prepare)
+    monkeypatch.setattr(
+        mod,
+        "prefetch_required_data",
+        lambda **_kwargs: provider_calls.append("prefetch"),
+    )
+    monkeypatch.setattr(
+        mod,
+        "run_one_account",
+        lambda **_kwargs: account_calls.append("account"),
+    )
+
+    outcome = mod.run_tick_account_execution(
+        _request(
+            tmp_path,
+            accounts=["lx"],
+            workers=1,
+            force=False,
+        )
+    )
+
+    assert provider_calls == []
+    assert account_calls == []
+    assert outcome.prefetch_invocation_count == 0
+    assert outcome.results[0].should_notify is False
+    assert (
+        outcome.results[0].decision_reason
+        == "account_config_portfolio_source_invalid"
+    )
+    assert list(run_dir.iterdir()) == []
+
+
+def test_recovery_reuses_early_portfolio_receipt_without_provider_refresh(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from dataclasses import replace
+
+    from domain.domain.decision_state_fingerprint import canonical_sha256
+    from src.application import tick_account_execution as mod
+    from src.infrastructure.io_utils import atomic_write_json
+
+    request = _request(
+        tmp_path,
+        accounts=["lx"],
+        workers=1,
+        force=False,
+    )
+    manifest = {
+        "schema_version": "required_data_snapshot_manifest.v1",
+        "run_id": request.run_id,
+        "status": "complete",
+        "plan_id": "a" * 64,
+        "symbols": {},
+        "summary": {},
+    }
+    provider_calls: list[str] = []
+
+    def _prefetch(**_kwargs):
+        provider_calls.append("prefetch")
+        return {
+            "global_required_data_plan": {
+                "plan_id": "a" * 64,
+                "symbols": [],
+            },
+            "symbols": [],
+            "results": {},
+        }
+
+    def _seal(**kwargs):
+        atomic_write_json(kwargs["manifest_path"], manifest)
+        return manifest
+
+    monkeypatch.setattr(mod, "prepare_portfolio_contexts", _fake_prepare)
+    monkeypatch.setattr(mod, "prefetch_required_data", _prefetch)
+    monkeypatch.setattr(mod, "seal_required_data_snapshot", _seal)
+    monkeypatch.setattr(
+        mod,
+        "run_one_account",
+        lambda *, request, **_kwargs: mod.AccountRunOutcome(
+            result=AccountResult(request.acct, True, False, "ok", ""),
+            acct_metrics={"account": request.acct},
+            prefetch_done=True,
+            ran_pipeline=True,
+        ),
+    )
+
+    mod.run_tick_account_execution(request)
+    run_dir = (
+        request.run_dir
+        / "accounts"
+        / "lx"
+        / "state"
+        / "position_advice_producers"
+        / "portfolio"
+        / canonical_sha256({"producer_run_id": request.run_id})
+    )
+    receipt_path = next(run_dir.glob("*/receipt.json"))
+    receipt_bytes = receipt_path.read_bytes()
+    monkeypatch.setattr(
+        mod,
+        "load_required_data_snapshot_manifest",
+        lambda **_kwargs: (manifest, request.shared_required.resolve()),
+    )
+
+    recovered = mod.run_tick_account_execution(
+        replace(request, prefetch_done=True)
+    )
+
+    assert provider_calls == ["prefetch"]
+    assert recovered.prefetch_invocation_count == 0
+    assert receipt_path.read_bytes() == receipt_bytes
+    assert len(list(run_dir.iterdir())) == 1
+    assert recovered.ran_pipeline_accounts == ["lx"]
 
 
 def test_quote_drift_is_frozen_once_while_account_capacity_can_differ(


### PR DESCRIPTION
## Summary

- Route HK capture statuses by owning strategy and combo variant, so `combo_yield` statuses no longer enter the opening put/call validator.
- Publish or strictly reuse the current-run portfolio identity receipt before shared prefetch, preserving Daily Brief failure-notification authority when the prefetch barrier or account pipeline fails early.
- Fail closed on malformed, stale, or conflicting receipts without changing notification schemas, production config, or user-facing wording.

## Root cause

- The 09:40 HK run hit an OpenD option-expiration timeout before account execution. Because the portfolio receipt did not yet exist, the run resolved to `decision=none`; there was no notification-provider attempt.
- The 10:00 HK run reached account execution, but Combo Yield capture statuses were routed into the opening-scan validator, which accepts only put/call scopes. It raised `ValueError: unexpected opening scan scopes ... combo_yield`; again there was no provider attempt.
- The regression began when combo capture filtering was introduced and became active once the producer correctly emitted `strategy_mode=combo_yield`.

## Validation

- Capture-routing focused suite: 52 passed.
- Broader pipeline suite: 129 passed.
- Early-receipt and notification-authority suite: 180 passed.
- Aggregate accepted-plan suite: 265 passed, with 4 pre-existing renderer deprecation warnings.
- Latest-`main` integration replay of the branch commits: 265 passed.
- Ruff, compileall, and Git diff checks passed.
- Aggregate DeepReview reported no remaining findings.

## Safety and scope

- No live notification, replay, configuration/runtime mutation, service operation, release, deployment, or production upgrade was performed.
- Scheduler retry behavior and the upstream OpenD timeout are explicitly deferred.
- Unrelated pre-existing dirty worktree changes were excluded from every commit.