### PR TITLE
fix(candidates): seal combo-yield rank as nullable int

### DIFF
--- a/docs/gateflow/combo-yield-rank-int-seal/final-closeout.md
+++ b/docs/gateflow/combo-yield-rank-int-seal/final-closeout.md
@@ -1,0 +1,62 @@
+# Gateflow Final Closeout — combo-yield-rank-int-seal
+
+- Work unit: `combo-yield-rank-int-seal`
+- Gate: `final closeout`
+- Branch: `fix/combo-yield-rank-int-seal`
+- Date: 2026-08-13
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/152`
+- Status: `final closeout pass`（待用户 merge PR）
+
+## What Changed
+
+- `src/application/sell_put_call_helper.py` — `build_yield_enhancement_rank_shadow` 末尾对
+  `baseline_rank` / `shadow_rank` 两列 `astype("Int64")`，使 rank 列从 float64 修正为 pandas nullable
+  `Int64`。
+- `tests/test_sell_put_linked_call_helper.py` — 新增
+  `test_yield_enhancement_rank_shadow_emits_nullable_int_ranks`，锁定 dtype 与 int/None 形态。
+
+## What Was Verified
+
+- focused 测试：`55 passed`（`test_sell_put_linked_call_helper.py` +
+  `test_combo_yield_candidate_snapshot.py` + `test_combo_yield_steps.py`）。
+- CI：`Analyze (actions)`、`Analyze (python)`、`CodeQL`、`agent-plugin`、`guardrails` 全部 pass。
+
+## Docs Updates
+
+- `docs/gateflow/combo-yield-rank-int-seal/plan.md`
+- `docs/gateflow/combo-yield-rank-int-seal/s1-implementation.md`
+- `docs/reviews/plan-review-20260813-103204.md`
+- `docs/reviews/code-review-20260813-103936.md`
+- `docs/reviews/code-review-20260813-104203.md`（aggregate deepreview）
+- `docs/reviews/pr-152-review-20260813-110952.md`（PR review）
+- 本文档（final closeout）
+- 无需更新 `docs/AGENT_WIKI.md`（无公共命令 / 契约变化）。
+
+## Finding Status
+
+- plan review：唯一 accepted finding（新增测试构造规格化 + 覆盖 unselected→None）→ `已修复`。
+- code review：未发现实质性问题。
+- aggregate deepreview：未发现实质性问题。
+- PR review：未发现实质性问题（`pass`，无需 fix）。
+- 无 rejected-with-reason / deferred-with-owner / needs-more-evidence findings。
+
+## Remaining Risks / Owners
+
+- 空 DataFrame 分支返回 `object` dtype 空列（与非空路径 `Int64` 不一致）：既有行为、无正确性影响，
+  本轮不处理。
+- deferred follow-up（owner: 后续单独 work unit）：`opening_candidate_snapshot.json` 中
+  `contract_symbol` 别名 `HK.POP261029C177500` 线索，与本次根因无关，建议后续单独核查。
+- 远端 live Feishu / 运行验证：属独立发布 / 远端升级授权，不在本 work unit。
+
+## Issue Link Status
+
+- N/A（本 work unit 不是 issue）。
+
+## Issue Closeout Comment Status
+
+- N/A（本 work unit 不是 issue）。
+
+## Next Entry Point
+
+- 用户 merge PR #152 后，可进入独立的发布 / 远端升级授权流程，验证线上 HK 批次恢复正常；
+  本 work unit 已到 `final closeout pass`。

--- a/docs/gateflow/combo-yield-rank-int-seal/plan.md
+++ b/docs/gateflow/combo-yield-rank-int-seal/plan.md
@@ -1,0 +1,203 @@
+# Gateflow Plan — combo-yield-rank-int-seal
+
+- Work unit: `combo-yield-rank-int-seal`
+- Gate: `plan`
+- Branch: `fix/combo-yield-rank-int-seal`
+- Date: 2026-08-13
+
+## Goal / Motivation / Success Signal
+
+- Goal: 修复 combo yield（sp_lc）候选快照密封时 `baseline_rank` / `shadow_rank` 的类型契约，使
+  producer 产出的 rank 列经 `to_dict("records")` + `normalize_json_value` 后为 Python `int`
+  （选中行）或 `None`（未选中行），从而通过 `_rank_records` 的严格 int 校验。
+- Motivation: 线上 HK 09:40 批次 `lx` / `sy` 均因 `rank record baseline_rank is invalid`
+  失败，Daily Brief 渲染成固定失败文案「数据异常 · 09:40 批次失败」。
+- Success signal: `build_yield_enhancement_rank_shadow` 返回的 `baseline_rank` / `shadow_rank`
+  两列为 pandas nullable `Int64` dtype；`to_dict("records")` 后选中行 rank 是 Python `int`
+  且非 `bool`；未选中行为 `None`；`_rank_records` 对真实 producer 输出不再抛错。
+
+## Non-goals / Scope Boundary
+
+- 不修改 `_rank_records` 的严格 int 校验语义（保留 `isinstance(rank, int)`、排除 bool、`> 0`）。
+- 不修改 `candidate_snapshot_contract.normalize_json_value` 的全局 float 归一化语义（避免扩大 blast radius）。
+- 不引入新的 dtype 抽象层、不新增配置项、不新增实体/状态。
+- 不处理 `contract_symbol` 别名线索（`HK.POP...`），作为 deferred follow-up 记录。
+- 不部署、不升级远端、不发消息、不改生产配置。
+
+## Goal Alignment
+
+- 唯一改动（producer dtype 修正）直接映射到 success signal 的第 1 条（rank 列 nullable Int64）。
+- 唯一新增测试直接映射到 success signal 的第 2 条（to_dict 后 int/None，且非 bool）。
+- 不触碰 non-goals 中列出的任何边界。
+
+## First-principles Judgment & Direct Code Evidence
+
+根因链（已逐一读代码确认，非猜测）：
+
+1. `src/application/sell_put_call_helper.py:995` `build_yield_enhancement_rank_shadow` 末尾
+   `return pd.DataFrame(out)`。`out` 中 `baseline_rank` / `shadow_rank` 是 `int | None` 混合
+   （`enumerate(..., start=1)` 产生 int，未选中为 `None`），pandas 自动推断为 `float64`
+   （int 变 `1.0`，None 变 `NaN`）。
+2. `src/application/combo_yield_steps.py:344` 用 `rank_shadow.to_dict("records")` 转 dict，
+   产出 `1.0` / `NaN`。
+3. `src/application/candidate_snapshot_contract.py` `normalize_json_value` 把 NaN 归一为 `None`，
+   但对 `Real` 保留 float，因此 `1.0` 仍是 float。
+4. `src/application/combo_yield_candidate_snapshot.py:308` `_rank_records` 要求
+   `isinstance(rank, int)`，float `1.0` 被拒，抛 `rank record baseline_rank is invalid`。
+5. 子进程 exit 1 → Daily Brief 渲染固定失败文案，`lx` / `sy` 同时失败。
+
+所有权判断：
+
+- `build_yield_enhancement_rank_shadow` 是 `baseline_rank` / `shadow_rank` 的唯一 producer
+  （`grep` 确认仅 `combo_yield_steps.py:261` 调用）。
+- 类型缺陷在 producer 边界（把「整数位次」表达成 float64 列），密封端 `_rank_records` 的 int
+  契约是正确的。因此根因修复应在 producer，而非放宽接收端。
+
+## Affected Files / Modules
+
+- `src/application/sell_put_call_helper.py` — `build_yield_enhancement_rank_shadow`（唯一源码改动）。
+- `tests/test_sell_put_linked_call_helper.py` — 新增一个 focused 回归测试。
+
+## Contract / Schema / State-machine / Public-interface Changes
+
+- 无外部契约变化。`combo_yield_candidate_snapshot.v2` schema 不变；`baseline_rank` / `shadow_rank`
+  的语义（int 或 null）不变，仅修正 producer 表达为 float64 的实现缺陷。
+- 无状态机变化、无公共命令/工具 payload 变化。
+
+## Implementation Decisions
+
+在 `build_yield_enhancement_rank_shadow` 末尾，把两列显式转换为 pandas nullable `Int64`：
+
+```python
+    frame = pd.DataFrame(out)
+    for column in ("baseline_rank", "shadow_rank"):
+        frame[column] = frame[column].astype("Int64")
+    return frame
+```
+
+依据（已本地验证）：
+
+- `astype("Int64")` 后 dtype 为 `Int64Dtype()`，`to_dict("records")` 产出选中行 Python `int`
+  （非 `numpy.int64`，非 float），未选中行 `None`。
+- `_rank_records` 中 `normalize_json_value` 对 `Integral` 转 `int`，对 pandas `NA` 转 `None`，
+  两列均能通过现有校验。
+- 空 DataFrame 分支（`pairs_df.empty` 时 `return pd.DataFrame(columns=...)`）保持不变；
+  非空路径下 `out` 由非空 `rows` 构造，两列必然存在，`astype` 安全。
+
+## Implementation Slices
+
+单一 slice（修复足够小，拆分不产生可验证增量）：
+
+### slice-1: producer 输出 nullable int rank
+
+- id: `slice-1`
+- objective: 修正 `build_yield_enhancement_rank_shadow` 的 rank 列 dtype。
+- allowed files: `src/application/sell_put_call_helper.py`,
+  `tests/test_sell_put_linked_call_helper.py`
+- expected outcome: rank 两列为 `Int64`；`to_dict("records")` 后 selected 行 int、unselected 行 None。
+- exact allowed changes: 仅上述 `astype("Int64")` 两列转换 + 一个 focused 回归测试。
+- non-goals: 不改 normalizer、不改 seal 校验、不改其他列 dtype。
+- completion signal: 新增测试通过；现有 helper/seal/steps 测试通过。
+
+## Tests / Validation Commands & Expected Assertions
+
+```bash
+./.venv/bin/python -m pytest \
+  tests/test_sell_put_linked_call_helper.py \
+  tests/test_combo_yield_candidate_snapshot.py \
+  tests/test_combo_yield_steps.py \
+  -q
+```
+
+新增测试（置于 `tests/test_sell_put_linked_call_helper.py`）：
+
+```python
+def test_yield_enhancement_rank_shadow_emits_nullable_int_ranks() -> None:
+    from src.application.sell_put_call_helper import build_yield_enhancement_rank_shadow
+
+    rows = pd.DataFrame(
+        [
+            {
+                "symbol": "NVDA",
+                "candidate_pair_id": "combo_yield:NVDA:NVDA_P100:NVDA_C110",
+                "put_contract_symbol": "NVDA_P100",
+                "call_contract_symbol": "NVDA_C110",
+                "funding_accepted": True,
+                "premium_funding_score": 0.9,
+                "net_credit_retention": 0.80,
+                "call_cost_to_put_credit": 0.20,
+                "call_delta": 0.18,
+                "call_spread_ratio": 0.12,
+                "call_open_interest": 500,
+                "call_payoff_multiple_at_1_5_sigma": 1.8,
+                "call_payoff_multiple_at_2_0_sigma": 4.0,
+                "put_assignment_margin_pct": 0.05,
+                "put_only_annualized_net_return": 0.14,
+                "combo_spread_ratio": 0.20,
+                "annualized_net_credit_yield": 0.09,
+                "residual_premium_ratio": 0.80,
+            },
+            {
+                "symbol": "NVDA",
+                "candidate_pair_id": "combo_yield:NVDA:NVDA_P100:NVDA_C115",
+                "put_contract_symbol": "NVDA_P100",
+                "call_contract_symbol": "NVDA_C115",
+                "funding_accepted": True,
+                "premium_funding_score": 1.1,
+                "net_credit_retention": 0.88,
+                "call_cost_to_put_credit": 0.12,
+                "call_delta": 0.10,
+                "call_spread_ratio": 0.08,
+                "call_open_interest": 900,
+                "call_payoff_multiple_at_1_5_sigma": 1.0,
+                "call_payoff_multiple_at_2_0_sigma": 3.0,
+                "put_assignment_margin_pct": 0.05,
+                "put_only_annualized_net_return": 0.14,
+                "combo_spread_ratio": 0.15,
+                "annualized_net_credit_yield": 0.11,
+                "residual_premium_ratio": 0.88,
+            },
+        ]
+    )
+    shadow = build_yield_enhancement_rank_shadow(rows)
+
+    assert str(shadow["baseline_rank"].dtype) == "Int64"
+    assert str(shadow["shadow_rank"].dtype) == "Int64"
+    # 两行同 put、不同 call：baseline 与 shadow 各选一行，产生 selected(int) + unselected(None)。
+    assert any(record["baseline_rank"] is None for record in shadow.to_dict("records"))
+    assert any(record["shadow_rank"] is None for record in shadow.to_dict("records"))
+    for record in shadow.to_dict("records"):
+        for field in ("baseline_rank", "shadow_rank"):
+            value = record[field]
+            assert value is None or (isinstance(value, int) and not isinstance(value, bool))
+```
+
+断言目的：锁定 producer 不再产出 float64 rank；非空 rank 是 Python int 且非 bool（与
+`_rank_records` 契约一致）；同时覆盖 selected(int) 与 unselected(None) 两个分支。
+
+## Docs Decision
+
+- 新增 `docs/gateflow/combo-yield-rank-int-seal/plan.md`（本文档）。
+- 后续 gate 的 review/fix/closeout artifact 同目录落地。
+- 无需更新 `docs/AGENT_WIKI.md`（无公共命令/契约变化）。
+
+## Risks / Open Questions
+
+- 无 blocking open question。
+- Residual risk（本轮不处理，deferred）：`opening_candidate_snapshot.json` 中
+  `contract_symbol` 出现别名 `HK.POP261029C177500` 的线索，与本次根因无关，建议后续单独核查。
+
+## Completion Report Format
+
+- changed files；
+- test command + result；
+- finding status（accepted/rejected/deferred 及原因）；
+- residual risks（含 owner/destination）；
+- draft PR URL；
+- next entry point。
+
+## Over-design / Goal-drift 说明
+
+- 本方案只改 producer 两列 dtype，不新增层/实体/配置，不触碰正常化与密封逻辑，无 goal drift。
+- 备选方向（在 `normalize_json_value` 对积分 float 转 int）被排除，因其全局影响所有 float
+  字段、可能静默改变无关证据语义，blast radius 大于根因修复本身。

--- a/docs/gateflow/combo-yield-rank-int-seal/s1-implementation.md
+++ b/docs/gateflow/combo-yield-rank-int-seal/s1-implementation.md
@@ -1,0 +1,42 @@
+# Gateflow Implementation — combo-yield-rank-int-seal slice-1
+
+- Work unit: `combo-yield-rank-int-seal`
+- Gate: `implementation` (slice-1)
+- Branch: `fix/combo-yield-rank-int-seal`
+- Date: 2026-08-13
+
+## Slice
+
+- id: `slice-1`
+- objective: 修正 `build_yield_enhancement_rank_shadow` 的 `baseline_rank` / `shadow_rank` 列
+  dtype，从 float64 修正为 nullable `Int64`。
+
+## Changed Files
+
+- `src/application/sell_put_call_helper.py`
+  - `build_yield_enhancement_rank_shadow` 末尾 `return pd.DataFrame(out)` 改为构造 `frame` 后对
+    `baseline_rank` / `shadow_rank` 两列 `astype("Int64")` 再返回。
+- `tests/test_sell_put_linked_call_helper.py`
+  - 新增 `test_yield_enhancement_rank_shadow_emits_nullable_int_ranks`。
+
+## Validation
+
+```bash
+./.venv/bin/python -m pytest tests/test_sell_put_linked_call_helper.py tests/test_combo_yield_candidate_snapshot.py tests/test_combo_yield_steps.py -q
+```
+
+结果：`55 passed in 0.60s`。
+
+新增测试单独验证：`1 passed`。
+
+## Completion Signal
+
+- `build_yield_enhancement_rank_shadow` 的 `baseline_rank` / `shadow_rank` dtype 为 `Int64`。
+- `to_dict("records")` 后 selected 行 rank 为 Python `int`（非 bool），unselected 行为 `None`。
+- 既有 helper / seal / steps 测试全部通过，无回归。
+
+## Residual Risks
+
+- 无本轮新增风险。
+- deferred（plan 已记录，与本次无关）：`opening_candidate_snapshot.json` 中 `contract_symbol`
+  别名 `HK.POP261029C177500` 线索，建议后续单独核查。

--- a/docs/reviews/code-review-20260813-103936.md
+++ b/docs/reviews/code-review-20260813-103936.md
@@ -1,0 +1,55 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch: `fix/combo-yield-rank-int-seal`
+- Base: `main`
+- Output file: `docs/reviews/code-review-20260813-103936.md`
+- Included scope: implementation slice-1
+  - `src/application/sell_put_call_helper.py` — `build_yield_enhancement_rank_shadow` rank 列 dtype 修正
+  - `tests/test_sell_put_linked_call_helper.py` — 新增 `test_yield_enhancement_rank_shadow_emits_nullable_int_ranks`
+- Excluded scope:
+  - `docs/gateflow/combo-yield-rank-int-seal/plan.md`（已在 plan review gate 审查）
+  - `docs/reviews/plan-review-20260813-103204.md`（plan review 产物）
+  - 既有无关未跟踪文件 `docs/plans/...`、`docs/reviews/plan-review-20260813-092047.md`
+- Parallel review coverage: 无（改动足够小，主 reviewer 单线程走读完整数据链）
+
+## Findings
+
+未发现实质性问题。
+
+验证性说明（非 finding）：
+
+- **改动意图**：把 `build_yield_enhancement_rank_shadow` 产出的 `baseline_rank` / `shadow_rank`
+  从 float64 修正为 pandas nullable `Int64`，使 `to_dict("records")` 后 selected 行是 Python `int`、
+  unselected 行是 `None`，从而通过密封端 `_rank_records` 的严格 int 校验。
+- **数据链走读（直接证据）**：
+  - `src/application/sell_put_call_helper.py:995` `build_yield_enhancement_rank_shadow` 末尾
+    `baseline_position = baseline_rank.get(key)`（`enumerate(..., start=1)` 的 int 或 `None`）。
+  - 原 `return pd.DataFrame(out)` 对 int|None 混合列推断为 float64（`1.0` / `NaN`）。
+  - `src/application/combo_yield_steps.py:344-345` 用 `rank_shadow.to_dict("records")` 组装 `rank_records`。
+  - `src/application/pipeline_watchlist.py:1150-1154` 把 `evidence.get("rank_records")` 透传给 seal。
+  - `src/application/combo_yield_candidate_snapshot.py:285-313` `_rank_records` 要求
+    `isinstance(rank, int) and not bool and rank > 0`，float `1.0` 被拒。
+  - `src/application/candidate_snapshot_contract.py:76-85` `normalize_json_value` 对 `Integral` 转 `int`、
+    对 `Real` 保留 float，因此 float64 不会被静默转 int，修复必须在 producer。
+- **修复正确性**：`astype("Int64")` 后 `to_dict("records")` 产出 selected 行 Python `int`、unselected 行
+  `None`；`normalize_json_value` 对 int 走 `Integral -> int`，对 `None` 原样保留，均通过 `_rank_records`。
+  已由新增测试锁定 dtype 与 int/None 形态。
+- **唯一 producer 确认**：`build_yield_enhancement_rank_shadow` 是 `combo_yield_candidate_snapshot.v2`
+  `rank_records` 的 producer（`combo_yield_steps.py:261` 唯一调用）。`shadow_replay/combo_variants.py`
+  是另一套 `COMBO_PAIR_DECISION_SCHEMA_VERSION` 的 Shadow Replay 决策 schema，其 rank 来自
+  `_baseline_rank_map`（纯 Python `dict[..., int]`，不经过 DataFrame），不在本次失败路径。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 空 DataFrame 分支（`pairs_df.empty`）仍返回 `object` dtype 空列（`baseline_rank`/`shadow_rank`），
+  与非空路径的 `Int64` dtype 不一致。该分支只产出空 `rank_records`（`to_dict("records")` → `[]`，
+  `_rank_records([])` 直接通过），无下游消费者依赖空 frame 的 dtype；属既有行为、无正确性影响，本轮不处理。
+- 新增测试锁定 producer 输出形态，未新增端到端 seal 回归测试；但既有 `test_combo_yield_candidate_snapshot.py`
+  与 `test_combo_yield_steps.py` 已覆盖 `_rank_records` 契约，全量 55 passed 无回归。

--- a/docs/reviews/code-review-20260813-104203.md
+++ b/docs/reviews/code-review-20260813-104203.md
@@ -1,0 +1,55 @@
+# Code Review（Aggregate Deepreview）
+
+## Scope
+
+- Mode: current changes（aggregate deepreview，累计改动）
+- Branch: `fix/combo-yield-rank-int-seal`
+- Base: `main`
+- Output file: `docs/reviews/code-review-20260813-104203.md`
+- Reviewed commits:
+  - `c78f91fe chore(gateflow): accept plan for combo-yield-rank-int-seal`
+  - `6818556d chore(gateflow): accept combo-yield-rank-int-seal slice-1`
+- Included scope:
+  - `docs/gateflow/combo-yield-rank-int-seal/plan.md`
+  - `docs/gateflow/combo-yield-rank-int-seal/s1-implementation.md`
+  - `docs/reviews/plan-review-20260813-103204.md`
+  - `docs/reviews/code-review-20260813-103936.md`
+  - `src/application/sell_put_call_helper.py`（rank 列 dtype 修正）
+  - `tests/test_sell_put_linked_call_helper.py`（新增回归测试）
+- Excluded scope: 无（本 work unit 累计改动全部纳入）；工作区既有无关未跟踪文件
+  `docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md`、
+  `docs/reviews/plan-review-20260813-092047.md`、`docs/reviews/plan-review-20260813-103939.md`
+  属其它 work unit，未纳入、未触碰。
+- Parallel review coverage: 无（单一 slice，累计改动小，主 reviewer 单线程走读）
+
+## Findings
+
+未发现实质性问题。
+
+累计一致性核对（非 finding）：
+
+- **plan ↔ implementation 一致**：plan 的 implementation decision 是「对 `baseline_rank` /
+  `shadow_rank` 两列 `astype("Int64")`」，实现逐字落地于 `sell_put_call_helper.py:1054-1056`，
+  无 scope 漂移、无额外改动。
+- **plan review finding 闭环**：`plan-review-20260813-103204.md` 唯一 accepted finding（新增测试构造
+  未规格化 + 未覆盖 unselected→None）在 re-review 标记 `已修复`；实际测试确实采用「两行同 put
+  `NVDA_P100`、不同 call `NVDA_C110` / `NVDA_C115`」，并断言 `any(record[field] is None ...)`，
+  覆盖 selected(int) 与 unselected(None) 两个分支。
+- **slice code review 与 aggregate 一致**：`code-review-20260813-103936.md` 结论 `未发现实质性问题`，
+  与本 aggregate 走读一致。
+- **验证一致性**：focused 测试集复跑 `55 passed`（`test_sell_put_linked_call_helper.py` +
+  `test_combo_yield_candidate_snapshot.py` + `test_combo_yield_steps.py`），与 slice 实现 artifact
+  记录一致，无回归。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 空 DataFrame 分支（`pairs_df.empty`）返回 `object` dtype 空列，与非空路径 `Int64` 不一致；
+  属既有行为、无下游消费者依赖空 frame dtype、无正确性影响，本轮不处理。
+- deferred follow-up（owner: 后续单独 work unit）：`opening_candidate_snapshot.json` 中
+  `contract_symbol` 出现别名 `HK.POP261029C177500` 的线索，与本次根因无关，建议后续单独核查。
+- 本轮未做 live Feishu / 远端运行验证；修复通过 repository/unit-level 确定性测试验证，远端 cutover
+  属独立发布授权，不在本 work unit。

--- a/docs/reviews/plan-review-20260813-103204.md
+++ b/docs/reviews/plan-review-20260813-103204.md
@@ -1,0 +1,90 @@
+# Plan Review — combo-yield-rank-int-seal
+
+- Reviewed target: `docs/gateflow/combo-yield-rank-int-seal/plan.md`
+- Work unit: `combo-yield-rank-int-seal`
+- Review timestamp: 2026-08-13 10:32:04 (Asia/Shanghai)
+- Reviewer posture: adversarial plan review（Gateflow `plan review` gate）
+
+## Reviewed Target & Scope
+
+单一 slice 修复 `build_yield_enhancement_rank_shadow` 的 rank 列 dtype，从 float64 修正为 nullable
+`Int64`，使 combo yield（sp_lc）候选快照密封时 `baseline_rank` / `shadow_rank` 经 `to_dict("records")`
+后为 `int` / `None`，通过 `_rank_records` 的严格 int 校验。
+
+## Assumptions Tested
+
+1. `build_yield_enhancement_rank_shadow` 是 rank 列唯一 producer。
+   - 验证：`grep` 确认仅 `combo_yield_steps.py:261` 调用；输出在 `combo_yield_steps.py:345`
+     `to_dict("records")` 后作为 evidence 进入密封。成立。
+2. 根因是 producer 把「整数位次」表达为 float64 列，而非接收端 `_rank_records` 契约过严。
+   - 验证：`return pd.DataFrame(out)` 中 int/None 混合触发 pandas float64 推断，已本地复现。
+     成立。
+3. `astype("Int64")` 后 `to_dict("records")` 产出 int / None，且能通过 `normalize_json_value`。
+   - 验证：本地脚本确认 dtype 为 `Int64Dtype()`，非空值为 Python `int`，空值为 `None`；`Integral`
+     与 pandas `NA` 分支均被 `normalize_json_value` 正确处理。成立。
+4. 无其它同类 rank 类型缺陷（cc_lp）。
+   - 验证：`cc_lp_candidate_snapshot.py` 无 `baseline_rank` / `shadow_rank` 或
+     `isinstance(rank, int)`，说明 cc_lp 无同类严格 int rank 契约。成立。
+
+## Findings
+
+### 1-未修复-中-新增回归测试的构造未完全规格化，且「不同 put」构造无法覆盖 unselected→None
+
+- **位置**: `plan.md` 的 `Tests / Validation Commands & Expected Assertions` 章节，新增测试
+  `test_yield_enhancement_rank_shadow_emits_nullable_int_ranks`。
+- **问题类型**: 不可直接实施 / 测试缺口
+- **当前写法**: 测试构造写成占位符 `rows = pd.DataFrame([...两行不同 put 的完整字段...])`，
+  未给出确切字段；且「两行不同 put」会让 baseline 与 shadow 各选一行，两行 rank 均为 int，
+  无法覆盖 success signal 中「未选中行为 None」的断言分支。
+- **反例/失败场景**: implementation agent 需要自行确定 pairs_df 字段集合，若字段缺失会导致
+  `rank_yield_enhancement_rows` 的排序 key 抛 KeyError；若沿用「不同 put」构造，`value is None`
+  分支永远不执行，测试实际无法证明 unselected 行 rank 为 None。
+- **为什么有问题**: 与 plan 要求 code-generation-ready 冲突；success signal 明确列出「未选中行为
+  None」，测试必须能覆盖该分支，否则弱化断言、留下 float→None 之外的回归盲区。
+- **直接证据**: `plan.md` 测试段 `rows = pd.DataFrame([...两行不同 put 的完整字段...])`；
+  `test_combo_yield_steps.py:690-730` 已存在「两行同 put 不同 call」的完整字段构造，可直接复用，
+  且该构造被 `build_yield_enhancement_rank_shadow` 的排序函数正常消费。
+- **影响**: 实施 Agent 跑偏 / review 不可验收 / 测试缺口
+- **建议改法和验证点**: 将测试构造改为「两行同 put（`NVDA_P100`）、不同 call（`NVDA_C110` /
+  `NVDA_C115`）」，字段直接复用 `tests/test_combo_yield_steps.py` 中
+  `test_combo_yield_emits_shadow_rank_evidence_without_changing_selection` 的 `pairs` 字段集
+  （含 `candidate_pair_id`、`put_contract_symbol`、`call_contract_symbol`、`funding_accepted`、
+  `premium_funding_score`、`net_credit_retention`、`call_cost_to_put_credit`、`call_delta`、
+  `call_spread_ratio`、`call_open_interest`、`call_payoff_multiple_at_1_5_sigma`、
+  `call_payoff_multiple_at_2_0_sigma`、`put_assignment_margin_pct`、
+  `put_only_annualized_net_return`、`combo_spread_ratio`、`annualized_net_credit_yield`、
+  `residual_premium_ratio`）。这样既有 selected 行（int）又有 unselected 行（None），完整覆盖
+  两个断言分支。同时保留 dtype `Int64` 断言。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+- 无 blocking open question。
+
+## Residual Risks
+
+- fixed in current slice：无。
+- covered by later approved slice：无（单一 slice）。
+- assigned to later work unit：无。
+- tracked by existing issue：无。
+- requiring new issue or explicit user decision：
+  - `opening_candidate_snapshot.json` 中 `contract_symbol` 出现别名 `HK.POP261029C177500`，
+    与本次根因无关，建议后续单独核查（已在 plan 记录为 deferred）。
+
+## Final Plan Review Conclusion
+
+`pass-with-risks`
+
+方案本身（producer 边界 `astype("Int64")`）证据充分、blast radius 极小、无 goal drift 或
+overengineering；唯一 material finding 是新增测试构造未完全规格化且未覆盖 unselected→None 分支。
+该 finding 修复风险低，不阻塞方案方向，但应在 implementation 前按建议补强测试构造。
+
+## Re-review（finding 状态回写）
+
+- Finding 1（新增回归测试构造规格化 + 覆盖 unselected→None）：`已修复`。
+  - `plan.md` 测试段已改为「两行同 put `NVDA_P100`、不同 call `NVDA_C110` / `NVDA_C115`」的完整
+    字段构造，并新增 `baseline_rank` / `shadow_rank` 均存在 `None` 值的断言，覆盖 selected(int)
+    与 unselected(None) 两个分支。
+
+Re-review conclusion: `pass`（唯一 accepted finding 已修复，无剩余 blocking open question）。

--- a/docs/reviews/pr-152-review-20260813-110952.md
+++ b/docs/reviews/pr-152-review-20260813-110952.md
@@ -1,0 +1,81 @@
+# Code Review（PR Review）
+
+## Scope
+
+- Mode: PR
+- Branch or PR: `#152` — `fix/combo-yield-rank-int-seal` ← `main`
+- Base: `main`
+- Output file: `docs/reviews/pr-152-review-20260813-110952.md`
+- Included scope: PR #152 相对 `main` 的完整 diff
+  - `src/application/sell_put_call_helper.py` — `build_yield_enhancement_rank_shadow` rank 列 dtype 修正
+  - `tests/test_sell_put_linked_call_helper.py` — 新增 `test_yield_enhancement_rank_shadow_emits_nullable_int_ranks`
+  - `docs/gateflow/combo-yield-rank-int-seal/plan.md` / `s1-implementation.md`（gate artifacts）
+  - `docs/reviews/plan-review-20260813-103204.md`、`code-review-20260813-103936.md`、
+    `code-review-20260813-104203.md`（历史 review artifacts）
+- Excluded scope: 工作区既有无关未跟踪文件（`docs/plans/...`、`docs/reviews/plan-review-20260813-092047.md`、
+  `docs/reviews/plan-review-20260813-103939.md`）属其它 work unit，未纳入。
+- Parallel review coverage: 无（单一 slice，diff 小，主 reviewer 单线程走读完整数据链）
+
+## PR Facts
+
+- Repository: `liuxie066/options-monitor`
+- PR: `#152`
+- Title: `fix(candidates): seal combo-yield rank as nullable int`
+- Author: `liuxie066`
+- Head: `fix/combo-yield-rank-int-seal`
+- Base: `main`
+- State: `OPEN`, draft
+- URL: `https://github.com/liuxie066/options-monitor/pull/152`
+
+## CI / Checks
+
+- `Analyze (actions)` — pass
+- `Analyze (python)` — pass
+- `CodeQL` — pass
+- `agent-plugin` — pass
+- `guardrails` — pass
+
+## Findings
+
+未发现实质性问题。
+
+验证性说明（非 finding）：
+
+- **改动意图**：把 `build_yield_enhancement_rank_shadow` 产出的 `baseline_rank` / `shadow_rank`
+  从 float64 修正为 pandas nullable `Int64`，使 `to_dict("records")` 后 selected 行是 Python `int`、
+  unselected 行是 `None`，从而通过密封端 `_rank_records` 的严格 int 校验。
+- **数据链走读（直接证据）**：
+  - `sell_put_call_helper.py:1049-1057` `build_yield_enhancement_rank_shadow` 构造 `out`（
+    `baseline_rank` / `shadow_rank` 为 `enumerate(..., start=1)` 的 int 或 `None`），末尾对两列
+    `astype("Int64")` 再返回。
+  - `combo_yield_steps.py:344-345` 用 `rank_shadow.to_dict("records")` 组装 `rank_records`。
+  - `combo_yield_candidate_snapshot.py:285-313` `_rank_records` 要求 `isinstance(rank, int)` 且
+    非 bool 且 `> 0`，float `1.0` 会被拒；`candidate_snapshot_contract.py` `normalize_json_value`
+    对 `Integral` 转 `int`、对 `Real` 保留 float，因此修复必须在 producer。
+- **修复正确性**：`astype("Int64")` 后 `to_dict("records")` 产出 selected 行 Python `int`、unselected
+  行 `None`，能通过 `normalize_json_value`（`Integral -> int`、`None` 原样保留）与 `_rank_records`。
+  新增测试锁定 dtype 为 `Int64`，并断言 `baseline_rank` / `shadow_rank` 均存在 `None` 值且非空值为
+  `int` 且非 bool，覆盖 selected(int) 与 unselected(None) 两个分支。
+- **唯一 producer 确认**：`build_yield_enhancement_rank_shadow` 是 `combo_yield_candidate_snapshot.v2`
+  `rank_records` 的 producer（`combo_yield_steps.py:261` 唯一调用）。`shadow_replay/combo_variants.py`
+  是另一套 Shadow Replay 决策 schema，rank 来自纯 Python `dict[..., int]`，不经过 DataFrame，
+  不在本次失败路径。
+- **CI 一致性**：全部 check pass，与本地 focused 测试 `55 passed` 一致。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 空 DataFrame 分支（`pairs_df.empty`）仍返回 `object` dtype 空列（`baseline_rank` / `shadow_rank`），
+  与非空路径的 `Int64` dtype 不一致。该分支只产出空 `rank_records`（`to_dict("records")` → `[]`，
+  `_rank_records([])` 直接通过），无下游消费者依赖空 frame 的 dtype；属既有行为、无正确性影响，本轮不处理。
+- deferred follow-up（owner: 后续单独 work unit）：`opening_candidate_snapshot.json` 中
+  `contract_symbol` 出现别名 `HK.POP261029C177500` 的线索，与本次根因无关，建议后续单独核查。
+- 本轮未做 live Feishu / 远端运行验证；修复通过 repository/unit-level 确定性测试 + CI 验证，远端
+  cutover 属独立发布授权，不在本 work unit。
+
+## PR Review Conclusion
+
+`pass`（无 accepted findings，无需 fix）。

--- a/src/application/sell_put_call_helper.py
+++ b/src/application/sell_put_call_helper.py
@@ -1051,4 +1051,7 @@ def build_yield_enhancement_rank_shadow(pairs_df: pd.DataFrame) -> pd.DataFrame:
                 ),
             }
         )
-    return pd.DataFrame(out)
+    frame = pd.DataFrame(out)
+    for column in ("baseline_rank", "shadow_rank"):
+        frame[column] = frame[column].astype("Int64")
+    return frame

--- a/tests/test_sell_put_linked_call_helper.py
+++ b/tests/test_sell_put_linked_call_helper.py
@@ -914,6 +914,66 @@ def test_yield_enhancement_shadow_rank_orders_selected_pairs_by_put_quality() ->
     assert shadow["rank_changed"].all()
 
 
+def test_yield_enhancement_rank_shadow_emits_nullable_int_ranks() -> None:
+    from src.application.sell_put_call_helper import build_yield_enhancement_rank_shadow
+
+    rows = pd.DataFrame(
+        [
+            {
+                "symbol": "NVDA",
+                "candidate_pair_id": "combo_yield:NVDA:NVDA_P100:NVDA_C110",
+                "put_contract_symbol": "NVDA_P100",
+                "call_contract_symbol": "NVDA_C110",
+                "funding_accepted": True,
+                "premium_funding_score": 0.9,
+                "net_credit_retention": 0.80,
+                "call_cost_to_put_credit": 0.20,
+                "call_delta": 0.18,
+                "call_spread_ratio": 0.12,
+                "call_open_interest": 500,
+                "call_payoff_multiple_at_1_5_sigma": 1.8,
+                "call_payoff_multiple_at_2_0_sigma": 4.0,
+                "put_assignment_margin_pct": 0.05,
+                "put_only_annualized_net_return": 0.14,
+                "combo_spread_ratio": 0.20,
+                "annualized_net_credit_yield": 0.09,
+                "residual_premium_ratio": 0.80,
+            },
+            {
+                "symbol": "NVDA",
+                "candidate_pair_id": "combo_yield:NVDA:NVDA_P100:NVDA_C115",
+                "put_contract_symbol": "NVDA_P100",
+                "call_contract_symbol": "NVDA_C115",
+                "funding_accepted": True,
+                "premium_funding_score": 1.1,
+                "net_credit_retention": 0.88,
+                "call_cost_to_put_credit": 0.12,
+                "call_delta": 0.10,
+                "call_spread_ratio": 0.08,
+                "call_open_interest": 900,
+                "call_payoff_multiple_at_1_5_sigma": 1.0,
+                "call_payoff_multiple_at_2_0_sigma": 3.0,
+                "put_assignment_margin_pct": 0.05,
+                "put_only_annualized_net_return": 0.14,
+                "combo_spread_ratio": 0.15,
+                "annualized_net_credit_yield": 0.11,
+                "residual_premium_ratio": 0.88,
+            },
+        ]
+    )
+    shadow = build_yield_enhancement_rank_shadow(rows)
+
+    assert str(shadow["baseline_rank"].dtype) == "Int64"
+    assert str(shadow["shadow_rank"].dtype) == "Int64"
+    records = shadow.to_dict("records")
+    assert any(record["baseline_rank"] is None for record in records)
+    assert any(record["shadow_rank"] is None for record in records)
+    for record in records:
+        for field in ("baseline_rank", "shadow_rank"):
+            value = record[field]
+            assert value is None or (isinstance(value, int) and not isinstance(value, bool))
+
+
 def test_yield_enhancement_rejects_crossed_call_quote(tmp_path: Path) -> None:
     from src.application.sell_put_call_helper import find_sell_put_yield_enhancement_pairs
 


### PR DESCRIPTION
## 摘要

修复 combo yield（sp_lc）候选快照密封阶段因 `baseline_rank` / `shadow_rank` 被表达为 float64，导致 `_rank_records` 严格 int 校验失败、HK 09:40 批次 `lx`/`sy` 同时失败的问题。

## 根因

- `src/application/sell_put_call_helper.py:build_yield_enhancement_rank_shadow` 末尾 `pd.DataFrame(out)` 把 `int|None` 混合的 rank 列自动推断为 float64（`1.0`/`NaN`）。
- `to_dict("records")` 后仍是 float，`normalize_json_value` 对 `Real` 保留 float，被 `combo_yield_candidate_snapshot.py:_rank_records` 的 `isinstance(rank, int)` 拒绝。

## 修复

producer 边界显式把两列转为 nullable `Int64`：

```python
frame = pd.DataFrame(out)
for column in ("baseline_rank", "shadow_rank"):
    frame[column] = frame[column].astype("Int64")
return frame
```

不修改接收端校验、不修改全局 normalizer，blast radius 最小。

## 验证

- 新增回归测试 `test_yield_enhancement_rank_shadow_emits_nullable_int_ranks`，锁定 rank 列 `Int64` dtype、selected 行 Python `int`（非 bool）、unselected 行 `None`。
- 聚焦测试集复跑：`55 passed`。

## Residual Risks

- 空 DataFrame 分支（`pairs_df.empty`）返回 `object` dtype 空列，与非空路径 `Int64` 不一致；属既有行为、无下游消费者依赖空 frame dtype，无正确性影响，本轮不处理。
- `opening_candidate_snapshot.json` 中 `contract_symbol` 别名 `HK.POP261029C177500` 线索与本次无关，建议后续单独核查（deferred follow-up）。