### PR TITLE
test(perf): add resolver-to-attribution E2E regression for Combo Yield

### DIFF
--- a/docs/gateflow/perf-e2e-regression-final-closeout-20260811.md
+++ b/docs/gateflow/perf-e2e-regression-final-closeout-20260811.md
@@ -1,0 +1,86 @@
+# Gateflow Final Closeout — perf-e2e-regression
+
+- Gate: `final closeout`
+- Work unit: `perf-e2e-regression`
+- Date: 2026-08-11
+- Branch: `perf-e2e-regression`
+- Artifact path: `docs/gateflow/perf-e2e-regression-final-closeout-20260811.md`
+- Status: `work unit completed; awaiting user-authorized merge`
+- Draft PR: https://github.com/liuxie066/options-monitor/pull/147
+
+## What Changed
+
+- New E2E regression test `tests/test_performance_resolver_projection_e2e.py`
+  covering the real production chain:
+  `resolve_trade_deal(apply_changes=True)` resolver open -> SQLite
+  persistence -> `persist_trade_event_object` close/expire -> period
+  performance attribution (`build_option_period_performance`) for a
+  same-expiry Combo Yield pair (funding put short 100 @ 5.00,
+  participation call long 120 @ 4.00, expire 0 / close 7.00).
+- No production code, schema, config, CLI, or output-path changes.
+- Gateflow artifacts committed on this branch: goal confirmation, plan,
+  plan review, slice-1 implementation, slice code review, aggregate
+  deepreview, PR review, and this closeout.
+
+Branch commits (base `c9d64129`, v1.13.10):
+
+```text
+4941e32d docs(gateflow): accept plan for perf-e2e-regression
+2bae387a docs(gateflow): accept perf-e2e-regression slice-1
+7a5b1e66 docs(gateflow): accept deepreview for perf-e2e-regression
+80118435 docs(gateflow): accept PR review for perf-e2e-regression
+```
+
+## What Was Verified
+
+- Focused run: `tests/test_performance_resolver_projection_e2e.py` — 1 passed.
+- Regression set: 85 passed (E2E + performance attribution + period service +
+  resolver close + assigned-stock intake).
+- Broader performance/resolver/combo suite: 212 passed.
+- Post-rebase focused set: 71 passed.
+- `ruff check` clean; repository CI on the PR head commit: all 5 check runs
+  `success` (CodeQL, guardrails, agent-plugin, Analyze actions, Analyze
+  python).
+- Draft PR #147: state open, mergeable, head matches branch tip
+  `7a5b1e66...` (CI evidence); a later push added the accepted PR review
+  commit (`80118435`), which may re-trigger checks.
+- No real notifications, no `output/`/`output_runs/`/state-file writes, no
+  config or runtime mutation anywhere in this work unit.
+
+## Docs Updates
+
+- Gate artifacts under `docs/gateflow/` and `docs/reviews/` (listed above).
+- No user-facing doc change: test-only addition with no public contract.
+
+## Finding Status
+
+- Plan review: 2 low findings — both fixed by implementation (required fields
+  enumerated in the fixture; close-via-writer boundary documented).
+- Slice code review: no material findings; residual risks recorded.
+- Aggregate deepreview: no material findings.
+- PR review (#147): no material findings; pass recorded at
+  `docs/reviews/pr-147-review-20260811-115449.md`.
+
+## Remaining Risks / Owners
+
+- Happy-path E2E only (rejected opens, lifecycle-pending expiries,
+  `partial_data` attribution remain unit-level coverage). Owner: later work
+  unit if required; not part of this work unit's success signal.
+- Fixture injects `strategy_snapshot` manually; production combo-snapshot
+  enrichment leftovers (`_with_combo_yield_*` helpers) are a separate work
+  unit (previously recorded as Combo Yield S2 follow-up).
+- `_lot_record_id` exact-float strike matching: test-local, safe for used
+  values.
+- `attribution["coverage"]["status"]` not asserted directly; group/conservation
+  assertions still fail closed on a partial-coverage regression.
+
+## Issue Link Status
+
+- Not an issue work unit: no issue number associated, no closing keyword in
+  the PR body, no issue closeout comment required.
+
+## Next Entry Point
+
+- User authorizes merging PR #147, then deletion of branch
+  `perf-e2e-regression` and closure of this work unit. Those actions are
+  outside this work unit's authority and were not performed.

--- a/docs/gateflow/perf-e2e-regression-goal-confirmation-20260811.md
+++ b/docs/gateflow/perf-e2e-regression-goal-confirmation-20260811.md
@@ -1,0 +1,80 @@
+# Gateflow Goal Confirmation — perf-e2e-regression
+
+- Gate: `goal confirmation`
+- Work unit: `perf-e2e-regression`
+- Date: 2026-08-11
+- Branch: `perf-e2e-regression`
+- Baseline: `db2c361e` (tag `v1.13.9`); origin/main 已前进到 `c9d64129`（v1.13.10 release + health-check fix），rebase 留到 PR 准备阶段，本 work unit 期间锁定 baseline。
+- Artifact path: `docs/gateflow/perf-e2e-regression-goal-confirmation-20260811.md`
+- Status: `awaiting user confirmation`
+
+## Goal
+
+新增一条性能报告端到端回归测试，覆盖真实生产数据链：
+
+`resolver 开仓真实写 SQLite (apply_changes=True) -> trade_events/projection -> build_option_period_performance -> attribution groups`
+
+验证在真实 SQLite 持久化 + `strategy_snapshot` 元数据（`strategy` / `leg_role` / `strategy_group_id` / `expiry_structure`）下，
+Combo Yield 的 funding / participation 归因仍然正确，防止 resolver 落账、事件解码、projection 或 attribution 任一层回归。
+
+## Motivation
+
+- `tests/test_performance_service.py` 用 `repo.upsert_trade_event(TradeEvent)` 直插事件，未经过 resolver 真实写库路径。
+- `tests/test_performance_strategy_attribution.py` 直接构造内存事件，不覆盖 `resolve_trade_deal(apply_changes=True)`、SQLite 持久化与 projection 解码。
+- 目前没有任何测试覆盖 `resolver 写库 -> performance 报告` 的单一链路；该链路是 production 报告的权威数据路径。
+- 生产 attribution 依赖 `raw_payload.strategy_snapshot` 与 `lot_id` / `target_lot_id` 关联，是最容易在重构中静默损坏的部分。
+
+## Success Signals
+
+1. 新增 `tests/test_performance_resolver_projection_e2e.py`，全部通过。
+2. 开仓事件经 `resolve_trade_deal(..., apply_changes=True)` 真实写入 SQLite `trade_events` 表。
+3. close/expire 事件经 writer 的真实持久化路径（`persist_trade_event_object` / SQLite repo）落库，`raw_payload` 显式携带 `strategy_snapshot`。
+4. `build_option_period_performance` 输出断言与现有 attribution 基线一致：
+   - `attribution.groups[0]` 存在，且 funding / participation group 归类正确；
+   - `funding.put_open_credit_gross == 500.0`、`funding.call_open_debit_gross == 400.0`、
+     `funding.call_cost_funded_by_put == 400.0`、`funding_surplus == 100.0`；
+   - participation `realized_gross == 300.0`（USD）；
+   - 总账 `realized_gross == 800.0`（USD）；
+   - `attribution.conservation.realized_gross.residual_by_currency == {"USD": 0.0}`。
+5. 测试不发送真实通知、不写 `output/` / `output_runs/` / 状态文件，不触碰主仓库并行会话产物。
+
+## Non-Goals / Scope Boundary
+
+- 不修改 resolver / projection / performance engine 生产代码；本 work unit 只新增测试与必要测试夹具。
+  若测试暴露真实 bug，记录为 finding，修复范围需单独确认，不顺手扩实现。
+- 不做错期/组合残留清理（`_with_combo_yield_long_call_payload` / `_with_combo_yield_sell_put_payload` 等 dead code 归后续 work unit）。
+- 不发布、不升级生产、不 merge、不删除分支；merge / delete 是独立授权边界。
+- 不触碰主仓库工作树（并行会话在改写）。
+- 不做性能优化、不重构 attribution 语义、不新增 repo 抽象或配置项。
+
+## Direct Code Evidence
+
+- `src/application/performance/service.py:21` `build_option_period_performance`
+- `src/application/performance/adapters.py:37` `load_ledger_performance_inputs`（trade_event_log -> projection）
+- `src/application/ledger/writer.py:4097` `_trade_event_from_normalized_deal`（保留 `raw_payload`，close 解析 `target_lot_id`）
+- `src/application/trades/workflows.py:24/43` `apply_trade_open_with` / `apply_trade_close_with`
+- `src/application/ledger/commands.py:166/372` `persist_trade_open_event_with_ledger` / `persist_trade_close_events_with_ledger`
+- performance attribution 调用点：`engine.py` 中 `_append_capital_exposure_segments`（约 628 行）与 `_event_fact_kwargs`（约 1556 行）通过 `lot_id_for_open_event` / `target_lot_id` 关联 lifecycle
+- 现有测试基线：`tests/test_performance_strategy_attribution.py`（`_event` 元数据形态与数值断言）、`tests/test_performance_service.py`、`tests/test_trades_resolver_close.py`
+
+## 不会做的过度设计
+
+- 不新增 repository 层抽象、不改 SQLite schema、不引入新依赖。
+- 测试夹具保持最小：一个真 SQLite repo + 一组 open/close 事件。
+- 不把实现层发现的其他风险升级为本 work unit 目标。
+
+## Blocking Open Questions
+
+- 无。Plan 阶段的确定性决策：
+  - 方案 A（推荐）：open 事件经 resolver 落账，close/expire 经 writer 真实持久化并显式携带 `strategy_snapshot`；
+  - rebase 到 origin/main 仅在 draft PR 准备时执行。
+
+## Deferred Follow-ups（不属于本 work unit）
+
+- 生产升级到已发布版本（v1.13.9 / v1.13.10）：需用户单独授权并确认目标版本。
+- 错期/组合残留与 dead code 清理。
+- 并行会话发布产物（release/CHANGELOG）的后续核对。
+
+## Completion Report Format
+
+Final closeout 将包含：changed files、验证命令与结果、docs decision、finding status、residual risks / owners、draft PR URL、next entry point。

--- a/docs/gateflow/perf-e2e-regression-plan-20260811.md
+++ b/docs/gateflow/perf-e2e-regression-plan-20260811.md
@@ -1,0 +1,151 @@
+# Gateflow Plan — perf-e2e-regression
+
+- Gate: `plan`
+- Work unit: `perf-e2e-regression`
+- Date: 2026-08-11
+- Branch: `perf-e2e-regression`（baseline `db2c361e`）
+- Goal confirmation: `docs/gateflow/perf-e2e-regression-goal-confirmation-20260811.md`（user confirmed 2026-08-11）
+- Artifact path: `docs/gateflow/perf-e2e-regression-plan-20260811.md`
+- Status: `awaiting plan review`
+
+## Goal / Motivation / Success Signal
+
+Goal（来自 goal confirmation）：新增一条端到端回归测试，覆盖真实生产链：
+
+`resolver 开仓真实写 SQLite (apply_changes=True) -> trade_events/projection -> build_option_period_performance -> attribution groups`
+
+Success signal：
+
+1. 新增 `tests/test_performance_resolver_projection_e2e.py` 通过。
+2. 开仓经 `resolve_trade_deal(..., apply_changes=True)` 真实写入 SQLite。
+3. close/expire 事件经 writer 真实持久化路径落库，`raw_payload` 携带 `strategy_snapshot`。
+4. attribution 断言与现有基线一致：
+   - `attribution.groups[0]` 存在；
+   - `funding.put_open_credit_gross == 500.0`、`call_open_debit_gross == 400.0`、
+     `call_cost_funded_by_put == 400.0`、`funding_surplus == 100.0`；
+   - participation `realized_gross == 300.0`（USD）；
+   - 总账 `realized_gross == 800.0`（USD）；
+   - `attribution.conservation.realized_gross.residual_by_currency == {"USD": 0.0}`。
+5. 不发送真实通知、不写 `output/` / `output_runs/` / 状态文件。
+
+## Non-Goals / Scope Boundary
+
+- 不改 resolver / projection / performance 生产代码；只新增测试文件。
+- 不做错期/组合残留清理（`_with_combo_yield_long_call_payload` / `_with_combo_yield_sell_put_payload` 等归后续 work unit）。
+- 不发布、不升级、不 merge、不删除分支。
+- 不触碰主仓库工作树（并行会话产物不动）。
+- 不引入新依赖、不改 SQLite schema、不加配置项。
+
+## Goal Alignment
+
+| Plan element | Aligned goal / success signal |
+|---|---|
+| 真 SQLite repo + resolver open | Success signal 2（resolver 写库真实路径） |
+| writer 持久化 close/expire + strategy_snapshot | Success signal 3（事件解码与 projection） |
+| attribution 数值断言 | Success signal 4（attribution 正确性） |
+| 仅新增测试文件 | Non-goal：不改生产代码 |
+
+## Design Document Alignment
+
+无传入 design_doc；以 goal confirmation + 代码事实为准。
+
+## First-Principles Judgment and Direct Code Evidence
+
+1. `src/application/performance/service.py:21` `build_option_period_performance(repo, period, account, now_ms)` — performance 报告唯一公共入口。
+2. `src/application/performance/adapters.py:37` `load_ledger_performance_inputs(repo)` — 只经 `ledger_api.trade_event_log(repo)`（SQLite `list_trade_events`）读取并 projection。
+3. `src/application/trades/resolver.py:302` `resolve_trade_deal(deal, repo, state, apply_changes=True)` — 开仓真实写库入口；`_trade_open_ledger_inputs`（`src/application/ledger/preflight.py:792`）构造 `TradeEvent(event_id=broker_external_event_key(deal), lot_id=f"lot_{event_id}", raw_payload=dict(deal.raw_payload))`，因此 deal 的 `raw_payload["strategy_snapshot"]` 会原样落库。
+4. `src/application/ledger/commands.py:1808` `record_normalized_trade_event` → `persist_trade_event` → `persist_trade_event_object`（writer.py:335），对 SQLite repo 走真实事务并重建 projection。
+5. `src/application/ledger/writer.py:4097` `_trade_event_from_normalized_deal` — close 时 `target_lot_id` 从 `raw_payload["target_lot_id"]` / `["record_id"]` 解析，`raw_payload` 原样保留（含 `strategy_snapshot`）。
+6. `domain/domain/performance/attribution.py::resolve_event_attribution` — 从 `raw_payload.strategy_snapshot` 读 `strategy` / `leg_role` / `strategy_group_id` / `expiry_structure`；open 事件 lifecycle source = `lot_id`，close 事件 = `target_lot_id`（engine.py 约 1556 行 `_event_fact_kwargs`）。
+7. 现有基线测试：`tests/test_performance_strategy_attribution.py`（相同数值断言）、`tests/test_performance_service.py`（SQLite + service 入口）、`tests/test_trades_resolver_close.py`（resolver + SQLite 真实落库断言）。
+
+## Affected Files / Modules
+
+- 新增：`tests/test_performance_resolver_projection_e2e.py`（唯一代码改动）。
+- 文档：`docs/gateflow/perf-e2e-regression-plan-20260811.md`（本文件）及后续 gate artifacts。
+
+## Contract / Schema / State-Machine / Public-Interface Changes
+
+无。不改生产代码、公开接口、schema 或状态机。
+
+## Implementation Decisions
+
+### 决策 1：开仓经 resolver 真实写库（方案 A，goal confirmation 已确认）
+
+- 构造两个 `NormalizedTradeDeal`（put short open + call long open），`position_effect="open"`，`raw_payload` 显式携带：
+  ```python
+  "strategy_snapshot": {
+      "strategy": "combo_yield",
+      "leg_role": "funding_put" | "participation_call",
+      "strategy_group_id": "combo_yield:lx:pair-1",
+      "expiry_structure": "same_expiry",
+  }
+  ```
+- 分别 `resolve_trade_deal(deal, repo=repo, state={}, apply_changes=True)`，断言 `status == "applied"`。
+
+### 决策 2：close/expire 经 writer 真实持久化
+
+- 从 `repo.list_position_lots()` 读取 resolver 生成的开仓 lot `record_id`（= open event 的 `lot_id`，`lot_{event_id}`），作为 close 事件的 `target_lot_id`。
+- 构造 `TradeEvent`（put `expire_close` price=0；call `close` price=7），`raw_payload` 携带同一 `strategy_snapshot`，经 `persist_trade_event_object(repo, event)` 落库。
+- 理由：resolver 对零价到期 close 会走 lifecycle pending 分支，绕开会引入无关状态；writer 真实持久化已覆盖事件解码 + projection，且与生产 attribution 所需元数据形态一致。
+
+### 决策 3：报告入口与断言
+
+- `build_option_period_performance(repo, period={"period": "month", "month": "2026-05"}, account="lx", broker="futu", now_ms=NOW_MS, include_rows=False)`。
+- 断言与现有 `test_group_attribution_keeps_call_basis_out_of_put_pnl_and_conserves_group_pnl` 数值完全一致。
+- 额外断言 `repo.list_trade_events()` 中含 strategy_snapshot 的 open/close 事件，证明元数据真实落库并完成 round-trip。
+
+## Implementation Slices
+
+### Slice 1（唯一 slice）：`tests/test_performance_resolver_projection_e2e.py`
+
+- **Objective**：一条端到端回归测试通过。
+- **Expected outcome**：resolver 开仓写库 + writer close/expire 落库 + performance attribution 数值正确。
+- **Allowed files**：仅 `tests/test_performance_resolver_projection_e2e.py`。
+- **Exact allowed changes**：新增测试文件，包含：
+  - 常量 `TZ` / `NOW_MS` / `_ms()` 辅助；
+  - `_open_deal(role, option_type, side, strike, price, event_time)` 构造 `NormalizedTradeDeal`；
+  - `_close_event(...)` 构造 `TradeEvent`（含 `strategy_snapshot` 与 `target_lot_id`）；
+  - `test_resolver_open_to_performance_attribution_round_trip(tmp_path)`。
+- **Functions/call path/data flow**：见 Implementation Decisions；错误路径不做额外覆盖。
+- **Non-goals**：不覆盖 resolver close 真实写库（已有 `test_trades_resolver_close.py`）；不覆盖 live collector / evidence / FX。
+- **Tests/validation**：见下节验证命令。
+- **Completion signal**：`pytest tests/test_performance_resolver_projection_e2e.py -q` 全绿；再跑相关回归集合全绿。
+
+## Tests / Validation Commands and Expected Assertions
+
+```bash
+cd <worktree-root>
+PYTHONPYCACHEPREFIX=<tmp-cache> <repo-root>/.venv/bin/python -m pytest tests/test_performance_resolver_projection_e2e.py -q -p no:cacheprovider
+```
+
+Expected：1 passed。
+
+相关回归集合：
+
+```bash
+PYTHONPYCACHEPREFIX=<tmp-cache> <repo-root>/.venv/bin/python -m pytest \
+  tests/test_performance_resolver_projection_e2e.py \
+  tests/test_performance_strategy_attribution.py \
+  tests/test_performance_service.py \
+  tests/test_trades_resolver_close.py \
+  tests/test_assigned_stock_sale_intake.py \
+  -q -p no:cacheprovider
+```
+
+Expected：全绿（数值断言见 Success Signal 4）。
+
+## Docs Decision
+
+- 新增 gate artifacts（goal confirmation、plan、plan review、implementation、code review、aggregate deepreview、PR review、final closeout）至 `docs/gateflow/`。
+- 不更新用户文档：无公共命令、工具 payload、输出路径或安全边界变化。
+
+## Risks / Open Questions
+
+- 若测试暴露真实生产 bug（例如 resolver 落库后 attribution 数据不一致），只记录 finding，不顺手改生产代码；是否修复由用户单独确认。
+- Baseline 与 origin/main 漂移（`c9d64129`）：rebase 仅在 draft PR 准备时执行，避免本 work unit 期间引入并行会话冲突。
+- `persist_trade_event_object` 对 expire_close 事件与 projection 的兼容性：已由现有 projection 语义保证（`expire_close` ∈ CLOSE_EVENT_TYPES）；若验证失败会记录为 finding，不改语义。
+
+## Completion Report Format
+
+Final closeout 将包含：changed files、验证命令与结果、docs decision、finding status、residual risks / owners、draft PR URL、next entry point。

--- a/docs/gateflow/perf-e2e-regression-slice-1-implementation-20260811-112719.md
+++ b/docs/gateflow/perf-e2e-regression-slice-1-implementation-20260811-112719.md
@@ -1,0 +1,76 @@
+# Gateflow Implementation Artifact — perf-e2e-regression slice-1
+
+- Gate: `implementation`
+- Work unit: `perf-e2e-regression`
+- Slice: `slice-1`
+- Artifact path: `docs/gateflow/perf-e2e-regression-slice-1-implementation-20260811-112719.md`
+- Branch: `perf-e2e-regression`
+- Baseline: `db2c361e`
+
+## Objective
+
+Add a real end-to-end regression test proving that a Combo Yield pair opened through the trade resolver is
+persisted to SQLite and then correctly attributed by the period performance service. This closes the gap where
+attribution logic was only exercised against hand-built in-memory `TradeEvent` objects.
+
+## Scope
+
+Allowed changes: `tests/test_performance_resolver_projection_e2e.py` only. No production code changes.
+
+## Changed files
+
+- `tests/test_performance_resolver_projection_e2e.py` (new)
+
+## Implementation decisions
+
+1. Open path uses the real production chain: `resolve_trade_deal` -> `record_normalized_trade_event` ->
+   `persist_trade_event` -> `persist_trade_event_object` -> SQLite persistence -> lot projection. No mocks in the
+   ledger write path.
+2. Close/expire path uses `persist_trade_event_object` directly with explicit `target_lot_id` and a
+   `strategy_snapshot` in `raw_payload`. Rationale: a zero-price expiry through the resolver enters the
+   lifecycle-pending flow instead of producing a plain realized close, which is out of scope for this regression.
+3. The resolver's `_enrich_combo_yield_open` returns `combination_relation_pending` diagnostics for both legs and
+   does not block the open; the test therefore asserts `status == "applied"` and does not assert pair-relation state.
+4. Attribution assertions match the existing hand-built attribution baseline (put 500 / call 400 / funded 400 /
+   surplus 100 / participation 300 / group 800 / total 800 / residual 0.0), so the two test layers stay consistent.
+5. Timezone is fixed to Asia/Shanghai and `NOW_MS` is pinned so period selection and time bucketing are deterministic.
+
+## Validation
+
+Focused run:
+
+```bash
+PYTHONPYCACHEPREFIX=<tmp-cache> <repo-root>/.venv/bin/python -m pytest tests/test_performance_resolver_projection_e2e.py -q -p no:cacheprovider
+# 1 passed
+```
+
+Regression run (attribution, period service, resolver close, assigned-stock intake):
+
+```bash
+PYTHONPYCACHEPREFIX=<tmp-cache> <repo-root>/.venv/bin/python -m pytest \
+  tests/test_performance_resolver_projection_e2e.py \
+  tests/test_performance_strategy_attribution.py \
+  tests/test_performance_service.py \
+  tests/test_trades_resolver_close.py \
+  tests/test_assigned_stock_sale_intake.py \
+  -q -p no:cacheprovider
+# 85 passed
+```
+
+## Docs decision
+
+No user-facing docs change: this is a test-only addition with no public contract, output path, or CLI change.
+
+## Residual risks
+
+- Happy-path only: no rejected/validation-failed opens, lifecycle-pending expiries, or `partial_data` attribution
+  paths. Classified: covered by later work unit if such coverage is ever required; not part of this work unit's
+  success signal.
+- `_lot_record_id` locates lots by exact float strike comparison; safe for the exact values used here, brittle for
+  computed strikes. Classified: fixed in current slice is not needed; noted for future test authors.
+- No production code was touched, so this slice introduces no production behavior risk.
+
+## Completion status
+
+`implementation complete` for slice-1. Validation green (1 passed focused, 85 passed regression). Next gate:
+`code review`.

--- a/docs/reviews/code-review-20260811-112846.md
+++ b/docs/reviews/code-review-20260811-112846.md
@@ -1,0 +1,59 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `perf-e2e-regression`
+- Base: `db2c361e`
+- Output file: `docs/reviews/code-review-20260811-112846.md`
+- Included scope: `tests/test_performance_resolver_projection_e2e.py` (new E2E regression test);
+  gateflow implementation artifact `docs/gateflow/perf-e2e-regression-slice-1-implementation-20260811-112719.md`
+- Excluded scope: production code (none changed); plan/plan-review artifacts from the accepted plan gate
+- Parallel review coverage: 无；single-file test change, reviewed end-to-end against the real resolver/writer/performance chain
+
+## Findings
+
+未发现实质性问题。
+
+Verification performed:
+
+1. Open path traced through real production code: `resolve_trade_deal` (resolver.py:302) -> `_trade_open_ledger_inputs`
+   (ledger/preflight.py:792) -> `record_broker_trade_open` -> `persist_trade_event` -> `persist_trade_event_object`
+   (writer.py:335). Event id is `broker_external_event_key` (`futu:lx:REAL_1:<deal_id>`), lot id is `lot_<event_id>`,
+   and `raw_payload` (including `strategy_snapshot`) is passed through to storage. The test's assertions match this chain.
+2. Close/expire path traced: `_events_for_storage` (writer.py:3936) returns events with `target_lot_id` as-is;
+   `persist_trade_event_object` upserts, rebuilds the projection, and reports `created=any(created_flags)`. The test
+   targets lots resolved from `list_position_lots()` so the close events exercise the persisted lot ids.
+3. Attribution path traced: `_event_fact_kwargs` (domain/domain/performance/engine.py:1555) uses
+   `lot_id_for_open_event` for opens and `target_lot_id` for closes, and `resolve_event_attribution`
+   (domain/domain/performance/attribution.py:21) reads `strategy_snapshot`. `service.build_option_period_performance`
+   returns `report["attribution"]`/`report["pnl"]` from `build_period_performance(...).to_dict()`; group/conservation
+   structure matches the assertions.
+4. Expected values cross-checked against the existing domain-level baseline
+   (`tests/test_performance_strategy_attribution.py::test_group_attribution_keeps_call_basis_out_of_put_pnl_and_conserves_group_pnl`):
+   the E2E test asserts the identical 500/400/400/100/300/800/800/0.0 numbers, so the numbers are non-trivial and would
+   fail if attribution ignored these events.
+5. Discriminating power: if the resolver dropped `strategy_snapshot`, the storage-snapshot assertions fail; if lot id
+   or projection changed, lot lookup fails; if `expiry_structure` degraded, group attribution fails closed to partial.
+6. Repo instructions checked: no import-boundary violation (tests may import both layers; existing tests do the same);
+   no writes outside `tmp_path`; no notification/config/output/state mutation. `ruff check` passes (120-col limit).
+7. Regression: 85 passed across the E2E test plus performance attribution, period service, resolver close, and
+   assigned-stock intake suites.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Happy path only: the E2E test covers one successful Combo Yield pair cycle. Rejected opens, lifecycle-pending
+  expiries, and `partial_data` attribution paths remain covered only by unit-level tests. Classified: covered by later
+  work unit if required; not part of this work unit's success signal.
+- Close/expire persistence intentionally bypasses the resolver (documented implementation decision): the resolver
+  close branch itself is not re-exercised by this test; existing `tests/test_trades_resolver_close.py` covers that path.
+- `_lot_record_id` uses exact float strike equality; safe for the exact representable values used here, brittle for
+  computed strikes. Classified: test-local helper with no production impact.
+- The test asserts group numbers but not `attribution["coverage"]["status"]`; a partial-coverage regression would
+  still fail via the empty/mismatched group assertions in practice, but the coverage invariant is not asserted directly.
+- `ruff format --check` would reformat one line in the new file; repository CI only enforces `ruff check`, and existing
+  related test files also deviate from `ruff format`, so this is not treated as a defect.

--- a/docs/reviews/code-review-20260811-113132.md
+++ b/docs/reviews/code-review-20260811-113132.md
@@ -1,0 +1,51 @@
+# Code Review — Aggregate Deepreview
+
+## Scope
+
+- Mode: current changes (aggregate deepreview over the complete work unit)
+- Branch or PR: `perf-e2e-regression`
+- Base: `db2c361e`
+- Output file: `docs/reviews/code-review-20260811-113132.md`
+- Included scope: complete `perf-e2e-regression` work unit — accepted plan gate
+  (`0e578329`) and accepted slice-1 (`5a3ce7e0`); reviewed target
+  `tests/test_performance_resolver_projection_e2e.py` plus gateflow artifacts
+- Excluded scope: production code (none changed); unrelated repository areas
+- Parallel review coverage: 无；single-file test change, reviewed end-to-end against the real resolver/writer/performance chain
+
+## Findings
+
+未发现实质性问题。
+
+Aggregate verification performed on top of the slice-1 review:
+
+1. Commit scope confirmed: branch contains exactly the accepted plan commit and the accepted slice commit; no
+   unrelated changes. Working tree clean.
+2. Open chain re-traced with the repository's real entry: `resolve_trade_deal` -> `apply_trade_open_with` ->
+   `record_broker_trade_open` -> `persist_trade_open_event_with_ledger` (ledger/commands.py:166), which builds the
+   event via `_trade_open_ledger_inputs`, checks duplicates by `event_id`/`lot_id`, runs the open preflight, and
+   persists through `record_normalized_trade_event`. No external side effects (notifications, config, network) exist
+   in this path; the write is a pure SQLite persistence + projection.
+3. Broker normalization verified: open fields carry broker `"富途"`, which `normalize_broker`
+   (domain/domain/option_position_identity.py:46) maps to `"futu"`, matching the `broker="futu"` filter used by
+   `build_option_period_performance`. The test therefore exercises the real account/broker filtering path.
+4. Storage round-trip verified: `list_trade_events()` returns application payloads via
+   `trade_event_application_payload`, and the snapshot assertions prove `strategy_snapshot` survives
+   canonicalization/encoding for both resolver-opened and writer-persisted close events.
+5. Attribution discrimination verified: expected values are non-trivial (500/400/400/100/300/800/800/0.0) and equal
+   the independent domain-level baseline, so the E2E test would fail if any of resolver open, SQLite persistence,
+   projection/lot identity, or attribution dropped or distorted facts.
+6. Broad regression evidence: 212 passed across all `tests/test_performance_*.py`, resolver open/close, and combo
+   reconciliation suites; plus the earlier 85-passed focused regression set.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Happy-path E2E only; rejected opens, lifecycle-pending expiries, and partial-data attribution remain unit-level
+  coverage. Classified: covered by later work unit if required; not part of this work unit's success signal.
+- Close/expire persistence intentionally bypasses the resolver (documented plan decision); the resolver close branch
+  is covered by `tests/test_trades_resolver_close.py`.
+- `_lot_record_id` exact-float strike matching is test-local and safe for the values used.
+- PR review and merge remain pending external gates; no release/upgrade/merge authority has been exercised.

--- a/docs/reviews/plan-review-20260811-112333.md
+++ b/docs/reviews/plan-review-20260811-112333.md
@@ -1,0 +1,78 @@
+# Plan Review — perf-e2e-regression
+
+- Gate: `plan review`
+- Work unit: `perf-e2e-regression`
+- Review date: 2026-08-11 11:23:33 (Asia/Shanghai)
+- Reviewed artifact: `docs/gateflow/perf-e2e-regression-plan-20260811.md`
+- Baseline: `db2c361e` (tag `v1.13.9`)
+- Artifact path: `docs/reviews/plan-review-20260811-112333.md`
+- Status: `pass-with-risks`
+
+## Reviewed Target and Scope
+
+Plan 的目标是在唯一新增测试文件 `tests/test_performance_resolver_projection_e2e.py` 中，覆盖生产权威数据链：
+
+`resolver 开仓真实写 SQLite (apply_changes=True) -> trade_events/projection -> build_option_period_performance -> attribution groups`
+
+Review 范围：plan 的 goal/non-goal 边界、implementation decisions、slice 规格、测试/验证命令、
+预期断言是否与代码事实一致，以及是否 code-generation-ready。不改动生产代码、不实施 fix。
+
+## Assumptions Tested
+
+| # | Plan 假设 | 验证方式 | 结果 |
+|---|---|---|---|
+| 1 | `resolve_trade_deal(deal, repo=repo, state={}, apply_changes=True)` 对 open 会真实写 SQLite | `resolver.py:302` 默认 `persist_fn = record_normalized_trade_event`；open 分支 `apply_trade_open_with` -> `record_broker_trade_open` -> `persist_trade_open_event_with_ledger` -> `persist_trade_event_object`（writer.py:335，`with_sqlite_repo_transaction` + upsert + replace_position_lots） | 成立 |
+| 2 | `deal.raw_payload["strategy_snapshot"]` 会原样落库 | `preflight.py:792` `_trade_open_ledger_inputs`：`raw_payload=dict(deal.raw_payload)`；`_canonical_storage_event`/codec 保留 raw_payload（`_trade_event_from_application_payload` adapters.py:231） | 成立 |
+| 3 | open 的 lot `record_id == lot_id == lot_{event_id}` | `_trade_open_ledger_inputs` 设 `lot_id=f"lot_{event_id}"`（event_id=`broker_external_event_key`=`futu:lx:REAL_1:<deal_id>`）；`events.py:101` `lot_id_for_open_event` 返回 `event.lot_id`；`publisher.py:127` `PositionLotRecord(record_id=lot.lot_id, ...)` | 成立 |
+| 4 | close/expire 经 `persist_trade_event_object(repo, event)` 可直接落库 | `_events_for_storage` 对已带 `target_lot_id` 的 TradeEvent 原样返回；`expire_close`/`close` 属 close event types；`ensure_projection_publishable` 对 error diagnostics 抛错 | 成立 |
+| 5 | attribution 通过 `raw_payload.strategy_snapshot` + `lot_id`/`target_lot_id` 归组 | `attribution.py::resolve_event_attribution` 读取 `strategy/leg_role/strategy_group_id/expiry_structure`；engine.py `_event_fact_kwargs` open 用 `lot_id_for_open_event`、close 用 `target_lot_id` | 成立 |
+| 6 | 数值断言与现有基线一致 | `tests/test_performance_strategy_attribution.py` 同数值（500/400/400/100/300/800/0.0） | 成立 |
+| 7 | `account="lx"` 在 service 中可用 | `test_performance_service.py` 已验证 "LX" 归一化为 "lx"；小写输入走同一归一化 | 成立 |
+| 8 | 开仓必填字段可满足 | `_required_open_missing`（resolver.py:226）11 字段 + `broker_deal_key` 要求 `futu_account_id`；`test_trades_resolver_close._deal()` base 已含 `futu_account_id="REAL_1"` | 成立（见 Finding 1） |
+| 9 | `_enrich_combo_yield_open` 不阻塞 open | `resolver.py:685` 两条分支均返回 `deal=None` + `combination_relation_pending` 诊断，open 继续执行 | 成立 |
+
+## Findings
+
+### 1-未修复-低-测试夹具必填字段未在 plan 中显式枚举，存在实施返工风险
+- **位置**: plan「Implementation Decisions 决策 1」与「Slice 1 Exact allowed changes」中 `_open_deal` helper
+- **问题类型**: 不可直接实施
+- **当前写法**: plan 只描述 helper 名称与参数 `(role, option_type, side, strike, price, event_time)`，未枚举 `NormalizedTradeDeal` 必填字段
+- **反例/失败场景**: 实施 agent 按直觉构造 deal：缺 `futu_account_id` 时 resolver 在 `broker_deal_key` 处直接返回 `identity_needs_review`；缺 `expiration_ymd`/`currency`/`trade_time_ms`/`multiplier` 时返回 `missing_required_fields`，测试无法一次通过
+- **为什么有问题**: resolver 的必填字段集合是硬约束；plan 若不显式列出，实施 agent 需重新读 resolver 代码推导，不满足 code-generation-ready 要求
+- **直接证据**: `resolver.py:226` `_required_open_missing`（deal_id/internal_account/symbol/option_type/contracts/price/strike/multiplier/expiration_ymd/currency/trade_time_ms）；`resolver.py:346` 空 `broker_deal_key` 返回 `identity_needs_review`；`external_event_key.py:6` 要求 deal_id + internal_account + futu_account_id；`test_trades_resolver_close.py::_deal()` base 已含 `futu_account_id="REAL_1"`
+- **影响**: 实施 Agent 跑偏 / 生成错误代码 / 返工
+- **建议改法和验证点**: 实施时在 `_open_deal` 中显式包含全部必填字段：`broker="富途"`、`futu_account_id="REAL_1"`、`internal_account="lx"`、`symbol="NVDA"`、`option_type`、`side="sell"/"buy"`、`position_effect="open"`、`contracts=1`、`price`、`strike=100/120`、`multiplier=100`、`multiplier_source="cache"`、`expiration_ymd="2026-05-31"`、`currency="USD"`、`trade_time_ms`、`raw_payload` 携带 `strategy_snapshot`；验证点 = 测试一次通过，无 `missing_required_fields` / `identity_needs_review` 分支
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 低
+
+### 2-未修复-低-端到端覆盖为 happy path，close 经 writer 而非 resolver close
+- **位置**: plan「Non-Goals / Scope Boundary」与「Slice 1 Non-goals」
+- **问题类型**: 测试缺口
+- **当前写法**: close/expire 经 `persist_trade_event_object` 直接落库，明确排除 resolver close 真实写库
+- **反例/失败场景**: 若 resolver close 的 target_lot_id 解析/落库逻辑未来回归，本 E2E 无法发现；测试只证明 happy path，不覆盖 fail-closed 分支
+- **为什么有问题**: 生产链路中真实 close 通常经 resolver（`apply_trade_close_with`）；"端到端"只覆盖 open→writer-close 组合，读者若误读为覆盖全部 close 路径会产生偏差
+- **直接证据**: goal confirmation 已由用户确认方案 A（close 经 writer）；resolver close 真实写库已由 `tests/test_trades_resolver_close.py` 覆盖；attribution fail-closed 已由 `test_legacy_diagonal_group_fails_closed_to_partial_attribution` 覆盖
+- **影响**: 风险后移（非本 work unit 缺陷）
+- **建议改法和验证点**: 保持当前边界，residual risk 已记录于本 artifact；后续 work unit 可扩展 resolver-close→attribution E2E；验证点 = `test_trades_resolver_close.py` 保留在回归集合中
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 低
+
+## Open Questions
+
+- 无 blocking open questions。
+
+## Residual Risks and Suggested Tracking Destination
+
+1. resolver close 路径不在本 E2E 覆盖内 — `covered by existing test`（`test_trades_resolver_close.py`）；如需要更完整链路，建议作为后续 work unit（`assigned to later work unit`）。
+2. 本 E2E 仅 happy path — `covered by existing test`（attribution fail-closed 测试已存在）。
+3. baseline 与 origin/main 漂移（origin/main 已到 `c9d64129`）— `covered by later approved slice`（PR 准备阶段 rebase，gate: ready-to-open-draft-PR）。
+4. `expire_close` price=0 经 `persist_trade_event_object` 的 projection 兼容性 — 现有 `CLOSE_EVENT_TYPES` + projection 语义保证；若实施验证失败，按 finding 记录并由用户单独裁决修复。
+
+## Final Plan Review Conclusion
+
+`pass-with-risks`。
+
+Plan 目标与 goal confirmation 一致，slice 规格可实施，测试断言与现有 attribution 基线一致，关键代码事实
+（resolver 写库路径、strategy_snapshot 透传、lot record_id 映射、close/expire 持久化、attribution 归组）
+均经源代码验证成立。两个低危 finding 不阻塞实施：Finding 1 在实施时按建议补全 helper 字段即可；
+Finding 2 是已记录边界，由现有测试覆盖。

--- a/docs/reviews/pr-147-review-20260811-115449.md
+++ b/docs/reviews/pr-147-review-20260811-115449.md
@@ -1,0 +1,94 @@
+# Code Review
+
+## Scope
+
+- Mode: PR review
+- PR: #147 — `test(perf): add resolver-to-attribution E2E regression for Combo Yield`
+- Author: `liuxie066`
+- Head: `perf-e2e-regression` (`7a5b1e66203347075237c134094bc355290c3207`)
+- Base: `main` (`c9d64129`, v1.13.10)
+- URL: https://github.com/liuxie066/options-monitor/pull/147
+- Output file: `docs/reviews/pr-147-review-20260811-115449.md`
+- Included scope: complete PR diff — new test
+  `tests/test_performance_resolver_projection_e2e.py` plus the six gateflow
+  artifacts (goal confirmation, plan, plan review, slice-1 implementation,
+  slice code review, aggregate deepreview); real-chain verification against
+  resolver / ledger writer / performance engine; CI check information for the
+  PR head commit.
+- Excluded scope: production code (none changed in this PR); unrelated
+  repository areas.
+- Parallel review coverage: 无；single-file test change, reviewed end-to-end
+  against the real resolver/writer/performance chain.
+
+## Findings
+
+未发现实质性问题。
+
+Independent verification performed for this PR review (not copied from prior
+artifacts):
+
+1. PR facts verified via GitHub API: state `open`, `draft: true`,
+   `mergeable: true`, head SHA matches the local branch tip exactly
+   (`7a5b1e66203347075237c134094bc355290c3207`).
+2. Open chain re-traced on the real code path: `resolve_trade_deal`
+   (`src/application/trades/resolver.py:302`, default persist fn
+   `record_normalized_trade_event`) -> `apply_trade_open_with` ->
+   `record_broker_trade_open` -> `persist_trade_event_object`
+   (`src/application/ledger/writer.py:335`). `raw_payload` (including
+   `strategy_snapshot`) is preserved through
+   `_trade_open_ledger_inputs` (`src/application/ledger/preflight.py:792`) and
+   the storage codec; the test's event-id key
+   `futu:lx:REAL_1:<deal_id>` matches `broker_external_event_key`.
+3. Close/expire chain verified: `persist_trade_event_object` upserts events
+   with `target_lot_id` as-is and rebuilds the projection; `created=True` is
+   asserted on a fresh `tmp_path` SQLite file, so the write actually happened.
+4. Attribution chain verified: `resolve_event_attribution`
+   (`domain/domain/performance/attribution.py:21`) reads the four snapshot
+   keys (`strategy`, `leg_role`, `strategy_group_id`, `expiry_structure`) that
+   the test fixture sets; open facts key on `lot_id` and close facts on
+   `target_lot_id`; `strategy_group_id="combo_yield:lx:pair-1"` matches the
+   production `combo_yield:` prefix convention
+   (`domain/domain/performance/engine.py:1346-1360`). The asserted output keys
+   (`put_open_credit_gross`, `call_open_debit_gross`, `call_cost_funded_by_put`,
+   `funding_surplus`, `funding_cycles`, `participation_lifecycles`,
+   `realized_gross.by_currency`, `conservation.residual_by_currency`) all exist
+   in `domain/domain/performance/strategy_attribution.py`.
+5. Discriminating power: the asserted values
+   (500/400/400/100/300/800/800/0.0) are non-trivial and match the independent
+   domain-level baseline (`tests/test_performance_strategy_attribution.py`);
+   snapshot round-trip assertions fail if any layer drops or distorts
+   `strategy_snapshot`; the conservation residual assertion fails on any
+   double-count or leak. Focused run re-executed in this review: `1 passed`.
+6. CI evidence (GitHub API, PR head commit): all 5 check runs completed
+   `success` (CodeQL, guardrails, agent-plugin, Analyze actions, Analyze
+   python). Legacy commit-status API reports 0 statuses, which is not
+   authoritative here; check-runs is the authoritative surface and is green.
+7. Repo instructions checked: no import-boundary violation, no writes outside
+   `tmp_path`, no notification/config/output/state mutation; deterministic
+   fixture (fixed `Asia/Shanghai` TZ, pinned `NOW_MS`, exact representable
+   strikes). Commit set contains exactly the three accepted gate commits plus
+   the rebased base; working tree clean.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- Happy-path E2E only: rejected/validation-failed opens, lifecycle-pending
+  expiries, and `partial_data` attribution paths remain unit-level coverage.
+  Classified: covered by later work unit if required; not part of this work
+  unit's success signal.
+- Close/expire persistence intentionally bypasses the resolver (accepted plan
+  decision); resolver-close real-write coverage remains in
+  `tests/test_trades_resolver_close.py`.
+- The fixture injects `strategy_snapshot` manually; production enrichment of
+  combo snapshots on intake (`_with_combo_yield_*` leftover helpers) is a
+  separate work unit and is not proven by this test.
+- `_lot_record_id` matches lots by exact float strike; safe for the values
+  used, brittle for computed strikes. Test-local helper, no production impact.
+- `attribution["coverage"]["status"]` is not asserted directly; empty/mismatched
+  group assertions would still fail on a partial-coverage regression.
+- `ruff format --check` would reformat one line; repository CI only enforces
+  `ruff check` (green), and existing related test files deviate similarly, so
+  this is not treated as a defect.

--- a/tests/test_performance_resolver_projection_e2e.py
+++ b/tests/test_performance_resolver_projection_e2e.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from domain.domain.ledger import ContractKey, TradeEvent
+from src.application.ledger.repository import SQLiteOptionPositionsRepository
+from src.application.ledger.writer import persist_trade_event_object
+from src.application.performance.service import build_option_period_performance
+from src.application.trades.normalizer import NormalizedTradeDeal
+from src.application.trades.resolver import resolve_trade_deal
+
+
+TZ = ZoneInfo("Asia/Shanghai")
+NOW_MS = int(datetime(2026, 7, 17, 12, 0, tzinfo=TZ).timestamp() * 1000)
+
+
+def _ms(value: str) -> int:
+    return int(datetime.fromisoformat(value).replace(tzinfo=TZ).timestamp() * 1000)
+
+
+def _snapshot(role: str) -> dict:
+    return {
+        "strategy": "combo_yield",
+        "leg_role": role,
+        "strategy_group_id": "combo_yield:lx:pair-1",
+        "expiry_structure": "same_expiry",
+    }
+
+
+def _open_deal(
+    *,
+    role: str,
+    option_type: str,
+    side: str,
+    strike: float,
+    price: float,
+    deal_id: str,
+    order_id: str,
+    event_time: str,
+) -> NormalizedTradeDeal:
+    return NormalizedTradeDeal(
+        broker="富途",
+        futu_account_id="REAL_1",
+        internal_account="lx",
+        deal_id=deal_id,
+        order_id=order_id,
+        symbol="NVDA",
+        option_type=option_type,
+        side=side,
+        position_effect="open",
+        contracts=1,
+        price=price,
+        strike=strike,
+        multiplier=100,
+        multiplier_source="cache",
+        expiration_ymd="2026-05-31",
+        currency="USD",
+        trade_time_ms=_ms(event_time),
+        raw_payload={
+            "fee_provenance": {"basis": "actual", "amount": 0, "source": "test"},
+            "strategy_snapshot": _snapshot(role),
+        },
+    )
+
+
+def _close_event(
+    *,
+    event_id: str,
+    event_type: str,
+    event_time: str,
+    role: str,
+    option_type: str,
+    position_side: str,
+    strike: float,
+    price: float,
+    target_lot_id: str,
+) -> TradeEvent:
+    return TradeEvent(
+        event_id=event_id,
+        event_type=event_type,
+        event_time_ms=_ms(event_time),
+        contract_key=ContractKey.from_values(
+            broker="futu",
+            account="lx",
+            underlying_symbol="NVDA",
+            option_type=option_type,
+            position_side=position_side,
+            strike=strike,
+            expiration_ymd="2026-05-31",
+        ),
+        contracts=1,
+        price=price,
+        currency="USD",
+        source="test",
+        multiplier=100,
+        fees=0,
+        target_lot_id=target_lot_id,
+        raw_payload={
+            "fee_provenance": {"basis": "actual", "amount": 0, "source": "test"},
+            "strategy_snapshot": _snapshot(role),
+        },
+    )
+
+
+def _lot_record_id(lots: list[dict], *, option_type: str, side: str, strike: float) -> str:
+    for lot in lots:
+        fields = lot["fields"]
+        if (
+            str(fields.get("option_type") or "") == option_type
+            and str(fields.get("side") or "") == side
+            and float(fields.get("strike") or 0.0) == strike
+        ):
+            return str(lot["record_id"])
+    raise AssertionError(f"lot not found: option_type={option_type} side={side} strike={strike}")
+
+
+def test_resolver_open_to_performance_attribution_round_trip(tmp_path) -> None:
+    repo = SQLiteOptionPositionsRepository(tmp_path / "perf-e2e.sqlite3")
+
+    put_open = _open_deal(
+        role="funding_put",
+        option_type="put",
+        side="sell",
+        strike=100.0,
+        price=5.0,
+        deal_id="put-open",
+        order_id="order-put-open",
+        event_time="2026-05-01T00:00:00",
+    )
+    call_open = _open_deal(
+        role="participation_call",
+        option_type="call",
+        side="buy",
+        strike=120.0,
+        price=4.0,
+        deal_id="call-open",
+        order_id="order-call-open",
+        event_time="2026-05-01T00:00:00",
+    )
+
+    put_result = resolve_trade_deal(put_open, repo=repo, state={}, apply_changes=True)
+    assert put_result.status == "applied"
+    assert put_result.action == "open"
+    assert put_result.reason == "applied_open"
+
+    call_result = resolve_trade_deal(call_open, repo=repo, state={}, apply_changes=True)
+    assert call_result.status == "applied"
+    assert call_result.action == "open"
+    assert call_result.reason == "applied_open"
+
+    lots = repo.list_position_lots()
+    assert len(lots) == 2
+    put_lot_id = _lot_record_id(lots, option_type="put", side="short", strike=100.0)
+    call_lot_id = _lot_record_id(lots, option_type="call", side="long", strike=120.0)
+
+    put_expire = _close_event(
+        event_id="put-expire",
+        event_type="expire_close",
+        event_time="2026-05-10T00:00:00",
+        role="funding_put",
+        option_type="put",
+        position_side="short",
+        strike=100.0,
+        price=0.0,
+        target_lot_id=put_lot_id,
+    )
+    call_close = _close_event(
+        event_id="call-close",
+        event_type="close",
+        event_time="2026-05-20T00:00:00",
+        role="participation_call",
+        option_type="call",
+        position_side="long",
+        strike=120.0,
+        price=7.0,
+        target_lot_id=call_lot_id,
+    )
+
+    put_write = persist_trade_event_object(repo, put_expire)
+    assert put_write.created is True
+    call_write = persist_trade_event_object(repo, call_close)
+    assert call_write.created is True
+
+    stored_events = repo.list_trade_events()
+    assert len(stored_events) == 4
+    snapshots = {
+        str(item["event_id"]): (item.get("raw_payload") or {}).get("strategy_snapshot")
+        for item in stored_events
+    }
+    assert snapshots["futu:lx:REAL_1:put-open"] == _snapshot("funding_put")
+    assert snapshots["futu:lx:REAL_1:call-open"] == _snapshot("participation_call")
+    assert snapshots["put-expire"] == _snapshot("funding_put")
+    assert snapshots["call-close"] == _snapshot("participation_call")
+
+    report = build_option_period_performance(
+        repo,
+        period={"period": "month", "month": "2026-05"},
+        account="lx",
+        broker="futu",
+        now_ms=NOW_MS,
+        include_rows=False,
+    )
+
+    attribution = report["attribution"]
+    assert len(attribution["groups"]) == 1
+    group = attribution["groups"][0]
+
+    assert group["funding"]["put_open_credit_gross"] == 500.0
+    assert group["funding"]["call_open_debit_gross"] == 400.0
+    assert group["funding"]["call_cost_funded_by_put"] == 400.0
+    assert group["funding"]["funding_surplus"] == 100.0
+    assert group["funding_cycles"][0]["pnl"]["realized_gross"]["by_currency"] == {"USD": 500.0}
+    assert group["participation_lifecycles"][0]["pnl"]["realized_gross"]["by_currency"] == {"USD": 300.0}
+    assert group["pnl"]["realized_gross"]["by_currency"] == {"USD": 800.0}
+    assert report["pnl"]["realized_gross"]["by_currency"] == {"USD": 800.0}
+    assert attribution["conservation"]["realized_gross"]["residual_by_currency"] == {"USD": 0.0}


### PR DESCRIPTION
Gateflow work unit perf-e2e-regression: adds an end-to-end regression test covering the real production chain trade resolver open -> SQLite persistence -> period performance attribution for a same-expiry Combo Yield pair.

- Branch contains the accepted plan, implementation slice-1 (new test only), slice code review, and aggregate deepreview artifacts.
- No production code changes.
- Validation: focused test 1 passed; regression set 85 passed; broader performance/resolver/combo suite 212 passed; post-rebase focused set 71 passed.
- Residual risks and uncovered areas are recorded in the review artifacts under docs/reviews/.