### PR TITLE
fix(health-check): use metadata-only secret status in feishu-ws --check

### DIFF
--- a/src/application/inbound/feishu_ws.py
+++ b/src/application/inbound/feishu_ws.py
@@ -145,6 +145,7 @@ def build_feishu_ws_settings(
     environ: Mapping[str, str] | None = None,
     env_file: str | Path | None = None,
     credential_env_file: str | Path | None = None,
+    metadata_only: bool = False,
 ) -> FeishuWsSettings:
     effective_env = build_effective_env(environ=environ, env_file=env_file)
     if credential_env_file is not None and str(credential_env_file).strip():
@@ -153,7 +154,7 @@ def build_feishu_ws_settings(
             env_file=credential_env_file,
         )
     env = effective_env.values
-    bot_cfg = resolve_feishu_bot_config(environ=env)
+    bot_cfg = resolve_feishu_bot_config(environ=env, metadata_only=metadata_only)
     assistant_cfg = _load_assistant_behavior_config(config_path=assistant_config_path)
     behavior_cfg = _dict(_dict(assistant_cfg.get("inbound")).get("feishu_ws"))
     assistant_settings = AssistantSettings.from_runtime_config(assistant_cfg)

--- a/src/application/secret_resolver.py
+++ b/src/application/secret_resolver.py
@@ -8,6 +8,7 @@ from src.application.secret_store import (
     FEISHU_HOLDINGS_APP_SECRET,
     SecretProvider,
     resolve_secret,
+    resolve_secret_status,
 )
 from src.application.settings import build_effective_env
 
@@ -184,6 +185,7 @@ def resolve_feishu_bot_config(
     *,
     environ: Mapping[str, str] | None = None,
     secret_provider: SecretProvider | None = None,
+    metadata_only: bool = False,
 ) -> FeishuBotConfig:
     del notifications
     app_id_env = DEFAULT_FEISHU_BOT_APP_ID_ENV
@@ -192,14 +194,26 @@ def resolve_feishu_bot_config(
     allowed_open_ids_env = DEFAULT_FEISHU_BOT_ALLOWED_OPEN_IDS_ENV
     user_open_id = _env(environ, user_open_id_env)
     allowed_open_ids = _split_csv(_env(environ, allowed_open_ids_env)) or ((user_open_id,) if user_open_id else ())
-    return FeishuBotConfig(
-        app_id=_env(environ, app_id_env),
-        app_secret=_secret(
+    if metadata_only:
+        # Check/diagnostic path: report credential presence without resolving the value.
+        # Falls back to legacy env check so the health check works in any backend context.
+        status = resolve_secret_status(
+            FEISHU_BOT_APP_SECRET,
+            provider=secret_provider,
+            environ=environ if secret_provider is None else None,
+            legacy_env_name=app_secret_env,
+        )
+        app_secret = "configured" if status.configured else ""
+    else:
+        app_secret = _secret(
             FEISHU_BOT_APP_SECRET,
             environ=environ,
             provider=secret_provider,
             legacy_env_name=app_secret_env,
-        ),
+        )
+    return FeishuBotConfig(
+        app_id=_env(environ, app_id_env),
+        app_secret=app_secret,
         user_open_id=user_open_id,
         allowed_open_ids=allowed_open_ids,
         app_id_env=app_id_env,

--- a/src/application/secret_store/runtime.py
+++ b/src/application/secret_store/runtime.py
@@ -6,7 +6,12 @@ import os
 from threading import RLock
 from typing import Iterator, Mapping
 
-from src.application.secret_store.contracts import SecretProvider, SecretStatus, SnapshotSecretProvider
+from src.application.secret_store.contracts import (
+    SecretBackendUnavailable,
+    SecretProvider,
+    SecretStatus,
+    SnapshotSecretProvider,
+)
 
 
 _provider_override: ContextVar[SecretProvider | None] = ContextVar("options_monitor_secret_provider", default=None)
@@ -89,10 +94,25 @@ def resolve_secret_status(
     environ: Mapping[str, str] | None = None,
     legacy_env_name: str | None = None,
 ) -> SecretStatus:
-    return _provider_for(provider=provider, environ=environ).status(
-        logical_name,
-        legacy_env_name=legacy_env_name,
-    )
+    try:
+        return _provider_for(provider=provider, environ=environ).status(
+            logical_name,
+            legacy_env_name=legacy_env_name,
+        )
+    except SecretBackendUnavailable:
+        # Diagnostic path must not crash when the backend context is unavailable
+        # (e.g. health-check subprocess lacks systemd CREDENTIALS_DIRECTORY).
+        # Fall back to checking the legacy env name directly.
+        env = environ if environ is not None else os.environ
+        configured = bool(
+            legacy_env_name and str(env.get(legacy_env_name) or "").strip()
+        )
+        return SecretStatus(
+            logical_name=logical_name,
+            configured=configured,
+            backend="unavailable",
+            source="legacy_env_fallback" if configured else "missing",
+        )
 
 
 __all__ = [

--- a/src/interfaces/cli/inbound_ops.py
+++ b/src/interfaces/cli/inbound_ops.py
@@ -133,6 +133,7 @@ def handle_inbound_command(
             environ=os.environ,
             env_file=args.env_file,
             credential_env_file=args.credential_env_file,
+            metadata_only=bool(args.check),
         )
         if args.check:
             return _print(check_feishu_ws_settings_fn(settings))

--- a/tests/test_secret_resolver.py
+++ b/tests/test_secret_resolver.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from src.application.secret_resolver import (
     resolve_feishu_bot_config,
     resolve_feishu_holdings_config,
@@ -107,3 +109,69 @@ def test_feishu_bot_resolver_ignores_custom_env_name_config() -> None:
         "feishu.bot.app_secret",
         "OM_FEISHU_BOT_ALLOWED_OPEN_IDS",
     )
+
+
+def test_feishu_bot_config_metadata_only_with_legacy_env() -> None:
+    """metadata_only mode reports credential presence without resolving the value."""
+    env = {
+        "OM_FEISHU_BOT_APP_ID": "cli_test",
+        "OM_FEISHU_BOT_APP_SECRET": "real-secret-here",
+        "OM_FEISHU_BOT_USER_OPEN_ID": "ou_test",
+    }
+
+    cfg = resolve_feishu_bot_config(environ=env, metadata_only=True)
+
+    assert cfg.app_id == "cli_test"
+    assert cfg.app_secret == "configured"
+    assert cfg.credentials_ready is True
+
+
+def test_feishu_bot_config_metadata_only_without_secret() -> None:
+    """metadata_only mode returns empty app_secret when no credential is found."""
+    env = {
+        "OM_FEISHU_BOT_APP_ID": "cli_test",
+        "OM_FEISHU_BOT_USER_OPEN_ID": "ou_test",
+    }
+
+    cfg = resolve_feishu_bot_config(environ=env, metadata_only=True)
+
+    assert cfg.app_id == "cli_test"
+    assert cfg.app_secret == ""
+    assert cfg.credentials_ready is False
+
+
+def test_resolve_secret_status_fallback_on_backend_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """resolve_secret_status degrades gracefully when the secret backend is unavailable."""
+    from src.application.secret_store.runtime import resolve_secret_status
+    from src.application.secret_store.registry import FEISHU_BOT_APP_SECRET
+    import src.infrastructure.secret_store.factory as factory
+
+    monkeypatch.delenv("OM_SECRET_BACKEND", raising=False)
+    original_platform = factory._platform_name
+    factory._platform_name = lambda v=None: "linux"
+    try:
+        # No CREDENTIALS_DIRECTORY, no legacy env → unavailable but not crashed
+        # Use environ={} to isolate from process env (OM_SECRET_BACKEND may be set)
+        env: dict[str, str] = {}
+        status = resolve_secret_status(
+            FEISHU_BOT_APP_SECRET,
+            environ=env,
+            legacy_env_name="OM_FEISHU_BOT_APP_SECRET",
+        )
+        assert status.configured is False
+        assert status.backend == "unavailable"
+        assert status.source == "missing"
+
+        # With legacy env present → detected via fallback
+        env2 = dict(env)
+        env2["OM_FEISHU_BOT_APP_SECRET"] = "real-secret"
+        status2 = resolve_secret_status(
+            FEISHU_BOT_APP_SECRET,
+            environ=env2,
+            legacy_env_name="OM_FEISHU_BOT_APP_SECRET",
+        )
+        assert status2.configured is True
+        assert status2.backend == "unavailable"
+        assert status2.source == "legacy_env_fallback"
+    finally:
+        factory._platform_name = original_platform


### PR DESCRIPTION
The upgrade health check subprocess lacks systemd CREDENTIALS_DIRECTORY (filtered by _child_env_from_profile), causing SecretBackendUnavailable on Linux auto backend. Switch --check to resolve_secret_status with a SecretBackendUnavailable fallback so diagnostics never crash.