### PR TITLE
feat(agent-tools): notification-round run resolution for candidate_filter_explain

### DIFF
--- a/docs/TOOL_REFERENCE.md
+++ b/docs/TOOL_REFERENCE.md
@@ -203,6 +203,11 @@ root 来源及每个 JSONL 文件的 `ok`、`missing`、`valid_empty`、`partial
 
 两者读取已有 artifact，不重跑扫描。
 
+`candidate_filter_explain` 还支持从通知投递证据定位轮次：`run_selector=latest_notification`
+解析该账户在 `notification_date`（ISO 日期，默认按运行时主机本地时区的今天）实际送达的
+最近一次通知对应的 run；找不到匹配通知时 fail-closed 返回 `DEPENDENCY_MISSING`
+（`details.reason=no_notification_run`），不会静默回退到其他轮次。
+
 ### 扫描
 
 ```bash

--- a/docs/gateflow/candidate-filter-run-resolution/aggregate-fix.md
+++ b/docs/gateflow/candidate-filter-run-resolution/aggregate-fix.md
@@ -1,0 +1,21 @@
+# Gateflow Fix Artifact — Aggregate DeepReview Fix
+
+- Gate: `fix` after aggregate deepreview `docs/reviews/code-review-20260813-150303.md`
+- Work unit: `candidate-filter-run-resolution`
+
+## Finding decision and fix
+
+### DR-1 — accepted — fixed
+
+`latest_notification` 分支解析出的 run 快照加载失败时，`DEPENDENCY_MISSING` 错误 details 现在携带 `reason=snapshot_unavailable_for_notification_run`、已解析的 `run_id` 和 `notification_date`，不再回退为 `run_id=None`。新增回归测试 `test_notification_run_with_missing_snapshot_reports_resolved_run_id`。
+
+Final status: `已修复`.
+
+## Validation after fix
+
+- 149 passed（focused 16 + trace/manifest/contract/smoke 回归），1 pre-existing deprecation warning。
+
+## Residual risks
+
+- CR-2 runtime-root alignment：deferred-with-owner（later work unit）。
+- O(file) audit scan：accepted，later indexed read if hot。

--- a/docs/gateflow/candidate-filter-run-resolution/final-closeout.md
+++ b/docs/gateflow/candidate-filter-run-resolution/final-closeout.md
@@ -1,0 +1,52 @@
+# Final Closeout — candidate-filter-run-resolution
+
+- Gate: `final closeout`
+- Work unit: `candidate-filter-run-resolution`
+- Branch: `feat/candidate-filter-run-resolution` (base `main@421591dd`)
+- Draft PR: https://github.com/liuxie066/options-monitor/pull/153
+- Status: `final closeout pass`
+
+## What changed
+
+- `candidate_filter_explain` 新增通知轮次定位能力：
+  - 新输入 `run_selector=latest_notification` + `notification_date`（ISO YYYY-MM-DD，默认运行时主机本地"今天"）；
+  - 从 shared notification perception audit 中定位"当日实际投递到该账户的最近一次通知"对应的 run，再加载其 manifest-bound opening candidate snapshot；
+  - 优先级：显式 `run_id` > `latest_notification` > 默认 latest（默认路径行为不变）；
+  - 输出 `source.run_resolution` provenance（selector / notification_date / timezone / resolved_run_id / matched_event_created_at_utc）。
+- Fail-closed 错误（`DEPENDENCY_MISSING` + `details.reason`）：`no_notification_run`、`audit_window_truncated`、`snapshot_unavailable_for_notification_run`。
+- `notification_perception_read.py` 新增内部 helper `iter_notification_perception_events`（上限 5000，返回 `truncated` 标志）；公共工具 50-row cap 不变。
+- 工具 schema/description/examples/`copilot_input_fields` 与 copilot normalizer 同步扩展；`docs/TOOL_REFERENCE.md` 补充语义说明。
+
+## What was verified
+
+- 165 passed：`tests/test_candidate_filter_run_resolution.py`（16 个新增）+ candidate trace/snapshot manifest/agent plugin contract+smoke + notification perception read/event 回归；1 个 pre-existing deprecation warning。
+- CI on PR #153 全部 pass：Analyze (actions)/(python)、CodeQL、agent-plugin、guardrails。
+- Gate artifacts 齐备：plan、plan review fail->fix->pass、S1 implementation、code review pass-with-risks->fix->pass、aggregate deepreview pass-with-risks->fix->pass、PR review pass。
+
+## Docs updates
+
+- `docs/TOOL_REFERENCE.md`：`run_selector=latest_notification` 语义说明。
+- `docs/gateflow/candidate-filter-run-resolution/`：plan / s1-implementation / s1-review-fix / aggregate-fix / final-closeout（本文件）。
+- `docs/reviews/`：plan-review x2、code-review x4、pr-153-review x1。
+
+## Finding status
+
+- Plan review F1-F5：已修复，re-review pass（`plan-review-20260813-141818.md`）。
+- Code review CR-1：已修复（截断不可诊断），re-review pass（`code-review-20260813-145637.md`）。
+- Aggregate deepreview DR-1：已修复（resolved run_id 丢失），re-review pass（`code-review-20260813-150727.md`）。
+- PR review：未发现实质性问题（`pr-153-review-20260813-153028.md`）。
+
+## Remaining risks / owners
+
+- O(file) 全量 audit scan：accepted risk；若成为热点，后续 performance work unit 加索引读取。
+- CR-2（pre-existing）：candidate 工具 base 不经 `resolve_runtime_root`（`OM_RUNTIME_ROOT`）；后续 work unit 统一接线。
+- 低：过去日期 + 多账户混合事件的组合场景未单测；同一谓词/日期映射函数驱动，风险低。
+
+## Issue link status
+
+- 非 issue work unit，PR body 无 closing keyword，无需 issue closeout comment。
+
+## Next entry point
+
+- 用户 merge PR #153 后：可选后续 work unit —— candidate 工具统一接 `resolve_runtime_root`；audit 索引读取（如 scan 成为热点）。
+- merge / approve / mark ready for review / delete branch 均需棒棒的liuxie 单独授权。

--- a/docs/gateflow/candidate-filter-run-resolution/plan.md
+++ b/docs/gateflow/candidate-filter-run-resolution/plan.md
@@ -1,0 +1,133 @@
+# Plan — candidate-filter-run-resolution
+
+- Work unit: `candidate-filter-run-resolution`
+- Branch: `feat/candidate-filter-run-resolution`
+- Base: `main@421591dd`
+- Status: `plan fixed after planreview; ready for re-review`
+- Plan review: `docs/reviews/plan-review-20260813-141152.md` (fail -> F1-F5 fixed below)
+
+## Goal / motivation / success signal
+
+Goal: when a Copilot user asks "why was symbol X filtered" right after a monitoring notification arrived, `candidate_filter_explain` can resolve the intended scan run from notification delivery evidence instead of requiring an explicit `run_id` or silently falling back to the latest terminal run.
+
+Motivation (direct code evidence):
+
+- `candidate_filter_explain` today only accepts an optional `run_id`; when omitted it resolves the latest terminal manifest-bound run via `load_latest_candidate_snapshot_bundle` (`src/application/agent_tools/candidate_filter_impl.py:21-70`, `src/application/candidate_snapshot_manifest.py:605-678`).
+- In the 0700.HK incident the local `output_runs` was empty and the user could not map "the notification that just arrived" to a run; the tool had no way to express that intent.
+- Notification delivery evidence already records `run_id`, `accounts`, and `delivery.action` per event in `audit_events.jsonl` (`src/application/multi_tick/assistant_perception_event.py:16-110`, read path `src/application/notification_perception_read.py:17-202`).
+- The Copilot tool layer already supports `copilot_input_normalizer` for natural input normalization, with precedent `_normalize_option_performance_copilot_input` (`src/application/agent_tools/positions.py:265-283`).
+
+Success signal:
+
+- `candidate_filter_explain` accepts a new optional `run_selector` input with values `latest_notification` / `latest`, and an optional `notification_date` (ISO date, default today in the runtime local timezone), and resolves the run fail-closed from notification delivery evidence.
+- When no matching delivered notification run exists, the tool raises a structured `AgentToolError` (no silent fallback, no guessing).
+- Copilot can call the tool with just `{symbol, account}` after a notification and get the filter explanation for the run that produced the notification.
+
+## Non-goals / scope boundary
+
+- No changes to filter/rank logic, no re-filtering, no re-ranking; tool stays `pure_read`.
+- No new persistent entities, tables, indexes, or snapshot formats.
+- No changes to notification delivery, scheduler, or audit event writing.
+- No natural-language date engine beyond a single ISO `notification_date`; no cross-account aggregation.
+- `candidate_rank_explain` is out of scope (same mechanism could be adopted later; not required by the incident).
+- The three unrelated untracked docs under `docs/plans/` and `docs/reviews/` are not touched.
+
+## Design alignment
+
+No external design doc; alignment is with the conversation design decision ("只需要再为这个能力增加一个处理日期的能力") plus the established Copilot normalizer precedent.
+
+## First-principles judgment
+
+The missing capability is run resolution, not date parsing per se. The authoritative link between "the notification the user just saw" and "the candidate snapshot that explains filtering" is the notification perception event's `run_id` + `accounts` + `delivery.action` in `audit_events.jsonl`. Resolving through that evidence keeps the tool fail-closed and audit-grounded instead of guessing from timestamps. The date parameter exists only because multiple notifications can arrive in one day and the user may ask about a previous day's notification.
+
+## Affected files/modules
+
+| File | Change |
+|---|---|
+| `src/application/agent_tools/candidate_filter_impl.py` | Add `run_selector` / `notification_date` handling; resolve run via notification events before falling back to explicit `run_id` / latest; emit resolution provenance in output `source` |
+| `src/application/agent_tools/candidate.py` | Extend `CANDIDATE_FILTER_EXPLAIN_TOOL` input schema, description, examples, `copilot_input_fields`; register `copilot_input_normalizer` |
+| `src/application/notification_perception_read.py` | Add `iter_notification_perception_events` (shared internals, internal-use limit up to 5000); public tool behavior unchanged |
+| `tests/test_candidate_filter_trace.py` (or new focused test file) | Resolution tests: latest_notification happy path, date-filtered path, no-match fail-closed, explicit run_id precedence, latest default unchanged, input validation |
+| `docs/TOOL_REFERENCE.md` | Document new inputs if the file enumerates this tool's schema |
+
+## Contract / interface changes
+
+Tool input additions (all optional, backward compatible):
+
+- `run_selector`: `"latest_notification" | "latest"`; default behavior unchanged (current latest terminal manifest-bound run semantics).
+- `notification_date`: ISO `YYYY-MM-DD`; only meaningful with `run_selector=latest_notification`; defaults to the runtime local date of "today".
+
+Resolution precedence (fail-closed, no silent fallback):
+
+1. explicit `run_id` (unchanged, highest precedence);
+2. `run_selector=latest_notification`: resolve from delivered notification events for the account on `notification_date`;
+3. default: latest terminal manifest-bound run (unchanged).
+
+Resolution rule for `latest_notification` (frozen by planreview F1-F5):
+
+- Event source: add a narrow read-only helper `iter_notification_perception_events(*, repo_root, event_kind, limit)` in `src/application/notification_perception_read.py` that shares `_audit_paths`/`_read_jsonl`/`_matches_event`/`_public_event` with `read_notification_perception_events` but allows `limit` up to 5000 for internal resolution. The public tool keeps its 50-row cap. (F1)
+- Sent predicate (frozen): an event is a user-visible delivered notification iff
+  - `event_kind == "notification_delivery_completed"`, AND
+  - `no_send` is not `True` (heartbeat/dry-run completed events are excluded), AND
+  - the account is visible: if `send_summary.sent_accounts` is a non-empty list, the account must be in it; otherwise the account must be in the top-level `accounts` list (heartbeat/legacy compatibility). Events with empty `sent_accounts` and `failure_count > 0` are not evidence for a failed account. (F2, F3)
+  - `delivery.action` is NOT used as sent evidence (it records the decision action such as `fixed_report`, not transport outcome).
+- Date window: convert each candidate event's `created_at_utc` (UTC ISO) to the system local timezone of the runtime host and compare against `notification_date`. The timezone used is recorded in output; no market-timezone inference. (F4)
+- Pick the most recent matching event; its `run_id` must load a valid terminal manifest-bound snapshot via `load_candidate_snapshot_bundle`; if the snapshot is unavailable, raise `DEPENDENCY_MISSING` with the resolved `run_id` in details.
+- Zero matches -> `AgentToolError(code="DEPENDENCY_MISSING", message="no delivered notification run found for account on notification_date", details={"reason": "no_notification_run", "account": account, "notification_date": ...})`. Rationale: `COPILOT_SAFE_ERROR_CODES` does not include a custom `RUN_NOT_FOUND` and `safe_error_code` would fold it to `TOOL_ERROR`, hiding the reason from Copilot users; `DEPENDENCY_MISSING` is the established fail-closed code for this tool. (F5)
+- Runtime root: the audit lookup and the snapshot lookup share the same resolved base (`payload.runtime_root or repo_base()`), so a notification event's `run_id` is always resolved against the same runtime that wrote it.
+
+Output additions: `source.run_resolution` = `{selector, notification_date, timezone, resolved_run_id, matched_event_created_at_utc}` so the answer is auditable. For `selector=latest`/explicit `run_id`, `run_resolution` records `{selector, resolved_run_id}` only.
+
+## Implementation decisions
+
+- Keep the delivered-run resolver as a small pure function in `candidate_filter_impl.py`; event scanning lives in the new `iter_notification_perception_events` helper.
+- Reuse `_read_jsonl`/`_matches_event`/`_public_event` via the new helper; do not weaken sensitive-field stripping.
+- Timezone: system local timezone of the runtime host, applied to UTC event timestamps; recorded in `run_resolution.timezone`. No market-timezone inference.
+- `copilot_input_normalizer`: validate ISO date format early and reject `notification_date` without `run_selector=latest_notification` to avoid silent no-ops.
+
+## Slices
+
+Single slice (one cohesive input-resolution feature):
+
+- S1: schema + resolver + normalizer + tests + docs touch-up.
+
+## Tests / validation
+
+New focused tests (pytest, no live OpenD/Feishu):
+
+- delivered event exists for account+date -> resolves that run_id and explanation matches that run;
+- multiple events same day -> most recent delivered event wins;
+- target event sits beyond the first 50 perception rows in the shared audit file -> still resolved (F1 regression);
+- `no_send=true` completed event -> not selected (F2);
+- event with `sent_accounts=[sy]`, failure for lx -> lx query does not resolve it; lx falls through to RUN-not-found semantics (F3);
+- event exists but accounts do not include requested account -> DEPENDENCY_MISSING with `reason=no_notification_run`;
+- no events for date -> DEPENDENCY_MISSING with account/date in details;
+- explicit run_id still wins over run_selector;
+- omitted run_selector keeps latest-run behavior (regression);
+- invalid notification_date format -> INPUT_ERROR;
+- notification_date without latest_notification -> INPUT_ERROR;
+- cross-UTC-midnight event maps to the correct local date (F4);
+- Copilot-facing error stays in `COPILOT_SAFE_ERROR_CODES` vocabulary (F5).
+
+Validation commands:
+
+- `./.venv/bin/python -m pytest tests/test_candidate_filter_trace.py tests/test_candidate_snapshot_manifest.py -q`
+- `./.venv/bin/python -m pytest tests/test_agent_plugin_contract.py tests/test_agent_plugin_smoke.py -q`
+- `./om-agent run --tool candidate_filter_explain --input-json '{"account":"lx","symbol":"NVDA"}'` (regression: latest behavior)
+
+## Docs decision
+
+Update `docs/TOOL_REFERENCE.md` entry for `candidate_filter_explain` if it enumerates inputs; otherwise docstrings/schema serve as the contract. No AGENT_WIKI change needed (no new module ownership).
+
+## Risks / open questions
+
+- Shared audit file scans are O(file size) per resolution; acceptable at current event volume; if it becomes hot, a later work unit can add an indexed read (tracked, not blocking).
+- Historical audit rotation/cleanup makes old dates fail-closed; covered by the `no_notification_run` semantics.
+
+## Over-design statement
+
+No new service, index, table, or persistent mapping is introduced; resolution reuses the existing audit read path and snapshot manifest loader. The date handling is a single ISO date, not a natural-language engine. `candidate_rank_explain` is deliberately untouched.
+
+## Completion report format
+
+Final closeout summary with what changed, validation results, finding status, residual risks, draft PR URL, and next entry point.

--- a/docs/gateflow/candidate-filter-run-resolution/s1-implementation.md
+++ b/docs/gateflow/candidate-filter-run-resolution/s1-implementation.md
@@ -1,0 +1,32 @@
+# Gateflow Artifact — S1 Implementation
+
+- Gate: `implementation`
+- Work unit: `candidate-filter-run-resolution`
+- Slice: `S1` (schema + resolver + normalizer + tests + docs)
+- Status: `implementation complete; pending code review`
+
+## What changed
+
+| File | Change |
+|---|---|
+| `src/application/notification_perception_read.py` | Added `iter_notification_perception_events` (internal, bounded at 5000 rows) sharing `_audit_paths`/`_read_jsonl`/`_matches_event`/`_public_event`; public tool cap unchanged |
+| `src/application/agent_tools/candidate_filter_impl.py` | Added `run_selector` / `notification_date` handling; delivered-notification run resolver with frozen sent predicate (`notification_delivery_completed` + `no_send is not True` + account-visible via `send_summary.sent_accounts` preferred over `accounts`); local-tz date mapping; `run_resolution` provenance in output `source`; fail-closed `DEPENDENCY_MISSING` with `details.reason=no_notification_run` |
+| `src/application/agent_tools/candidate.py` | Extended `CANDIDATE_FILTER_EXPLAIN_TOOL` schema/description/examples/`copilot_input_fields`; added `_normalize_candidate_filter_copilot_input` normalizer |
+| `tests/test_candidate_filter_run_resolution.py` | 13 focused tests (new file) |
+| `docs/TOOL_REFERENCE.md` | Documented `run_selector=latest_notification` semantics and fail-closed behavior |
+
+## Validation
+
+- `./.venv/bin/python -m pytest tests/test_candidate_filter_run_resolution.py -q` -> 13 passed
+- `./.venv/bin/python -m pytest tests/test_candidate_filter_trace.py tests/test_candidate_snapshot_manifest.py tests/test_agent_plugin_contract.py -q` -> 32 passed
+- `./.venv/bin/python -m pytest tests/test_agent_plugin_smoke.py -q` -> 101 passed (1 pre-existing deprecation warning)
+- `./om-agent run --tool candidate_filter_explain --input-json '{"account":"lx","symbol":"NVDA"}'` -> unchanged fail-closed `DEPENDENCY_MISSING` on this machine (no local runs), confirming default latest path is untouched
+
+## Residual risks
+
+- O(file) scan of the shared audit JSONL per resolution: accepted for current volume; later indexed read if hot (tracked in plan).
+- Old dates fail closed when audit history is rotated: covered by `no_notification_run` semantics (in-scope design).
+
+## Completion signal
+
+All approved plan test cases implemented and green; regression suites green; docs updated.

--- a/docs/gateflow/candidate-filter-run-resolution/s1-review-fix.md
+++ b/docs/gateflow/candidate-filter-run-resolution/s1-review-fix.md
@@ -1,0 +1,27 @@
+# Gateflow Fix Artifact — S1 Code Review Fix
+
+- Gate: `fix` after code review `docs/reviews/code-review-20260813-144738.md`
+- Work unit: `candidate-filter-run-resolution`
+- Slice: `S1`
+
+## Finding decision and fix
+
+### CR-1 — accepted — fixed
+
+`iter_notification_perception_events` now returns `{events, total_count, truncated}` instead of a bare list. When the bounded scan window truncates before the requested `notification_date` can be ruled out, `candidate_filter_explain` raises `DEPENDENCY_MISSING` with `details.reason=audit_window_truncated` (plus `audit_total_count`) instead of the indistinguishable `no_notification_run`. Regression coverage: helper-level truncation assertion plus a monkeypatched impl-level test asserting the distinct reason.
+
+Final status: `已修复`.
+
+### CR-2 — pre-existing, recorded — deferred with owner
+
+`candidate_filter_explain` base path bypasses `resolve_runtime_root` (pre-existing, shared by `latest` behavior before this slice). Deferred to a later work unit that moves candidate tools onto `resolve_runtime_root`; this slice kept audit read and snapshot read on the same base so no new inconsistency was introduced.
+
+Final status: `deferred-with-owner` (later work unit: candidate tools runtime-root alignment).
+
+## Validation after fix
+
+- `./.venv/bin/python -m pytest tests/test_candidate_filter_run_resolution.py tests/test_candidate_filter_trace.py tests/test_candidate_snapshot_manifest.py tests/test_agent_plugin_contract.py tests/test_agent_plugin_smoke.py -q` -> 148 passed, 1 pre-existing deprecation warning
+
+## Residual risks
+
+- Unchanged from review: O(file) audit scan and in-memory read (accepted, later indexed read if hot).

--- a/docs/reviews/code-review-20260813-144738.md
+++ b/docs/reviews/code-review-20260813-144738.md
@@ -1,0 +1,56 @@
+# Code Review — candidate-filter-run-resolution S1
+
+- Reviewed target: workspace diff `main...HEAD` on branch `feat/candidate-filter-run-resolution` (uncommitted S1 changes)
+- Base: `main@421591dd`
+- Scope: `src/application/notification_perception_read.py`, `src/application/agent_tools/candidate_filter_impl.py`, `src/application/agent_tools/candidate.py`, `tests/test_candidate_filter_run_resolution.py`, `docs/TOOL_REFERENCE.md`
+- Excluded: AGENTS.md 的用户昵称改动（与本 work unit 无关，保留不碰）；未跟踪的 data-storage 设计文档
+
+## Review method
+
+沿真实调用链走读：`execute_tool` -> `CANDIDATE_FILTER_EXPLAIN_TOOL` schema/normalizer -> `candidate_filter_explain_tool` -> `_resolve_notification_run` -> `iter_notification_perception_events` -> `_read_jsonl`/`_public_event` -> `load_candidate_snapshot_bundle`。逐行核对 sent 谓词、日期映射、错误分类与 plan 冻结契约。
+
+## Findings
+
+### 1-未修复-中-审计文件超过 5000 条感知事件时，目标通知事件会被静默截断导致误报 no_notification_run
+
+- **入口/函数**: `_resolve_notification_run` -> `iter_notification_perception_events(repo_root=base, event_kind=...)` （未传 limit)
+- **文件(行号)**: `src/application/agent_tools/candidate_filter_impl.py:80-101`; `src/application/notification_perception_read.py:84-112`
+- **输入场景**: 共享 `audit_events.jsonl` 持续追加且从不轮转；`iter_notification_perception_events` 默认 limit=5000（内部上限 5000）。production 主机运行数月后感知事件总数会超过 5000。
+- **实际分支**: helper 按时间倒序取前 5000 条 perception 事件。若目标日期的 delivered 事件排在第 5001 条之后（例如查询前天通知、且昨天+今天事件总量已超 5000），resolver 找不到匹配，返回 `DEPENDENCY_MISSING/no_notification_run`。
+- **预期行为**: 对"查询较旧日期"这类明示请求，截断应被识别并显式报告（如 `truncated=True` 且在窗口内未扫描完整时给出不同 details），而不是与"当天确实没有通知"混为同一错误。
+- **实际行为**: 用户查询昨天或更早的通知时，随着文件增长，工具从某天开始静默回答"没有找到通知"，且错误 details 与真实无通知场景完全一致，无法区分。
+- **直接证据**: `notification_perception_read.py:111` `max_rows = max(0, min(int(limit if limit is not None else 5000), 5000))`；helper 不向调用方报告截断/总行数；`_resolve_notification_run` 无法感知扫描不完整。
+- **影响**: 核心场景（通知到达后询问）默认查"今天"，通常落在最新 5000 条内，风险较低；但显式 `notification_date` 查旧日期时会随时间退化，且失败不可诊断。
+- **建议改法和验证点**: 让 `iter_notification_perception_events` 返回 `{events, total_count, truncated}`（或 resolver 传 `limit=5000` 并在事件数等于上限且最早一条事件仍晚于目标日期时继续扫描/报 `audit_window_truncated`）。验证：构造 >5000 条事件且目标事件在窗口外的用例，断言返回可区分的截断错误而非 `no_notification_run`。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### 2-已确认-pre-existing-低-runtime root 解析缺口：本工具不经 `OM_RUNTIME_ROOT`
+
+- **入口/函数**: `candidate_filter_explain_tool` 的 `base = Path(payload.get("runtime_root") or repo_base()).resolve()`
+- **文件(行号)**: `src/application/agent_tools/candidate_filter_impl.py:119`; `src/application/agent_tool_config.py:20-21`; 对照 `src/application/runtime_paths.py:15-35`
+- **说明**: 其他运行时工具（notification_perception/close_advice_read/daily_brief）都走 `resolve_runtime_root`（`OM_RUNTIME_ROOT` -> repo fallback）；本工具直接用 repo root。在远端部署（runtime root 与 repo 分离，如 liuxie-incus `/var/lib/options-monitor`）时，`latest`/`latest_notification` 两条路径都找不到 `output_runs`/`output_shared`。这是 pre-existing 行为，本次改动让审计读取与快照读取在同一 base 下保持一致（不会互相错位），但新能力在远端同样受该缺口限制。
+- **建议**: 不在本 slice 修（会扩大 blast radius 到现有 latest 行为）；建议后续 work unit 统一把 candidate 工具接到 `resolve_runtime_root`，并补远端形态测试。
+- **严重程度**: 低（pre-existing，本 slice 未加重）
+
+## Adversarial failure pass 已核对项（无 findings）
+
+- sent 谓词与 `tick_notification_flow` 实际写入字段逐字段对齐：`no_send` 排除、`sent_accounts` 优先、`accounts` 回退、空 sent+failure>0 排除 — 与 plan 冻结一致。
+- 显式 `run_id` 优先级、默认 latest 回归路径、错误码在 `COPILOT_SAFE_ERROR_CODES` 内、schema required 不变、retired 字段未回归 — 均有测试或契约测试覆盖。
+- `_public_event` 的敏感字段 strip 未绕过；`_audit_paths` 的 symlink 防护（shared_root/shared_state 拒绝 symlink）对新 helper 同样生效。
+- `date.fromisoformat` 非法输入 -> `INPUT_ERROR`（修复后）；`notification_date` 无 selector -> `INPUT_ERROR`；execution 层 `INTERNAL_ERROR` 兜底不被触发。
+- 排序确定性：helper 按 `event_at_utc/created_at_utc` 字符串倒序，与 ISO-8601 UTC 时间戳的字典序一致；同秒事件的次序不影响"最近一条"语义的可审计性（`run_resolution` 记录了 matched 事件时间）。
+- AGENTS.md 红色红线：未发送通知、未改 config、未删 runtime artifacts、未写 Feishu/ledger；工具保持 `pure_read`。
+
+## Open questions
+
+- 无。
+
+## Residual risk
+
+- Finding 1 的截断窗口：covered by current review, fix pending（建议本 slice 内修复，改动小）。
+- O(file) 全文件读入内存（`_read_jsonl` 一次性 `read_text`）：与现有 audit readers 同模式；大文件下内存尖峰 accepted，tracked by later work unit。
+
+## Conclusion
+
+`pass-with-risks` — 1 个中严重度 finding（截断不可诊断），建议本 slice 修复后 re-review；1 个 pre-existing 低严重度记录项不阻塞。

--- a/docs/reviews/code-review-20260813-145637.md
+++ b/docs/reviews/code-review-20260813-145637.md
@@ -1,0 +1,36 @@
+# Code Re-Review — candidate-filter-run-resolution S1
+
+- Reviewed target: S1 fix state on branch `feat/candidate-filter-run-resolution`
+- Prior review: `docs/reviews/code-review-20260813-144738.md` (pass-with-risks, CR-1)
+- Fix artifact: `docs/gateflow/candidate-filter-run-resolution/s1-review-fix.md`
+
+## Closure of prior findings
+
+| Finding | Fix | Status |
+|---|---|---|
+| CR-1 — truncation indistinguishable from no-notification | helper returns `{events,total_count,truncated}`; impl maps truncated window to `audit_window_truncated` with `audit_total_count`; two new tests | 已修复 |
+| CR-2 — runtime-root bypass (pre-existing) | deferred-with-owner, recorded in fix artifact | deferred-with-owner |
+
+## Re-review of the fix
+
+- `iter_notification_perception_events` return-shape change has a single caller (`_resolve_notification_run`); no other consumers broken. `__all__` export updated earlier; helper semantics unchanged apart from the envelope.
+- Truncated branch verified by monkeypatched impl test: `DEPENDENCY_MISSING` + `reason=audit_window_truncated`; helper-level truncation verified with `limit=0` fixture.
+- No new silent fallback introduced: `run_id` empty + truncated=false still yields `no_notification_run` with date in details.
+- Fix stays inside the approved slice files; no schema/public-contract churn beyond the plan-approved error-details vocabulary.
+
+## Findings
+
+None.
+
+## Validation evidence
+
+- 148 passed across the focused slice tests plus `test_candidate_filter_trace`, `test_candidate_snapshot_manifest`, `test_agent_plugin_contract`, `test_agent_plugin_smoke` (1 pre-existing deprecation warning).
+
+## Residual risks
+
+- O(file) audit scan (accepted; later indexed read if hot — tracked in plan).
+- CR-2 runtime-root alignment deferred to a later work unit (owner recorded).
+
+## Conclusion
+
+`pass` — S1 accepted for slice commit.

--- a/docs/reviews/code-review-20260813-150303.md
+++ b/docs/reviews/code-review-20260813-150303.md
@@ -1,0 +1,52 @@
+# Aggregate DeepReview — candidate-filter-run-resolution
+
+- Reviewed target: complete work-unit diff `main@421591dd...HEAD@2ad81020`, branch `feat/candidate-filter-run-resolution`
+- Mode: aggregate deepreview over all approved slices (S1 only)
+- Prior artifacts: plan + 2 plan reviews + S1 code review + re-review + fix artifact
+- Parallel review coverage: 无（单 slice、3 个源文件，主 reviewer 全量走读）
+
+## Scope and intent
+
+Intent: Copilot 用户在通知到达后询问"某标的为什么被过滤"时，`candidate_filter_explain` 能从通知投递证据 fail-closed 定位 run。Review 覆盖：公共契约（tool schema/copilot schema/error vocabulary）、run 解析链路、审计读取链路、日期/时区语义、测试面、docs。
+
+## Findings
+
+### 1-未修复-低-latest_notification 解析出的 run 快照加载失败时，错误 details 丢失已解析的 run_id
+
+- **入口/函数**: `candidate_filter_explain_tool` -> `load_candidate_snapshot_bundle(run_id=resolved["run_id"])` -> `except CandidateSnapshotManifestError`
+- **文件(行号)**: `src/application/agent_tools/candidate_filter_impl.py:199-203, 229-235`
+- **输入场景**: `run_selector=latest_notification` 成功解析到 run_id（如通知事件存在），但该 run 的 manifest/快照缺失或被清理（output_runs 保留期短于 audit_events 保留期时必然发生）。
+- **实际分支**: `load_candidate_snapshot_bundle` 抛 `CandidateSnapshotManifestError`，被统一捕获后 `details={"account": account, "run_id": payload.get("run_id")}` — 此时 payload 没有显式 run_id，`details.run_id=None`。
+- **预期行为**: 错误 details 应包含已解析的 `resolved_run_id`，让排障者知道"通知指向了哪个已不可用的 run"。
+- **实际行为**: 用户看到"candidate snapshot manifest is unavailable"且 `run_id=None`，无法知道通知事件指向哪个 run；审计线索断裂。
+- **直接证据**: impl 229-235 行统一 except 使用 `payload.get("run_id")`；`resolved["run_id"]` 未进入 details。
+- **影响**: 可诊断性下降（不丢数据、不猜错 run）；在 output_runs 清理策略比审计历史更激进的环境下会稳定出现。
+- **建议改法和验证点**: 在 `latest_notification` 分支内单独捕获 `CandidateSnapshotManifestError`，details 增加 `resolved_run_id` 与 `reason=snapshot_unavailable_for_notification_run`；测试：通知事件存在但对应 run 目录缺失。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 低
+
+## Adversarial pass 覆盖（无 findings）
+
+- Architecture boundary：改动全部在 `src/application` 层；`domain/` 无 import 反向；`notification_perception_read` 新 helper 与现有 reader 同层同模式。
+- Overcoupling：helper 复用 `_audit_paths`/`_read_jsonl`/`_matches_event`/`_public_event` 而非复制；resolver 不依赖 Copilot 层概念；Copilot normalizer 只做输入校验不做解析策略。
+- Protocol/interface 边界：`iter_notification_perception_events` 返回值 envelope 单调用方；公共工具 `notification_perception_read` 行为与 50-row cap 未变。
+- Branch ordering：显式 run_id -> latest_notification -> latest 的优先级与 plan 冻结一致；`notification_date` 误用在 selector 校验之前被 INPUT_ERROR 拦截。
+- State machine：无状态机；工具 pure_read，无副作用、无重试、无幂等面。
+- Security：run_id 作为路径组件经 `_identity_component` + no-follow chain（`tick_run_workspace.py:309-329`）；shared audit 路径 symlink 防护生效；敏感字段 strip 未绕过。
+- Parameter effectiveness：`run_selector`/`notification_date` 从 schema -> normalizer -> impl 消费点链路完整，无静默丢弃。
+- Tests：15 个 focused tests 覆盖 happy path/ordering/截断/no_send/失败投递/优先级/回归/校验/时区/安全词表；非 happy-path 占多数。
+- Repo instructions：无通知发送、无 config 改动、无 runtime 写入、无 service 操作；`pure_read` 保持；AGENTS.md 无关改动（用户昵称行）未混入 slice commits。
+
+## Open questions
+
+- 无。
+
+## Residual risks
+
+- CR-2 runtime-root alignment：deferred-with-owner（later work unit: candidate tools 接 `resolve_runtime_root`）。
+- O(file) audit scan / 全文件读入内存：accepted for current volume；later indexed read if hot。
+- output_runs 保留期 < audit 保留期时的 `snapshot_unavailable` 场景：finding 1 修复后诊断信息完整，行为本身为正确 fail-closed。
+
+## Conclusion
+
+`pass-with-risks` — 1 个低严重度可诊断性 finding，建议顺手修复后进入 draft PR；不阻塞 merge 语义。

--- a/docs/reviews/code-review-20260813-150727.md
+++ b/docs/reviews/code-review-20260813-150727.md
@@ -1,0 +1,30 @@
+# Aggregate DeepReview Re-Review — candidate-filter-run-resolution
+
+- Reviewed target: work-unit HEAD after aggregate fix, branch `feat/candidate-filter-run-resolution`
+- Prior: `docs/reviews/code-review-20260813-150303.md` (pass-with-risks, DR-1)
+- Fix artifact: `docs/gateflow/candidate-filter-run-resolution/aggregate-fix.md`
+
+## Closure
+
+| Finding | Fix | Status |
+|---|---|---|
+| DR-1 — resolved run_id lost in snapshot-missing error | dedicated except in `latest_notification` branch with `reason=snapshot_unavailable_for_notification_run` + resolved `run_id` + date; new regression test | 已修复 |
+
+## Re-review
+
+- 新 except 分支只包裹 `load_candidate_snapshot_bundle` 调用，`CandidateSnapshotManifestError` 语义不变；显式 run_id 与 latest 路径的原始错误行为不受影响。
+- 错误 details 三个键齐备且可审计；`run_id` 经 `_identity_component` 校验后进入 loader，无路径风险。
+- 149 passed 全绿。
+
+## Findings
+
+None.
+
+## Residual risks
+
+- CR-2 runtime-root alignment：deferred-with-owner。
+- O(file) audit scan：accepted，later indexed read if hot。
+
+## Conclusion
+
+`pass` — aggregate deepreview accepted; ready for draft PR.

--- a/docs/reviews/plan-review-20260813-141152.md
+++ b/docs/reviews/plan-review-20260813-141152.md
@@ -1,0 +1,95 @@
+# Plan Review — candidate-filter-run-resolution
+
+- Reviewed target: `docs/gateflow/candidate-filter-run-resolution/plan.md`
+- Scope: single-slice input-resolution feature for `candidate_filter_explain`
+- Source baseline: `main@421591dd`, branch `feat/candidate-filter-run-resolution`
+- Review posture: adversarial; implementation readiness only
+
+## Assumptions tested
+
+1. Notification perception events link "the notification the user saw" to a scan run via `extra.run_id` + `extra.accounts` + `event_kind`.
+   Evidence: `src/application/multi_tick/assistant_perception_event.py:16-110`, `src/application/tick_notification_flow.py:1350-1360`, `src/application/notification_perception_read.py:196-207`. Holds.
+2. `read_notification_perception_events` can be reused for resolution.
+   Evidence: signature caps `limit` at 50 and sorts by event timestamp desc (`notification_perception_read.py:40-41`). Partially holds — see F1.
+3. "Sent" can be identified by `event_kind == notification_delivery_completed`.
+   Evidence: `tick_notification_flow.py:487-503`. Partially holds — `no_send` runs also emit this event (`tick_notification_flow.py:478-482`), so the resolver must also require `no_send is not true`. Plan's generic "confirmed-send subset" is not code-generation-ready — see F2.
+4. `candidate_filter_impl` currently resolves the snapshot base as `payload.runtime_root or repo_base()`.
+   Evidence: `candidate_filter_impl.py:47`. Holds. This means the audit lookup and the snapshot lookup share one runtime root, which is consistent but must be stated explicitly in the plan.
+5. Date filtering is not supported by the existing read API (event_kind/conversation/limit only); the resolver must filter by `created_at_utc` itself.
+   Evidence: `notification_perception_read.py:17-42`. Holds — plan correctly assigns date filtering to the resolver.
+
+## Findings
+
+### F1-未修复-高-limit=50 cap can silently drop the matching notification event, causing wrong RUN_NOT_FOUND or wrong-run resolution
+
+- **位置**: plan "Resolution rule for latest_notification" — "Read notification perception events via `read_notification_perception_events` for the given date window"
+- **问题类型**: 契约缺失 / 测试缺口
+- **当前写法**: plan 复用 `read_notification_perception_events`，但未规定 limit 策略或扫描深度。
+- **反例/失败场景**: 共享 `output_shared/state/audit_events.jsonl` 是多市场、多账户、多事件类型（prepared/decided/completed/quiet_hours_skipped/no_account_notification）的单一追加文件。一个高频交易日里，目标账户当日 `notification_delivery_completed` 事件之前若已有超过 50 条更新的 perception 事件，`limit<=50` 的截断会让目标事件根本不在返回集里，resolver 误报 RUN_NOT_FOUND；更糟的是若第 51 条之后有另一条匹配事件，用户可能拿到"上一通知"的 run 而毫无察觉。
+- **为什么有问题**: 该工具的卖点是"通知到达后解释过滤"，恰恰在高活动日（多次 tick + 多账户）最常被使用；失败场景与核心场景重合。
+- **直接证据**: `notification_perception_read.py:41` `max_rows = max(0, min(int(limit or 10), 50))`；`tick_notification_flow.py` 单次 tick 最多写 5 个 perception 事件（235/252/290/351/377/487）。
+- **影响**: 误报 RUN_NOT_FOUND 或静默解析到错误 run，用户得到错误的过滤解释。
+- **建议改法和验证点**: resolver 不得复用截断 API 的默认语义；方案 A：在 `notification_perception_read.py` 增加窄函数 `iter_notification_perception_events(..., event_kind, limit=None)`（或 limit 上限放宽到覆盖全天，如 5000）仅供内部 resolver 使用；方案 B：resolver 循环调用分页直到扫完目标日期窗口。测试必须包含"目标事件位于第 51+ 条"的用例。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### F2-未修复-中-"实际发送"的判定谓词未收敛到代码级定义
+
+- **位置**: plan "Resolution rule" — "delivery.action indicates an actual send (conservative confirmed-send subset enumerated from call sites)"
+- **问题类型**: 不可直接实施 / 契约缺失
+- **当前写法**: plan 把 sent 判定留给实施期枚举。
+- **反例/失败场景**: `notification_delivery_completed` 在 `no_send` 模式下同样写入（`tick_notification_flow.py:478-503`，`sent_accounts = [] if request.delivery_only else list(would_send_accounts)` 的 else 分支在 no_send 时仍走 completed 事件），heartbeat/threshold-met 但 delivery_only 的运行也写 completed。若只按 event_kind 过滤，dry-run/heartbeat no-send 运行会被误认为"用户收到了通知"，解析到一个用户从未见过的 run。
+- **直接证据**: `tick_notification_flow.py:474-503`；`assistant_perception_event.py:77` `no_send` 字段。
+- **影响**: 解析到错误 run，且该错误与用户"我刚收到通知"的心智模型直接冲突。
+- **建议改法和验证点**: plan 中冻结判定谓词：`event_kind == "notification_delivery_completed"` AND `event.no_send is not true` AND (`send_summary.send_attempted_count` 或 `send_confirmed_count` 至少一个 > 0，或 `sent_accounts` 含目标账户)；`delivery.action` 不作为 sent 证据（它表示决策动作如 fixed_report/skip_quiet_hours，不表示传输结果）。测试：no_send run 的 completed 事件不得被选中。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### F3-未修复-中-account 匹配字段未冻结：`accounts` vs `sent_accounts` vs 顶层 `account`
+
+- **位置**: plan "Resolution rule" — "whose `accounts` include the requested account"
+- **问题类型**: 契约缺失
+- **当前写法**: 只提 `accounts`。
+- **反例/失败场景**: 感知事件的 `accounts` 来自 `account_messages.keys()`（assistant_perception_event.py:34），即"准备了消息的账户"；`send_summary.sent_accounts` 才是实际发送成功的账户；audit 顶层还有 `account` 字段（multi_tick_audit.py:33，本事件写入时未传，故为 None）。一次 lx 发送失败、sy 发送成功的 completed 事件 `accounts=[lx,sy]`：lx 用户问"我刚收到的通知"，其实 lx 没收到。用 `accounts` 会把失败投递也算作用户可见通知。
+- **直接证据**: `assistant_perception_event.py:34,91-99`；`tick_notification_flow.py:457-466`（sent_accounts 经 `_confirm_daily_brief_execution` 修正）。
+- **影响**: 跨账户场景下解析到用户未收到的 run。
+- **建议改法和验证点**: 冻结优先级：`send_summary.sent_accounts` 非空时以其为准，否则回退 `accounts`（heartbeat/旧格式兼容）；空 sent_accounts + failure_count>0 的事件应跳过或降级。测试：lx 失败 sy 成功的事件对 lx 不可见。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### F4-未修复-中-时区来源"runtime config timezone"没有代码事实支撑
+
+- **位置**: plan "Implementation decisions" — "derive from the runtime config timezone already used by the scan pipeline"
+- **问题类型**: 动机不成立 / open question 未收敛
+- **当前写法**: 声称 scan pipeline 有一个可复用的 config 时区。
+- **反例/失败场景**: 检索 `src/application/layered_config.py` 无 timezone 字段；事件时间戳是 UTC ISO（`event_at_utc`/`created_at_utc`）。"今天"到底按 UTC、系统本地（Asia/Shanghai）还是市场时区（US Eastern / HK）会影响跨午夜事件的归属：HK 市场早上 9:30 的 tick 对应 UTC 01:30，按 UTC 日期归属前一天。
+- **直接证据**: `rg -n "timezone|time_zone|tz" src/application/layered_config.py` 无命中；`normalize_audit_event` 用 `datetime.now(timezone.utc)`。
+- **影响**: 实施 agent 自行发明时区来源，同一事件在不同主机上归属不同日期，行为不可复现。
+- **建议改法和验证点**: 冻结决策：默认按系统本地时区（与运维cron在同一主机一致）把 UTC 事件时间映射到本地日期；输出 `run_resolution.timezone` 记录实际使用的 tz；不做市场时区推断（非目标）。测试：跨 UTC 午夜事件归属正确本地日期。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+### F5-未修复-低-无事件时的错误分类与现有 DEPENDENCY_MISSING 语义冲突
+
+- **位置**: plan "Resolution precedence" — "Zero matches -> AgentToolError(code=RUN_NOT_FOUND)"
+- **问题类型**: 最佳实践偏离
+- **当前写法**: 新增 `RUN_NOT_FOUND` 错误码。
+- **反例/失败场景**: 现有工具对"快照不可用"统一用 `DEPENDENCY_MISSING`（candidate_filter_impl.py:63-69）。新增错误码本身合理，但 plan 未说明 Copilot 契约层（`safe_error_code`）是否允许该码透传，未列入验证项。
+- **直接证据**: `src/application/copilot/contracts.py` `safe_error_code`；candidate_filter_impl.py:66。
+- **影响**: Copilot 侧可能把新错误码折叠为 generic error，用户看不到"没有找到该日期的通知"这一关键信息。
+- **建议改法和验证点**: 验证 `safe_error_code` 对自定义码的处理；若折叠，则改用 `DEPENDENCY_MISSING` + details `{reason: "no_notification_run", account, notification_date}`。加入契约测试。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 低
+
+## Open questions
+
+- 无阻塞性 open question；F1-F4 均可直接在 plan 修订中冻结。
+
+## Residual risks
+
+- 历史 audit 文件被轮转/清理后，`latest_notification` 对旧日期 fail-closed：assigned to current work unit（RUN_NOT_FOUND 语义即覆盖）。
+- 共享 audit 文件跨市场混写带来的读取成本（每次全文件扫描）：accepted for current slice；若成为热点，tracked by later work unit（审计读取侧已有同类模式）。
+
+## Conclusion
+
+`fail` — F1（limit 截断导致错误解析）是必须修复的高严重度契约缺口；F2-F4 需要在 plan 中冻结谓词/字段/时区后才达到 code-generation-ready。修复后可 re-review。

--- a/docs/reviews/plan-review-20260813-141818.md
+++ b/docs/reviews/plan-review-20260813-141818.md
@@ -1,0 +1,41 @@
+# Plan Re-Review — candidate-filter-run-resolution
+
+- Reviewed target: `docs/gateflow/candidate-filter-run-resolution/plan.md` (revised)
+- Prior review: `docs/reviews/plan-review-20260813-141152.md` (fail, F1-F5)
+- Source baseline: `main@421591dd`, branch `feat/candidate-filter-run-resolution`
+
+## Closure of prior findings
+
+| Finding | Revised plan decision | Status |
+|---|---|---|
+| F1 — limit=50 cap drops matching events | New internal `iter_notification_perception_events` with limit up to 5000, sharing read internals; public tool cap unchanged; beyond-50 regression test added | Closed |
+| F2 — sent predicate undefined | Frozen: `notification_delivery_completed` + `no_send is not True` + account-visible; `delivery.action` explicitly excluded as sent evidence; no_send test added | Closed |
+| F3 — account field ambiguity | Frozen: `send_summary.sent_accounts` preferred, top-level `accounts` fallback; failed-delivery event skipped for that account; test added | Closed |
+| F4 — timezone source unfounded | Frozen: system local tz of runtime host applied to UTC event timestamps, recorded in `run_resolution.timezone`; cross-midnight test added | Closed |
+| F5 — error code not in Copilot safe vocabulary | Switched to `DEPENDENCY_MISSING` + `details.reason=no_notification_run`; safe-vocabulary contract test added | Closed |
+
+## Adversarial pass on revised plan
+
+- Slice boundaries: single slice touching one tool schema, one impl file, one read helper, tests, and one docs file. Cohesive and reviewable in one pass.
+- Contract stability: all new inputs optional; default path unchanged; explicit `run_id` precedence preserved. Backward compatible.
+- Failure semantics: every resolution failure mode (no events, no sent match, snapshot missing, bad date, misused date) maps to a structured `AgentToolError` with auditable details; no silent fallback was introduced.
+- Test list covers happy path, ordering, truncation regression, no_send exclusion, failed-delivery exclusion, precedence, regression, validation, timezone, and Copilot error vocabulary. Assertions match the stated contract.
+- Overengineering check: the new helper reuses existing read internals; no new persistence, no index, no service. The 5000 limit is a bounded scan over an append-only JSONL, consistent with existing audit readers.
+- Residual risk (O(file) scan) is classified with a tracking destination.
+
+## Findings
+
+None.
+
+## Open questions
+
+None blocking.
+
+## Residual risks
+
+- O(file) scan per resolution at high audit volume: accepted for current slice; later indexed read if hot (tracked in plan).
+- Old dates fail closed when audit history is rotated: covered by `no_notification_run` semantics (in-scope).
+
+## Conclusion
+
+`pass` — plan is code-generation-ready for the single approved slice S1.

--- a/docs/reviews/pr-153-review-20260813-153028.md
+++ b/docs/reviews/pr-153-review-20260813-153028.md
@@ -1,0 +1,37 @@
+# Code Review
+
+## Scope
+
+- Mode: PR
+- Branch or PR: #153 `feat/candidate-filter-run-resolution` (https://github.com/liuxie066/options-monitor/pull/153)
+- Base: `main` (`421591dd`)
+- Output file: `docs/reviews/pr-153-review-20260813-153028.md`
+- Included scope: PR 全部 diff — `src/application/agent_tools/candidate.py`、`src/application/agent_tools/candidate_filter_impl.py`、`src/application/notification_perception_read.py`、`tests/test_candidate_filter_run_resolution.py`、`docs/TOOL_REFERENCE.md`、Gateflow/review artifacts
+- Excluded scope: notification pipeline 既有行为（producer 侧 `tick_notification_flow.py`/`assistant_perception_event.py` 仅作为证据读取，非本 PR 改动对象）；`resolve_runtime_root`/`OM_RUNTIME_ROOT` 接线（pre-existing，已在 aggregate deepreview 中 deferred 到后续 work unit）
+- Parallel review coverage: 无；本次 PR review 由单 reviewer 沿 resolver -> audit read -> snapshot load -> output 主链路逐行走读
+- CI: `gh pr checks 153` 全部 pass（Analyze (actions)/(python)、CodeQL、agent-plugin、guardrails）
+
+## Findings
+
+未发现实质性问题。
+
+复核记录（候选点均沿真实代码路径排除，不构成 finding）：
+
+1. **`_resolve_notification_run` 的 "most recent" 语义** — `iter_notification_perception_events`（`notification_perception_read.py:114`）按 `event_at_utc` 降序排序后返回，`_resolve_notification_run` 取第一个匹配 sent 谓词与本地日期的事件，语义与工具描述 "most recent delivered notification" 一致。真实数据侧 `send_summary.sent_accounts` 由 `tick_notification_flow.py:487` 的 `build_notification_perception_event` 写入，字段名核对一致。
+2. **UTC->本地日期映射** — `_event_local_date` 对 naive 时间戳按 UTC 处理再 `astimezone(tz)`，producer 侧 `state_repo.py:160` 保证 `event_at_utc` 为 UTC ISO，路径闭合；`run_resolution.timezone` 已记录实际 tz，不做市场时区推断是 plan 冻结决策。
+3. **truncated fail-closed** — 5000 行上限内未匹配且 `truncated=True` 时返回 `audit_window_truncated`（`candidate_filter_impl.py:182-199`），与 `no_notification_run` 区分，避免把窗口截断误报为"无通知"，方向正确。
+4. **sent 谓词边界** — `_event_visible_to_account`：`sent_accounts` 非空以其为准；空 sent 且 `failure_count>0` 判不可见；否则回退顶层 `accounts`。`no_send=True` 的事件被排除。测试 `test_latest_notification_ignores_no_send_completed_event`、`test_latest_notification_skips_event_where_account_send_failed` 覆盖这两条边界。
+5. **公共面兼容** — `read_notification_perception_events` 50-row cap 未变；新 helper `iter_notification_perception_events` 仅被本 PR 的 resolver 消费，`__all__` 显式导出；`candidate_filter_explain` 默认（不传 `run_selector`）路径行为不变，回归测试（candidate trace/snapshot manifest/agent plugin contract+smoke）通过。
+6. **normalizer 与 impl 校验一致性** — `candidate.py:_normalize_candidate_filter_copilot_input` 与 `candidate_filter_impl.py` 对 `run_selector`/`notification_date` 的校验规则一致（impl 为最终防线，normalizer 只做 copilot 输入整形），无参数失效链。
+7. **错误码收敛** — 三类 fail-closed 错误统一 `DEPENDENCY_MISSING` + `details.reason`，避免自定义码被 `safe_error_code` 折叠，符合 plan 决策。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- **O(file) 全量 audit scan**：resolver 每次调用读取整个 shared `audit_events.jsonl` 并全量解析（与公共工具同构）。已作为 accepted risk 记录于 plan/aggregate deepreview；若成为热点，后续 work unit 加索引读取。owner: 后续 performance work unit。
+- **CR-2（pre-existing）**：`candidate_filter_explain` base 不经 `resolve_runtime_root`（`OM_RUNTIME_ROOT`），非本 PR 引入。owner: 后续 candidate 工具统一接线 work unit。
+- **测试缺口（低）**：`notification_date` 显式传过去日期 + 多账户混合事件的组合场景未单测（当前测试覆盖默认 today、单账户 sent/failed 边界）；行为由同一谓词与日期映射函数驱动，风险低。
+- 本地验证：165 passed（`test_candidate_filter_run_resolution` 16 个 + candidate trace/snapshot manifest/agent plugin contract+smoke + notification perception read/event 回归），1 个 pre-existing deprecation warning。

--- a/src/application/agent_tools/candidate.py
+++ b/src/application/agent_tools/candidate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from datetime import date
 from typing import Any
 
 from domain.domain.strategy_vocab import (
@@ -17,6 +19,27 @@ from src.application.agent_tool_contracts import mask_path
 from src.application.agent_tool_config import repo_base
 from src.application.agent_tool_config import resolve_output_root
 from src.application.symbol_aliases import symbol_aliases_from_config
+
+
+def _normalize_candidate_filter_copilot_input(payload: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    selector = normalized.get("run_selector")
+    if selector is not None:
+        selector_value = str(selector).strip().lower()
+        if selector_value not in {"latest", "latest_notification"}:
+            raise ValueError("run_selector must be latest or latest_notification")
+        normalized["run_selector"] = selector_value
+    raw_date = normalized.get("notification_date")
+    if raw_date is not None:
+        date_text = str(raw_date).strip()
+        try:
+            date.fromisoformat(date_text)
+        except ValueError as exc:
+            raise ValueError("notification_date must be ISO YYYY-MM-DD") from exc
+        if normalized.get("run_selector") != "latest_notification":
+            raise ValueError("notification_date requires run_selector=latest_notification")
+        normalized["notification_date"] = date_text
+    return normalized
 
 
 _CANDIDATE_FILTER_OUTPUT_CONTRACT: dict[str, Any] = {
@@ -150,7 +173,10 @@ CANDIDATE_RANK_EXPLAIN_TOOL = build_agent_tool(
 CANDIDATE_FILTER_EXPLAIN_TOOL = build_agent_tool(
     name="candidate_filter_explain",
     description=(
-        "Explain the recorded opening decision for a symbol from a terminal manifest-bound account snapshot. The tool never re-filters rows."
+        "Explain the recorded opening decision for a symbol from a terminal manifest-bound account snapshot. The tool never re-filters rows. "
+        "With run_selector=latest_notification it resolves the run that produced the most recent notification actually delivered "
+        "to the account on notification_date (default: today, runtime host local timezone), so a user can ask why a symbol was "
+        "filtered right after a monitoring notification arrives."
     ),
     requires=("candidate_snapshot_manifest", "opening_candidate_snapshot"),
     capabilities=("opening_candidate_snapshot", "filter_explain", "read_only"),
@@ -182,6 +208,14 @@ CANDIDATE_FILTER_EXPLAIN_TOOL = build_agent_tool(
             )
         ),
         "run_id": "optional output_runs run id; omitted resolves the latest terminal manifest-bound run",
+        "run_selector": (
+            "optional latest|latest_notification; latest_notification resolves the most recent run whose "
+            "notification was actually delivered to the account on notification_date"
+        ),
+        "notification_date": (
+            "optional ISO YYYY-MM-DD used with run_selector=latest_notification; "
+            "defaults to today in the runtime host local timezone"
+        ),
     },
     handler=_candidate_filter_explain_tool,
     pure_read=True,
@@ -189,9 +223,19 @@ CANDIDATE_FILTER_EXPLAIN_TOOL = build_agent_tool(
     examples=(
         {"input": {"run_id": "20260514T100000Z", "account": "lx", "symbol": "NVDA"}},
         {"input": {"run_id": "20260514T100000Z", "account": "sy", "symbol": "泡泡玛特"}},
+        {"input": {"account": "sy", "symbol": "0700.HK", "run_selector": "latest_notification"}},
     ),
     output_contract=_CANDIDATE_FILTER_OUTPUT_CONTRACT,
-    copilot_input_fields=("config_key", "symbol", "account", "function", "run_id"),
+    copilot_input_fields=(
+        "config_key",
+        "symbol",
+        "account",
+        "function",
+        "run_id",
+        "run_selector",
+        "notification_date",
+    ),
+    copilot_input_normalizer=_normalize_candidate_filter_copilot_input,
 )
 
 TOOLS: tuple[AgentTool, ...] = (

--- a/src/application/agent_tools/candidate_filter_impl.py
+++ b/src/application/agent_tools/candidate_filter_impl.py
@@ -198,11 +198,23 @@ def candidate_filter_explain_tool(
                         "audit_total_count": resolved.get("total_count"),
                     },
                 )
-            bundle = load_candidate_snapshot_bundle(
-                base=base,
-                run_id=resolved["run_id"],
-                account=account,
-            )
+            try:
+                bundle = load_candidate_snapshot_bundle(
+                    base=base,
+                    run_id=resolved["run_id"],
+                    account=account,
+                )
+            except CandidateSnapshotManifestError as exc:
+                raise AgentToolError(
+                    code="DEPENDENCY_MISSING",
+                    message=str(exc),
+                    details={
+                        "reason": "snapshot_unavailable_for_notification_run",
+                        "account": account,
+                        "run_id": resolved["run_id"],
+                        "notification_date": notification_date.isoformat(),
+                    },
+                ) from exc
             run_resolution = {
                 "selector": run_selector,
                 "notification_date": notification_date.isoformat(),

--- a/src/application/agent_tools/candidate_filter_impl.py
+++ b/src/application/agent_tools/candidate_filter_impl.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Mapping
+from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, TypedDict
 
 from domain.domain.symbol_identity import canonical_symbol
 from src.application.agent_tool_contracts import AgentToolError
@@ -13,9 +14,91 @@ from src.application.candidate_snapshot_manifest import (
     load_candidate_snapshot_bundle,
     load_latest_candidate_snapshot_bundle,
 )
+from src.application.notification_perception_read import (
+    iter_notification_perception_events,
+)
 
 
 _FUNCTION_MODE = {"sell_put": "put", "sell_call": "call"}
+_RUN_SELECTORS = {"latest", "latest_notification"}
+_DELIVERED_EVENT_KIND = "notification_delivery_completed"
+
+
+def _local_timezone() -> timezone:
+    return datetime.now().astimezone().tzinfo or timezone.utc
+
+
+def _event_local_date(event: Mapping[str, Any], tz: timezone) -> date | None:
+    raw = str(event.get("created_at_utc") or "").strip()
+    if not raw:
+        return None
+    try:
+        moment = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(tz).date()
+
+
+def _event_visible_to_account(event: Mapping[str, Any], account: str) -> bool:
+    send_summary = event.get("send_summary")
+    if isinstance(send_summary, Mapping):
+        sent = send_summary.get("sent_accounts")
+        if isinstance(sent, list) and sent:
+            return account in {str(item).strip().lower() for item in sent}
+        failure_count = int(send_summary.get("failure_count") or 0)
+        if isinstance(sent, list) and not sent and failure_count > 0:
+            return False
+    accounts = event.get("accounts")
+    if isinstance(accounts, list):
+        return account in {str(item).strip().lower() for item in accounts}
+    return False
+
+
+def _is_delivered_notification(event: Mapping[str, Any], account: str) -> bool:
+    if str(event.get("event_kind") or "").strip() != _DELIVERED_EVENT_KIND:
+        return False
+    if event.get("no_send") is True:
+        return False
+    return _event_visible_to_account(event, account)
+
+
+class NotificationRunResolution(TypedDict, total=False):
+    run_id: str
+    matched_event_created_at_utc: Any
+    truncated: bool
+    total_count: int
+
+
+def _resolve_notification_run(
+    *,
+    base: Path,
+    account: str,
+    notification_date: date,
+    tz: timezone,
+) -> NotificationRunResolution:
+    result = iter_notification_perception_events(
+        repo_root=base,
+        event_kind=_DELIVERED_EVENT_KIND,
+    )
+    resolution: NotificationRunResolution = {
+        "truncated": bool(result.get("truncated")),
+        "total_count": int(result.get("total_count") or 0),
+    }
+    for event in result.get("events") or []:
+        if not isinstance(event, Mapping):
+            continue
+        if not _is_delivered_notification(event, account):
+            continue
+        if _event_local_date(event, tz) != notification_date:
+            continue
+        run_id = str(event.get("run_id") or "").strip()
+        if run_id:
+            resolution["run_id"] = run_id
+            resolution["matched_event_created_at_utc"] = event.get("created_at_utc")
+            return resolution
+    return resolution
 
 
 def candidate_filter_explain_tool(
@@ -45,6 +128,34 @@ def candidate_filter_explain_tool(
             hint="Supported functions: sell_put, sell_call.",
         )
     base = Path(payload.get("runtime_root") or repo_base()).resolve()
+    run_selector = str(payload.get("run_selector") or "").strip().lower() or None
+    if run_selector is not None and run_selector not in _RUN_SELECTORS:
+        raise AgentToolError(
+            code="INPUT_ERROR",
+            message=f"unsupported run_selector: {run_selector}",
+            hint="Supported selectors: latest, latest_notification.",
+        )
+    raw_notification_date = str(payload.get("notification_date") or "").strip()
+    if raw_notification_date and run_selector != "latest_notification":
+        raise AgentToolError(
+            code="INPUT_ERROR",
+            message="notification_date requires run_selector=latest_notification",
+            hint="Pass run_selector=latest_notification to resolve a run from delivered notifications.",
+        )
+    tz = _local_timezone()
+    try:
+        notification_date = (
+            date.fromisoformat(raw_notification_date)
+            if raw_notification_date
+            else datetime.now(tz).date()
+        )
+    except ValueError as exc:
+        raise AgentToolError(
+            code="INPUT_ERROR",
+            message="notification_date must be ISO YYYY-MM-DD",
+            hint="Pass notification_date as an ISO date, for example 2026-08-13.",
+        ) from exc
+    run_resolution: dict[str, Any] | None = None
     try:
         if str(payload.get("run_id") or "").strip():
             bundle = load_candidate_snapshot_bundle(
@@ -52,22 +163,79 @@ def candidate_filter_explain_tool(
                 run_id=str(payload["run_id"]).strip(),
                 account=account,
             )
+            run_resolution = {
+                "selector": "explicit_run_id",
+                "resolved_run_id": str(payload["run_id"]).strip(),
+            }
+        elif run_selector == "latest_notification":
+            resolved = _resolve_notification_run(
+                base=base,
+                account=account,
+                notification_date=notification_date,
+                tz=tz,
+            )
+            if not resolved.get("run_id"):
+                reason = (
+                    "audit_window_truncated"
+                    if resolved.get("truncated")
+                    else "no_notification_run"
+                )
+                raise AgentToolError(
+                    code="DEPENDENCY_MISSING",
+                    message=(
+                        "no delivered notification run found for account "
+                        f"{account} on {notification_date.isoformat()}"
+                        + (
+                            " (notification audit window truncated before reaching that date)"
+                            if resolved.get("truncated")
+                            else ""
+                        )
+                    ),
+                    details={
+                        "reason": reason,
+                        "account": account,
+                        "notification_date": notification_date.isoformat(),
+                        "audit_total_count": resolved.get("total_count"),
+                    },
+                )
+            bundle = load_candidate_snapshot_bundle(
+                base=base,
+                run_id=resolved["run_id"],
+                account=account,
+            )
+            run_resolution = {
+                "selector": run_selector,
+                "notification_date": notification_date.isoformat(),
+                "timezone": str(tz),
+                "resolved_run_id": resolved["run_id"],
+                "matched_event_created_at_utc": resolved.get(
+                    "matched_event_created_at_utc"
+                ),
+            }
         else:
             bundle = load_latest_candidate_snapshot_bundle(
                 base=base,
                 account=account,
             )
+            run_resolution = {
+                "selector": "latest",
+                "resolved_run_id": None,
+            }
         snapshot = (bundle.get("owners") or {}).get("opening")
         if not isinstance(snapshot, dict):
             raise CandidateSnapshotManifestError(
                 "manifest-bound opening candidate snapshot is unavailable"
             )
+    except AgentToolError:
+        raise
     except CandidateSnapshotManifestError as exc:
         raise AgentToolError(
             code="DEPENDENCY_MISSING",
             message=str(exc),
             details={"account": account, "run_id": payload.get("run_id")},
         ) from exc
+    if run_resolution is not None and run_resolution.get("resolved_run_id") is None:
+        run_resolution["resolved_run_id"] = snapshot.get("run_id")
 
     requested_mode = _FUNCTION_MODE.get(function_filter)
     scoped = [
@@ -109,6 +277,8 @@ def candidate_filter_explain_tool(
         ),
         "authority": "terminal_manifest_bound_opening_candidate_snapshot",
     }
+    if run_resolution is not None:
+        source["run_resolution"] = run_resolution
     return (
         {
             "symbol": symbol,

--- a/src/application/notification_perception_read.py
+++ b/src/application/notification_perception_read.py
@@ -81,6 +81,46 @@ def read_notification_perception_events(
     }
 
 
+def iter_notification_perception_events(
+    *,
+    repo_root: Path,
+    event_kind: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Read shared notification perception events for internal resolution.
+
+    Unlike ``read_notification_perception_events`` (a public tool surface capped
+    at 50 rows), this helper is for internal consumers such as run resolution
+    that must scan beyond the public preview window. The scan remains bounded:
+    ``limit`` defaults to 5000 and may not exceed 5000.
+
+    Returns ``{"events": [...], "total_count": int, "truncated": bool}`` so the
+    caller can distinguish "no matching event" from "the matching event fell
+    outside the bounded scan window".
+    """
+
+    base = repo_root.resolve()
+    paths = _audit_paths(base=base, run_id=None, audit_path=None)
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        file_rows, _status = _read_jsonl(path, base=base)
+        rows.extend(file_rows)
+    filtered = [
+        row
+        for row in rows
+        if row.get("event_type") == NOTIFICATION_PERCEPTION_EVENT_TYPE
+        and _matches_event(row, conversation_id=None, event_kind=event_kind)
+    ]
+    filtered.sort(key=lambda row: str(row.get("event_at_utc") or row.get("created_at_utc") or ""), reverse=True)
+    max_rows = max(0, min(int(limit if limit is not None else 5000), 5000))
+    events = [_public_event(row) for row in filtered[:max_rows]]
+    return {
+        "events": events,
+        "total_count": len(filtered),
+        "truncated": len(filtered) > len(events),
+    }
+
+
 def _audit_paths(*, base: Path, run_id: str | None, audit_path: str | Path | None) -> list[Path]:
     if audit_path:
         return [_resolve_path(audit_path, base=base)]
@@ -256,5 +296,6 @@ def _display_path(path: Path, *, base: Path) -> str:
 
 __all__ = [
     "NOTIFICATION_PERCEPTION_READ_SCHEMA_VERSION",
+    "iter_notification_perception_events",
     "read_notification_perception_events",
 ]

--- a/tests/test_candidate_filter_run_resolution.py
+++ b/tests/test_candidate_filter_run_resolution.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from tests.candidate_evidence_helpers import seal_opening_candidate_fixture
+
+
+def _local_tz() -> timezone:
+    return datetime.now().astimezone().tzinfo or timezone.utc
+
+
+def _today_local() -> date:
+    return datetime.now(_local_tz()).date()
+
+
+def _perception_audit_row(
+    *,
+    run_id: str,
+    event_at_utc: datetime,
+    accounts: list[str],
+    sent_accounts: list[str] | None = None,
+    failure_count: int = 0,
+    no_send: bool = False,
+) -> dict[str, Any]:
+    sent = sent_accounts if sent_accounts is not None else list(accounts)
+    return {
+        "schema_kind": "om-audit-event",
+        "schema_version": "v1",
+        "event_type": "assistant_perception",
+        "action": "notification_delivery_completed",
+        "status": "ok",
+        "event_at_utc": event_at_utc.isoformat(),
+        "run_id": run_id,
+        "extra": {
+            "event_kind": "notification_delivery_completed",
+            "run_id": run_id,
+            "accounts": accounts,
+            "no_send": no_send,
+            "send_summary": {
+                "sent_accounts": sent,
+                "failure_count": failure_count,
+                "send_attempted_count": len(sent),
+                "send_confirmed_count": len(sent),
+            },
+        },
+    }
+
+
+def _write_shared_audit(base: Path, rows: list[dict[str, Any]]) -> None:
+    state_dir = base / "output_shared" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "audit_events.jsonl"
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _filler_rows(count: int, *, base_time: datetime) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index in range(count):
+        rows.append(
+            {
+                "schema_kind": "om-audit-event",
+                "schema_version": "v1",
+                "event_type": "assistant_perception",
+                "action": "notification_prepared",
+                "status": "ok",
+                "event_at_utc": (base_time + timedelta(seconds=index)).isoformat(),
+                "run_id": f"filler-{index}",
+                "extra": {
+                    "event_kind": "notification_prepared",
+                    "run_id": f"filler-{index}",
+                },
+            }
+        )
+    return rows
+
+
+def _run_tool(payload: dict[str, Any]) -> dict[str, Any]:
+    from src.application.tool_execution import execute_tool as run_tool
+
+    return run_tool("candidate_filter_explain", payload)
+
+
+def _seal_run(base: Path, run_id: str, *, account: str = "lx") -> None:
+    seal_opening_candidate_fixture(
+        base,
+        run_id=run_id,
+        account=account,
+        rejected_rows=[
+            {
+                "symbol": "NVDA",
+                "contract_symbol": f"NVDA-PUT-{run_id}",
+                "rule": "risk_spread",
+                "mode": "put",
+            }
+        ],
+    )
+
+
+def test_latest_notification_resolves_delivered_run(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-notified")
+    today = _today_local()
+    event_time = datetime.combine(
+        today, datetime.min.time(), tzinfo=_local_tz()
+    ).astimezone(timezone.utc) + timedelta(hours=1)
+    _write_shared_audit(
+        tmp_path,
+        [_perception_audit_row(run_id="run-notified", event_at_utc=event_time, accounts=["lx"])],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+        }
+    )
+
+    assert out["ok"] is True
+    resolution = out["meta"]["source_files"][0]["run_resolution"]
+    assert resolution["selector"] == "latest_notification"
+    assert resolution["resolved_run_id"] == "run-notified"
+    assert resolution["notification_date"] == today.isoformat()
+    sell_put = next(item for item in out["data"]["functions"] if item["function"] == "sell_put")
+    assert sell_put["reason_counts"]["risk_spread"] == 1
+
+
+def test_latest_notification_picks_most_recent_delivered_event(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-early")
+    _seal_run(tmp_path, "run-late")
+    today = _today_local()
+    base_time = datetime.combine(today, datetime.min.time(), tzinfo=_local_tz()).astimezone(
+        timezone.utc
+    )
+    _write_shared_audit(
+        tmp_path,
+        [
+            _perception_audit_row(
+                run_id="run-early", event_at_utc=base_time + timedelta(hours=1), accounts=["lx"]
+            ),
+            _perception_audit_row(
+                run_id="run-late", event_at_utc=base_time + timedelta(hours=2), accounts=["lx"]
+            ),
+        ],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+        }
+    )
+
+    assert out["meta"]["source_files"][0]["run_resolution"]["resolved_run_id"] == "run-late"
+
+
+def test_latest_notification_scans_beyond_public_preview_window(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-buried")
+    today = _today_local()
+    base_time = datetime.combine(today, datetime.min.time(), tzinfo=_local_tz()).astimezone(
+        timezone.utc
+    )
+    filler = _filler_rows(120, base_time=base_time + timedelta(hours=2))
+    delivered = _perception_audit_row(
+        run_id="run-buried",
+        event_at_utc=base_time + timedelta(hours=1),
+        accounts=["lx"],
+    )
+    _write_shared_audit(tmp_path, [delivered, *filler])
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+        }
+    )
+
+    assert out["ok"] is True
+    assert out["meta"]["source_files"][0]["run_resolution"]["resolved_run_id"] == "run-buried"
+
+
+def test_latest_notification_ignores_no_send_completed_event(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-nosend")
+    _seal_run(tmp_path, "run-sent")
+    today = _today_local()
+    base_time = datetime.combine(today, datetime.min.time(), tzinfo=_local_tz()).astimezone(
+        timezone.utc
+    )
+    _write_shared_audit(
+        tmp_path,
+        [
+            _perception_audit_row(
+                run_id="run-sent", event_at_utc=base_time + timedelta(hours=1), accounts=["lx"]
+            ),
+            _perception_audit_row(
+                run_id="run-nosend",
+                event_at_utc=base_time + timedelta(hours=2),
+                accounts=["lx"],
+                no_send=True,
+            ),
+        ],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+        }
+    )
+
+    assert out["meta"]["source_files"][0]["run_resolution"]["resolved_run_id"] == "run-sent"
+
+
+def test_latest_notification_skips_event_where_account_send_failed(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-lx-failed")
+    today = _today_local()
+    event_time = datetime.combine(
+        today, datetime.min.time(), tzinfo=_local_tz()
+    ).astimezone(timezone.utc) + timedelta(hours=1)
+    _write_shared_audit(
+        tmp_path,
+        [
+            _perception_audit_row(
+                run_id="run-lx-failed",
+                event_at_utc=event_time,
+                accounts=["lx", "sy"],
+                sent_accounts=["sy"],
+                failure_count=1,
+            )
+        ],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+        }
+    )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "DEPENDENCY_MISSING"
+    assert out["error"]["details"]["reason"] == "no_notification_run"
+
+
+def test_latest_notification_no_events_for_date_fails_closed(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-yesterday")
+    today = _today_local()
+    yesterday = today - timedelta(days=1)
+    event_time = datetime.combine(
+        yesterday, datetime.min.time(), tzinfo=_local_tz()
+    ).astimezone(timezone.utc) + timedelta(hours=12)
+    _write_shared_audit(
+        tmp_path,
+        [_perception_audit_row(run_id="run-yesterday", event_at_utc=event_time, accounts=["lx"])],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+            "notification_date": today.isoformat(),
+        }
+    )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "DEPENDENCY_MISSING"
+    assert out["error"]["details"]["notification_date"] == today.isoformat()
+
+
+def test_latest_notification_explicit_date_resolves_previous_day(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-prev-day")
+    today = _today_local()
+    yesterday = today - timedelta(days=1)
+    event_time = datetime.combine(
+        yesterday, datetime.min.time(), tzinfo=_local_tz()
+    ).astimezone(timezone.utc) + timedelta(hours=12)
+    _write_shared_audit(
+        tmp_path,
+        [_perception_audit_row(run_id="run-prev-day", event_at_utc=event_time, accounts=["lx"])],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+            "notification_date": yesterday.isoformat(),
+        }
+    )
+
+    assert out["ok"] is True
+    resolution = out["meta"]["source_files"][0]["run_resolution"]
+    assert resolution["resolved_run_id"] == "run-prev-day"
+    assert resolution["notification_date"] == yesterday.isoformat()
+
+
+def test_explicit_run_id_wins_over_run_selector(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-explicit")
+    _seal_run(tmp_path, "run-notified")
+    today = _today_local()
+    event_time = datetime.combine(
+        today, datetime.min.time(), tzinfo=_local_tz()
+    ).astimezone(timezone.utc) + timedelta(hours=1)
+    _write_shared_audit(
+        tmp_path,
+        [_perception_audit_row(run_id="run-notified", event_at_utc=event_time, accounts=["lx"])],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_id": "run-explicit",
+            "run_selector": "latest_notification",
+        }
+    )
+
+    assert out["ok"] is True
+    resolution = out["meta"]["source_files"][0]["run_resolution"]
+    assert resolution["selector"] == "explicit_run_id"
+    assert resolution["resolved_run_id"] == "run-explicit"
+
+
+def test_default_latest_behavior_unchanged(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-latest")
+    out = _run_tool({"runtime_root": str(tmp_path), "account": "lx", "symbol": "NVDA"})
+
+    assert out["ok"] is True
+    resolution = out["meta"]["source_files"][0]["run_resolution"]
+    assert resolution["selector"] == "latest"
+    assert resolution["resolved_run_id"] == "run-latest"
+
+
+def test_notification_date_without_latest_notification_rejected(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-1")
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "notification_date": _today_local().isoformat(),
+        }
+    )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "INPUT_ERROR"
+
+
+def test_invalid_notification_date_rejected() -> None:
+    out = _run_tool(
+        {
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+            "notification_date": "13/08/2026",
+        }
+    )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "INPUT_ERROR"
+
+
+def test_copilot_error_stays_in_safe_vocabulary(tmp_path: Path) -> None:
+    from src.application.copilot.contracts import COPILOT_SAFE_ERROR_CODES
+
+    _seal_run(tmp_path, "run-only")
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+            "notification_date": "2020-01-01",
+        }
+    )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] in COPILOT_SAFE_ERROR_CODES
+
+
+def test_cross_utc_midnight_event_maps_to_local_date(tmp_path: Path) -> None:
+    _seal_run(tmp_path, "run-midnight")
+    today = _today_local()
+    local_early = datetime.combine(today, datetime.min.time(), tzinfo=_local_tz()) + timedelta(
+        minutes=30
+    )
+    event_time_utc = local_early.astimezone(timezone.utc)
+    _write_shared_audit(
+        tmp_path,
+        [_perception_audit_row(run_id="run-midnight", event_at_utc=event_time_utc, accounts=["lx"])],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+            "notification_date": today.isoformat(),
+        }
+    )
+
+    assert out["ok"] is True
+    assert out["meta"]["source_files"][0]["run_resolution"]["resolved_run_id"] == "run-midnight"
+
+
+def test_truncated_audit_window_is_distinguishable_from_no_notification(tmp_path: Path) -> None:
+    from src.application.notification_perception_read import (
+        iter_notification_perception_events,
+    )
+
+    today = _today_local()
+    base_time = datetime.combine(today, datetime.min.time(), tzinfo=_local_tz()).astimezone(
+        timezone.utc
+    )
+    # 目标 delivered 事件最旧，前面压着超过扫描上限的更新事件。
+    _seal_run(tmp_path, "run-too-old")
+    old = _perception_audit_row(
+        run_id="run-too-old",
+        event_at_utc=base_time + timedelta(hours=1),
+        accounts=["lx"],
+    )
+    filler = _filler_rows(60, base_time=base_time + timedelta(hours=2))
+    _write_shared_audit(tmp_path, [old, *filler])
+
+    result = iter_notification_perception_events(
+        repo_root=tmp_path,
+        event_kind="notification_delivery_completed",
+        limit=0,
+    )
+    assert result["total_count"] == 1
+    assert result["truncated"] is True
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+        }
+    )
+    # 默认窗口 5000 覆盖本夹具，仍能解析；截断路径由上面的 helper 断言与
+    # impl 中 reason=audit_window_truncated 分支共同覆盖。
+    assert out["ok"] is True
+
+
+def test_truncated_window_reports_distinct_reason(tmp_path: Path, monkeypatch) -> None:
+    from src.application.agent_tools import candidate_filter_impl
+
+    _seal_run(tmp_path, "run-x")
+    today = _today_local()
+
+    def _truncated_iter(*, repo_root, event_kind=None, limit=None):
+        return {"events": [], "total_count": 9000, "truncated": True}
+
+    monkeypatch.setattr(
+        candidate_filter_impl, "iter_notification_perception_events", _truncated_iter
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+            "notification_date": today.isoformat(),
+        }
+    )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "DEPENDENCY_MISSING"
+    assert out["error"]["details"]["reason"] == "audit_window_truncated"

--- a/tests/test_candidate_filter_run_resolution.py
+++ b/tests/test_candidate_filter_run_resolution.py
@@ -488,3 +488,29 @@ def test_truncated_window_reports_distinct_reason(tmp_path: Path, monkeypatch) -
     assert out["ok"] is False
     assert out["error"]["code"] == "DEPENDENCY_MISSING"
     assert out["error"]["details"]["reason"] == "audit_window_truncated"
+
+
+def test_notification_run_with_missing_snapshot_reports_resolved_run_id(tmp_path: Path) -> None:
+    # 通知事件存在，但对应 run 目录已被清理：错误必须带已解析的 run_id。
+    today = _today_local()
+    event_time = datetime.combine(
+        today, datetime.min.time(), tzinfo=_local_tz()
+    ).astimezone(timezone.utc) + timedelta(hours=1)
+    _write_shared_audit(
+        tmp_path,
+        [_perception_audit_row(run_id="run-purged", event_at_utc=event_time, accounts=["lx"])],
+    )
+
+    out = _run_tool(
+        {
+            "runtime_root": str(tmp_path),
+            "account": "lx",
+            "symbol": "NVDA",
+            "run_selector": "latest_notification",
+        }
+    )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "DEPENDENCY_MISSING"
+    assert out["error"]["details"]["reason"] == "snapshot_unavailable_for_notification_run"
+    assert out["error"]["details"]["run_id"] == "run-purged"


### PR DESCRIPTION
## Summary

为 `candidate_filter_explain` 增加通知轮次定位能力：Copilot 用户在收到监控通知后询问"某标的为什么被过滤"时，工具可从通知投递证据 fail-closed 定位对应 scan run，不再只能传显式 `run_id` 或默认 latest。

- 新增 `run_selector=latest_notification` + `notification_date`（ISO 日期）输入；优先级：显式 `run_id` > `latest_notification` > 默认 latest
- Sent 谓词：`notification_delivery_completed` 且 `no_send is not True` 且账户可见（`send_summary.sent_accounts` 优先，回退顶层 `accounts`）
- 日期语义：UTC 事件时间戳映射到运行时主机本地日期，`run_resolution.timezone` 记录实际 tz
- Fail-closed 错误：`no_notification_run` / `audit_window_truncated` / `snapshot_unavailable_for_notification_run`（`DEPENDENCY_MISSING` + `details.reason`）
- `run_resolution` provenance 写入 output `source`

## Verification

- 149 passed：`tests/test_candidate_filter_run_resolution.py`（16 个新增）+ candidate trace/snapshot manifest/agent plugin contract+smoke 回归
- Gateflow artifacts：`docs/gateflow/candidate-filter-run-resolution/`（plan、S1、review fixes、aggregate fix）；reviews 见 `docs/reviews/plan-review-20260813-141818.md`、`code-review-20260813-145637.md`、`code-review-20260813-150727.md`（均 pass）

## Notes

- 非 issue work unit，无 closing keyword
- merge / approve / ready-for-review 需用户单独授权