### PR TITLE
research: add storage and projection performance baselines

### DIFF
--- a/docs/AGENT_WIKI.md
+++ b/docs/AGENT_WIKI.md
@@ -159,7 +159,9 @@ symlinks, and never opens the source ledger. It copies the source SQLite
 queries aggregate row/JSON-byte counts from that copy in `mode=ro` with
 `query_only=ON`. Research payload bodies are neither read nor hashed: declared
 manifest hashes and sizes are capacity metadata, while current content remains
-`not_verified`.
+`not_verified`. The payload-free account baseline is the count of immediate,
+non-symlink directories under `output_accounts`; missing or unsafe roots remain
+explicitly unavailable instead of being inferred from file counts.
 
 Pass prior reports in chronological order to obtain a measured growth and
 90-day forecast; one observation remains `insufficient_history`:
@@ -201,7 +203,8 @@ the threshold timing. The `history_10x` result contains both a fixed-output
 history-cost case and a retained-closed-lot case, each with at least 10,000
 events.
 
-Absolute p95 wall/CPU decisions require an exact host-profile match. First run
+Absolute p95 wall/CPU decisions require an exact host-profile match, including
+separate CPU and hardware-model fields. First run
 without a reference to record the `host_fingerprint`; only a deliberately
 designated reference run should repeat with:
 

--- a/docs/AGENT_WIKI.md
+++ b/docs/AGENT_WIKI.md
@@ -178,6 +178,47 @@ explicit. Capacity warnings and cold-candidate rows are read-only decision
 previews; this command has no move, delete, compact, checkpoint, repair, or
 notification action.
 
+To measure the current canonical position projector and the real SQLite full-
+replay writer on deterministic synthetic data:
+
+```bash
+./.venv/bin/python scripts/benchmark_data_storage_projection.py \
+  --baseline ./baseline-2026-08.json \
+  --scenario all \
+  --output-dir ./projection-benchmark-2026-08
+```
+
+The output directory must be absent or empty. The runner never opens a runtime
+ledger: it derives bounded dimensions from aggregate baseline metadata, creates
+fresh temporary SQLite ledgers, and atomically publishes `fixture-manifest.json`,
+`timing.json`, `cpu-profile.json`, `allocation-profile.json`, and
+`decision.json`. Omit `--baseline` to use deterministic safe defaults.
+
+Timing uses 5 warmups and 30 measured repetitions by default. Lower values are
+allowed for plumbing checks but are labeled `non_acceptance_smoke`. `cProfile`
+and `tracemalloc` run in separate child processes and therefore never influence
+the threshold timing. The `history_10x` result contains both a fixed-output
+history-cost case and a retained-closed-lot case, each with at least 10,000
+events.
+
+Absolute p95 wall/CPU decisions require an exact host-profile match. First run
+without a reference to record the `host_fingerprint`; only a deliberately
+designated reference run should repeat with:
+
+```bash
+./.venv/bin/python scripts/benchmark_data_storage_projection.py \
+  --scenario history_10x \
+  --reference-host-fingerprint <recorded-sha256> \
+  --output-dir ./projection-benchmark-reference
+```
+
+Without an exact match, timing is still reported but the writer gate is
+`not_comparable`. `projector_only` is diagnostic evidence, not a writer pass.
+Because diff publication is not implemented in Phase 1,
+`lot_diff_publication=not_implemented` and the combined Phase 3A decision stays
+`not_ready`; the command never enables checkpointing, tiering, migration, or
+runtime mutation.
+
 ### Scopes
 
 | Scope | Purpose |

--- a/docs/AGENT_WIKI.md
+++ b/docs/AGENT_WIKI.md
@@ -201,7 +201,12 @@ allowed for plumbing checks but are labeled `non_acceptance_smoke`. `cProfile`
 and `tracemalloc` run in separate child processes and therefore never influence
 the threshold timing. The `history_10x` result contains both a fixed-output
 history-cost case and a retained-closed-lot case, each with at least 10,000
-events.
+events. It also measures `research_storage_status.history_10x` against a
+deterministic 10,000-partition manifest fixture. Fixture construction and module
+imports are outside the storage timing/allocation scope; the decision freezes
+p95 wall at 5 seconds and Python peak allocation at 64 MiB while preserving
+zero payload-content reads and zero runtime mutations. Use
+`--scenario research_storage_status` to run only that component.
 
 Absolute p95 wall/CPU decisions require an exact host-profile match, including
 separate CPU and hardware-model fields. First run

--- a/docs/AGENT_WIKI.md
+++ b/docs/AGENT_WIKI.md
@@ -145,6 +145,39 @@ With a readiness snapshot:
   --no-write-outputs
 ```
 
+To collect a payload-free storage and capacity baseline for a selected runtime
+root:
+
+```bash
+./om research storage-baseline \
+  --runtime-root /var/lib/options-monitor
+```
+
+The command traverses only the fixed runtime subroots, does not follow
+symlinks, and never opens the source ledger. It copies the source SQLite
+`db/wal/shm` set to a temporary directory after a bounded stability check, then
+queries aggregate row/JSON-byte counts from that copy in `mode=ro` with
+`query_only=ON`. Research payload bodies are neither read nor hashed: declared
+manifest hashes and sizes are capacity metadata, while current content remains
+`not_verified`.
+
+Pass prior reports in chronological order to obtain a measured growth and
+90-day forecast; one observation remains `insufficient_history`:
+
+```bash
+./om research storage-baseline \
+  --runtime-root /var/lib/options-monitor \
+  --history-report ./baseline-2026-06.json \
+  --history-report ./baseline-2026-07.json \
+  --output ./baseline-2026-08.json
+```
+
+`--output` writes one atomic local JSON file and must point outside the
+inventoried runtime root. Existing output is refused unless `--overwrite` is
+explicit. Capacity warnings and cold-candidate rows are read-only decision
+previews; this command has no move, delete, compact, checkpoint, repair, or
+notification action.
+
 ### Scopes
 
 | Scope | Purpose |

--- a/docs/architecture/data-storage-runtime-source-inventory.v1.json
+++ b/docs/architecture/data-storage-runtime-source-inventory.v1.json
@@ -1,0 +1,341 @@
+{
+  "schema_version": "data_storage_runtime_source_inventory.v1",
+  "scan_roots": [
+    "domain",
+    "src",
+    "scripts"
+  ],
+  "discovery_rules": [
+    {
+      "id": "ledger_event_reads",
+      "kind": "call",
+      "symbols": [
+        "list_trade_events"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/ledger/**",
+          "owner": "ledger",
+          "operation": "read",
+          "history_dimension": "trade_event_lifetime",
+          "path_class": "hot_and_offline",
+          "later_phase": "phase_3"
+        },
+        {
+          "path_glob": "src/application/trades/**",
+          "owner": "trade_workflows",
+          "operation": "read",
+          "history_dimension": "trade_event_lifetime",
+          "path_class": "operator_write_path",
+          "later_phase": "phase_3"
+        },
+        {
+          "path_glob": "src/application/agent_tools/**",
+          "owner": "agent_read_surfaces",
+          "operation": "read",
+          "history_dimension": "trade_event_lifetime",
+          "path_class": "operator_read_path",
+          "later_phase": "phase_3"
+        },
+        {
+          "path_glob": "src/interfaces/**",
+          "owner": "cli_adapters",
+          "operation": "read",
+          "history_dimension": "trade_event_lifetime",
+          "path_class": "operator_path",
+          "later_phase": "phase_3"
+        }
+      ]
+    },
+    {
+      "id": "position_lot_replacement",
+      "kind": "call",
+      "symbols": [
+        "replace_position_lots"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/ledger/**",
+          "owner": "ledger_projection_writer",
+          "operation": "write",
+          "history_dimension": "current_position_projection",
+          "path_class": "operator_write_path",
+          "later_phase": "phase_3"
+        }
+      ]
+    },
+    {
+      "id": "lifecycle_history_reads",
+      "kind": "call",
+      "symbols": [
+        "list_trade_lifecycle_evidence",
+        "list_trade_lifecycle_cases",
+        "list_trade_lifecycle_allocations",
+        "list_trade_lifecycle_source_consumptions",
+        "list_trade_lifecycle_timing_policies"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/ledger/**",
+          "owner": "ledger_lifecycle",
+          "operation": "read",
+          "history_dimension": "lifecycle_history",
+          "path_class": "hot_and_offline",
+          "later_phase": "phase_2_to_4"
+        },
+        {
+          "path_glob": "src/application/trades/**",
+          "owner": "trade_lifecycle_workflows",
+          "operation": "read",
+          "history_dimension": "lifecycle_history",
+          "path_class": "operator_write_path",
+          "later_phase": "phase_2_to_4"
+        },
+        {
+          "path_glob": "src/application/quality/**",
+          "owner": "quality",
+          "operation": "read",
+          "history_dimension": "lifecycle_history",
+          "path_class": "ordinary_quality",
+          "later_phase": "phase_4"
+        },
+        {
+          "path_glob": "src/interfaces/**",
+          "owner": "cli_adapters",
+          "operation": "read",
+          "history_dimension": "lifecycle_history",
+          "path_class": "operator_path",
+          "later_phase": "phase_2_to_4"
+        }
+      ]
+    },
+    {
+      "id": "lifecycle_history_writes",
+      "kind": "text",
+      "patterns": [
+        "upsert_trade_lifecycle_case",
+        "upsert_trade_lifecycle_evidence",
+        "upsert_trade_lifecycle_settlement_admission_head"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/ledger/**",
+          "owner": "ledger_lifecycle_writer",
+          "operation": "write",
+          "history_dimension": "lifecycle_history",
+          "path_class": "operator_write_path",
+          "later_phase": "phase_2"
+        },
+        {
+          "path_glob": "src/application/trades/**",
+          "owner": "trade_lifecycle_workflows",
+          "operation": "write",
+          "history_dimension": "lifecycle_history",
+          "path_class": "operator_write_path",
+          "later_phase": "phase_2"
+        }
+      ]
+    },
+    {
+      "id": "required_data_csv",
+      "kind": "call",
+      "symbols": [
+        "read_csv",
+        "safe_read_csv",
+        "to_csv"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/**",
+          "owner": "application_data_adapters",
+          "operation": "encode_decode",
+          "history_dimension": "required_data_and_reports",
+          "path_class": "compatibility_adapter",
+          "later_phase": "phase_5"
+        },
+        {
+          "path_glob": "src/infrastructure/**",
+          "owner": "infrastructure_io",
+          "operation": "encode_decode",
+          "history_dimension": "required_data_and_reports",
+          "path_class": "compatibility_adapter",
+          "later_phase": "phase_5"
+        }
+      ]
+    },
+    {
+      "id": "inline_base64_payloads",
+      "kind": "call",
+      "symbols": [
+        "b64encode",
+        "b64decode"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/**",
+          "owner": "application_data_adapters",
+          "operation": "encode_decode",
+          "history_dimension": "required_data_and_channel_payloads",
+          "path_class": "compatibility_adapter",
+          "later_phase": "phase_5"
+        },
+        {
+          "path_glob": "src/infrastructure/**",
+          "owner": "infrastructure_adapters",
+          "operation": "encode_decode",
+          "history_dimension": "required_data_and_process_payloads",
+          "path_class": "compatibility_adapter",
+          "later_phase": "phase_5"
+        }
+      ]
+    },
+    {
+      "id": "sealed_snapshot_consumers",
+      "kind": "call",
+      "symbols": [
+        "load_opening_candidate_snapshot",
+        "load_combo_yield_candidate_snapshot",
+        "load_cc_lp_candidate_snapshot",
+        "load_candidate_snapshot_bundle",
+        "load_required_data_snapshot_manifest"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/**",
+          "owner": "sealed_snapshot_consumers",
+          "operation": "manifest",
+          "history_dimension": "sealed_scan_input_output",
+          "path_class": "hot_and_offline",
+          "later_phase": "phase_5_to_7"
+        }
+      ]
+    },
+    {
+      "id": "decision_context_consumers",
+      "kind": "call",
+      "symbols": [
+        "load_prepared_option_positions_context",
+        "load_prepared_portfolio_context",
+        "load_account_portfolio_context",
+        "load_portfolio_context",
+        "load_option_positions_context"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/**",
+          "owner": "decision_context_consumers",
+          "operation": "read",
+          "history_dimension": "current_account_input",
+          "path_class": "hot",
+          "later_phase": "phase_3_to_5"
+        }
+      ]
+    },
+    {
+      "id": "research_replay_roots",
+      "kind": "call",
+      "symbols": [
+        "build_shadow_replay_dataset",
+        "validate_dataset_integrity"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "src/application/**",
+          "owner": "strategy_lab_and_shadow_replay",
+          "operation": "manifest",
+          "history_dimension": "research_generation",
+          "path_class": "offline",
+          "later_phase": "phase_6_to_7"
+        },
+        {
+          "path_glob": "src/interfaces/**",
+          "owner": "research_cli",
+          "operation": "manifest",
+          "history_dimension": "research_generation",
+          "path_class": "offline",
+          "later_phase": "phase_6_to_7"
+        }
+      ]
+    },
+    {
+      "id": "runtime_root_literals",
+      "kind": "literal",
+      "values": [
+        "output_runs",
+        "output_accounts",
+        "output_shared",
+        "output_shared/research",
+        "output_shared/required_data",
+        "required_data",
+        "research",
+        "remote_archive",
+        "logs"
+      ],
+      "classifiers": [
+        {
+          "path_glob": "domain/**",
+          "owner": "domain_storage_paths",
+          "operation": "root",
+          "history_dimension": "runtime_artifacts",
+          "path_class": "hot_and_offline",
+          "later_phase": "phase_5_to_7"
+        },
+        {
+          "path_glob": "src/**",
+          "owner": "runtime_path_consumers",
+          "operation": "root",
+          "history_dimension": "runtime_artifacts",
+          "path_class": "hot_and_offline",
+          "later_phase": "phase_5_to_7"
+        },
+        {
+          "path_glob": "scripts/**",
+          "owner": "operational_wrappers",
+          "operation": "root",
+          "history_dimension": "runtime_artifacts",
+          "path_class": "operator_path",
+          "later_phase": "phase_5_to_7"
+        }
+      ]
+    }
+  ],
+  "declared_locators": [
+    {
+      "path": "src/application/ledger/writer.py",
+      "locator": "list_trade_events",
+      "owner": "ledger_projection_writer",
+      "reason": "canonical full-replay reader"
+    },
+    {
+      "path": "src/application/ledger/writer.py",
+      "locator": "replace_position_lots",
+      "owner": "ledger_projection_writer",
+      "reason": "canonical global position-lot publisher"
+    },
+    {
+      "path": "src/application/ledger/repository.py",
+      "locator": "trade_lifecycle_evidence",
+      "owner": "ledger_lifecycle",
+      "reason": "canonical lifecycle evidence storage"
+    },
+    {
+      "path": "src/application/required_data_snapshot.py",
+      "locator": "b64decode",
+      "owner": "required_data_snapshot",
+      "reason": "legacy inline-payload compatibility consumer"
+    },
+    {
+      "path": "src/application/shadow_replay/common.py",
+      "locator": "validate_dataset_integrity",
+      "owner": "shadow_replay",
+      "reason": "offline replay integrity authority"
+    },
+    {
+      "path": "src/application/research/archive.py",
+      "locator": "remote_archive",
+      "owner": "research_archive",
+      "reason": "local remote-evidence archive root"
+    }
+  ],
+  "ignores": []
+}

--- a/docs/gateflow/data-storage-runtime-projection-p1/aggregate-deepreview.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/aggregate-deepreview.md
@@ -1,0 +1,75 @@
+# Gateflow Artifact — Aggregate DeepReview
+
+- Gate: `aggregate deepreview -> fix -> re-review`
+- Work unit: `data-storage-runtime-projection-p1`
+- Branch: `perf/data-storage-runtime-projection-p1`
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Initial review artifact: `docs/reviews/code-review-20260813-160956.md`
+- Re-review artifact: `docs/reviews/code-review-20260813-163436.md`
+- Artifact path: `docs/gateflow/data-storage-runtime-projection-p1/aggregate-deepreview.md`
+- Status: `pass; accepted findings fixed and re-reviewed`
+
+## Scope and changed files
+
+The aggregate review covered the complete Phase 1 branch. Its fix loop changed:
+
+- `src/application/research/storage_baseline.py`
+- `src/application/research/performance_baseline.py`
+- `tests/test_research_storage_baseline.py`
+- `tests/test_research_performance_baseline.py`
+- `docs/AGENT_WIKI.md`
+- the aggregate review and Gateflow artifacts
+
+No schema, runtime config, production database, notification, broker, service,
+release, or deployment path changed.
+
+## Finding decisions
+
+- `DR-AGG-01`: `accepted`; final state `已修复`. Payload-free account cardinality
+  now comes from immediate non-symlink `output_accounts` directories; unavailable
+  or malformed facts make the fanout axis fail closed.
+- `DR-AGG-02`: `accepted`; final state `已修复`. Reference identity now binds
+  separate CPU and machine-model facts and no longer collapses the reviewed Mac
+  to generic `arm`.
+
+No findings were rejected, deferred, or left needing evidence.
+
+## Validation and performance decision
+
+- Aggregate focused suite: `158 passed`; final post-fix focused suite:
+  `54 passed`; independent research regression: `30 passed`.
+- `ruff check`, `compileall`, and `git diff --check` passed.
+- Source-inventory validation has no stale or unclassified matches.
+- Formal default 5/30 benchmark completed with all five schemas and exact
+  projector/writer parity.
+- `fixed_output` passes at 0.357 s wall / 0.357 s CPU p95.
+- `retained_closed_lots` fails at 2.849 s wall / 2.739 s CPU p95.
+- Writer result is `fail`; diff publication is `not_implemented`; combined
+  Phase 3A is `not_ready`. This is accepted evidence, not a validation failure.
+
+## Documentation decision
+
+`docs/AGENT_WIKI.md` now explains the exact payload-free account-count basis and
+that reference fingerprints bind separate CPU and hardware-model facts. Release
+notes remain out of scope because no release is authorized.
+
+## Residual risks
+
+- Current writer O(E) replay plus O(current retained lots) global replacement:
+  `assigned to later work unit` — Phase 3A diff publication / checkpoint
+  planreview only after this evidence is reviewed.
+- Non-atomic live SQLite snapshot edge: `assigned to later work unit` — storage
+  hardening.
+- Same-size content tampering: `assigned to later work unit` — explicit verifier.
+- Synthetic versus production distribution: `assigned to later work unit` —
+  separately authorized read-only calibration.
+- Allocation-worker RSS is a labeled cumulative process high-water mark rather
+  than an isolated per-scenario peak: `assigned to later work unit` — split
+  allocation scenarios into fresh processes if a later gate needs absolute RSS.
+
+No residual risk is unclassified.
+
+## Completion status
+
+All aggregate findings are fixed and re-reviewed. Next entry point:
+`accepted deepreview commit`.

--- a/docs/gateflow/data-storage-runtime-projection-p1/aggregate-deepreview.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/aggregate-deepreview.md
@@ -47,6 +47,11 @@ No findings were rejected, deferred, or left needing evidence.
 - Writer result is `fail`; diff publication is `not_implemented`; combined
   Phase 3A is `not_ready`. This is accepted evidence, not a validation failure.
 
+The later PR review found that this aggregate review had not exercised the
+separately frozen `research storage status` 5-second / 64-MiB budget. That
+omission is not accepted by this artifact; see the PR review fix and re-review
+artifacts for the repaired benchmark component and its 5/30 evidence.
+
 ## Documentation decision
 
 `docs/AGENT_WIKI.md` now explains the exact payload-free account-count basis and

--- a/docs/gateflow/data-storage-runtime-projection-p1/final-closeout.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/final-closeout.md
@@ -1,0 +1,99 @@
+# Gateflow Final Closeout — data-storage-runtime-projection-p1
+
+- Status: `final closeout pass`
+- Completed at: `2026-08-13 18:00:09 +0800`
+- Branch: `perf/data-storage-runtime-projection-p1`
+- Accepted PR-review commit: `c8e08b2c67bfa53a5073b982ec48075da2aed5b1`
+- Remote parity before closeout artifact: `origin/head = 0/0`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/154`
+- Issue link status: `not applicable; this work unit was not opened from an issue`
+- Issue closeout comment status: `not applicable`
+
+## What changed
+
+- Added a bounded, payload-free `storage_runtime_baseline.v1` read surface for
+  source ownership, SQLite aggregate metadata, runtime/research capacity,
+  manifest-declared dedup, growth forecast, and preview-only thresholds.
+- Added one deterministic five-artifact benchmark harness for current canonical
+  projection/full-replay cost and research-storage status time/space cost.
+- Recorded the accepted Phase 1 contract, source inventory, Gateflow decisions,
+  slice reviews, aggregate DeepReview, PR review/fix/re-review, and operator
+  documentation.
+- Optimized the manifest-reference hot path to reuse the no-follow scan index;
+  it no longer repeats filesystem canonicalization/stat work per reference.
+- Added `research_storage_status.history_10x`: 10,000 declared partitions, setup
+  excluded from timing/allocation, exact fixture identity, frozen 5-second /
+  64-MiB decision, and a storage-only scenario.
+
+## What was verified
+
+- Final focused storage/performance suite: `60 passed`.
+- Final aggregate research/ledger suite: `164 passed`.
+- Ruff, compileall, and diff hygiene: pass.
+- Formal storage-only reference acceptance (5 warmups / 30 repetitions):
+  - host fingerprint
+    `327f740925923dfe92919e74ae630d072bacc6259298e8e0a57b8060ca056aec`;
+  - p95 wall `4,063,991,416 ns` <= `5,000,000,000 ns`;
+  - Python peak allocation `18,966,815 bytes` <= `67,108,864 bytes`;
+  - payload-content reads `0`, mutation operations `0`.
+- Projection reference evidence remains valid and intentionally reports:
+  - fixed-output writer p95 wall/CPU about `0.357 s` / `0.357 s` — pass;
+  - retained-closed-lot p95 wall/CPU about `2.849 s` / `2.739 s` — fail;
+  - lot diff `not_implemented`, combined Phase 3A `not_ready`.
+- Draft PR head before this closeout artifact was mergeable, remained Draft,
+  and showed all five GitHub checks successful: Agent Plugin, Guardrails,
+  CodeQL actions, CodeQL Python, and code-scanning results.
+
+## Documentation updates
+
+- `docs/AGENT_WIKI.md` documents the read-only baseline, five output artifacts,
+  storage-only selection, setup exclusion, and frozen storage budget.
+- `docs/architecture/data-storage-runtime-source-inventory.v1.json` records the
+  checked-in source ownership/discovery contract.
+- `docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md`
+  remains the accepted Phase 1 authority.
+- PR body was updated to the final validation/performance facts without marking
+  the PR ready or requesting reviewers.
+
+## Finding status
+
+- Slice reviews: pass.
+- Aggregate DeepReview findings: 2 accepted, 2 fixed, re-review pass.
+- PR review findings: 1 accepted, 1 fixed, re-review pass.
+- No rejected, deferred, open, or unclassified finding remains in this work
+  unit.
+
+## Remaining risks and owners
+
+- O(E) replay and global lot replacement: owner `later Phase 3A diff/checkpoint
+  work unit`; current evidence blocks Phase 3A readiness.
+- Stable-copy non-atomic edge under indistinguishable file tuples: owner
+  `storage-hardening work unit`.
+- Same-size content tampering: owner `explicit payload verifier`; the status
+  command intentionally remains payload-free.
+- Source-inventory token discovery is a visible constant CPU cost: owner
+  `future measured optimization only if operator cadence justifies a
+  revision-keyed cache`.
+- Storage scan remains O(files + manifest references): accepted current Phase 1
+  contract and protected by the new frozen time/space benchmark.
+- Allocation worker RSS is cumulative process high-water; accepted because the
+  frozen decision uses isolated Python peak allocation and labels RSS scope.
+
+Every remaining risk has an owner/destination.
+
+## Draft PR status
+
+- URL: `https://github.com/liuxie066/options-monitor/pull/154`
+- State: open Draft; not merged; not marked ready; no reviewers requested.
+- PR body: matches the final code, tests, storage-status optimization, and known
+  Phase 3A non-readiness.
+- This closeout artifact is the only post-review source change and must be
+  committed and pushed before reporting completion.
+
+## Next entry point
+
+After the user reviews and merges Draft PR #154, begin a focused Phase 3A
+planreview for changed-lot diff publication versus checkpoint/tail projection,
+using the retained-closed-lot failure as the decision evidence. Merge, ready
+transition, release, deployment, production collection, and cleanup remain
+separate explicit authorities.

--- a/docs/gateflow/data-storage-runtime-projection-p1/goal-confirmation.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/goal-confirmation.md
@@ -1,0 +1,86 @@
+# Gateflow Goal Confirmation — data-storage-runtime-projection-p1
+
+- Gate: `goal confirmation`
+- Work unit: `data-storage-runtime-projection-p1`
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Branch: `perf/data-storage-runtime-projection-p1`
+- User confirmation: 2026-08-13, after the Phase 1 boundary and isolated-worktree proposal
+- Status: `pass`
+
+## Goal and motivation
+
+Produce the read-only inventories, deterministic fixtures, benchmark baselines,
+profiles, and research-capacity status needed to decide which later storage and
+runtime-projection optimizations are justified. The work unit must expose the
+current time, CPU, memory, call-count, and physical-storage costs without
+changing their persistence authorities.
+
+## Success signals
+
+- Writer, reader, CSV/base64, run-root, lifecycle-evidence, and research-root
+  inventories are machine-readable and reproducible.
+- Current-scale and growth-axis fixtures are deterministic and contain no live
+  account or broker data.
+- Benchmark output separates uninstrumented wall-time measurement from CPU and
+  allocation profiling and records the reference environment.
+- Research storage status reports logical versus unique physical bytes,
+  deduplication ratio, growth observations, a 90-day forecast, and candidate
+  hot/warm/cold classification without moving or deleting files.
+- The Phase 1 artifact can decide whether the existing full-replay writer meets
+  the frozen `history_10x` gate; it does not activate a checkpoint path.
+
+## Scope boundary
+
+Allowed: read-only source/runtime inventory logic, synthetic fixtures,
+benchmark/profile tooling, deterministic report schemas, tests, and operator
+documentation for those surfaces.
+
+Excluded: schema changes, SQLite triggers, lifecycle sidecar implementation,
+position/decision projection implementation, checkpoint activation, shared
+blob cutover, cold-storage backend activation, migration, eviction, deletion,
+runtime-config changes, notifications, broker writes, and production-service
+changes.
+
+## Direct code evidence
+
+- `src/application/ledger/writer.py` repeatedly calls `list_trade_events()` and
+  republishes via `replace_position_lots()`, so the full-replay writer cost is a
+  real measurement target.
+- `src/application/ledger/projection_verify.py` reads all trade events and all
+  current lots for canonical verification.
+- `src/application/positions/context_builder.py` consumes a decision snapshot
+  containing account lots, lifecycle, assigned-stock, and combo facts.
+- `src/interfaces/cli/research.py` and `src/application/research/` already own
+  offline evidence collection, making a read-only inventory/benchmark surface
+  preferable to a new orchestration layer.
+
+## First-principles judgment
+
+The work unit is justified because later optimization choices depend on which
+cost scales with historical events, current positions, account fan-out, or
+unique stored content. Measuring those axes is lower-risk than implementing a
+checkpoint or storage tier based on aggregate directory size alone.
+
+## Parsimony
+
+This unit will not introduce a general monitoring framework, a new authority,
+an incremental event projector, or a cold-storage service. It adds only the
+evidence needed by the already-confirmed implementation gates.
+
+## Blocking open questions
+
+None. The user confirmed the Phase 1 boundary and creation of an isolated
+worktree. Later checkpoint, movement, eviction, and deletion decisions remain
+separately gated.
+
+## Residual risks
+
+- Production-scale distributions may differ from synthetic fixtures. This work
+  unit records reference-host and fixture identity so later read-only production
+  sampling can be separately authorized if required.
+- Phase 2 and later implementation remain separate work units/gates and are not
+  implied by this goal confirmation.
+
+## Next entry point
+
+`plan`

--- a/docs/gateflow/data-storage-runtime-projection-p1/plan.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/plan.md
@@ -1,0 +1,513 @@
+# Gateflow Plan — data-storage-runtime-projection-p1
+
+- Gate: `plan`
+- Work unit: `data-storage-runtime-projection-p1`
+- Date: 2026-08-13
+- Branch: `perf/data-storage-runtime-projection-p1`
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Goal artifact: `docs/gateflow/data-storage-runtime-projection-p1/goal-confirmation.md`
+- Design contract: `docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md`
+- Prior design reviews: `docs/reviews/plan-review-20260813-092047.md`, `docs/reviews/plan-review-20260813-103939.md`
+- Artifact path: `docs/gateflow/data-storage-runtime-projection-p1/plan.md`
+- Status: `accepted after PlanReview re-review (pass-with-risks)`
+
+## Goal, motivation, and success signals
+
+Deliver Phase 1 only: a read-only inventory/capacity surface and a deterministic
+benchmark harness that make later storage and projection choices measurable.
+The implementation must answer four questions with machine-readable evidence:
+
+1. Which current source paths read or rewrite lifetime ledger/lifecycle data,
+   and which runtime roots retain CSV, base64, manifests, SQLite, run, and
+   research artifacts?
+2. How many rows and bytes exist per canonical SQLite table and bounded runtime
+   root without decoding production payloads?
+3. How does the existing canonical full replay behave at `current_scale` and
+   the frozen growth axes, especially `history_10x`?
+4. At the current unique-byte growth rate, when do warning/critical capacity
+   boundaries become relevant, without moving or deleting anything?
+
+Success is the five signals in the goal artifact: deterministic inventories,
+synthetic fixtures, separate timing/CPU/allocation outputs, read-only research
+capacity status, and an explicit full-replay gate result that cannot activate a
+checkpoint.
+
+## Non-goals and scope boundary
+
+- No SQLite schema, trigger, migration, or production-data write.
+- No lifecycle audit sidecar, lot-diff publisher, generation head, current
+  decision projection, checkpoint, blob store, research generation, or cold
+  backend implementation.
+- No automatic file movement, eviction, cleanup, deletion, notification,
+  broker call, service change, config mutation, release, deployment, or merge.
+- No production payload export into fixtures or checked-in reports.
+- No general observability framework and no third-party benchmark dependency.
+- Phase 2 and later remain separate work units after this evidence is reviewed.
+
+## Goal alignment
+
+| Plan element | Confirmed goal / success signal |
+|---|---|
+| Slice 1 read-only inventory and capacity status | inventories; logical/physical bytes; growth and 90-day forecast |
+| SQLite `mode=ro` and bounded root traversal | no authority mutation; reproducible safe metadata collection |
+| Slice 2 deterministic fixtures and benchmark runner | current/growth axes; wall/CPU/allocation profiles; full-replay gate |
+| JSON schemas, fixture identity, reference-host identity | comparable, auditable measurements |
+| Focused tests plus filesystem/SQLite immutability assertions | read-only safety and deterministic evidence |
+
+## Design-document alignment
+
+- Contract sections 3–9 remain authority and complexity constraints; this work
+  unit observes them but creates no new persistence authority.
+- Section 10.1 supplies fixture axes, repetition rules, timing authorities, and
+  separation of timing from profiling.
+- Section 10.2 supplies the existing full-replay `history_10x` wall/CPU gate.
+  Budgets for paths not implemented until later phases are recorded as
+  `not_applicable`, never fabricated from a substitute benchmark.
+- Section 11 Phase 1 requires inventory, metadata baseline, fixtures, benchmark
+  JSON/profiles, and research-capacity status. Every slice below maps only to
+  those deliverables.
+- Section 7.4 capacity thresholds are reported as status/preview only. The
+  implementation has no movement or deletion function.
+
+## First-principles judgment and direct code evidence
+
+1. `src/application/ledger/writer.py` repeatedly executes
+   `list_trade_events()` before `replace_position_lots()`, so current trade
+   writers have a real O(E) projection and O(current lots) replacement path.
+2. `src/application/ledger/projection_verify.py` reads all events and stored
+   lots to prove canonical projection equality; that remains the offline oracle.
+3. `src/application/ledger/repository.py::SQLiteOptionPositionsRepository`
+   initializes schema and WAL in its constructor, so Phase 1 inventory must not
+   instantiate it for a production database.
+4. `src/application/ledger/read_only_evidence.py` already establishes the safe
+   SQLite contract: URI `mode=ro` plus `PRAGMA query_only=ON`. Phase 1 extends
+   that pattern with aggregate SQL only, rather than decoding every JSON row.
+   Because opening a live WAL database can touch shared-memory reader state,
+   Phase 1 queries a stable temporary copy rather than the source files.
+5. `src/application/runtime_paths.py` owns explicit runtime-root resolution.
+   Inventory will traverse only caller-selected canonical subroots and will not
+   crawl the repository parent, home directory, mounts, or symlink targets.
+6. `src/interfaces/cli/research.py` is the existing offline advisory surface.
+   A `research storage-baseline` subcommand is smaller and safer than a new
+   top-level CLI or orchestration layer.
+7. `domain/domain/ledger/projection.py` and
+   `src/application/ledger/publisher.py` are the canonical deterministic replay
+   path. `src/application/ledger/writer.py::rebuild_position_lots_from_trade_events()`
+   is the existing end-to-end replay writer and must be measured separately
+   from the pure projector on synthetic temporary SQLite.
+
+## Public contracts and schemas
+
+### Read-only CLI
+
+Add:
+
+```text
+./om research storage-baseline \
+  --runtime-root <root> \
+  [--ledger-sqlite <path>] \
+  [--history-report <prior-storage-runtime-baseline.json>]... \
+  [--output <json-path>]
+```
+
+Behavior:
+
+- without `--output`, emit the normal structured CLI response to stdout only;
+- with `--output`, write exactly one local JSON report chosen by the operator;
+- input roots must exist and resolve to directories; an explicit ledger path
+  must be a regular file inside the runtime root unless
+  `--allow-external-ledger` is explicitly present;
+- traversal does not follow directory symlinks; symlinks are reported as
+  metadata with zero traversed children;
+- no `--write`, move, delete, compact, vacuum, checkpoint, or repair option
+  exists.
+
+The structured data schema is `storage_runtime_baseline.v1` and contains:
+
+- `identity`: UTC observation time, runtime root, ledger path, Python/SQLite/
+  platform/Git identity, and collection options;
+- `source_inventory`: checked-in discovery rules and owned call-site
+  classifications, plus stale-declaration and unclassified-discovery status;
+- `sqlite`: db/wal/shm physical bytes, page metadata, and for an allowlisted
+  table set only, row count plus `SUM(length(json_column))`; missing tables are
+  explicit and SQL never selects JSON payload values. The query target is a
+  stable temporary `db/wal/shm` snapshot, never the source SQLite files;
+- `runtime_storage`: bounded-root file counts/bytes by root, class, suffix,
+  month, and tier candidate; largest files expose runtime-relative paths only;
+- `research_storage`: manifest-declared logical referenced bytes,
+  declared-hash unique bytes and dedup ratio, physical bytes, unmanifested/
+  unknown-unique bytes, root/generation counts, reference presence/size status,
+  prior-report growth observations, 90-day forecast, and hot/warm/cold-candidate
+  preview. `content_verification` is explicitly `not_performed`; a prior
+  verifier receipt may be reported as historical evidence but is not refreshed
+  or relabeled by this command;
+- `thresholds`: deterministic warning/critical facts from contract section 7.4;
+- `safety`: query-only SQLite, no-follow traversal, payload-content reads, and
+  mutation operations, with expected values `true`, `true`, `0`, and `0`.
+
+`--output` is a local evidence write, not a runtime authority. It uses atomic
+temp-file replace, refuses a path inside an inventoried runtime root by default,
+and tests prove the runtime tree and SQLite sidecar set are unchanged.
+
+### Checked-in source inventory
+
+Add `docs/architecture/data-storage-runtime-source-inventory.v1.json`. Each
+entry binds an owner category, file, symbol or literal pattern, operation
+(`read`, `write`, `encode`, `decode`, `root`, `manifest`), history dimension,
+hot/offline classification, and later contract phase. The same file contains
+versioned discovery rules for a bounded AST/text scan of `domain/`, `src/`, and
+`scripts/`. The collector validates every declaration and fails inventory when
+a discovered production match is unclassified. Explicit ignores require a
+reason and owner. It does not claim runtime call frequency or mathematical
+coverage of APIs outside the versioned discovery vocabulary.
+
+The manifest covers at least:
+
+- ledger event reads and lot replacement writers;
+- lifecycle evidence/case/allocation/source-consumption readers and writers;
+- decision snapshot/context consumers;
+- required-data CSV and base64 producers/consumers;
+- run, account, shared, state, research, Shadow Replay, and archive roots;
+- manifest/root readers that protect replay evidence.
+
+### Benchmark artifacts
+
+The repository-local runner is:
+
+```text
+./.venv/bin/python scripts/benchmark_data_storage_projection.py \
+  --baseline <storage-runtime-baseline.json> \
+  --scenario all \
+  --output-dir <empty-local-dir>
+```
+
+It accepts metadata only from the baseline. If omitted, deterministic safe
+defaults are used and the manifest records `dimension_source=defaults`.
+It writes into an explicit output directory only:
+
+- `fixture-manifest.json` (`data_storage_projection_fixture.v1`);
+- `timing.json` (`data_storage_projection_timing.v1`);
+- `cpu-profile.json` (`data_storage_projection_cpu_profile.v1`);
+- `allocation-profile.json` (`data_storage_projection_allocation_profile.v1`);
+- `decision.json` (`data_storage_projection_gate_decision.v1`).
+
+Scenarios are `current_scale`, `history_10x`, `current_state_10x`, and
+`account_fanout`. Fixture generation is seeded, uses only synthetic canonical
+trade-event payloads, clamps hostile baseline dimensions to documented safe
+limits, and records requested versus effective dimensions. A clamp that prevents
+the contract-required axis makes that axis `not_evaluable`, never `pass`.
+`history_10x` has two explicit subcases, each with at least 10,000 events:
+
+- `fixed_output` combines a fixed deterministic open-lot set with valid
+  read-only `verification` events. Projected lot/view/allocation counts remain
+  fixed, isolating event load/decode/validation/sort overhead.
+- `retained_closed_lots` uses deterministic open/close pairs. Its closed lots
+  and allocations intentionally grow because that is the current canonical
+  projection and persistence behavior; it exposes replay plus global-replace
+  coupling instead of pretending the state is fixed.
+
+The artifact records event, projected-lot, open-lot, risk-view, and allocation
+counts for every scenario. It labels `fixed_output` as a complexity-isolation
+fixture rather than a production event-mix sample. On a comparable reference
+host, `existing_full_replay_writer` passes the history component only when both
+subcases meet the frozen wall/CPU threshold.
+
+Every replay scenario reports two measured components on synthetic data:
+
+- `projector_only` invokes the canonical stored-event codec/projector;
+- `existing_full_replay_writer` uses a temporary SQLite ledger and calls
+  `rebuild_position_lots_from_trade_events()`, thereby including SQLite event
+  loading/decoding, publishability checks, and the current global lot replace.
+
+Both components bind the same canonical lots/diagnostic fingerprint. The writer
+component additionally records temporary `db + wal + shm` bytes before, peak,
+and after the replay. Because Phase 3A diff publication does not yet exist, the
+gate decision reports three separate facts:
+
+- `projector_only`: diagnostic evidence, never sufficient for writer pass;
+- `existing_full_replay_writer`: measured against p95 wall <= 2 s and CPU <= 1.5 s
+  on an explicitly matching reference-host profile;
+- `lot_diff_publication`: `not_implemented`, making the combined Phase 3A gate
+  `not_ready` rather than a false pass.
+
+Timing uses five warmups and thirty measured repetitions with
+`perf_counter_ns()` and `process_time_ns()` and no profiler. CPU profile uses
+`cProfile` in a separate invocation. Allocation profile uses `tracemalloc` in a
+separate invocation. Peak RSS is reported when `resource.getrusage` exists.
+Non-reference hosts report timing but set absolute decisions to
+`not_comparable`. The runner never opens a production SQLite file.
+
+## State transitions and error handling
+
+This work unit creates evidence files only when an explicit output path is
+provided. It has no persistent runtime state machine.
+
+- Missing runtime root or invalid explicit ledger path: `INPUT_ERROR`, no scan.
+- Missing ledger: overall report remains usable with SQLite status `missing`.
+- SQLite source snapshotting records `(exists, size, mtime_ns, inode)` before
+  and after copying the exact `db/wal/shm` set, retries at most three times when
+  the tuple changes, and opens only the temporary copy. If no stable copy is
+  obtained, or the copy is corrupt/unreadable, SQLite status is
+  `data_unavailable`; filesystem inventory continues and overall status is
+  `partial_data`. This is a bounded coherence check, not an atomicity claim.
+- Unknown table/schema revision: only allowlisted present tables are counted;
+  unknown tables are reported by name/count metadata but never dynamically
+  interpolated into content queries.
+- Manifest parse failure, missing reference, or declared-size mismatch becomes
+  `data_unavailable` or `critical`; same-size content tampering remains
+  `not_verified` because this command does not hash payloads.
+- Prior reports are accepted only when schema, resolved runtime-root identity,
+  and observation ordering match. With fewer than two compatible observations,
+  forecast status is `insufficient_history` and forecast bytes are null.
+- Output path collision: refuse unless `--overwrite` is explicitly supplied;
+  overwrite affects only the named local report path.
+- Benchmark output directory must be absent or empty. Partial artifacts use a
+  temporary sibling directory and are atomically published only after all
+  schemas validate.
+
+## Implementation slices
+
+Two slices are the smallest behavior-oriented split. Slice 1 independently
+delivers safe operational evidence. Slice 2 independently answers the
+performance question using that metadata. Splitting source inventory, SQLite,
+and filesystem accounting into separate slices would add gate cost without a
+useful operator outcome; combining profiling with the read-only collector would
+make filesystem safety regressions harder to isolate from CPU-heavy fixtures.
+
+### Slice 1 — read-only inventory and capacity status
+
+**Objective:** Add one bounded, payload-free command that inventories source
+ownership, SQLite metadata, runtime storage, research roots, growth, forecast,
+and thresholds without mutating the runtime root.
+
+**Expected outcome:** `./om research storage-baseline --runtime-root <fixture>`
+returns `storage_runtime_baseline.v1`; an optional report is atomically written
+outside the runtime root; before/after filesystem and SQLite hashes match.
+
+**Allowed files/modules:**
+
+- `src/application/research/storage_baseline.py` (new)
+- `src/interfaces/cli/research.py`
+- `docs/architecture/data-storage-runtime-source-inventory.v1.json` (new)
+- `tests/test_research_storage_baseline.py` (new)
+- `tests/test_research.py` for narrow CLI dispatch assertions only
+- `docs/AGENT_WIKI.md` for the new public read-only command
+- Gateflow artifacts for this work unit
+
+**Exact allowed changes and data flow:**
+
+1. CLI parses explicit roots/options and delegates to
+   `collect_storage_runtime_baseline()`; CLI formatting remains the existing
+   `build_response()` JSON contract.
+2. Collector resolves/validates bounded paths, loads and validates the checked-
+   in source inventory, executes its bounded discovery rules and rejects stale
+   or unclassified matches, copies the exact ledger `db/wal/shm` set into a
+   temporary directory with bounded before/after source-stat validation, opens
+   only that copy via URI `mode=ro` plus `query_only=ON`, performs allowlisted
+   aggregate SQL, traverses fixed runtime
+   subroots with `os.scandir(..., follow_symlinks=False)` semantics, resolves
+   manifest-declared references without opening referenced payload bodies,
+   classifies tiers, validates compatible prior reports, computes observation
+   deltas/forecast/threshold facts, and returns one dict.
+3. Optional output validates it is outside runtime root, serializes canonical
+   JSON to a sibling temp file, fsyncs, and atomically replaces only the named
+   report.
+4. Errors are classified as specified above; partial sources do not fabricate
+   zero values.
+
+**Invariants:** no production repository constructor or source SQLite
+connection; no SQLite PRAGMA that can checkpoint/change source journal state;
+no followed symlink; no payload JSON/CSV/base64
+decode or hash; manifest metadata may be parsed but never upgrades content to
+`verified`; no absolute runtime path inside largest-file/source entries except
+the single masked/declared root identity; no mutation callback exists.
+
+**Non-goals:** no content-addressed store, generation manifest writer, cold
+backend, cleanup preview execution, or live production collection.
+
+**Validation:**
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om-data-storage-p1-s1 ./.venv/bin/python -m pytest -q -p no:cacheprovider \
+  tests/test_research_storage_baseline.py tests/test_research.py
+./.venv/bin/python -m compileall -q src/application/research src/interfaces/cli/research.py
+git diff --check
+```
+
+Expected assertions include deterministic schema, aggregate-only SQLite trace,
+WAL/SHM/database byte identity, runtime-tree identity, no-follow symlinks,
+stale/unclassified source discovery, manifest-declared dedup, missing/size-
+mismatch versus same-size-unverified behavior, incompatible/out-of-order prior
+reports, stable-copy retry/exhaustion under a simulated concurrent writer,
+two/three-observation forecast boundaries, alert-with-zero-action behavior, and
+CLI output rules.
+
+**Completion signal / stop condition:** complete when focused tests and safety
+assertions pass. Stop if accurate logical-byte accounting requires reading raw
+payload contents or a persistence authority not named by the design contract.
+
+### Slice 2 — deterministic fixture and performance baseline harness
+
+**Prerequisite:** accepted Slice 1 commit.
+
+**Objective:** Generate synthetic fixture axes and reproducible uninstrumented,
+CPU, and allocation evidence for the existing canonical replay path, with an
+honest readiness decision.
+
+**Expected outcome:** one runner produces the five versioned artifacts; repeated
+runs with the same seed have identical fixture/content hashes; timing and
+profiles are separate; `history_10x` contains at least 10,000 events and reports
+full-replay result without claiming diff/checkpoint readiness.
+
+**Allowed files/modules:**
+
+- `src/application/research/performance_baseline.py` (new)
+- `scripts/benchmark_data_storage_projection.py` (new, thin wrapper)
+- `tests/test_research_performance_baseline.py` (new)
+- `docs/AGENT_WIKI.md` for the benchmark command and interpretation
+- Gateflow artifacts for this work unit
+
+**Exact allowed changes and data flow:**
+
+1. Load and schema-check optional Slice 1 metadata; discard paths and any
+   unexpected payload-like fields before deriving dimensions.
+2. Build canonical synthetic event sequences with a fixed seed and bounded
+   low/median/high entropy metadata. Preserve fixed current state in
+   `history_10x.fixed_output`; separately model retained closed-lot coupling in
+   `history_10x.retained_closed_lots`; scale current state and accounts only in
+   their named orthogonal scenarios.
+3. Measure `project_stored_trade_events_to_position_lots()` and, on a synthetic
+   temporary ledger, `rebuild_position_lots_from_trade_events()` as distinct
+   components. Record output fingerprint/count/diagnostic hash and assert exact
+   equality; for the writer also capture SQLite db/wal/shm bytes and the known
+   global-replace behavior.
+4. Run timing, cProfile, and tracemalloc in separate child-process modes of the
+   same script. The parent validates and atomically publishes the complete
+   artifact set to an empty explicit directory.
+5. Evaluate reference-host comparability and emit `pass`/`fail`,
+   `not_comparable`, or `not_implemented` per gate component. Never recommend or
+   activate checkpoint/tiering behavior.
+
+**Invariants:** no production ledger/runtime read; deterministic events and
+hashes; no profiler in timing; no wall/CPU threshold decision on a mismatched
+host; no projector-only result presented as writer pass; no benchmark
+dependency; output bounded to explicit directory.
+
+**Non-goals:** no lot diff writer benchmark pretending to be implemented, no
+Phase 2 audit-sidecar benchmark, no checkpoint benchmark, and no optimization
+of the projector during measurement.
+
+**Validation:**
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om-data-storage-p1-s2 ./.venv/bin/python -m pytest -q -p no:cacheprovider \
+  tests/test_research_performance_baseline.py tests/test_research_storage_baseline.py
+./.venv/bin/python scripts/benchmark_data_storage_projection.py \
+  --scenario history_10x --warmups 1 --repetitions 2 \
+  --output-dir /tmp/om-data-storage-p1-smoke
+./.venv/bin/python -m compileall -q src/application/research scripts/benchmark_data_storage_projection.py
+git diff --check
+```
+
+The smoke run uses reduced repetitions only for plumbing validation and must
+label itself `non_acceptance_smoke`; acceptance evidence uses 5/30. Tests assert
+fixture hashes, fixed-output axis independence, retained-closed-lot counts,
+canonical output equality, profiler
+separation, reference-host gating, hostile-baseline clamping, atomic output,
+writer/projector parity, temporary SQLite byte accounting, and
+`lot_diff_publication=not_implemented`.
+
+**Completion signal / stop condition:** complete when tests and smoke run pass
+and a 5/30 reference artifact can be generated within the recorded resource
+budget. Stop if 10,000 canonical events exceed available local resources or if
+the current projector cannot consume a deterministic contract-valid sequence;
+do not weaken the fixture or threshold silently.
+
+## Aggregate validation
+
+After both accepted slice commits:
+
+```bash
+PYTHONPYCACHEPREFIX=/tmp/om-data-storage-p1-aggregate ./.venv/bin/python -m pytest -q -p no:cacheprovider \
+  tests/test_research_storage_baseline.py \
+  tests/test_research_performance_baseline.py \
+  tests/test_research.py \
+  tests/test_ledger_event_codec.py \
+  tests/test_ledger_sqlite_workflows.py
+./.venv/bin/python -m pytest -q -p no:cacheprovider tests/test_research.py
+./.venv/bin/python -m compileall -q domain src scripts tests
+./.venv/bin/python scripts/benchmark_data_storage_projection.py \
+  --scenario all --output-dir /tmp/om-data-storage-p1-acceptance
+git diff --check
+```
+
+The final benchmark uses the default 5 warmups/30 repetitions and records
+whether the current host is comparable; timing failure is an evidence outcome,
+not a reason to alter the test. The aggregate review also checks `git status`,
+the exact source-inventory validation result, absence of forbidden mutation
+symbols in the new modules, and that the original shared worktree remains
+unchanged.
+
+## Documentation decision
+
+- Check in the confirmed design contract and its two prior review artifacts so
+  the implementation and later work units have a durable authority boundary.
+- Add Gateflow artifacts under
+  `docs/gateflow/data-storage-runtime-projection-p1/`.
+- Update `docs/AGENT_WIKI.md` with the read-only baseline command, benchmark
+  invocation, output schemas, and interpretation boundaries.
+- Do not update release notes or `CHANGELOG.md`: this work unit adds an offline
+  diagnostic/research surface and does not release it.
+
+## Risks and residual-risk classification
+
+| Risk | Classification / handling |
+|---|---|
+| Static source inventory can drift | Fixed in Slice 1 by stale-locator plus unclassified-discovery failure; novel APIs outside the vocabulary remain an aggregate-review residual risk |
+| Filesystem scan races concurrent writers | Fixed in Slice 1 by descriptive observation timestamps and partial/coherence status; no atomic snapshot claim |
+| Logical dedup/content integrity cannot be known for unmanifested or unhashed files without reading payloads | Fixed in Slice 1 by separating declared hashes, presence/size, historical verifier status, and unknown/unverified bytes |
+| Synthetic distributions differ from production | Assigned to later explicit read-only sampling; baseline identity exposes metadata source/defaults |
+| Projector passes while current SQLite writer fails | Fixed in Slice 2 by measuring both and forbidding projector-only writer pass |
+| Closed-lot retention couples history to publication size | Fixed in Slice 2 by reporting fixed-output and retained-closed-lot subcases separately and requiring both for the comparable writer result |
+| Current writer passes but future diff publication is absent | Fixed in Slice 2 by separate component status and combined `not_ready` |
+| Full replay fails `history_10x` | Covered by the already-approved later focused checkpoint planreview; no checkpoint work in this unit |
+| Concrete cold backend/restore cost is unknown | Assigned to later Phase 7 work unit requiring reviewed backend contract |
+| Existing admitted evidence and duplicate run copies continue growing | Covered by later approved Phase 2/6/7 work units; this unit only quantifies them |
+
+No residual risk is unclassified. A discovery that requires payload reads,
+schema mutation, runtime write, or a new authority triggers the Gateflow stop
+condition instead of expanding this work unit.
+
+## No overdesign and no goal drift
+
+Two small modules reuse existing boundaries: Research CLI/runtime-root ownership,
+SQLite query-only access, and the canonical ledger projector. Versioned JSON is
+necessary because later gates consume the evidence; it is not a new database or
+service. The source inventory is data, not a second policy engine. The runner
+uses the standard library only. Every output maps directly to a confirmed Phase
+1 success signal, and every later optimization remains explicitly absent.
+
+## Completion report format
+
+Final closeout reports accepted commits, changed files, exact focused/full and
+benchmark results, output schemas, documentation changes, all review findings
+and final status, residual risks/owners, Draft PR URL, confirmation that no
+runtime data was changed, and the next entry point: user review/merge followed
+by a separately confirmed Phase 2 work unit.
+
+## PlanReview finding decisions
+
+- `PR-P1-01`: accepted; fixed by splitting manifest-declared identity,
+  presence/size, historical verifier evidence, and current content verification.
+- `PR-P1-02`: accepted; fixed by deriving growth only from compatible prior
+  baseline reports and returning `insufficient_history` otherwise.
+- `PR-P1-03`: accepted; fixed by measuring projector-only and the real existing
+  replay writer on synthetic temporary SQLite as separate components.
+- `PR-P1-04`: accepted; fixed by versioned bounded discovery rules plus failure
+  on stale declarations and unclassified production matches.
+- `PR-P1-05`: accepted; fixed by separate fixed-output and retained-closed-lot
+  history subcases with explicit event/lot/view/allocation cardinalities.
+
+## Next entry point
+
+`accepted plan commit`

--- a/docs/gateflow/data-storage-runtime-projection-p1/pr-review.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/pr-review.md
@@ -1,0 +1,63 @@
+# Gateflow Artifact — PR Review
+
+- Gate: `PR review -> fix -> re-review`
+- Work unit: `data-storage-runtime-projection-p1`
+- Pull request: `#154`
+- URL: `https://github.com/liuxie066/options-monitor/pull/154`
+- Initial review: `docs/reviews/pr-154-review-20260813-173232.md`
+- Re-review: `docs/reviews/pr-154-review-20260813-175534.md`
+- Status: `pass after accepted finding was fixed`
+
+## Finding decision
+
+- `PR-154-01`: `accepted`; final state `已修复`.
+- No finding was rejected or deferred.
+- Re-review found no new substantive issue.
+
+## What changed in the fix loop
+
+- Manifest reference resolution now reuses the no-follow runtime file index and
+  avoids repeated canonical filesystem resolution per reference.
+- The existing benchmark artifact set now includes a deterministic,
+  independently runnable `research_storage_status.history_10x` component.
+- Storage timing, CPU, and Python allocation use separate worker measurements;
+  fixture setup/import is excluded and worker identity is validated.
+- `decision.json` now records the frozen 5-second and 64-MiB storage-status
+  budgets with fail-closed comparability semantics.
+- Symlink escape, fixture identity, setup exclusion, decision, storage-only
+  selection, and artifact validation have regression coverage.
+
+## Evidence
+
+- Storage-only formal 5/30 reference run:
+  - p95 wall `4,063,991,416 ns`;
+  - Python peak allocation `18,966,815 bytes`;
+  - status `pass`;
+  - payload-content reads `0`;
+  - mutation operations `0`.
+- Focused suite: `60 passed`.
+- Aggregate suite: `164 passed`.
+- Ruff, compileall, and diff hygiene: pass.
+- Published pre-fix PR head CI: Agent Plugin and Guardrails succeeded; CI will
+  rerun after the accepted review commit is pushed.
+
+## Residual-risk classification
+
+- O(E) replay/global replacement: assigned to later Phase 3A work; still
+  blocked by existing evidence.
+- O(files + references) bounded storage scan: accepted current contract and now
+  protected by the frozen time/space gate.
+- Source-inventory token discovery cost: assigned only if measured repeated-use
+  need justifies a revision-keyed cache.
+- Same-size tamper verification: assigned to explicit verifier.
+- Stable SQLite-copy atomicity edge: assigned to storage hardening.
+- RSS cumulative high-water semantics: accepted; decision uses isolated Python
+  peak allocation.
+
+No residual risk is unclassified.
+
+## Next gate
+
+Commit and push the accepted PR review fix, then perform Draft-PR pass and final
+Gateflow closeout. Do not merge, mark ready, request reviewers, release, deploy,
+or mutate production state.

--- a/docs/gateflow/data-storage-runtime-projection-p1/slice-1-review.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/slice-1-review.md
@@ -1,0 +1,62 @@
+# Gateflow Slice 1 Review — read-only storage baseline
+
+- Gate: `code review -> fix -> re-review`
+- Work unit: `data-storage-runtime-projection-p1`
+- Slice: 1 of 2
+- Initial review: `docs/reviews/code-review-20260813-133609.md`
+- Re-review: `docs/reviews/code-review-20260813-134318.md`
+- Artifact path: `docs/gateflow/data-storage-runtime-projection-p1/slice-1-review.md`
+- Status: accepted; ready for Slice 1 local commit
+
+## Finding disposition
+
+### DR-S1-01 — accepted — fixed
+
+The generic walker omitted current Shadow Replay Combo manifests whose file
+paths and hashes live in sibling maps. The collector now joins `files` and
+`file_sha256` by logical filename. The regression fixture verifies that the
+present protected object is accounted as a manifest reference, is not reported
+unmanifested, and keeps its undeclared byte size explicitly unknown.
+
+### DR-S1-02 — accepted — fixed
+
+Research archive verification paths were previously resolved relative to the
+manifest directory. The collector now has a bounded `research_archive.v2`
+adapter that binds every `runs[].file_manifest[].path` to that run's archived
+root. Regression fixtures prove both present-object accounting and missing-
+object critical status.
+
+## Acceptance evidence
+
+```text
+PYTHONPYCACHEPREFIX=/tmp/om-data-storage-p1-s1 \
+  ./.venv/bin/python \
+  -m pytest -q -p no:cacheprovider \
+  tests/test_research_storage_baseline.py tests/test_research.py
+
+54 passed
+```
+
+Broader Research / Shadow Replay / Strategy Lab regression gate:
+
+```text
+192 passed
+```
+
+```text
+./.venv/bin/ruff check \
+  src/application/research/storage_baseline.py \
+  tests/test_research_storage_baseline.py
+
+All checks passed!
+```
+
+`git diff --check` passed. No runtime root, source ledger, service, config,
+notification, broker state, schema, or migration was changed.
+
+After review, the implementation was mechanically tightened without changing
+the contract: source discovery now consumes each source file once instead of
+retaining all source text/token maps, and runtime traversal keeps bounded
+aggregates plus Top-N and research/protected candidates instead of retaining
+ordinary log/output metadata. The 54 focused tests and 192-test broader gate
+were rerun after this change.

--- a/docs/gateflow/data-storage-runtime-projection-p1/slice-2-review.md
+++ b/docs/gateflow/data-storage-runtime-projection-p1/slice-2-review.md
@@ -1,0 +1,96 @@
+# Gateflow Slice 2 Review — deterministic projection performance baseline
+
+- Gate: `code review -> fix -> re-review`
+- Work unit: `data-storage-runtime-projection-p1`
+- Slice: 2 of 2
+- Initial review: `docs/reviews/code-review-20260813-152057.md`
+- Re-review: `docs/reviews/code-review-20260813-154154.md`
+- Artifact path: `docs/gateflow/data-storage-runtime-projection-p1/slice-2-review.md`
+- Status: accepted; ready for Slice 2 local commit
+
+## Delivered behavior
+
+- Added a deterministic synthetic replay fixture with orthogonal current,
+  event-history, current-state, and account-fanout axes.
+- Split history into fixed-output and retained-closed-lot cases, each with a
+  10,000-event floor.
+- Measured the canonical stored-event projector and the existing SQLite
+  `rebuild_position_lots_from_trade_events()` writer separately.
+- Ran uninstrumented timing, `cProfile`, and `tracemalloc` in three separate
+  child-process modes.
+- Bound every worker result to the same fixture hash and exact canonical lot /
+  diagnostic parity.
+- Added writer SQL row/statement accounting plus temporary SQLite db/wal/shm
+  before, peak-observed, post-replay, and checkpointed steady-state bytes.
+- Atomically publishes exactly five versioned artifacts to an explicit absent
+  or empty output directory; no production ledger is opened.
+
+## Finding disposition
+
+### DR-S2-01 — accepted — fixed
+
+The first implementation could default missing timing p95 fields to zero and
+therefore fabricate a reference-host pass. The parent now validates exact
+warmup/repetition/run-label identity, non-profiled timing mode, complete sample
+arrays, non-negative integer values, and recomputed summary statistics before
+publication. Decision logic consumes only validated explicit values. Reduced
+repetition smoke runs remain `not_evaluable` even when the host fingerprint
+matches.
+
+## Validation
+
+```text
+PYTHONPYCACHEPREFIX=/tmp/om-data-storage-p1-s2-full \
+  ./.venv/bin/python -m pytest -q -p no:cacheprovider \
+  tests/test_research_performance_baseline.py \
+  tests/test_research_storage_baseline.py \
+  tests/test_research.py \
+  tests/test_ledger_event_codec.py \
+  tests/test_ledger_sqlite_workflows.py
+
+143 passed
+```
+
+```text
+./.venv/bin/ruff check \
+  src/application/research/performance_baseline.py \
+  scripts/benchmark_data_storage_projection.py \
+  tests/test_research_performance_baseline.py
+
+All checks passed!
+```
+
+`compileall` and `git diff --check` passed.
+
+The required non-acceptance history smoke completed with two 10,000-event
+fixtures. On this host it observed approximately:
+
+| Fixture | Projected lots | Writer p95 wall | Writer p95 CPU | Decision |
+|---|---:|---:|---:|---|
+| `history_10x.fixed_output` | 50 | 0.337 s | 0.337 s | `not_evaluable/non_acceptance_smoke` |
+| `history_10x.retained_closed_lots` | 5,000 closed | 2.662 s | 2.651 s | `not_evaluable/non_acceptance_smoke` |
+
+This is plumbing evidence, not the formal 5/30 reference-host judgment. It
+already isolates the material amplification from retained closed lots and
+global replace from the lower event-history-only cost.
+
+## Documentation decision
+
+`docs/AGENT_WIKI.md` now documents the command, artifact set, synthetic-only
+safety boundary, reference-host fingerprint, smoke label, and honest
+`lot_diff_publication=not_implemented` / combined `not_ready` decision.
+
+## Residual risks
+
+- Production distributions may differ from synthetic fixtures; assigned to a
+  later separately authorized read-only calibration work unit.
+- Full-table lot replacement remains in current production code; covered by
+  the later approved Phase 3A implementation work unit.
+- Formal 5/30 reference evidence is not a Slice 2 smoke artifact; covered by
+  this work unit's aggregate validation gate.
+
+## Completion status
+
+All accepted Slice 2 findings are `已修复`; there are no blocking open
+questions or unclassified residual risks. Next entry point:
+`accepted slice commit`.

--- a/docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md
+++ b/docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md
@@ -1,0 +1,879 @@
+# Phase 1 Contract — data-storage-and-runtime-projection.v1
+
+## Status
+
+- Status: amended after second plan review; reviewed full-replay path remains
+  valid, while conditional checkpoint/tiering activation requires the focused
+  gates below
+- Source baseline: `main@421591dd`
+- Supersedes: the informal Phase 1 section reviewed in `docs/reviews/plan-review-20260813-092047.md`
+- Prior review artifact: `docs/reviews/plan-review-20260813-103939.md` (`pass-with-risks` before the checkpoint, research-tier, and dirty-once-publish-once amendments below)
+- Scope of this document: freeze authority, state-machine, migration, and performance contracts before implementation
+- This phase is design and measurement only. It does not change schemas, runtime data, retention, services, or production configuration.
+
+## 1. Goal and success condition
+
+The project has two histories with different jobs:
+
+1. `trade_events` is durable trading history. It explains what changed the option position and remains the authority from which `position_lots` can be rebuilt.
+2. scan/lifecycle observations record what the system saw and decided at a run or broker-check boundary. Most consumers need current state or a sealed historical input/output, not every repeated large payload.
+
+The optimization must remove full-history work from ordinary scan and quality paths without weakening audit, replay, account isolation, or Strategy Lab evidence.
+
+Phase 1 succeeds only when:
+
+- every authority and generation has one named owner;
+- the hot-path and offline-path complexity boundaries below are testable;
+- lifecycle repeated-observation storage has a bounded per-check cost;
+- run-artifact deletion cannot orphan protected research or replay inputs;
+- CSV/base64 consumers have an explicit cutover gate;
+- benchmark fixtures, commands, units, and pass/fail thresholds are fixed;
+- no implementation agent must choose a new persistence authority or recovery state machine.
+
+## 2. Non-goals and retained boundaries
+
+- Do not rewrite, compact, migrate, or delete existing `trade_lifecycle_evidence` rows in Phases 1–7.
+- Do not replace `trade_events` as the trading authority.
+- Do not introduce a general per-event delta position projector in the default
+  path. Low-frequency writes first use deterministic full replay; the bounded
+  checkpoint-and-tail path in section 5.6 is activated only by its measured
+  gate and requires focused re-review before implementation.
+- Do not repair a projection from inside a scan or ordinary quality check.
+- Do not merge the SQLite lifecycle receipt store with the filesystem scan blob store.
+- Do not claim that broker cash, broker positions, and SQLite facts are atomically observed.
+- Do not let Strategy Lab write runtime config, ledger/trade state, notification state, broker state, or scheduler state.
+- Do not activate a cold-storage backend, evict a protected local blob, or
+  delete a research artifact merely because a capacity threshold fired. The
+  thresholds produce status and a preview; movement or deletion needs separate
+  approval.
+- Data deletion remains a separate, explicitly authorized phase. A successful migration preview is not deletion authorization.
+
+## 3. Terms and authority map
+
+| Term | Exact meaning | Authority / owner |
+|---|---|---|
+| provider attempt | A provider call was actually made. Static blocking is not an attempt. A post-call stale-generation outcome is still an attempted call but is not a valid observation. | compact lifecycle attempt audit sidecar |
+| valid observation | A provider attempt returned a payload that can be projected and admitted by `settlement_observation_semantic.v1` or its successor. | admitted evidence plus compact audit sidecar |
+| admitted evidence | The first valid observation or a later business-semantic change. | existing `trade_lifecycle_evidence` and settlement admission head |
+| duplicate observation | A valid observation whose semantic schema and fingerprint equal the current admission head. | compact audit sidecar; it must not add admitted evidence |
+| operational retry state | Current attempt count, backoff, claim, and next-attempt data. It is overwriteable control-plane state. | existing trade-inbox settlement-attempt state; never audit authority |
+| position source generation | Global generation of canonical `trade_events` mutations that may affect the deterministic projection. | SQLite triggers on the authority table |
+| position lot generation | Per-account generation of physical `position_lots` mutations. | SQLite triggers on the projection table |
+| position projection head | The generations and fingerprint last published by a successful projector transaction. | position projector, at the end of the same transaction |
+| position projection checkpoint | A bounded, versioned, verified cache of a resumable projector accumulator for an exact event prefix. It is never trading authority. | position projector / explicit integrity verifier |
+| lifecycle evidence revision | Per-case invalidation revision for admitted lifecycle evidence. | existing evidence revision triggers |
+| decision-input dirty state | One per-account source generation changed only by the closed set of decision-bearing source tables; dirty is derived from source generation != projection built generation and is not a second stored boolean. | narrow SQLite triggers; publisher captures the final generation only after one successful transaction-end publish |
+| current decision projection | Per-account materialized facts needed by ordinary position/lifecycle/combo readers, derived from trusted current lots and canonical lifecycle/combo inputs. It is a cache/projection, never audit authority. | decision projection publisher |
+| research dataset generation | An immutable manifest generation that binds exact partition/blob hashes and provenance; experiments bind this id rather than copying a dataset. | Research/Shadow Replay manifest writer |
+| run seal | Integrity and run-binding hash over a manifest. | run artifact writer |
+| coherence | Descriptive timing relationship among independently observed source sections. | runtime snapshot builder; not an atomicity claim |
+
+The three revision domains—position projection, lifecycle evidence, and external broker observation—must not share a counter or be inferred from one another.
+
+## 4. Frozen decision A — preserve admitted evidence; add only a compact audit sidecar
+
+### 4.1 Authority boundary
+
+`trade_lifecycle_evidence` remains the logical and physical authority for admitted semantic evidence. Existing foreign keys from admission heads, source consumptions, and allocations continue to reference it. Existing rows are immutable, but the table continues accepting a new row whenever settlement semantics change.
+
+The sidecar records provider attempts and duplicate observations. It does not become a second evidence authority and is not an input to allocation or position projection.
+
+### 4.2 Canonical receipt and hash
+
+For a valid observation, the receipt payload is exactly the complete
+`evidence["observation"]` mapping produced after
+`attach_settlement_semantics()`.  This includes the versioned semantic
+projection and fingerprint that are actually admitted, but excludes the outer
+evidence envelope, generated evidence id, and database timestamps.  Both the
+first-evidence reader and the sidecar writer call one shared canonicalizer;
+neither reconstructs the receipt from selected fields.  `receipt_sha256` is
+calculated over its UTF-8 canonical JSON:
+
+```text
+json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+```
+
+The hash preimage includes a receipt-canonicalization schema identifier. “Raw receipt” in this contract means this canonical logical JSON, because the current application persists parsed JSON rather than the provider's original wire bytes.
+
+For provider failures, the audit row stores a small normalized outcome code and a hash of redacted diagnostic classification; it does not store raw exception text, request credentials, or provider payload bytes.
+
+### 4.3 Target schema contract for Phase 2
+
+Names may change mechanically during implementation, but cardinality, keys, and ownership may not.
+
+`trade_lifecycle_attempt_audit_heads` — one mutable row per lifecycle case:
+
+- `audit_case_key` integer primary key plus `case_id` unique foreign key to `trade_lifecycle_cases`;
+- `last_ordinal` non-negative integer;
+- `chain_sha256` 32-byte BLOB;
+- `current_span_ordinal` nullable;
+- `last_invocation_id` nullable 16-byte BLOB;
+- `updated_at_ms`.
+
+`trade_lifecycle_attempt_audits` — one compact append-only row per provider attempt:
+
+- `(audit_case_key, ordinal)` composite primary key, implemented `WITHOUT ROWID` in v1;
+- `invocation_id`, the 16-byte UUID value reserved durably in the inbox before the provider call; unique with `audit_case_key`;
+- `attempted_at_ms`;
+- `outcome_code` small integer from a versioned mapping;
+- `semantic_fingerprint` nullable 32-byte BLOB;
+- `receipt_sha256` nullable 32-byte BLOB;
+- `diagnostic_sha256` nullable 32-byte BLOB;
+- `span_ordinal` nullable integer;
+- no JSON payload and no repeated error string.
+
+`trade_lifecycle_observation_spans` — one row per contiguous admitted semantic state:
+
+- `(audit_case_key, span_ordinal)` composite primary key, implemented `WITHOUT ROWID`;
+- semantic schema and semantic fingerprint;
+- `first_evidence_id`, foreign-keyed to the existing evidence primary key; an
+  insert/update trigger additionally requires that evidence's `case_id` to
+  equal the case mapped by `audit_case_key` (the span deliberately does not
+  repeat the text case id);
+- first and last successful-observation ordinals and timestamps;
+- successful observation count and intervening failed-attempt count;
+- current chain hash at close;
+- `last_receipt_sha256` nullable;
+- `closed_at_ms` nullable;
+- no repeated text `case_id`; the audit head is the case mapping.
+
+`last_receipt_sha256` has an index. A receipt is unreferenced only when no
+span—open or closed—references that hash. The post-commit sweep must use this
+index to test the union of all span references before deleting the just-replaced
+candidate; sharing an equal last receipt across cases or spans can never make
+one owner's replacement delete another owner's live receipt.
+`last_receipt_sha256` is also a nullable foreign key to
+`trade_lifecycle_receipt_blobs`; foreign-key enforcement is enabled on every
+writer connection.
+
+`trade_lifecycle_receipt_blobs` — content-addressed storage for a span's last successful duplicate receipt only:
+
+- `receipt_sha256` 32-byte primary key;
+- codec and codec version;
+- uncompressed and compressed byte counts;
+- compressed payload BLOB;
+- creation time.
+
+The first receipt is already present in `trade_lifecycle_evidence`. If the last receipt is byte-identical to the first, `last_receipt_sha256` remains null and readers reuse the admitted evidence. Otherwise, each open or closed span references at most one additional full receipt. Equal last receipts across spans reuse the same content-addressed blob.
+
+### 4.4 Ordered audit chain
+
+For ordinal `n`, the chain is:
+
+```text
+chain_n = SHA256(
+  chain_schema || chain_(n-1) || case_id || ordinal || invocation_id || attempted_at_ms ||
+  outcome_code || semantic_fingerprint_or_zero || receipt_sha256_or_zero ||
+  diagnostic_sha256_or_zero
+)
+```
+
+Only the head and a closed span store the resulting chain; intermediate rows store the ordered inputs, not another 32-byte chain copy. Full verification is an explicit offline O(N) operation. Hot writes are O(1) in history length. The compact integer case/span keys avoid repeating long text identifiers in every row. `invocation_id` makes a retry after an uncertain commit a no-op instead of a second ordinal.
+
+Retained run manifests seal the relevant `(case_id, last_ordinal, chain_sha256)` heads. This detects accidental row loss or rewriting against a retained seal; it is not a claim of tamper-proof non-repudiation if an attacker can rewrite both the database and every retained manifest.
+
+### 4.5 State machine and transaction boundary
+
+For a valid observation, semantic projection, admission decision, evidence insert when needed, audit append, span update, last-receipt reference move, admission-head advance, and transaction commit are one SQLite transaction.  Physical deletion of any newly orphaned receipt blob is post-commit and is not part of this atomic list.
+
+Before calling the provider, the inbox claim transaction reserves a durable RFC 4122 UUIDv4 `invocation_id` and keeps it until that attempt is completed or explicitly reconciled. The ledger stores its 16-byte UUID representation and enforces `UNIQUE(audit_case_key, invocation_id)` with idempotent `INSERT ... ON CONFLICT DO NOTHING`. Lease renewal or process restart reuses that value; a genuinely new provider call must first reserve a new invocation id. Random process-local IDs created after the call are forbidden because they cannot distinguish retry-after-commit from a second call.
+
+- First valid observation: insert admitted evidence, open a span, append the next audit ordinal (ordinal 1 only when no failed attempt preceded it), and advance both heads.
+- Same schema and fingerprint: do not insert admitted evidence; append one compact audit row; update the open span; atomically replace its last-receipt reference.
+- Changed schema or fingerprint: close the old span, insert admitted evidence through the existing path, and open a new span. A semantic schema version change always opens a new span even if projected values happen to match.
+- Provider failure after a real call: append a compact audit row with no span change and no receipt blob. If a span is open, increment its intervening-failure count.
+- Static block before a provider call: update operational retry state only; do not claim a provider attempt.
+- Stale generation discovered after the provider call: append an attempted-but-not-admitted audit outcome with no span/receipt change. A stale short circuit before the provider call adds no audit row.
+- Crash before commit: none of the new evidence/audit/span state is visible. Retry uses the same admission/idempotency rules.
+
+The ledger audit transaction is authoritative even though operational retry completion happens later in the separate inbox database. If ledger commit succeeds and inbox completion fails, retrying the same `invocation_id` does not append a second audit row; control-state reconciliation reads the audit head and advances only the overwriteable retry state.
+
+Blob liveness is determined by actual span references and mark-and-sweep, not a mutable reference counter. The old moving “last” reference is replaced in the transaction; physical deletion of an unreferenced receipt blob happens in a bounded post-commit sweep, so a rollback can never restore a span reference to a deleted blob. That sweep is indexed by receipt hash, deletes at most the just-replaced candidate per attempt, and is idempotent. Existing admitted evidence is never garbage-collected by this mechanism.
+
+## 5. Frozen decision B — global source generation with per-account heads; deterministic full replay only on writes
+
+### 5.1 Normalized account key
+
+Phase 3A adds an additive nullable `account` column to `trade_events` and `position_lots`, backfills it from canonical JSON, validates lowercase account labels, and indexes:
+
+- `trade_events(account, trade_time_ms, event_id)`;
+- `position_lots(account, expiration, record_id)`.
+
+During a mixed-version window, triggers may derive the key from JSON only when the new column is null. A missing or conflicting account fails migration/readiness; it is never silently assigned. `NOT NULL` enforcement is a later schema rebuild after old writers are retired.
+
+### 5.2 Generation state
+
+`position_projection_source_state` is a singleton row:
+
+- `source_generation`: incremented for every projection-affecting `trade_events` mutation;
+- `projector_schema` and update time.
+
+The source generation is global because a `void` or `repair` event may target another event, projection validates a cross-event graph, and the first implementation deliberately retains the existing deterministic full replay. Claiming per-account source independence before proving that graph can be partitioned would be unsafe.
+
+The current `trade_events` table has only `event_id`, `event_json`, `trade_time_ms`, `created_at_ms`, and `updated_at_ms`. Trigger semantics are frozen as follows:
+
+- `INSERT` and `DELETE` increment `source_generation`;
+- `UPDATE OF event_json, trade_time_ms` increments it only when the corresponding old/new value differs;
+- `UPDATE OF created_at_ms, updated_at_ms` does not increment it;
+- the new normalized `account` column is an integrity/index projection of `event_json`, so account-only repair cannot commit unless JSON and the normalized column agree; a real account change therefore changes `event_json` and is already covered.
+
+Any future column must be classified as projection-affecting or metadata-only in this contract and trigger tests before schema merge. A generic `AFTER UPDATE` trigger is forbidden.
+
+`position_projection_heads` has one row per account:
+
+- `built_source_generation`: source generation consumed by the last successful publish;
+- `lots_generation`: incremented for every physical lot mutation for the account;
+- `built_lots_generation`: lot generation captured by the last successful publish;
+- `projection_fingerprint`: canonical hash of that account's projected lots;
+- `projector_schema`, status, and update time.
+
+SQLite triggers own the global `source_generation` and per-account `lots_generation`. Application writers cannot directly increment or reset them. The projector alone owns the `built_*`, fingerprint, schema, and trusted status fields, and advances all account heads only after all lots have been published in the same transaction.
+
+### 5.3 Complete mutation matrix
+
+| Mutation | Generation effect | Required publication behavior |
+|---|---|---|
+| New canonical `trade_events` insert | increment global `source_generation` | full deterministic replay and publish in the same writer transaction |
+| Idempotent insert with identical existing event | none | no replay required |
+| Conflicting same-id event | reject | no state change |
+| Append-only void/correction/repair event | same as insert | replay and publish in the same transaction |
+| Direct event JSON/account update used by a controlled migration | increment global `source_generation` once | migration must publish before commit or leave all heads explicitly dirty |
+| Event delete used by an explicitly authorized repair | increment global `source_generation` once | repair must publish before commit or leave all heads dirty |
+| Lifecycle mutation that does not append a trade event | none | no position replay |
+| Lifecycle resolution that appends terminal trade events | event trigger owns the change | replay and publish in that transaction |
+| Any `position_lots` insert/update/delete | increment `lots_generation` for the affected account | legitimate projector captures final value at transaction end; any later direct mutation causes mismatch |
+
+The first implementation retains deterministic full replay computation but retires global `DELETE + INSERT` publication. In the same transaction it canonicalizes current and projected lots by `record_id`, then performs DML only for added, changed, or removed rows. It must publish heads for the union of accounts present in old lots, canonical events, and new lots, including accounts whose resulting lot set is empty. Every head receives the same final global `built_source_generation`; only accounts with physical lot changes advance `lots_generation`, and every head captures its own final lot generation and fingerprint. Public `replace_position_lots` behavior remains facade-compatible even though its internal publication becomes diff-based.
+
+This is not a per-event delta projector: projection CPU remains O(E) at the low-frequency write boundary, while SQLite DML/WAL becomes O(changed lots) rather than O(all lots). The `history_10x` writer gate below is the exit condition. If it fails, Phase 3A cannot ship with full replay and must return to plan review for a checkpoint/delta design.
+
+### 5.4 Trusted read protocol
+
+`read_current_position_projection(account)` runs in one SQLite read transaction:
+
+1. read the account head;
+2. require global `source_generation == head.built_source_generation` and `lots_generation == built_lots_generation`;
+3. read only indexed `position_lots` for that account;
+4. canonicalize lots by `record_id` using the same projection fingerprint schema, recompute the account lot fingerprint, and compare it with the head;
+5. return trusted rows or a structured `data_unavailable` reason.
+
+This reader must not list `trade_events`, project events, read another account's lots, or write the database.
+
+The lot fingerprint schema is `position_lots_fingerprint.v1`: keep exactly `record_id` and the complete `fields` mapping; sort lot rows by `record_id`; recursively sort object keys; preserve list order; preserve missing-versus-null; reject NaN/Infinity; and serialize with UTF-8 `json.dumps(..., ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)`. Existing schema-valid timestamp/string/number representations are not silently coerced. Writer, reader, shadow comparator, and offline verifier must call the same domain-owned canonicalizer rather than copy this algorithm.
+
+Lot-generation/fingerprint mismatch in scan or ordinary quality paths is fail-closed for that account only. A global source-generation mismatch means the last full projection did not publish and therefore fails closed all account heads; that blast radius is an explicit consequence of retaining a global projector, not a false account-isolation claim. Both cases emit a bounded diagnostic and exit quickly. Recovery is the existing explicit rebuild facade extended with generation publication, or a separately scheduled reconcile. There is no automatic replay inside tick, scan, snapshot read, or regular quality refresh.
+
+### 5.5 Current decision projection
+
+Eliminating trade replay alone is insufficient: the current `decision_state_snapshot` also lists all lifecycle evidence/allocation/source-consumption rows, all assigned-stock events, and recomputes lifecycle overlay and combo membership. Phase 3B therefore publishes one `current_decision_projection` per account in the same SQLite transaction as any owning ledger mutation.
+
+The projection contains only the decision-bearing current facts already exposed by the existing snapshot contract:
+
+- the trusted position-head binding and current-lot-derived overlay/combo facts;
+  the lot rows themselves remain only in indexed `position_lots` and are not
+  copied into this JSON;
+- operational lifecycle cases (pending, conflict, needs-review, or still
+  referenced by a current lot, reservation, live combo, or assigned-stock
+  view), their current resolved facts, generation-token bindings, active
+  reservations, and timing policies;
+- current combo membership facts for live/current groups;
+- current assigned-stock view required by current position context, not its event history;
+- compact lifecycle quality facts per operational case, including
+  admitted-evidence count, immutable status inputs, and deadline timestamp, so
+  ordinary quality does not count historical evidence rows;
+- generation bindings for the canonical tables from which these facts were derived;
+- canonical fingerprint, projector schema, and update time.
+
+It does not embed terminal unreferenced case history, historical evidence, trade-event, allocation, source-consumption, or assigned-stock rows. Those remain queryable through explicit audit/replay APIs. Ordinary quality changes from one detailed dataset per terminal lifecycle case to account/market aggregate terminal counts/statuses plus detailed facts only for operational cases. The former detailed terminal-case output remains available through an explicit scheduled/manual audit artifact. Therefore the hot projection is bounded by current operational state rather than lifetime case count.
+
+That output-granularity change is a public data-contract migration, not an
+internal optimization. Phase 1 must inventory every reader of
+`dataset_id=om.lifecycle_evidence` and `scope.lifecycle_case_id`. Phase 3B must
+dual-publish legacy detailed quality output and the proposed aggregate output,
+compare aggregate counts/statuses and operational-case details, and obtain zero
+unexplained legacy-consumer reads for the same 14 eligible market days used by
+the artifact cutover. Until that gate passes, Phase 5 cannot retire the legacy
+detailed ordinary-quality output.
+
+Generation ownership is table-driven: existing per-case evidence revisions cover evidence invalidation; additive revision triggers cover lifecycle cases, allocations, source consumptions, timing policies, combo identities, and assigned-stock events. These triggers update compact per-account decision-input revision rows. For a case-scoped table, the trigger resolves account through `trade_lifecycle_cases`; for an update that changes ownership, both old and new accounts advance. A missing case/account mapping aborts the mutation rather than advancing an anonymous global bucket. The global position source generation and per-account lot generation are also inputs. A writer that mutates any input must either publish the affected account projection before commit or leave its generation binding mismatched. Global event-generation change republishes every account because combo/void relationships are not yet proven partitionable.
+
+The decision-specific revision trigger set is closed in v1: it covers
+`trade_lifecycle_cases`, admitted `trade_lifecycle_evidence`,
+`trade_lifecycle_allocations`, `trade_lifecycle_source_consumptions`,
+`trade_lifecycle_timing_policies`, `strategy_group_identities`,
+and `assigned_stock_events`. `trade_events` and `position_lots` are deliberately
+not given duplicate decision-specific counters; the decision projection binds
+their existing global position source generation and per-account lot generation
+directly. Phase 3B first adds the normalized account/owner keys and supporting
+indexes needed to resolve the affected account without scanning JSON history.
+The audit-only
+`trade_lifecycle_attempt_audit_heads`, `trade_lifecycle_attempt_audits`,
+`trade_lifecycle_observation_spans`, and `trade_lifecycle_receipt_blobs` are
+explicitly excluded, as are notification/outbox/delivery and diagnostic tables.
+Changing this set requires a contract and trigger-test amendment; a generic
+"any ledger table" revision trigger is forbidden.
+
+Those triggers implement invalidation only. Each affected account has one
+`decision_input_generation`; dirty is derived by comparing it with the
+projection's `built_decision_input_generation`, not persisted separately. A
+trigger resolves the old/new account and advances that small row, but it never
+decodes or rewrites the
+decision JSON, replays events, recomputes overlay/combo, or publishes a head.
+Multiple source mutations in one SQLite transaction may advance the source
+generation more than once, but they are coalesced into the same affected-account
+set and the transaction-end publisher writes at most one decision projection
+row per affected account. The publisher captures the final generation and
+advances `built_decision_input_generation` only after that one successful
+publish. A duplicate provider
+attempt and excluded-table write advance nothing. A direct SQL mutation of an
+included source table may leave the account dirty; reads then fail closed until
+explicit repair instead of silently trusting stale JSON.
+
+The implementation inventory for this projection must cover at least `upsert_trade_lifecycle_case`, `insert/update trade_lifecycle_evidence`, `update_trade_lifecycle_case_derived_status`, allocation/source-consumption/timing-policy inserts, `insert_strategy_group_identity`, `upsert_assigned_stock_event`, and all trade-event/position-lot writers. Notification outbox/batch and combo-pair proposal rows are excluded unless code evidence shows they alter the snapshot facts above. Direct SQL migration/repair mutations are covered by the same triggers and leave heads dirty if they do not republish.
+
+Publication cost is paid only on semantic/current-fact change. A duplicate settlement observation whose admission head, case resolution, lots, combo identities, and assigned-stock view are unchanged appends the compact audit sidecar but does not rebuild or rewrite `current_decision_projection`. The trigger revisions used for this projection therefore track decision-bearing changes, not every audit attempt.
+
+When one transaction changes lots and decision facts, publication order is
+frozen: finish the Phase 3A lot diff, capture the transaction's final
+`built_source_generation`, `built_lots_generation`, and lot fingerprint, then
+write the decision projection with exactly those final bindings, and only then
+advance its built decision-input revision. Reading pre-publication lot heads is
+forbidden. The transaction either exposes all final bindings together or none.
+
+The normal publisher receives the validated old/new mutation facts already in
+the owning command transaction. It updates the prior compact projection and may
+recompute overlay/combo only from indexed current lots plus current operational
+facts. Its work is O(current account state + changed facts), independent of
+lifetime evidence/case/assigned-stock history. It must not list historical
+tables to reconstruct the projection. An initial migration backfill or explicit
+repair may rebuild from full history offline, publishes a separate status
+artifact, and is never called by scan, tick, ordinary quality, or a normal
+decision-bearing write.
+
+`read_current_decision_projection(account)` reads the projection, indexed account
+lots, and all live generation/revision heads in one transaction. It requires
+the embedded global position source generation, account lot generation and
+fingerprint, and every account decision-input revision to equal their live
+heads, then verifies both canonical fingerprints. Integrity without exact
+generation equality is never fresh. A local lifecycle/combo/assigned-stock/lot
+binding mismatch returns account-scoped `data_unavailable`; a global position
+source-generation mismatch returns `data_unavailable` for every account. The
+reader performs no fallback, replay, repair, or write after a head exists.
+Ordinary scan/snapshot/quality consumers use this reader, including ledger
+projection trust and lifecycle evidence-count/deadline checks. Explicit
+lifecycle reconcile/write flows may use the existing detailed rows because
+they are low-frequency mutation paths and need compare-and-set evidence.
+
+The projection stores immutable timing inputs such as
+`settlement_deadline_ms`, not wall-clock classifications such as "overdue" or
+"remaining duration". Readers derive those classifications from an injected
+`now` without a database write. Any future time-driven stored state requires a
+named scheduler owner and its own revision contract.
+
+The decision-specific payload is stored as one canonical JSON document per
+account in v1. This keeps its hot read to one indexed row and one bounded
+decode/hash while reusing `position_lots` as the single physical current-lot
+projection. Partial normalized tables are deferred until measured current-state
+size or update cost violates the budgets; implementation must not
+pre-emptively create a second normalized projection graph.
+
+### 5.6 Conditional checkpoint-and-tail projection
+
+Full replay remains the Phase 3A default only while the `history_10x` budget
+passes. If it fails, implementation stops: it does not silently relax the
+threshold or substitute an ad-hoc incremental projector. A focused planreview
+must first freeze and approve the following bounded checkpoint path.
+
+The path is **checkpoint + deterministic tail replay**, not a second ledger and
+not an unrestricted per-event delta state machine:
+
+- `trade_events` remains the only event authority; `position_lots` remains the
+  only current-lot projection.
+- A checkpoint binds `projector_schema`, exact ordered event-prefix count,
+  prefix-end `(trade_time_ms, event_id)`, prefix hash/chain head, full source
+  generation, canonical accumulator payload/hash, creation time, and verification
+  status. The accumulator contains only state required to resume the current
+  projector exactly: current lots, open-event facts needed for later fee
+  allocation, allocated-open-fee state, allocation-sequence state, current
+  strategy/adjust projection inputs, and a bounded publishability/diagnostic
+  summary. It must not discard information that changes current lots, risk
+  views, public `position_lots` records, or the publishability verdict.
+- The fast path is an internal **current-position publication** entrypoint. It
+  does not serve APIs that request the complete historical
+  `ProjectionResult.allocations` or every per-event diagnostic; those remain
+  explicit offline/full-replay reads. Prefix allocation/diagnostic history is
+  represented in the checkpoint only by the resumable current accumulator,
+  severity/count/hash summary, and bounded samples—not by copying O(E) rows.
+  Phase 1 inventory must prove that no synchronous writer facade requires the
+  complete prefix lists; any such facade remains on full replay.
+- Keep the newest two verified checkpoints plus one last-known-good checkpoint.
+  Creating a new one and retiring an older cache are atomic within SQLite;
+  checkpoints are rebuildable caches and their fixed `K <= 3` bound makes space
+  O(K × resumable current state), not O(event history).
+- A normal append may resume from the newest verified checkpoint and replay the
+  strict ordered suffix only when every suffix event is proven append-safe.
+  Append-safe means no event reorders before the prefix end, no `void`/`repair`
+  targets an event inside or before the checkpoint prefix, no controlled
+  UPDATE/DELETE touches that prefix, and the projector schema/prefix hash match.
+- Hot-path append safety is derived from the current mutation, indexed target
+  lookup, checkpoint boundary, and its trusted/invalidated flag; the writer does
+  not rescan/re-hash the full prefix on every append. Insert/update/delete
+  triggers conservatively invalidate intersecting checkpoints. A direct or
+  unclassified mutation invalidates all checkpoints rather than trying to
+  infer safety from JSON.
+- A `void`, repair pair, late/backdated event, controlled UPDATE/DELETE, schema
+  change, prefix-hash mismatch, or any unproven dependency invalidates every
+  checkpoint whose prefix intersects the dependency. The writer chooses the
+  newest earlier verified checkpoint that is provably unaffected; if none
+  exists it performs the canonical full replay. Correctness fallback is always
+  allowed; tail replay is never used on an unproven graph.
+- Checkpoint/tail output must have exactly the same current lots, risk views,
+  public position records, publishability verdict, and canonical fingerprints
+  as a full replay; its diagnostic count/hash summary must also match the full
+  oracle. One shared domain projector owns both entry modes; application code
+  may not implement parallel business semantics.
+- After activation, an explicit scheduled/manual verifier periodically performs
+  a full replay and compares checkpoint/tail output. Any mismatch marks the
+  checkpoint path untrusted, fails closed for publication, emits a status
+  artifact, and returns writers to full replay until repair.
+
+Activation requires measurable benefit as well as correctness: full replay
+must first fail the frozen gate; checkpoint/tail must then pass the budgets in
+section 10, reduce reference-host p95 wall/CPU by at least 50%, and stay within
+the fixed checkpoint storage bound. Otherwise the simpler full replay remains
+the approved implementation.
+
+## 6. Frozen decision C — runtime snapshot integrity without false temporal claims
+
+`runtime_portfolio_snapshot.v1` is a run-bound envelope with independent sections:
+
+- `ledger_projection`;
+- `broker_cash`;
+- `broker_positions`;
+- derived cash-occupation facts;
+- source status and completeness.
+
+Every source section records account, schema, source-observed time, application-received time, receipt/content hash, completeness, and the source's existing freshness result. The top-level seal covers canonical content and run/account binding only.
+
+The envelope records descriptive minimum/maximum observed times and measured skew. Version 1 does not introduce a new cross-source skew gate and does not claim simultaneity. Consumers continue to fail closed using each source's existing freshness/completeness contract. A future business rule that blocks on cross-source skew requires a separately reviewed numeric policy; it is not smuggled into this storage change.
+
+The compact runtime snapshot contains current position lots, current cash/headroom facts, and the chosen run inputs/results. It does not contain full trade history, full lifecycle evidence history, embedded scan raw JSON, or base64 copies.
+
+## 7. Frozen decision D — scan blobs, roots, retention, and CSV/base64 cutover
+
+### 7.1 Filesystem blob protocol
+
+Large immutable scan payloads use a filesystem content store separate from the SQLite ledger:
+
+```text
+output_shared/blobs/sha256/<first-two-hex>/<sha256>.json.gz
+```
+
+- Hash the uncompressed canonical bytes.
+- Use deterministic gzip with a fixed codec version and `mtime=0`.
+- Write a temporary file in the target directory, fsync as supported, then atomically rename.
+- Concurrent publication of the same hash is idempotent.
+- Publish the run/artifact manifest only after the blob is durable.
+- Readers decompress and recompute the uncompressed hash.
+
+Run manifests hold hashes, schemas, byte counts, and logical roles; they never inline the same payload as base64 once cutover completes.
+
+### 7.2 Root manifests and mark-and-sweep
+
+The protected root set is the union of:
+
+- every retained online run manifest;
+- research archive manifests;
+- Shadow Replay dataset, experiment, mark, and settled-outcome manifests;
+- permanent daily representative manifests;
+- explicit manual keep/pin manifests.
+
+Retention of ordinary runs preserves the current union rule: keep a run if it is within 14 days **or** among the latest 200. A run is eligible for deletion only when neither condition holds. A blob is eligible only when no protected root reaches it and its publish time is older than a 24-hour orphan grace period.
+
+GC is mark-and-sweep with a read-only preview, deterministic plan hash, reference-integrity validation, and explicit confirmation. It does not use file mtime alone and does not use mutable reference counts. Blob-before-manifest crashes create harmless orphans that are recoverable until grace expiry. Missing/corrupt referenced blobs block deletion and mark the owning artifact incomplete.
+
+### 7.3 Frozen consumer inventory and cutover gate
+
+The minimum known consumer inventory is:
+
+| Contract | Current dependency | Required migration proof |
+|---|---|---|
+| required-data producer | raw JSON + CSV and inline base64 bundle in `opend_symbol_outputs.py` | canonical blob manifest emitted and validated |
+| receipt verifier/reentry | decodes and byte-compares both base64 fields | blob-aware verifier with identical integrity result |
+| Shadow Replay marking | globs `*_required_data.csv` | canonical reader produces identical marks |
+| scan/filter/coverage paths | candidate, CC/LP, Sell Put/Call helper, prefetch, multiplier, quote-cache, and coverage modules read `*_required_data.csv` | shared canonical frame reader returns decision-identical rows |
+| close advice / Daily Brief | frozen required-data snapshot resolves CSV bytes and pandas frames | canonical materializer is byte/field equivalent for decision inputs |
+| materialization and research CLI | tools accept a required-data directory/CSV contract | facade accepts canonical manifest and legacy directory during the window |
+| Strategy Lab dataset/outcome build | run paths and candidate/mark artifacts | end-to-end build/mark/settle with blob references only |
+| research archive | copies or inventories run paths | archive manifest retains reachable blob hashes |
+| diagnostics/tests | direct CSV/base64 fixtures | contract tests cover canonical and legacy adapter paths |
+
+Cutover order is fixed:
+
+1. complete the full `rg`/runtime inventory and add payload-free legacy-read counters;
+2. make every reader prefer the canonical manifest/blob and fall back to legacy data;
+3. shadow-compare canonical versus legacy decoded values;
+4. run Strategy Lab build/mark/settle and research archive end to end;
+5. require zero unexplained legacy reads for 14 consecutive eligible market days in both configured markets; an eligible day is a scheduled market-open day on which the configured account/strategy was enabled, and upstream failure remains in the denominator as incomplete rather than being discarded;
+6. stop default CSV/base64 persistence behind an explicit gate;
+7. retain a one-version on-demand compatibility materializer that reconstructs a legacy view from the canonical blob without storing a second default copy.
+
+Stopping legacy output before all seven gates pass is a contract violation.
+
+### 7.4 Research storage classes, dataset generations, and capacity control
+
+Logical retention and physical placement are separate decisions. A permanent
+research/replay root means its exact content remains addressable and verifiable;
+it does not require every derived representation or every physical copy to stay
+in each run directory.
+
+Every research artifact is classified before Phase 6/7 cutover:
+
+| Class | Examples | Retention and physical strategy |
+|---|---|---|
+| immutable replay authority | sealed run input/output, candidate and rejection facts, source status, marks, settled outcomes, trade/outcome references | permanent logical root; manifest and hashes retained; large payloads content-addressed and deduplicated |
+| experiment/provenance metadata | dataset generation, parameters, scorecard, proposal, holdout identity, software/schema versions | permanently retained compact manifest/JSON; never copied with the full dataset |
+| immutable shared partition | canonical required-data/research rows grouped by schema/market/date/account scope | stored once by content hash; many dataset generations reference the same partition |
+| reproducible compatibility/derived cache | CSV, inline base64, temporary decoded bytes/DataFrame, materialized legacy directory, report rendering | not a permanent root after its migration gate; generated on demand from canonical blobs; existing copies are not deleted without authorization |
+
+Research datasets use immutable **base + partition generations**. A generation
+manifest binds its parent generation (if any), ordered added/removed partition
+hashes, schema/provenance, logical row/count/hash summary, and a fully resolved
+generation hash. An experiment binds that immutable generation id. Creating a
+new generation writes only new unique partitions plus compact manifest metadata;
+it must not copy every prior partition into a new dataset directory. Reading a
+generation resolves its complete partition set deterministically and verifies
+every hash. Compaction may publish a new equivalent base manifest, but old
+generation ids and reachability remain valid. Parent-delta depth is capped at
+32. Creating generation 33 publishes a new base manifest containing the fully
+resolved ordered partition-hash list (metadata only, no payload copy), then
+starts a new delta chain. Resolution is therefore O(partition hashes + at most
+32 delta manifests), never O(all historical generations).
+
+Physical placement has three explicit tiers:
+
+1. **hot** — retained online runs and recent active research generations on the
+   local runtime filesystem;
+2. **warm** — older local canonical gzip blobs still reachable by permanent
+   manifests, with no duplicate CSV/base64/run-directory copy;
+3. **cold candidate** — old, unique, large blobs selected by a read-only plan
+   for a future content-addressed archive backend. No backend or local eviction
+   is activated in this contract.
+
+A future cold tier must preserve the same hash address, encryption/access
+boundary, manifest reachability, and restore verification. Activation requires
+an explicit reviewed backend, cost and restore-SLA contract. Copy-and-verify and
+evict-local are two separate operations; local eviction or deletion still needs
+explicit user authorization. Strategy Lab may restore through the canonical
+reader, but a missing/unverified cold object is `data_unavailable`, never a
+partial silent replay.
+
+The storage status artifact reports at least: logical referenced bytes, unique
+physical bytes, deduplication ratio, bytes by class/tier/market, orphan bytes,
+new unique bytes per month, trailing-three-month growth, 90-day forecast, root
+and generation counts, largest new unique partitions, and restore/integrity
+status. It is read-only and payload-free. It raises:
+
+- **warning** when forecast free space after 90 days is below
+  `max(10% of filesystem capacity, 20 GiB)`, or monthly new-unique-byte growth
+  exceeds twice the trailing-three-month median for two consecutive months;
+- **critical** when current free space is below
+  `max(5% of filesystem capacity, 10 GiB)`, a protected object is missing or
+  corrupt, or a generation cannot be resolved.
+
+Warnings and critical status create an operator decision point and a
+deterministic tiering/cleanup preview; they never automatically remove a root,
+move data off-host, delete a blob, or change Strategy Lab eligibility.
+
+For the Phase 1 payload-free collector, `integrity` is split into manifest
+parseability, declared-reference presence/size, and content verification.
+Manifest-declared hashes may be used for logical dedup accounting, but content
+is `not_verified` unless a separately executed verifier receipt is present;
+the collector never refreshes that receipt or claims that current bytes match
+it. Unmanifested bytes remain unknown-unique. Monthly growth and the 90-day
+forecast are derived only from two or more compatible timestamped baseline
+reports for the same resolved runtime root, never from file mtime alone. Missing
+history produces `insufficient_history`, not zero growth.
+
+## 8. Strategy Lab and replay contract
+
+The optimization must not remove either class of research input:
+
+- exact sealed run input/output: account positions, cash/headroom, candidate facts, selected/rejected results, source status, and blob hashes;
+- canonical trade events and closed outcome facts required to evaluate a strategy.
+
+The compact snapshot is sufficient to replay what the scanner saw and produced at that run. It intentionally does not explain why a user held three versus five contracts before the run; that history remains in `trade_events` and position projection. Strategy Lab may join sealed run facts, candidate/mark/outcome manifests, and ledger-derived closed outcomes offline. It remains advisory and cannot write operational authorities.
+
+Old run directories and lifecycle rows remain readable during the migration. New manifests must not depend on a mutable `latest` pointer for historical replay.
+
+Historical replay resolves the bound research generation and content hashes,
+not a physical hot/warm/cold path. Consequently deduplication, partition reuse,
+or an explicitly approved cold restore does not change experiment inputs.
+Reconstructible CSV/base64/report views are adapters, not independent evidence.
+
+## 9. Time and space complexity contract
+
+Let:
+
+- `E` = total trade events;
+- `L_a` = current lots for one account;
+- `N_c` = provider-attempt audit rows for one lifecycle case;
+- `S_c` = semantic spans for one lifecycle case;
+- `R` = canonical receipt bytes;
+- `B` = new immutable scan payload bytes;
+- `U` = unique content bytes across retained roots.
+- `K` = retained verified position checkpoints, fixed at at most 3 after activation;
+- `T` = trade-event suffix after the chosen verified checkpoint;
+- `P_g` = new unique research partitions added by one dataset generation.
+
+| Operation | Required complexity | Explicitly forbidden work |
+|---|---|---|
+| duplicate lifecycle attempt | O(R) hash/compress plus O(1) indexed SQLite rows; independent of `N_c` | listing/revalidating lifecycle history |
+| audit-chain verification | O(`N_c`) offline only | running in tick or ordinary quality refresh |
+| current position read | O(`L_a`) rows and hash | reading/projecting `E`; reading other accounts |
+| current decision read | O(`L_a` + current compact decision bytes for account) | listing lifecycle/assigned-stock history or recomputing overlay/combo |
+| trade writer | O(`E`) full replay is temporarily accepted because writes are low-frequency | a second replay after commit |
+| checkpoint trade writer, only after activation | O(`T` + changed lots) with bounded checkpoint decode; worst-case correctness fallback O(`E`) | using a checkpoint after an unproven back-reference/reorder/prefix mutation |
+| normal current-decision publish | O(current account state + changed facts) | listing lifetime lifecycle/evidence/assigned-stock history |
+| ordinary quality | O(accounts + compact current decision state) | full trade replay/history listing or overlay/combo recomputation |
+| runtime snapshot | O(current account state + chosen run facts) | embedding full histories or base64 payloads |
+| blob publish | O(B) only for a new hash; O(1) lookup for an existing hash | rewriting one copy per account/run |
+| blob GC | O(manifests + references + blobs), scheduled/manual | GC on every tick |
+| new research generation | O(new manifest + `P_g` unique bytes) | copying all parent-generation payloads |
+
+Steady-state lifecycle space is:
+
+```text
+existing admitted evidence
++ O(number of provider attempts * compact digest row)
++ O(number of semantic spans * one optional final receipt)
+```
+
+It must not be O(number of provider attempts * full receipt). Scan artifact space is O(U + manifest metadata), not O(runs * repeated payload bytes).
+
+If checkpoint projection is activated, its additional steady-state space is
+O(K × resumable current state) with `K <= 3`. Research space is O(unique
+partition/blob bytes + generation/root manifests), not O(generations × full
+dataset bytes). Permanent logical roots may still cause unique physical bytes
+to grow; section 7.4 therefore makes growth and capacity explicit rather than
+claiming a finite bound that the evidence contract cannot provide.
+
+Canonical JSON replaces persisted duplicate formats; it is not a mandate to materialize a second in-memory copy everywhere. Large-payload writers/readers must stream file hash/compression/decompression where practical. Compatibility CSV bytes or a pandas frame may be materialized on demand for one consumer, but raw JSON bytes, base64 text, decoded bytes, CSV bytes, and a DataFrame must not all be retained concurrently beyond the narrow adapter call. Shadow comparison hashes each stream incrementally, retains only bounded mismatch samples, and never keeps canonical and legacy full payload graphs resident together. Peak-allocation and transition-footprint gates below include this adapter behavior.
+
+## 10. Reproducible performance measurement contract
+
+### 10.1 Harness and fixtures
+
+Implementation adds one repository-local benchmark harness with no runtime dependency. Its checked-in manifest records schema version, Python version, SQLite version, platform, fixture seed, row counts, uncompressed payload-size distribution, compression-ratio distribution, entropy/compressibility class, Git SHA, and whether the run is process-cold or warm. Space budgets use uncompressed bytes and actual `db + wal + shm` bytes as their primary measures; compressed-byte results are reported separately and cannot make a highly compressible synthetic fixture appear representative.
+
+The deterministic `growth_10x` suite has three orthogonal axes so history
+independence cannot hide poor scaling in legitimate current state or account
+fanout:
+
+- `current_scale`: dimensions come from a read-only metadata baseline (counts,
+  uncompressed byte sizes, compression ratios, and categorical field/value
+  distributions only; no production payload copied). It contains deterministic
+  low-, median-, and high-entropy payload classes matching the observed
+  distribution rather than one repeated filler string.
+- `history_10x`: ten times lifetime cardinality and uncompressed byte volume,
+  with floors of 100,000 lifecycle attempts and 10,000 trade events. The trade
+  fixture has two reported subcases: `fixed_output` uses valid read-only events
+  so projected lot/view/allocation counts stay fixed and isolates event-history
+  cost; `retained_closed_lots` uses deterministic open/close pairs and exposes
+  the current canonical behavior in which closed lots and allocations remain
+  projected. Both preserve the same deterministic payload compressibility mix,
+  and their results are never collapsed into one unexplained number.
+- `current_state_10x`: ten times current lots, operational lifecycle cases,
+  live combo groups, and current assigned-stock facts while lifetime/current
+  ratios remain fixed.
+- `account_fanout`: `max(10, 5 × baseline account count)` accounts with fixed
+  per-account current state; it isolates the global-generation publication
+  cost.
+
+Each timing scenario uses 5 warm-ups and 30 measured repetitions. Process-cold means a fresh process and fresh temporary DB copy; it does not claim that the operating-system page cache was flushed. Report median and p95 wall time, CPU time, Python peak allocation, peak RSS when the platform exposes it, SQL statement/row counts, and disk bytes. Absolute timing gates run only on the recorded reference host/profile; CI on other hardware enforces correctness, call counts, query plans, allocation/space bounds, and reports timing without comparing incomparable hosts.
+
+Timing runs do not enable `cProfile` or `tracemalloc`. Separate diagnostic runs collect top cumulative CPU functions and top allocation sites, so instrumentation overhead cannot make a threshold pass or fail. `time.perf_counter_ns()` and `time.process_time_ns()` are the portable timing authorities; no benchmark plugin is required.
+
+SQLite steady-state size is measured on a temporary fixture after `wal_checkpoint(TRUNCATE)`; a copied temporary DB may be vacuumed only for normalized comparison. Peak `db + wal + shm` bytes are also reported separately so moving-last-receipt churn cannot hide in WAL.
+
+The moving-last-receipt benchmark runs at 64 KiB and at the read-only baseline p99 receipt size. Its persistence stopwatch begins before canonical hash/compression and ends after the bounded post-commit orphan sweep. Peak WAL growth per duplicate observation after steady-state auto-checkpointing must be ≤ `max(1 MiB, 4 × R)`; across 1,000 observations, peak `db + wal + shm` growth above retained compact rows and the one live receipt must be ≤ `max(64 MiB, 8 × R)`, and it must return to the steady-state envelope after `wal_checkpoint(TRUNCATE)`. If the existing SQLite auto-checkpoint policy cannot meet that bound, Phase 2 must add a reviewed connection-level checkpoint/journal-size policy; it may not checkpoint on every attempt.
+
+### 10.2 Pass/fail budgets
+
+| Scenario | Required budget |
+|---|---|
+| duplicate observation with 100,000 prior audit rows, 64 KiB canonical receipt | p95 persistence wall ≤ 25 ms; incremental compact DB ≤ 224 bytes per attempt averaged over 100,000 rows; Python peak allocation ≤ max(8 MiB, 3 × R); only one optional last-receipt blob remains live for the span; repeated `invocation_id` adds zero bytes/rows; WAL obeys the envelope above |
+| position generation tracking overhead on a normal trade write | p95 added wall/CPU ≤ max(10 ms, 10% of the baseline writer); no extra full replay |
+| deterministic full replay and diff publication, `history_10x` (10,000 events floor) | p95 wall ≤ 2 s and p95 CPU ≤ 1.5 s on the recorded reference host; SQLite changed-row count ≤ added + changed + removed lots plus head rows; no global lot-table delete/reinsert; failure blocks Phase 3A and requires a new checkpoint/delta planreview |
+| conditional checkpoint/tail append after focused approval | current lots/views/public records/publishability and canonical fingerprints are equivalent to full replay, diagnostic count/hash summary matches, and complete historical allocation/diagnostic APIs stay on full replay; p95 wall and CPU improve by at least 50% versus failing full replay and are each ≤ 500 ms when tail ≤ 1% of event history; peak allocation ≤ max(64 MiB, 2 × checkpoint bytes); retained checkpoints ≤ 3 and checkpoint bytes ≤ 3 × resumable-current-state bytes plus 10% metadata; no-prefix-mutation fixture reads only checkpoint + tail and performs zero full-prefix hash/scan calls |
+| conditional checkpoint invalidation (`void`/repair/backdate/update/delete/schema/prefix mismatch) | correct earlier-checkpoint or full-replay output is exactly equivalent; zero unsafe-tail publications; invalidation lookup p95 ≤ 50 ms before replay; mismatch marks checkpoint path untrusted |
+| current-decision publication after a decision-bearing write with `history_10x` and fixed current state | p95 added wall/CPU ≤ max(25 ms, 15% of the baseline writer); one account JSON row rewritten for account-local changes, all rows only for a global event-generation change; duplicate observations cause zero projection writes; lifetime history reader call counts are zero |
+| current-decision publication after global generation change, `account_fanout` | p95 wall ≤ 250 ms and CPU ≤ 200 ms; peak allocation ≤ 64 MiB; projection/head writes ≤ account count plus changed lot/head rows; lifetime-history reader calls are zero; failure requires a per-account partition/checkpoint planreview |
+| trusted current-position read, current scale | p95 wall ≤ 50 ms and Python peak allocation ≤ 16 MiB per account |
+| trusted current-position read, `current_state_10x` | p95 wall ≤ 200 ms; SQL plan uses the account index; trade-event reader call count is zero |
+| generation mismatch read | p95 wall ≤ 50 ms; zero writes and zero replay calls; lot mismatch blocks only its account, while global source mismatch explicitly blocks all heads |
+| trusted current-decision read, `history_10x` with fixed current state | p95 wall ≤ 200 ms and peak allocation ≤ 32 MiB; event/evidence/allocation/source-consumption/assigned-stock history readers and overlay/combo recomputation call counts are zero |
+| trusted current-decision read, `current_state_10x` | p95 wall ≤ 500 ms; decision JSON < 1 MiB per account; peak allocation ≤ 64 MiB; failure returns Phase 3B to planreview for a measured normalized projection rather than silently raising the bound |
+| ordinary control-plane quality, no external refresh | p95 wall < 10 s and CPU ≤ 25% of the current baseline; event/evidence/allocation/source-consumption/assigned-stock history reader and overlay/combo recomputation call counts are zero |
+| compact runtime snapshot | uncompressed canonical JSON < 1 MiB per account; p95 build ≤ 250 ms after source sections are supplied; Python peak allocation ≤ 32 MiB |
+| ordinary run directory after blob cutover | < 30 MiB of per-run physical bytes, excluding shared blob targets; no inline base64 copy |
+| canonical required-data blob write/read at baseline p99 payload | p95 wall no slower than legacy by >10%; Python peak allocation ≤ max(32 MiB, 2 × uncompressed payload); persisted run+shared bytes no greater than one canonical compressed payload plus manifests |
+| dual-output/shadow-compare transition at baseline p99 payload | peak Python allocation ≤ max(48 MiB, 2.5 × uncompressed payload); peak temporary + retained transition bytes ≤ two encoded representations plus manifests; comparator uses streaming hashes and retains at most 10 bounded mismatch samples |
+| research generation append with unchanged parent plus one new partition | physical growth ≤ new unique compressed partition bytes + 64 KiB manifest/index overhead; parent partitions are hard/hash references, not copies; generation resolution reproduces the full logical hash |
+| research generation resolution, 10,000 partition hashes and maximum delta depth | p95 wall ≤ 2 s; peak allocation ≤ 64 MiB; reads at most 32 delta manifests plus one base; zero partition payload reads until a consumer requests them |
+| research storage status | p95 wall ≤ 5 s on `history_10x`; peak allocation ≤ 64 MiB; reads metadata/manifests/filesystem sizes only, never payload contents; forecasts and thresholds are deterministic |
+
+Absolute thresholds and “no forbidden call” checks are both mandatory. Faster hardware cannot excuse an O(history) hot path. Any threshold adjustment requires a new baseline artifact and plan amendment, not a silent test change.
+
+## 11. Phase gates and implementation order
+
+### Phase 1 — contract, inventory, and baseline
+
+- Freeze this document through planreview.
+- Record read-only metadata baselines and deterministic synthetic fixture manifests.
+- Complete writer/reader/CSV/base64/root-manifest inventories.
+- Produce benchmark baseline JSON and profiles.
+- Produce a read-only research-storage inventory and capacity status artifact:
+  logical versus unique physical bytes, dedup ratio, growth history, 90-day
+  forecast, and candidate hot/warm/cold classification. No file moves/deletes.
+- No schema or production data change.
+
+### Phase 2 — lifecycle stop-growth and audit proof
+
+- Extend existing semantic admission with the compact sidecar transaction.
+- Keep admitted evidence and all existing foreign keys unchanged.
+- Shadow-verify counts, ordinals, chains, first/last receipts, and crash recovery.
+- Do not compact history.
+
+### Phase 3A — current position generation
+
+- Add normalized account columns and per-account heads additively.
+- Cover every mutation row in the matrix with transaction and direct-mutation tests.
+- Replace global lot-table delete/reinsert with diff publication.
+- Keep write-time deterministic full replay only if the `history_10x` writer gate passes; cut the current-position reader only after shadow comparison.
+- If that gate fails, stop Phase 3A and run a focused planreview of section 5.6;
+  checkpoint/tail projection is not implicitly authorized by this amendment.
+- Scan mismatch remains read-only and fail-closed.
+
+### Phase 3B — current decision projection
+
+- Add one per-account source-generation row (dirty is derived from source vs
+  built generation), narrow invalidation-only triggers,
+  and the per-account current decision projection.
+- Coalesce all affected accounts and publish at most once per account at the
+  transaction boundary; triggers never build projections.
+- Shadow-compare every decision-bearing fact with the legacy snapshot.
+- Dual-publish and inventory the lifecycle-quality granularity change; do not retire detailed ordinary-quality output yet.
+- Complete 3B independently of the Phase 3A current-position reader cutover; Phase 4 consumes both only after both heads are trusted.
+
+### Phase 4 — compact runtime snapshot
+
+- Emit independent source sections and integrity-only top-level seal.
+- Dual-output with the current snapshot and compare every decision-bearing field.
+
+### Phase 5 — quality hot-path cutover
+
+- Ordinary quality reads heads/current rows only.
+- Full replay moves to an explicit scheduled/manual integrity job with its own status artifact.
+
+### Phase 6 — shared scan blob and consumer gate
+
+- Implement blob protocol, root manifests, dry-run GC, dual readers, telemetry, and end-to-end replay tests.
+- Stop default CSV/base64 only after the seven-step gate in section 7.3.
+
+### Phase 7 — research generation and storage-tier optimization
+
+- Optimize research state only after the runtime authorities are stable.
+- Publish immutable base + partition generations and reuse content hashes; do
+  not copy parent datasets and do not join research writes to ledger transactions.
+- Add the read-only capacity/status surface and deterministic cold-candidate
+  preview. A cold backend, data movement, local eviction, or deletion remains a
+  separately reviewed and explicitly authorized follow-up.
+
+### Phase 8 — historical cleanup preview only
+
+- Require at least 14 eligible market days of stable new-path evidence, per-case/account reconciliation, backup proof, and a space forecast.
+- Generate a deterministic deletion/compaction preview.
+- Actual deletion requires a new explicit user authorization.
+
+## 12. Migration, mixed-version, and rollback invariants
+
+- All schema changes before Phase 8 are additive.
+- Old binaries may ignore sidecar/head tables without invalidating admitted evidence or trade history.
+- New readers fall back to the legacy full path only when the new schema/head is absent during the declared migration window; once a head exists but mismatches, they fail closed and never disguise corruption with fallback replay.
+- A feature can be rolled back to legacy reads without removing new tables or rewriting old rows.
+- Normalized account backfill is previewed and reconciled before writer cutover.
+- A failed writer transaction rolls back event, lot, evidence, audit, span, and generation changes within its SQLite boundary.
+- Operational retry state in the separate inbox database is allowed to lag the ledger audit after a crash; it is reconciled from the ledger head and never overwrites audit history.
+- Filesystem blob publication and manifest publication are not presented as one transaction; blob-first ordering plus grace-period mark-and-sweep is the recovery contract.
+- Checkpoints and decision projections are rebuildable caches. A missing,
+  mismatched, or unverified cache never replaces event/evidence authority and
+  causes fail-closed or canonical full-replay recovery according to its gate.
+- Research generation ids and content hashes remain stable across physical
+  tiering; a path move alone cannot change an experiment's logical input.
+
+## 13. Required test matrix
+
+At minimum, implementation tests must cover:
+
+- identical observation repeated N times: one admitted evidence row, N compact audits, one span, bounded full receipts;
+- byte-different but semantic-identical observations: same as above, with last receipt moving atomically;
+- A → B → A semantic sequence: three spans and three admitted evidence states;
+- provider failure between equal observations: audit ordinal continuity, no false evidence state, explicit gap count;
+- ledger commit followed by inbox completion failure: same `invocation_id` is idempotent and control state reconciles without a duplicate ordinal;
+- expired lease/process restart before reconciliation: no new provider call occurs until the prior durable invocation id is classified as committed or safely retryable;
+- semantic schema upgrade: forced new span;
+- crash injection before/after evidence, audit, blob ref, head, lots, and manifest publication;
+- idempotent event, append correction, controlled update, delete repair, account move, zero-lot account, and direct lot mutation;
+- two accounts with one lot-head mismatch: only that account fails closed; a global source mismatch explicitly blocks both;
+- decision binding freshness: one account-local lifecycle/combo/assigned-stock revision mismatch blocks only that account; an unpublished global event generation blocks every account; neither path falls back or writes;
+- same-transaction lot/decision publication captures the final lot head, never the pre-diff generation/fingerprint;
+- multiple decision-bearing mutations in one transaction mark affected
+  accounts but publish exactly one decision row per account; trigger bodies
+  perform no projection/replay work;
+- deadline classification changes across an injected `now` boundary without a database mutation;
+- hot-reader spies that fail if full event/evidence readers or projector are called;
+- fixed current facts over 10× lifecycle/assigned-stock history: compact decision read time, rows, and allocations remain bounded and no overlay/combo recomputation occurs;
+- canonical/legacy receipt equivalence and streaming-hash Shadow Replay build/mark/settle equivalence without simultaneous full payload graphs;
+- lifecycle-quality aggregate/detail dual-output equivalence and legacy-consumer telemetry;
+- retained-old-run, latest-200, research-root, orphan, corrupt-blob, and concurrent-same-hash GC cases;
+- two spans sharing one last-receipt hash: replacing one keeps the blob; replacing the final reference permits bounded cleanup;
+- duplicate lifecycle attempt leaves every decision-input revision and projection row unchanged;
+- checkpoint append-safe tail is identical to full replay for current lots,
+  risk views, public records, publishability, fingerprints, and diagnostic
+  count/hash summary; complete allocation/diagnostic-history APIs remain full
+  replay and checkpoint storage stays bounded;
+- `void`/repair targeting before a checkpoint, backdated append, controlled
+  prefix update/delete, schema change, and prefix corruption choose an earlier
+  safe checkpoint or full replay and never unsafe tail replay;
+- checkpoint verifier mismatch disables the checkpoint path and preserves
+  canonical full-replay recovery;
+- research generation append reuses all unchanged parent partition hashes and
+  remains exactly replayable after path-independent restore;
+- storage warning/critical thresholds produce only status/preview and perform
+  zero file movement, eviction, root removal, or deletion;
+- benchmark threshold and complexity-call-count assertions on `current_scale`
+  and all three `growth_10x` axes.
+
+## 14. Explicitly settled review questions
+
+1. Settlement semantic fields remain owned by the versioned semantic projector already used by admission. Any schema version change opens a new span.
+2. Position source generation is global because the projector/event graph is global; lot generations and trusted heads are per account and backed by normalized account columns. Lifecycle revisions remain per case.
+3. Scan mismatch never repairs. Recovery is explicit or separately scheduled and remains outside the tick budget.
+4. Every actual provider attempt gets one compact ordered audit row. This is the minimum needed for verifiable continuity; only storing a count is rejected.
+5. Runtime snapshot v1 introduces no cross-source simultaneity gate. It records skew and applies existing per-source freshness only.
+6. Blob liveness comes from retained run, research, replay/outcome, daily, and manual-pin manifests using mark-and-sweep.
+7. Legacy reads are measured by payload-free counters and must be zero for 14 eligible market days before old output stops. Scheduled market-open days remain in the denominator when upstream data is missing.
+8. Full replay remains the default until its measured gate fails; checkpoint
+   activation then requires a focused planreview and exact full-replay parity.
+9. Permanent research evidence is logically retained through immutable
+   generation/root manifests and content hashes. Physical tiering is
+   path-independent, and alerts never authorize movement or deletion.
+
+No unresolved decision in this document blocks Phase 2 or Phase 3B
+implementation. Phase 3A may implement its full-replay/diff path when the
+existing gate passes; if it fails, checkpoint activation is deliberately
+blocked on focused planreview. Later business choices—such as a future
+cross-source skew threshold, a concrete cold-storage backend, or actual local
+eviction/deletion—require their own reviewed contract and authorization when
+they enter scope.

--- a/docs/reviews/code-review-20260813-133609.md
+++ b/docs/reviews/code-review-20260813-133609.md
@@ -1,0 +1,111 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `perf/data-storage-runtime-projection-p1`, Slice 1 working tree
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Output file: `docs/reviews/code-review-20260813-133609.md`
+- Included scope: `research storage-baseline` CLI dispatch; source-inventory
+  rules and token discovery; stable-copy SQLite aggregate queries; bounded
+  runtime traversal; manifest metadata/reference accounting; growth/forecast;
+  capacity thresholds; external atomic output; Slice 1 tests and operator docs
+- Excluded scope: Slice 2 synthetic benchmark harness; Phase 2+ schema or
+  projection changes; live production collection; payload content verification
+- Parallel review coverage: 无；the Slice 1 call chain was reviewed end to end
+
+## Findings
+
+### DR-S1-01-未修复-高-generic manifest walker assigns sibling hash and size fields to the wrong path
+
+- **入口/函数**: `collect_storage_runtime_baseline()` ->
+  `_collect_research_storage()` -> `_extract_manifest_references()` ->
+  `_reference_from_mapping()`
+- **文件(行号)**: `src/application/research/storage_baseline.py:1001-1110`;
+  real producer shape in `src/application/shadow_replay/combo_variants.py:500-512`
+- **输入场景**: a current Shadow Replay Combo manifest contains the existing
+  `combo_pair_facet.files` mapping (`filename -> absolute path`) and the sibling
+  `combo_pair_facet.file_sha256` mapping (`filename -> digest`).
+- **实际分支**: the parent `combo_pair_facet` object is visited as one generic
+  mapping. `_first_key_value(..., _REFERENCE_PATH_KEYS)` does not recognize the
+  nested `files` map, while `_first_key_value(..., _REFERENCE_HASH_KEYS)` does
+  not recognize the nested `file_sha256` map. Recursing into `files` yields
+  string children with no reference; recursing into `file_sha256` does the
+  same. No declared protected objects are created from this valid manifest.
+- **预期行为**: every versioned manifest shape currently emitted by the
+  repository should resolve its file paths, declared sizes, and hashes by the
+  same logical filename without opening payload bodies.
+- **实际行为**: valid protected Combo files are omitted from
+  `logical_referenced_bytes`, `unique_declared_bytes`, presence/size status, and
+  missing-object critical detection. They instead fall into unmanifested /
+  unknown-unique accounting, so the report can silently understate protected
+  logical roots and deduplication.
+- **直接证据**: the collector only recognizes scalar path/hash/size keys in one
+  mapping or a keyed mapping whose child itself contains hash/size fields. The
+  current Combo producer writes path and digest in two parallel mappings. No
+  test covers this producer contract.
+- **影响**: the primary Phase 1 storage facts are wrong for an existing
+  Strategy Lab artifact family; later capacity and migration decisions could
+  treat protected replay inputs as unclassified bytes.
+- **建议改法和验证点**: replace loose recursive inference with small adapters
+  for the repository's versioned manifest schemas. At minimum, join sibling
+  `files` / `file_sha256` maps by filename and keep a clearly reported
+  `unsupported_manifest_schema` bucket for unknown shapes. Add regression tests
+  using actual Shadow Replay base, integrity, Combo facet, required-data, and
+  candidate-manifest shapes.
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-S1-02-未修复-高-research archive inventory paths are resolved against the manifest directory instead of each archived run
+
+- **入口/函数**: `collect_storage_runtime_baseline()` ->
+  `_collect_research_storage()` -> `_resolve_manifest_reference()`
+- **文件(行号)**: `src/application/research/storage_baseline.py:1127-1163`;
+  archive producer in `src/application/research/archive.py:377-431,1020-1060`
+- **输入场景**: the runtime contains
+  `output_shared/research/remote_archive/<remote>/manifests/inventory.latest.json`.
+  Each `runs[]` item contains a `file_manifest` whose `path` values are relative
+  to that run directory, not relative to `manifests/` or the runtime root.
+- **实际分支**: `_resolve_manifest_reference()` tries the manifest directory,
+  the runtime root, and top-level `*_root_relpath` values. Archive inventory has
+  `archive_root` as an absolute field (not `archive_root_relpath`) and the run id
+  is contextual. A relative item such as `state/tick_metrics.json` therefore
+  resolves to the nonexistent
+  `.../manifests/state/tick_metrics.json`, is returned as the first valid
+  in-root candidate, and becomes `missing`.
+- **预期行为**: current archive verification manifests should resolve each
+  protected file under `archive_root/output_runs/<run_id>/...`; a previously
+  verified archive must not become a false current critical merely because its
+  reference base was ignored.
+- **实际行为**: every archive `file_manifest` entry can be reported missing,
+  making `research_storage.status=data_unavailable` and
+  `thresholds.status=critical` on a healthy archive.
+- **直接证据**: the archive producer stores `run_id` beside `file_manifest` and
+  creates each manifest path with `path.relative_to(run_dir)`. The collector
+  does not pass mapping ancestors or run identity into path resolution and has
+  no archive fixture test.
+- **影响**: false critical capacity/integrity status on a canonical offline
+  research root; operators cannot distinguish real protected-object loss from
+  parser incompatibility.
+- **建议改法和验证点**: add a versioned `research_archive.v2` adapter that binds
+  `runs[].file_manifest[].path` to
+  `<archive_root>/output_runs/<run_id>` and reports unsupported/invalid entries
+  separately. Test a real-shaped `inventory.latest.json` with present, missing,
+  and size-mismatched files.
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+## Open Questions
+
+- None. Both failing shapes are current producer contracts in the reviewed
+  repository.
+
+## Residual Risk
+
+- The stable SQLite copy uses the reviewed before/after stat-tuple coherence
+  contract, not an atomic SQLite snapshot; a pathological same-size/same-mtime
+  writer remains outside Phase 1's proof boundary.
+- Manifest content is intentionally not hashed by this command. Presence and
+  declared size cannot detect same-size tampering.
+- The full source scan is bounded by an explicit vocabulary; novel APIs remain
+  a future inventory-owner update risk.

--- a/docs/reviews/code-review-20260813-134318.md
+++ b/docs/reviews/code-review-20260813-134318.md
@@ -1,0 +1,50 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `perf/data-storage-runtime-projection-p1`, Slice 1 after fixes
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Output file: `docs/reviews/code-review-20260813-134318.md`
+- Included scope: `research storage-baseline` CLI dispatch; source-inventory
+  rules and token discovery; stable-copy SQLite aggregate queries; bounded
+  runtime traversal; versioned/current manifest metadata/reference accounting;
+  growth/forecast; capacity thresholds; external atomic output; Slice 1 tests
+  and operator docs
+- Excluded scope: Slice 2 synthetic benchmark harness; Phase 2+ schema or
+  projection changes; live production collection; payload content verification
+- Parallel review coverage: 无；the Slice 1 call chain and both findings from
+  `code-review-20260813-133609.md` were reviewed end to end
+
+## Findings
+
+未发现实质性问题。
+
+The earlier findings are closed:
+
+- `DR-S1-01` is fixed by joining the current Shadow Replay sibling `files` and
+  `file_sha256` maps by logical filename. The regression fixture proves the
+  protected object is no longer counted as unmanifested; absent declared size
+  remains explicitly unknown rather than fabricated.
+- `DR-S1-02` is fixed by a `research_archive.v2` verification adapter that binds
+  each `runs[].file_manifest[].path` to
+  `<archive_root>/output_runs/<run_id>`. Present and missing-object regression
+  fixtures prove normal and critical behavior.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- The stable SQLite copy uses the reviewed before/after stat-tuple coherence
+  contract, not an atomic SQLite snapshot; a pathological same-size/same-mtime
+  writer remains outside Phase 1's proof boundary.
+- Manifest content is intentionally not hashed by this command. Presence and
+  declared size cannot detect same-size tampering.
+- Manifest schemas without a declared file path and outside the current
+  versioned/generic vocabulary remain unknown/unmanifested rather than
+  verified. Novel contracts require an inventory-owner update.
+- Runtime traversal retains bounded aggregates plus Top-N and
+  research/protected metadata, but manifest/reference accounting remains O(the
+  number of research/protected files) by design.

--- a/docs/reviews/code-review-20260813-152057.md
+++ b/docs/reviews/code-review-20260813-152057.md
@@ -1,0 +1,27 @@
+# Code Review
+
+## Findings
+
+### 1-未修复-高-父进程只校验 fixture 身份与 parity，缺失或畸形计时可被零值兜底判为通过
+
+- **入口/函数**: `run_data_storage_projection_benchmark()` -> `_validate_worker_artifacts()` -> `_build_gate_decision()`
+- **文件(行号)**: `src/application/research/performance_baseline.py:1444-1537`
+- **输入场景**: timing worker 返回正确 schema、scenario key、fixture hash 和 `parity.exact=true`，但 `existing_full_replay_writer.wall_time_ns` 或 `cpu_time_ns` 缺失、不是完整统计对象，或没有 30 个样本。该场景也覆盖子进程版本偏移、截断/手工构造 worker artifact，以及未来 worker regression。
+- **实际分支**: `_validate_worker_artifacts()` 不校验 timing 的 warmups/repetitions、样本数或 p95 字段；`_build_gate_decision()` 使用 `int(... or 0)`，把缺失值变成 0。只要 reference fingerprint 匹配且 axis 可评估，两个 subcase 都得到 `pass`。
+- **预期行为**: 只有完整的 5 warmup / 30 repetition 非 profiler timing artifact，且每个 history subcase 的 wall/CPU 统计均包含 30 个合法非负样本和一致 p95，才可进入绝对 pass/fail；任何缺失、畸形或缩减测量都必须 fail closed 为 `not_evaluable` 或直接拒绝发布 artifact。
+- **实际行为**: 一个没有任何 wall/CPU 测量值的 synthetic artifact 在匹配主机上被判成 `pass`。直接复现输出为 `wall_p95_ns=0, cpu_p95_ns=0`，两个 history subcase 和 writer 总状态均为 `pass`。
+- **直接证据**: `_validate_worker_artifacts()` 仅比较 schema、measurement mode、key/hash 和 parity；decision 对缺失 `p95` 使用 `or 0`。本 review 使用两个合法 fixture hash、匹配的 reference fingerprint，以及完全缺失的 writer timing mappings 调用这两函数，稳定复现假通过。
+- **影响**: 该 artifact 是 Phase 3A checkpoint/delta 设计的退出/阻断依据；假通过会把未测量的全量写入路径误标成满足 2 s / 1.5 s 门槛，直接破坏本 slice 最重要的真实性边界。
+- **建议改法和验证点**: 在父进程验证 timing artifact 的 `run_label`、精确 warmup/repetition 计数、每个组件 wall/CPU `unit=ns`、`sample_count`、samples 长度/类型/非负性，以及从 samples 重新计算的 median/p95；decision 只消费验证后的显式整数，绝不把缺失值默认成 0。新增回归测试覆盖缺失 stats、空/29 条 samples、伪造 p95、负值和 smoke label。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- 合成数据的 payload/账户分布不等于生产分布；已由 fixture identity、payload-free baseline 与非生产样本标签约束，分类为 `assigned to later work unit`。
+- 当前 `existing_full_replay_writer` 仍执行全量 lot 表删除/重插；本 slice 只测量并记录，diff publication 属于后续已批准 Phase 3A work unit，分类为 `covered by later approved slice`。
+- 10,000-event smoke 在当前非参考主机上显示 retained-closed-lot case 约 2.65 s wall / 2.64 s CPU；它是非验收、非可比证据，正式判断必须由 5/30 reference run 产生，分类为 `assigned to later work unit`。

--- a/docs/reviews/code-review-20260813-154154.md
+++ b/docs/reviews/code-review-20260813-154154.md
@@ -1,0 +1,63 @@
+# Code Re-review
+
+## Findings
+
+未发现新的实质性问题。
+
+## Finding status
+
+### DR-S2-01 — 已修复
+
+父进程现在在 artifact publication 和 gate decision 前验证：
+
+- timing worker 必须明确关闭 `cProfile` 与 `tracemalloc`；
+- warmup、repetition 和 run label 必须与父进程请求完全一致；
+- projector 与 writer 的 wall/CPU distribution 都必须是 `unit=ns`；
+- `sample_count` 与 samples 长度必须等于请求的 repetition 数；
+- 每个样本必须是非负整数；
+- median、p95、min、max 必须从 samples 重新计算后完全一致。
+
+Gate decision 不再把缺失 timing 默认为 0；绝对 `pass` 只消费已经通过
+上述验证的显式值。即使 reference-host fingerprint 匹配，非 5/30 的
+smoke run 也只会得到 `not_evaluable/non_acceptance_smoke`。
+
+直接复现原 finding 使用完全缺失 wall/CPU mappings，现在在
+`_validate_worker_artifacts()` 稳定返回：
+
+```text
+RuntimeError timing distribution is invalid: projector_only.wall_time_ns
+```
+
+回归测试覆盖缺失 distribution、29 条 samples、伪造 p95、负样本和
+matching-host smoke；最终状态：`已修复`。
+
+## Validation
+
+```text
+19 passed in 5.33s
+All checks passed!  # ruff
+git diff --check    # passed
+```
+
+修复后的 10,000-event matching-host smoke 仍明确返回：
+
+```text
+existing_full_replay_writer.status=not_evaluable
+reason=non_acceptance_smoke
+phase_3a_combined.status=not_ready
+```
+
+## Open Questions
+
+无。
+
+## Residual Risk
+
+- 合成数据的 payload/账户分布不等于生产分布；fixture identity 与
+  payload-free metadata 使证据可重复，但生产分布校准属于后续单独授权的
+  read-only work unit，分类为 `assigned to later work unit`。
+- 全量 lot 删除/重插仍是现状，本 slice 仅测量；diff publication 属于后续
+  已批准 Phase 3A，分类为 `covered by later approved slice`。
+- 当前机器烟测不是正式 reference acceptance；正式 5/30 reference artifact
+  仍需在 aggregate gate 生成，分类为 `covered by later approved slice`（本
+  work unit 的 aggregate validation）。

--- a/docs/reviews/code-review-20260813-160956.md
+++ b/docs/reviews/code-review-20260813-160956.md
@@ -1,0 +1,117 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `perf/data-storage-runtime-projection-p1`
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Output file: `docs/reviews/code-review-20260813-160956.md`
+- Included scope: the complete Phase 1 branch relative to `main`, including the
+  read-only storage baseline, bounded runtime traversal, SQLite aggregate
+  snapshot reads, source inventory, research capacity facts, synthetic fixture
+  construction, projector/writer timing and profiling, reference-host gate,
+  CLI/script entry points, tests, plans, and operator documentation
+- Excluded scope: Phase 2+ schema/runtime implementation, production collection,
+  live payload verification, release, deployment, and runtime mutation
+- Parallel review coverage: 无；the aggregate review followed the Slice 1 and
+  Slice 2 entry points and their evidence/gate paths end to end
+
+## Findings
+
+### DR-AGG-01-未修复-高-account fanout silently substitutes one account for an unknown baseline cardinality
+
+- **入口/函数**: `run_data_storage_projection_benchmark()` ->
+  `_load_baseline_dimensions()` -> `_baseline_account_count()` ->
+  `_build_scenario_specs()`
+- **文件(行号)**: `src/application/research/performance_baseline.py:263,318-330,375-386`;
+  `src/application/research/storage_baseline.py:670-726`;
+  `tests/test_research_performance_baseline.py:474-502`
+- **输入场景**: a valid Slice 1 baseline is collected from a runtime whose
+  `output_accounts` root contains artifacts for three or more accounts. Slice 1
+  reports only the root's recursive file count and byte size, not the number of
+  immediate account directories.
+- **实际分支**: `_baseline_account_count()` sees a non-empty
+  `output_accounts` root and returns `1`. `_build_scenario_specs()` then computes
+  `max(10, 5 × 1)` and marks the resulting ten-account fixture `evaluable`.
+  The regression test explicitly freezes this substitution as expected
+  behavior even when the aggregate row contains three files.
+- **预期行为**: the frozen contract requires `account_fanout = max(10, 5 ×
+  baseline account count)` while retaining fixed per-account state. If the
+  account cardinality is unavailable, the artifact must say so and cannot
+  silently turn a lower bound into an exact baseline fact.
+- **实际行为**: for a baseline with at least three accounts, the runner can
+  measure ten rather than at least fifteen accounts and still label the axis
+  evaluable. This understates work on the exact axis intended to expose global
+  account publication scaling.
+- **直接证据**: Slice 1's `_collect_runtime_storage()` emits only `file_count`
+  and `size_bytes` per root. Slice 2 comments that a non-empty root proves only
+  one account, then returns that lower bound as the exact requested account
+  dimension. The axis-status comparison uses the substituted value, so no
+  later check can detect the under-sized fixture.
+- **影响**: the benchmark can produce a false-complete account-fanout result
+  and understate time, allocation, and write amplification for future Phase 3B
+  decisions.
+- **建议改法和验证点**: make Slice 1 publish a payload-free count of immediate,
+  non-symlink account directories plus an explicit availability/source status;
+  make Slice 2 consume only a positive exact count and otherwise use a labeled
+  safe default. Test 0, 1, 3, symlinked, missing, and legacy baseline cases, and
+  prove three accounts generate a fifteen-account fanout fixture.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### DR-AGG-02-未修复-高-Darwin reference fingerprint can collapse different Apple Silicon hosts to the same generic model
+
+- **入口/函数**: `run_data_storage_projection_benchmark()` -> `_host_profile()`
+  -> `_hardware_model()` -> `_build_gate_decision()`
+- **文件(行号)**: `src/application/research/performance_baseline.py:855-897,1533-1588`
+- **输入场景**: the runner executes on Apple Silicon where
+  `machdep.cpu.brand_string` returns a generic non-empty value such as `arm`,
+  while `hw.model` contains the machine model that differentiates hardware.
+- **实际分支**: `_hardware_model()` queries `machdep.cpu.brand_string` first
+  and returns immediately on any non-empty value, so `hw.model` is never read.
+  On the current review host, `_host_profile()` produced
+  `hardware_model="arm"`. The decision subsequently treats a SHA-256 equality
+  over this incomplete profile as an exact reference-host match.
+- **预期行为**: an absolute p95 wall/CPU pass must require an explicitly matching
+  profile that captures the hardware facts material to timing comparability;
+  a generic architecture label must not stand in for the Darwin hardware
+  model.
+- **实际行为**: two Apple Silicon machines with the same OS/Python/SQLite,
+  memory, logical CPU count, and generic `arm` brand can share a fingerprint
+  despite different hardware generations. A faster non-reference machine can
+  therefore satisfy a reference-host gate.
+- **直接证据**: `_hardware_model()` returns from the first successful key and
+  the current live function output records only `arm`, even though the function
+  lists `hw.model` second. `_build_gate_decision()` relies solely on equality of
+  the resulting fingerprint for comparability.
+- **影响**: the Phase 3A absolute performance decision can be a false pass on
+  hardware that was not actually designated as the reference host.
+- **建议改法和验证点**: collect CPU brand and hardware model as separate host
+  profile fields and bind both into the fingerprint; do not stop after a
+  generic brand succeeds. Add deterministic Darwin tests that return `arm` for
+  the first sysctl and a distinct `hw.model` for the second, and prove changing
+  either field changes the fingerprint.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- The stable SQLite copy proves a bounded before/after stat tuple, not an
+  atomic SQLite snapshot against pathological same-size/same-mtime writes;
+  assigned to a later storage-hardening work unit under the accepted Phase 1
+  boundary.
+- Manifest payload content is intentionally not hashed; same-size tampering
+  remains `not_verified` and is assigned to a separately authorized verifier
+  work unit.
+- Synthetic entropy/account/event mixes remain reproducible approximations,
+  not production payload samples; production-distribution calibration is
+  assigned to a later read-only evidence work unit.
+- The current global delete/reinsert writer remains intentionally measured,
+  not optimized; diff publication is covered by the later approved Phase 3A
+  work unit.
+- Formal 5-warmup/30-repetition reference evidence remains to be produced after
+  the accepted findings are fixed; covered by this aggregate validation gate.

--- a/docs/reviews/code-review-20260813-163436.md
+++ b/docs/reviews/code-review-20260813-163436.md
@@ -1,0 +1,101 @@
+# Code Re-review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `perf/data-storage-runtime-projection-p1`
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Output file: `docs/reviews/code-review-20260813-163436.md`
+- Included scope: the complete Phase 1 branch after fixes for
+  `DR-AGG-01` and `DR-AGG-02`, including the final reference-host acceptance
+  artifacts and aggregate validation results
+- Excluded scope: production collection, Phase 2+ implementation, release,
+  deployment, and runtime mutation
+- Parallel review coverage: 无；both accepted findings and the aggregate entry
+  paths were re-reviewed end to end
+
+## Findings
+
+未发现新的实质性问题。
+
+## Finding status
+
+### DR-AGG-01 — 已修复
+
+Slice 1 now publishes `runtime_storage.account_count` as the count of immediate,
+non-symlink directories under `output_accounts`, with a separate status and
+basis. It does not retain account labels or inspect payloads. Slice 2 consumes
+only a positive exact integer with `status=complete`; missing, empty, legacy,
+symlinked, boolean, fractional, textual, or negative values use a documented
+safe fixture default and mark `account_fanout` not evaluable. A three-account
+baseline now creates the required fifteen-account fixture.
+
+### DR-AGG-02 — 已修复
+
+The host profile now fingerprints separate `cpu_model` and `hardware_model`
+fields. Darwin reads both sysctl facts and uses a bounded
+`system_profiler SPHardwareDataType -json` fallback when sandboxed sysctl is
+unavailable. The reviewed host now resolves to `Apple M4` and `Mac16,10` rather
+than generic `arm`; changing either bound field changes the fingerprint.
+
+## Validation
+
+```text
+158 passed in 9.93s  # final aggregate focused suite
+54 passed in 7.93s   # storage/performance tests after all aggregate fixes
+30 passed in 3.06s   # independent research regression
+All checks passed!   # ruff check
+compileall passed    # domain, src, scripts, tests
+git diff --check     # passed
+```
+
+The checked-in source inventory remains complete: all declared locators and
+classifiers are live, with no unclassified discoveries.
+
+The one formal default 5-warmup/30-repetition reference run completed on:
+
+```text
+cpu_model=Apple M4
+hardware_model=Mac16,10
+host_fingerprint=327f740925923dfe92919e74ae630d072bacc6259298e8e0a57b8060ca056aec
+fixture_set_sha256=e5dd9dfdb012e1cb885ffcd0657f375c3c55296fdd3754484f8644083018ad24
+```
+
+Its writer results are:
+
+```text
+history_10x.fixed_output:
+  p95 wall=356,815,000 ns; p95 CPU=356,724,000 ns; pass
+history_10x.retained_closed_lots:
+  p95 wall=2,848,569,542 ns; p95 CPU=2,739,286,000 ns; fail
+existing_full_replay_writer=fail
+lot_diff_publication=not_implemented
+phase_3a_combined=not_ready
+```
+
+The failure is a valid evidence outcome: 10,000 events with fixed 50-lot output
+pass, while 10,000 open/close events retaining and globally replacing 5,000
+closed lots exceed both frozen limits. No threshold, fixture, or sample count
+was weakened.
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- The current global delete/reinsert writer fails the retained-closed-lot
+  history gate. It is assigned to the separately gated Phase 3A diff-publication
+  work unit; this Phase 1 work unit must not optimize it.
+- The stable SQLite copy's bounded stat-tuple coherence is not an atomic SQLite
+  snapshot; assigned to a later storage-hardening work unit.
+- Manifest same-size content tampering remains intentionally unverified;
+  assigned to a separately authorized verifier work unit.
+- Synthetic distributions remain reproducible approximations rather than live
+  production payload samples; any calibration requires a later read-only
+  evidence work unit.
+- `tracemalloc` peaks are reset per measured component, but reported RSS is the
+  explicitly labeled process high-water mark of one allocation worker. Later
+  scenarios can inherit an earlier larger RSS value, so per-scenario RSS
+  attribution requires a future fresh-process-per-scenario harness change; the
+  current Phase 1 timing decision does not consume RSS.

--- a/docs/reviews/plan-review-20260813-092047.md
+++ b/docs/reviews/plan-review-20260813-092047.md
@@ -1,0 +1,178 @@
+# Plan Review — data-storage-and-runtime-projection.v1
+
+## Reviewed target and scope
+
+- **Target**: 本轮对话中已冻结的 `data-storage-and-runtime-projection.v1` 设计。
+- **Review scope**: 生命周期观察压缩、`trade_events -> position_lots` 当前投影、运行时组合快照、扫描大对象内容寻址、质量检查、Strategy Lab/研究数据兼容、保留策略与迁移顺序。
+- **Evidence scope**: 当前 `main@421591dd` 的本地源代码和测试/契约入口；对话中已经确认的生产容量与耗时基线仅作为输入事实，本轮没有重新操作生产环境。
+- **Excluded**: 代码实现、schema migration、生产数据写入、旧数据删除、服务变更、发布与升级。
+- **Review posture**: code-generation readiness。方向正确不等于可以直接交给 implementation agent；会迫使实现者现场重新设计的关键契约缺口按 finding 处理。
+
+## Goal confirmation
+
+已确认目标是：
+
+1. 扫描和常规质量检查不再反复读取、重放和校验全部交易历史或巨大 JSON。
+2. `trade_events` 保持交易权威源，`position_lots` 保持当前物化投影。
+3. 保留生命周期审计能力以及 Strategy Lab 后续回测所需数据。
+4. 普通 run directory 显著缩小，相同原始内容只物理保存一次。
+5. 新旧路径可对账、可回滚；旧数据先保留，未经再次批准不删除。
+
+## Assumptions tested
+
+| Assumption | Review result | Evidence / reason |
+|---|---|---|
+| 新 span 表可以通过“新旧双读”直接替代旧 evidence 写路径 | 被证伪 | 当前 admission head、source consumption、allocation 都以 `trade_lifecycle_evidence` 为外键；decision snapshot 也要求完整 evidence 列表与接收时间映射。 |
+| position revision 可以作为普通应用字段补上 | 不安全 | 当前事件写入入口与全局 `position_lots` replace 分散；没有投影 revision trigger，应用层漏更会形成静默陈旧投影。 |
+| span 只保存 count、首末 hash 和最终 chain hash即可证明每次检查 | 被证伪 | 没有有序中间 digest，最终 accumulator 无法重算，也无法发现具体缺失的观察。 |
+| 每次扫描发现 revision mismatch 后自动 full replay 是安全自愈 | 缺少依据 | 当前 decision snapshot 和 quality check 的 full replay 正是热路径成本来源；计划没有 replay 锁、时限和扫描预算。 |
+| 一个 seal 可以表达 SQLite 投影与 broker 外部事实的一致性 | 被证伪 | 两类事实无法原子取得；seal 最多证明一个封包未变，不能证明多个来源同一时点。 |
+| 先切 writer、之后再停止 CSV/base64 已足够 | 不完整 | required-data receipt 的 producer/validator 直接依赖 base64，Shadow Replay mark reader 直接扫描 CSV。 |
+| “14 天或最近 200 次”足以定义 blob 回收 | 不完整 | 它只定义 run 保留窗口，没有定义长期 artifact 到 shared blob 的可达关系。当前 run cleanup 的实际语义是保留两者并集。 |
+| SQLite lifecycle blob 与文件系统 scan blob 必须合并成一个 store | 不成立 | 前者属于账本事务边界，后者属于高容量 immutable run artifact；强行统一会增加跨存储耦合。 |
+
+## Special review lenses
+
+- **Goal-bound minimal design**: 总体目标对齐；但扫描内自动 replay、额外后台常驻服务、交易事件 delta projector 都不是当前目标的必要条件。最小路径是把 full replay 留在低频写入/显式 reconcile 边界，扫描只读可信投影。
+- **Architecture boundary**: 交易投影 revision、生命周期 observation revision、外部 broker snapshot 是三个不同代际，必须分别命名和拥有，不能复用一个 revision 概念。
+- **Best practice**: 缺少 blob reachability/GC、span last-receipt 原子替换、跨来源时间偏差、崩溃恢复和 mixed-version 契约。
+- **Optimal solution**: 应扩展现有 settlement semantic admission，把重复观察作为 compact audit sidecar；不应先退休现有 admitted evidence authority。
+- **Overengineering**: 暂无证据要求把低频交易写入改为 per-event delta projector；可继续在写事务中做确定性 full replay，先消除扫描/质量热路径重放。
+- **Overcoupling**: 生命周期压缩与 position projection 是独立权威边界，不应合并成一个 phase；SQLite receipt content store 与文件 scan blob store也不应为了“统一”而合并。
+
+## DeepSeek 顾问意见与主审裁决
+
+DeepSeek V4 Pro 顾问给出的整体结论是 `pass-with-risks`。主审与其一致的部分是：revision 单一所有权、扫描内 replay 超时、last-receipt 孤儿增长、最终 chain hash 不可独立验证、shared blob 可达性、snapshot 时间错位以及 CSV 消费者切换都必须补齐。
+
+主审不接受三项具体延伸：
+
+1. 不把 per-event delta projector 设为前置要求。当前交易写入频率低，在写事务内做确定性 full replay 更简单；本目标首先消除扫描和常规质量热路径的 replay。
+2. 不合并生命周期 Phase 2 与 position projection Phase 3。两者 revision 与失败范围不同，合并会制造不必要的事务和测试耦合。
+3. 不把 SQLite lifecycle receipt store 与文件系统 scan blob store合成一个全局 store，也不强制采用容易漂移的 mutable reference count；各自边界内的显式引用加 mark-and-sweep 更稳妥。
+
+主审最终结论比顾问更严格，为 `fail`：不是方向错误，而是下列两个严重 finding 会让 implementation agent 在权威源和事务协议上重新做架构决策，尚未达到 code-generation-ready。
+
+## Findings
+
+### PR-01-未修复-严重-新 observation 存储与现有 admitted evidence authority 不兼容
+- **位置**: 生命周期证据 A、迁移 F 的“旧数据不迁移/新旧双读/旧表只读”边界。
+- **问题类型**: 架构边界 / 契约缺失 / 不可直接实施 / 过度耦合
+- **当前写法**: 新增 receipt content、observation span、receipt ref 三类表；历史 `trade_lifecycle_evidence` 不迁移，过渡期新旧双读，并倾向把旧表视为只读。
+- **反例/失败场景**: 新业务状态只写新 span/evidence，不再写 `trade_lifecycle_evidence`。现有 settlement admission head、source consumption 或 allocation 仍要引用该 evidence，外键无法成立；若为兼容而同一观察双写新旧两套，旧表继续增长且出现两个事实源。
+- **为什么有问题**: 当前系统已经把 `trade_lifecycle_evidence` 定义为“被 admission 接受的语义 evidence”，重复语义观察会提前返回而不新增 evidence。新设计真正缺少的是对被跳过重复观察的 compact audit，不是第二套 admitted evidence authority。
+- **直接证据**: `src/application/ledger/repository.py:477-600` 定义 evidence 与 admission head 外键；`:606-645` 的 source consumption/allocation 也引用旧 evidence；`src/application/ledger/writer.py:155-275` 已做 settlement semantic admission，并对相同 fingerprint 返回 duplicate；`src/application/ledger/decision_snapshot.py:252-350` 要求完整 evidence rows 与 received-at 映射并重新解析 lifecycle overlay。
+- **影响**: 实施 Agent 必须临场选择破坏外键、双写、改写所有 lifecycle consumer 或继续写旧表；最坏会造成终态分配失败、审计视图漂移或旧表继续膨胀。
+- **建议改法和验证点**: 把现有 `trade_lifecycle_evidence` 明确保留为 admitted semantic evidence authority；“旧数据只读”只指既有行不可改，不代表整张表停止接收新的状态变化 evidence。新增 span/digest 只作为重复观察 audit sidecar，状态变化仍走现有 admission/evidence/FK 路径。repository facade 保持现有 logical evidence contract，另提供 compact observation audit reader。只有将来真正退休旧 authority 时，才单独设计 FK 与 consumer migration。验证：连续相同观察只增长 digest/count，不新增 admitted evidence；状态变化新增 evidence 且 allocation/source-consumption 外键仍成立；legacy rows 和新 span 可同时读取；decision snapshot 语义不变。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 严重
+
+### PR-02-未修复-严重-position revision 所有权、账户隔离和 mismatch 恢复协议未冻结
+- **位置**: 当前投影 B、质量与阻断 E、Phase 3/5。
+- **问题类型**: 架构边界 / 状态机漏洞 / 并发恢复风险 / 不可直接实施
+- **当前写法**: 每账户新增 `source_revision` 与 `projection_head`；写事件、更新 `position_lots`、递增 revision、更新 head 同事务；扫描 mismatch 时每 run 自动 full replay 一次。
+- **反例/失败场景**: 一个事件入口写入 `trade_events` 却漏增 revision，扫描看到 revisions 相等并使用陈旧 lots；或全局 `replace_position_lots()` 重建了所有账户，但只更新当前账户 head；或扫描发现 mismatch 后执行耗时 full replay，重新触发超时，并与另一个 writer 竞争全局 lots。
+- **为什么有问题**: 当前 `trade_events` 只在 JSON 中携带业务字段，`position_lots` 的 replace 是全表 DELETE+INSERT；现有 lifecycle evidence revision trigger 是 case observation invalidation，不是 position projection generation，不能复用。计划未决定 revision 是全局还是账户级、由 DB trigger 还是应用 writer 所有，也未列出全部 projection-affecting mutation。
+- **直接证据**: `src/application/ledger/repository.py:519-587` 的现有 trigger 只维护 lifecycle evidence revision；`:854-903` 的 event upsert 没有 position revision；`:960-994` 全局替换全部 lots；`src/application/ledger/repository.py:3489-3513` 一次 SQLite snapshot 仍读取全部 events/lots；`src/application/ledger/decision_snapshot.py:95-103` 与 `src/application/quality/ledger_checks.py:53-80` 当前都执行 full replay。
+- **影响**: revision 可能提供虚假可信信号，导致错误持仓进入筛选/建议；或者 anomaly 自愈再次占用扫描预算，形成 fail-closed 风暴。
+- **建议改法和验证点**: Phase 1 先冻结 mutation matrix：哪些 `trade_events` 操作改变 position projection，void/repair 是否都是 append-only event，以及每个入口的事务边界。新增独立命名的 position projection generation，不能复用 lifecycle revision；优先由 SQLite trigger 观察 authority table mutation，built head 只能在 lots publish 成功的同一事务推进。明确选用“全局 generation + 账户状态”或“规范化 account 列 + per-account generation”，并写出全局 replace 时所有 head 的推进规则。第一版保留低频写入事务内 full replay，不引入 delta projector；扫描 mismatch 只快速 fail-closed、告警并暴露显式/scheduled reconcile，不在 tick 内自动 replay。验证：逐一覆盖全部 writer；直接 mutation 也会使 generation 失配；replace/head 任一步失败整事务回滚；账户隔离正确；mismatch scan 在固定小预算内退出且不写库。
+- **修复风险（低/中/高）**: 高
+- **严重程度（低/中/高/严重）**: 严重
+
+### PR-03-未修复-高-span 的 last receipt 与 hash-chain 状态机不能同时保证小存储和可验证审计
+- **位置**: 生命周期证据 A、Phase 2、对应验收标准。
+- **问题类型**: 状态机漏洞 / 数据损坏 / 最佳实践偏离 / 测试缺口
+- **当前写法**: span 保留 first/last 完整 receipt；中间连续相同状态只保存 count、起止时间和 receipt hash chain；schema 只列 first/last receipt hash 与一个最终 chain hash。
+- **反例/失败场景**: 同一 open span 每次 poll 的 raw 都不同。新 poll 成为 last 后，旧 last 变成 middle：若旧 blob 不删，unique raw 会持续增长；若直接删，可能删掉其它 span 仍引用的内容。与此同时，只有最终 chain hash 与 count，审计端没有中间输入，无法重算 chain 或定位缺失观察。
+- **为什么有问题**: “最后一次观察”在 span 关闭前是不断移动的状态，不是一条 append-only receipt；可验证的 hash chain 至少需要有序 digest 输入。当前方案没有 admission、引用替换、孤儿清理和 crash recovery 的事务顺序。
+- **直接证据**: 已确认 2,248 条 settlement observations 基本都不是 byte-identical，但约 2,238 次业务状态连续相同；当前 semantic admission 在 `src/application/ledger/writer.py:234-275` 只判断 fingerprint duplicate，尚不记录这些重复 poll 的 compact 证据。
+- **影响**: 实现可能仍保存几乎每条完整 raw，压缩目标落空；或清理过度造成首末 receipt 丢失；“证明持续检查”无法独立验收。
+- **建议改法和验证点**: 在 Phase 1 冻结 observation audit contract：每次 poll 至少追加小型有序 digest（`span_id, ordinal, observed_at, receipt_sha256, previous_chain_sha256, chain_sha256`），count 必须等于 digest 数；raw 先在内存计算 semantic/hash，再在一个 SQLite transaction 内处理 open span。相同状态时原子插入/复用新 last blob、移动 last ref、删除旧 last ref；只有在无任何 ref 时旧 blob 才可回收。状态变化时关闭旧 span并开新 span；semantic schema 升级强制开新 span。无需用 mutable refcount 替代引用表，可通过 FK 引用与 mark-and-sweep 判定 liveness。验证 N 次同状态后 admitted evidence 不增长、digest=N、raw blob 最多为该 span 的首末两份；A→B→A 为三个 span；删任意 digest 会导致 chain 校验失败；每个 crash 注入点均可重入。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-04-未修复-高-shared scan blob 没有从长期 artifact 出发的可达性与 GC 契约
+- **位置**: 扫描大对象 D、Phase 6、在线 14 天/最近 200 次与永久保留策略。
+- **问题类型**: 数据丢失 / 并发恢复风险 / 契约缺失 / 最佳实践偏离
+- **当前写法**: raw canonical JSON 以 SHA-256 路径存一次，manifest 后写；ordinary raw 有在线窗口，候选/建议/研究/每日完整链长期保留。
+- **反例/失败场景**: 第 15 天删除普通 run manifest 或按年龄 sweep blob，但永久保存的 Strategy Lab candidate/outcome 仍引用该 raw；或者 crash 发生在 blob rename 后、manifest publish 前，留下无人认领的 blob；多个 writer 同时首次写同一 hash。
+- **为什么有问题**: 内容寻址只解决重复，不自动解决 liveness。长期 artifact 到 blob 的引用集合、root manifests、sweep 顺序和 orphan grace period 尚未定义。SQLite 与文件系统也无法用一个事务消除所有 crash 窗口。
+- **直接证据**: `src/application/service_cleanup.py:191-226` 当前 run retention 语义是保护“最近 keep_count”与“keep_days 内”的并集，即仅在两者都不满足时删除；设计文本尚未把该语义和长期 blob 引用连接起来。现有 required-data receipt 在 `src/application/opend_symbol_outputs.py:1976-2005` 内嵌 payload，并未提供 shared blob reachability contract。
+- **影响**: 回测与审计的 compact 记录仍在，但原始特征链变成悬空引用；或者为了避免误删而永不 GC，磁盘继续无限增长。
+- **建议改法和验证点**: 明确沿用现有 union 语义：保留条件是“14 天内 OR 最近 200 次”；删除条件是二者都不满足且不被任何 protected manifest 引用。每个长期 artifact 必须直接持有 blob hash/manifest id；GC 使用 root-manifest mark-and-sweep、grace period、dry-run plan 与完整性校验，而不是仅按文件 mtime 或可漂移的 mutable refcount。写序为 canonicalize/hash → deterministic gzip（固定 mtime）→ 原子 blob publish → 原子 manifest publish；manifest 前 crash 产生的 orphan 在 grace 后回收。保持文件系统 scan store 与 SQLite lifecycle store 分离。验证：15 天前但被 outcome/每日样本引用的 blob 不删除；删除 run 后仅无引用 blob 进入计划；并发同 hash 首写幂等；各 crash 点没有可见半成品；读取必须解压重算 hash。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-05-未修复-高-runtime snapshot 的 seal 混淆内容完整性与跨来源时点一致性
+- **位置**: 每次运行快照 C、质量与阻断 E、Phase 4。
+- **问题类型**: 架构边界 / 契约缺失 / 状态机漏洞
+- **当前写法**: 一个 `runtime_portfolio_snapshot.v1` 同时封存 SQLite 投影、内部资金占用和 broker 现金/购买力/保证金/股票持仓，并带完整性与 seal。
+- **反例/失败场景**: SQLite transaction 在 T0 读取，OpenD 现金在 T0-30s，stock positions 在 T0+20s；文件 hash/seal 完全有效，但消费者把它理解成同一时点的资产状态，进而把合法时间差判成资金或持仓不一致。
+- **为什么有问题**: 内部账本事实和 broker 外部观察无法原子取得。单一 seal 只能证明封包内容没有变化，不能证明来源间 simultaneity；当前计划没有最大 skew、stale/degraded 语义及最小阻断范围。
+- **直接证据**: 当前 `decision_state_snapshot` 已通过一个 SQLite transaction 读取账本 rows（`src/application/ledger/repository.py:3489-3513`），但计划新增的 broker facts 来自该事务之外；`src/application/ledger/decision_snapshot.py:91-103` 也只对 ledger snapshot 注入一个 observed time。
+- **影响**: 扫描、质量门或回测会把时间错位当成真实业务矛盾；seal 成为过强且误导的可信声明。
+- **建议改法和验证点**: snapshot 分为 `ledger_projection`, `broker_cash`, `broker_positions` 等 source sections，每节独立记录 source-observed-at、received-at、receipt hash、complete/freshness；顶层 seal 只声明内容完整性和 run binding。另存 `coherence.max_skew_ms`、policy version 与 `coherence_status`，超阈值标 degraded/data_unavailable，并按 account/dataset 最小范围 fail-closed，不宣称跨来源原子一致。实现前需确认各市场可接受 skew。验证：前后错位、部分 provider 失败、stale cache、完整但不同步四类 fixture 均有明确状态，且 seal 验证不会把 degraded 变 trusted。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-06-未修复-高-CSV/base64 cutover 缺少可执行的 consumer gate，可能破坏 Strategy Lab
+- **位置**: 扫描大对象 D、Phase 6、Strategy Lab 永久数据边界。
+- **问题类型**: 切片过粗 / 兼容性回归 / 测试缺口 / open question 未收敛
+- **当前写法**: 先实现 blob store/readers，随后停止 base64；CSV 只保留过渡兼容，canonical JSON 成为唯一事实。
+- **反例/失败场景**: producer 停止 base64/CSV，但 receipt verifier 仍解码两个 base64 字段，或 Shadow Replay mark collector 仍只扫描 `*_required_data.csv`，导致在线 scan 成功而离线 mark/outcome 数据静默缺失。
+- **为什么有问题**: “reader 已切换”没有列出可证明完成的消费者集合、观测信号或 rollback gate。当前已知至少有生产与验证两端依赖 base64，研究端依赖 CSV。
+- **直接证据**: `src/application/opend_symbol_outputs.py:1976-1995` 生产 base64 bundle，`:2248-2291` verifier 解码并逐字节比较；`src/application/shadow_replay/marking.py:685-705` 直接 glob/read CSV。
+- **影响**: Strategy Lab 仍能构建 dataset manifest，但缺少 mark 或原始特征，形成“运行成功、回测证据不完整”的隐蔽回归。
+- **建议改法和验证点**: Phase 1 生成并冻结 consumer inventory（producer、receipt validator、reentry、marking、research archive、candidate/advice inputs、诊断工具）；Phase 6 采用 canonical JSON + legacy adapter 双读/双输出。只有全部消费者 contract tests 和 Shadow Replay 端到端 build/mark/settle 通过，且稳定窗口内 legacy-read telemetry 为零，才通过显式 gate 停止 base64/CSV。停旧格式必须可配置回滚一个版本窗口；不要只以“文件存在”验收。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-07-未修复-中-容量、耗时与每日归档验收口径还不可重复测量
+- **位置**: 验收目标 G、保留策略 D、Phase 1 baseline。
+- **问题类型**: 过度验收标准 / 契约缺失 / 测试缺口
+- **当前写法**: context <1 MB、常规质量 <10 秒、ordinary run directory <30 MB、每个合格交易日每市场完整链归档 100%。
+- **反例/失败场景**: context 用 gzip 后大小而 run dir 用磁盘占用；quality 在 warm cache、跳过外部检查时达标；“合格交易日”被定义成上游已有完整数据的日子，从而把 OpenD 失败日排除在分母外。
+- **为什么有问题**: 阈值已确认，但 measurement contract 未冻结，实现和验收可以选择不同分母、fixture 与缓存状态，结论不可比较。
+- **直接证据**: 当前对话基线同时包含 wall/CPU、累计目录/单次文件和压缩前 JSON 等不同量纲；现有 cleanup 已给出明确 union retention 语义，但新验收尚未引用同一口径。
+- **影响**: 可以在没有真正解决热路径或研究缺口时“通过”验收；也可能因合法的组合规模增长误报失败。
+- **建议改法和验证点**: Phase 1 定义固定 benchmark command、生产规模脱敏 fixture、cold/warm cache、wall/CPU、重复次数与 p95；context 以未压缩 canonical JSON bytes、run dir 以不含 shared blob 的 per-run physical bytes 计；quality <10 秒限定不做 external refresh 的常规 control-plane path。合格日按市场日历与策略运行资格定义，holiday 不入分母，上游失败的应运行日进入分母并标 missing/报警。把这些测量脚本与基线 artifact 纳入每 phase gate。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open questions
+
+1. `settlement_semantic` 业务指纹精确包含哪些字段？schema 升级是否总是强制关闭当前 span 并开启新 span？
+2. position projection generation 选择全局还是 per-account？若 per-account，是否为 `trade_events` 增加规范化 account 列，避免 trigger 解析 JSON？
+3. 扫描发现 generation mismatch 时，恢复入口是现有 rebuild facade 的扩展、定时 reconcile，还是人工命令；允许的最大恢复延迟是多少？
+4. “证明持续检查”是否确认要求每次观察一条小 digest？如果只需要运行次数统计而不要求可独立验证，验收文案必须相应降级，不能继续称为 hash-chain proof。
+5. broker cash、broker positions 与 ledger projection 允许的最大时间偏差分别是多少？过阈值时阻断 account、strategy 还是仅相关 dataset？
+6. 哪些 manifests 是 shared blob GC 的永久 root；每日研究样本以哪个 market calendar、timezone 和 run eligibility 规则选择？
+7. 稳定窗口内 legacy read 为零的观测入口是什么，是否需要在 adapter 里增加不含 payload 的计数指标？
+
+## Residual risks and tracking
+
+| Residual risk | Suggested tracking destination |
+|---|---|
+| 既有约 38.5 MB lifecycle history 第一阶段保留，短期数据库物理体积不会下降 | migration preview/report；不要把 Phase 2 误报成历史容量回收 |
+| 业务指纹漏字段会静默合并不同语义状态 | lifecycle contract tests + schema review checklist |
+| SQLite 与文件系统无法跨介质原子提交，blob-before-manifest 会留下孤儿 | blob integrity/GC status artifact + orphan grace metric |
+| 写入边界 full replay 随多年事件增长仍可能变慢 | scheduled benchmark；超过预算后再单独评估 checkpoint/delta projection |
+| mixed old/new readers 在迁移窗口可能语义漂移 | dual-read reconciliation artifact，按 case/account 报差异 |
+| 每市场每日完整链永久保留本身是无限增长项 | monthly growth forecast/alert；达到容量阈值后重新确认冷存储策略 |
+| 外部 broker 观察天然存在时间差和短时不可用 | runtime snapshot coherence status + account/dataset-scoped quality gate |
+
+## Required plan revision order
+
+1. **修订 Phase 1 契约**：先冻结 PR-01 evidence authority/sidecar 边界、PR-02 position generation 协议、PR-03 observation digest/last-ref 状态机、PR-04 blob root/GC、PR-05 temporal seal 和 PR-07 measurement contract。
+2. **Phase 2 只做 lifecycle stop-growth**：扩展现有 semantic admission，新增 compact audit sidecar；不得迁移旧数据、不得退休旧 evidence authority。
+3. **Phase 3 保持独立**：加入 position generation/head，在所有交易 writer 上 shadow compare；低频写入仍可 full replay，scan mismatch 不自愈写库。
+4. **Phase 4 前置 temporal contract**：双输出 compact snapshot 与 legacy adapter，逐字段对账，不先切 consumer。
+5. **Phase 5 只替换高频读**：常规 quality 读 generation/head；full replay 作为 scheduled/manual evidence，不隐藏在普通 refresh 内。
+6. **Phase 6 改为显式 consumer gate**：先完成 inventory、blob reachability 与双格式读写，再切所有 reader；legacy telemetry 归零和 Strategy Lab E2E 通过后才停 base64/CSV。
+7. **Phase 7 research delta/checkpoint 独立推进**：只复用 shared blob references，不把 research 状态机塞入运行时投影事务。
+8. **Phase 8 保持 preview-only**：14 天稳定、逐 case 对账、在线 backup 与空间预算完成后生成 preview；删除仍需新的明确授权。
+
+## Final conclusion
+
+**fail**
+
+方案方向和优化顺序基本正确，但 PR-01 与 PR-02 是代码生成前必须收敛的权威源/事务协议；PR-03 至 PR-06 也会直接影响审计、回测和数据保留正确性。完成上述 plan revision 后应重新执行 planreview；本结论不授权实施、迁移或删除任何数据。

--- a/docs/reviews/plan-review-20260813-103939.md
+++ b/docs/reviews/plan-review-20260813-103939.md
@@ -1,0 +1,152 @@
+# Plan Re-Review — data-storage-and-runtime-projection.v1
+
+## Reviewed target and scope
+
+- **Target**: `docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md`
+- **Prior review**: `docs/reviews/plan-review-20260813-092047.md`
+- **Source baseline**: `main@421591dd`
+- **Worktree note**: review execution observed branch `fix/combo-yield-rank-int-seal`, but its `HEAD`, local `main`, and `origin/main` all resolved to `421591dd`; unrelated untracked Gateflow work was excluded and untouched.
+- **Review scope**: lifecycle observation stop-growth, position and current-decision projections, runtime snapshot, shared scan blobs, retention roots, CSV/base64 migration, quality output migration, Strategy Lab/replay compatibility, and measurable time/space gates.
+- **Priority lens requested by the user**: time complexity, space complexity, write amplification, WAL growth, peak memory, transition-period duplicate storage, and benchmark reproducibility.
+- **Excluded**: implementation, schema migration, production data/config writes, history deletion, services, notifications, release, deploy, or remote operation.
+- **Review posture**: code-generation readiness for Phase 2, Phase 3A, and Phase 3B. Phase 1 inventory and baseline artifacts remain preconditions, not work completed by this document review.
+
+## Goal confirmation
+
+The revised contract is judged against these goals:
+
+1. Ordinary scan, snapshot, and quality paths must stop reading or replaying lifetime trade/lifecycle/assigned-stock history.
+2. `trade_events` remains the trading authority; `position_lots` remains the sole physical current-lot projection.
+3. Existing admitted lifecycle evidence and its foreign-key consumers remain authoritative and readable.
+4. Every real settlement provider attempt remains auditable without storing one full large receipt per attempt.
+5. Repeated scan payloads are stored once by content while retained online/research/replay roots remain replayable.
+6. Strategy Lab keeps exact sealed run input/output plus canonical trade/outcome facts and does not gain operational write authority.
+7. Migration is measurable and reversible; old data is retained unless deletion is separately authorized.
+
+## Evidence and assumptions rechecked
+
+| Assumption challenged | Result | Evidence / contract response |
+|---|---|---|
+| A new lifecycle store can replace `trade_lifecycle_evidence` immediately | Rejected | Existing admission heads, source consumptions, and allocations reference admitted evidence. The revised contract retains that authority and adds only an audit sidecar. |
+| Removing position replay alone removes the hot history cost | Rejected | The current decision snapshot also reads lifecycle evidence, allocations, source consumptions, and assigned-stock history and recomputes overlay/combo. Phase 3B now owns a separate bounded current-decision projection. |
+| A projection fingerprint alone proves freshness | Rejected | Position and decision readers must compare embedded generations/revisions with live heads before fingerprint verification; integrity and freshness are separate conditions. |
+| Moving history work from reads to every ordinary write is acceptable | Rejected | Normal decision publication is now O(current account state + changed facts) and may not list history. Only position projection temporarily retains O(E) CPU, with an explicit `history_10x` exit gate. |
+| Global lot `DELETE + INSERT` is harmless because trade writes are rare | Rejected | Phase 3A must publish a `record_id` diff. DML/WAL is O(changed lots), and full-table delete/reinsert is a gate failure. |
+| Any ledger write may advance a decision revision | Rejected | The trigger table set is closed; audit, notification, delivery, and diagnostic writes are excluded. Duplicate observations must cause zero decision revision/projection writes. |
+| Stored `overdue` status remains current without a mutation | Rejected | The projection stores the immutable deadline only; readers derive wall-clock classification from injected `now`. |
+| Keeping only a final chain hash proves attempt continuity | Rejected | Each real attempt gets one compact ordered input row; full O(N) chain verification is offline only. |
+| A content hash makes moving receipt blobs safe automatically | Rejected | Span references are indexed and liveness is the union across all spans; only a zero-reference candidate can be swept post-commit. |
+| Synthetic byte size alone predicts compression cost | Rejected | Fixtures record uncompressed size, compression ratio, and entropy/compressibility classes. Space gates use uncompressed and actual DB/WAL bytes as primary measures. |
+| Canonical and legacy payloads must both be fully materialized to compare them | Rejected | Shadow comparison is streaming-hash based, keeps at most ten bounded mismatch samples, and has explicit peak allocation/storage budgets. |
+| Aggregate lifecycle quality output is an internal-only change | Rejected | It is treated as a public data-contract migration with reader inventory, dual publication, semantic comparison, telemetry, and a 14-eligible-day gate. |
+
+## Closure of the first plan review
+
+| Prior finding | Revised contract decision | Status |
+|---|---|---|
+| PR-01 — incompatible second admitted-evidence authority | Existing admitted evidence remains logical/physical authority; sidecar stores attempts/duplicates only. | Closed |
+| PR-02 — undefined position generation/account recovery | Global event-source generation, per-account lot heads, exact mutation matrix, normalized accounts, and read-only fail-closed protocol are frozen. | Closed |
+| PR-03 — unverifiable chain and moving-last receipt growth | Compact per-attempt chain inputs, one optional final receipt per span, indexed all-span liveness, idempotent post-commit sweep, and WAL bounds are frozen. | Closed |
+| PR-04 — shared blob reachability/GC missing | Online, research, replay/outcome, daily, and manual roots form one protected set; GC is previewed mark-and-sweep with grace and integrity checks. | Closed |
+| PR-05 — seal overstated cross-source coherence | Each source has independent timestamps/status; the top-level seal asserts integrity/run binding only and introduces no hidden simultaneity gate. | Closed |
+| PR-06 — CSV/base64 cutover could break replay | Producer/verifier/scan/advice/research/Strategy Lab consumers are in the minimum inventory and the seven-step cutover gate is mandatory. | Closed |
+| PR-07 — measurement was not reproducible | Fixture provenance, warm/cold semantics, repetitions, p95, CPU/RSS/allocation/SQL/disk metrics, reference-host rules, and absolute budgets are frozen. | Closed |
+
+## DeepSeek V4 Pro adversarial re-review
+
+The requested DeepSeek V4 Pro subagent was rerun against the revised contract, with time and space efficiency as the primary lens. Its intermediate review raised seven material risks:
+
+1. full-table lot publication and unbounded O(E) writer cost;
+2. over-broad source-generation triggers;
+3. undefined lot fingerprint canonicalization;
+4. unstable cross-database attempt identity;
+5. moving-last receipt sweep/WAL ambiguity;
+6. non-representative compression fixtures;
+7. double-materialized CSV/base64 shadow comparison.
+
+All seven were incorporated into the contract. Its closing pass then challenged decision-projection freshness, same-transaction publication order, wall-clock-derived status, shared-receipt liveness, and audit-sidecar trigger exclusion. Those five items were also frozen explicitly. The consultant's final conclusion was `pass-with-risks`, with no remaining code-generation blocker. The primary review agrees.
+
+## Time and space efficiency verdict
+
+| Path | Final complexity/resource contract | Review verdict |
+|---|---|---|
+| Duplicate lifecycle attempt | O(R) canonicalization/compression plus O(1) indexed rows, independent of case history; ≤224 average incremental DB bytes/attempt; bounded WAL and one optional live last receipt/span. | Acceptable; eliminates full-receipt-per-poll growth while retaining one compact audit row per real attempt. |
+| Full audit proof | O(N) chain verification, explicit offline operation only. | Correct placement; prohibited in tick and ordinary quality. |
+| Current position read | O(account current lots), zero trade-event reads/replay. | Acceptable and account-scoped. |
+| Position write | O(E) projection CPU temporarily; O(changed lots) DML/WAL through diff publication. `history_10x` must meet p95 wall ≤2 s and CPU ≤1.5 s. | Residual scaling risk, but an honest hard exit gate prevents silently shipping an unbounded writer. |
+| Current decision publish | O(current account state + changed facts), zero lifetime-history reads. Duplicate attempts write no decision row. | Acceptable; the optimization is not merely moved from read time to every lifecycle write. |
+| Current decision read | O(account current lots + compact decision bytes), exact live-binding checks, no history readers or overlay/combo recomputation. | Acceptable. |
+| Global account fanout | Explicit fixture of at least 10 accounts; p95 wall ≤250 ms, CPU ≤200 ms, allocation ≤64 MiB. | Residual global-generation coupling is now measured and has a plan-review fallback. |
+| Current-state growth | Separate 10× current-state fixture; decision JSON <1 MiB, p95 read ≤500 ms, peak allocation ≤64 MiB. | Prevents a fixed-current-state history test from hiding legitimate current-state growth. |
+| Ordinary quality | O(accounts + compact current decision state), no lifetime readers; detailed terminal history becomes scheduled/manual after compatibility gate. | Acceptable, subject to the public output migration gate. |
+| Scan/run artifacts | O(unique retained content + manifests), deterministic gzip/content hashes, no default inline base64 after cutover. | Correct architecture for cross-run deduplication. |
+| Migration shadow path | Streaming hashes, bounded samples, peak allocation ≤max(48 MiB, 2.5× payload), at most two encoded representations plus manifests. | Transition overhead is explicit rather than hidden. |
+| GC | O(manifests + references + blobs), scheduled/manual only. | Correct; it is deliberately absent from every tick. |
+
+The performance measurement contract was also checked against profiling practice: timing is isolated from `cProfile`/`tracemalloc`; separate CPU and allocation profiles explain failures without contaminating pass/fail timing. This is sufficient for implementation agents to build repeatable benchmarks without choosing a new measurement method.
+
+## Material findings
+
+No unresolved material finding remains in the revised Phase 1 contract.
+
+## Open questions
+
+No open question blocks Phase 2, Phase 3A, or Phase 3B code generation.
+
+The following are consciously deferred rather than unresolved:
+
+- a future numeric cross-source skew policy;
+- a future cold-storage tier for permanent daily/research/replay roots;
+- a checkpoint or per-event delta projector, but only if the frozen writer/fanout gates fail;
+- normalized partial decision tables, but only if the `current_state_10x` JSON/read/allocation gates fail.
+
+## Residual risks and required tracking
+
+| Residual risk | Required control / exit condition |
+|---|---|
+| Existing lifecycle evidence, including the previously observed ~38.5 MB, remains physically present. | Phase 2 is stop-growth/audit optimization, not reclaimed-space success. Historical cleanup stays preview-only until separately authorized. |
+| Position projection CPU remains O(E) on low-frequency writes. | `history_10x` hard budget; failure returns to planreview for checkpoint/delta design before Phase 3A ships. |
+| A global event generation republishes every account. | `account_fanout` hard budget; failure requires account partition/checkpoint redesign. |
+| Current operational state itself can grow. | `current_state_10x` JSON, latency, and allocation gates; failure requires measured normalized projection design. |
+| Multi-table SQLite revision triggers have ordering/ownership implementation risk. | Exact table allowlist, old/new-account mutation tests, crash injection, and decision shadow comparison. |
+| Lifecycle detailed/aggregate quality migration and CSV/base64 migration may overlap. | Both transition footprints must be measured together; do not retire either legacy contract until its independent 14-day/consumer gates pass. |
+| Filesystem manifests and blobs are not one atomic transaction. | Blob-first publication, 24-hour grace, integrity validation, orphan metrics, and previewed mark-and-sweep. |
+| Daily/research/replay roots are intentionally permanent in this iteration and therefore grow without a finite bound. | Monthly growth forecast/alert; cold-tier/deletion design requires a later reviewed decision and explicit authorization. |
+| Absolute latency thresholds depend on the recorded reference host. | Phase 1 baseline artifact records the host/profile; CI elsewhere enforces complexity, query plans, row counts, and allocation/space bounds. |
+
+## Required execution order
+
+1. Finish Phase 1's read-only metadata baseline, complete writer/reader/quality/CSV/base64/root inventory, and commit benchmark manifests/results. Contract approval does not waive these outputs.
+2. Implement Phase 2 lifecycle stop-growth without migrating or deleting existing admitted evidence.
+3. Implement Phase 3A normalized account keys, generations, diff lot publication, and position shadow comparison; the `history_10x` gate must pass before reader cutover.
+4. Implement Phase 3B independently: decision revisions/projection, final-head publication order, quality dual output, and all three performance axes.
+5. Proceed to compact snapshot, quality cutover, and shared blob cutover only after their respective semantic and resource gates pass.
+6. Keep historical cleanup at preview-only; actual deletion remains a separate explicit authorization.
+
+## Final conclusion
+
+**pass-with-risks — scoped to the reviewed full-replay/diff path**
+
+The revised Phase 1 contract is code-generation-ready for Phase 2, Phase 3A, and Phase 3B. It now prevents the two common false optimizations challenged in this review: moving O(history) work from reads to every write, and reducing retained disk bytes by creating uncontrolled WAL/memory/transition peaks. Remaining risks have explicit measurable exit gates and do not require an implementation agent to invent a new authority, state machine, recovery rule, or performance target.
+
+This review authorizes no implementation, migration, data deletion, production write, release, or deployment.
+
+## Post-review amendment note — checkpoint, research tiering, and dirty-once/publish-once
+
+After this review, the Phase 1 contract was amended at the user's request to
+incorporate three optimization paths that were previously residual risks:
+
+1. a conditional bounded position checkpoint + tail replay design if the
+   reviewed `history_10x` full-replay gate fails;
+2. immutable base + partition research generations, storage-class inventory,
+   capacity forecasting, and a future cold-candidate preview;
+3. invalidation-only per-account decision generation triggers with at most one
+   transaction-end projection publish per affected account.
+
+These amendments do not weaken this review's `pass-with-risks` conclusion for
+Phase 2, Phase 3B, or the Phase 3A full-replay/diff path when its existing gate
+passes. They also do not authorize checkpoint activation, a cold backend, data
+movement, eviction, or deletion. Section 5.6 explicitly requires a focused
+planreview before the conditional checkpoint path is implemented, and section
+7.4 requires a separate reviewed backend/restore contract plus explicit
+authorization before physical tiering changes.

--- a/docs/reviews/plan-review-20260813-123726.md
+++ b/docs/reviews/plan-review-20260813-123726.md
@@ -1,0 +1,126 @@
+# Plan Review — data-storage-runtime-projection-p1
+
+## Reviewed target and scope
+
+- Target: `docs/gateflow/data-storage-runtime-projection-p1/plan.md`
+- Goal authority: `docs/gateflow/data-storage-runtime-projection-p1/goal-confirmation.md`
+- Design authority: `docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md`
+- Base: `main@421591ddb5e298cda064ec414c8b87f62b0811b2`
+- Review focus: Phase 1 only; read-only guarantees, inventory completeness,
+  research-capacity semantics, benchmark validity, time/space efficiency, and
+  whether two implementation slices are code-generation-ready.
+- Excluded: implementation, schema/migration, production sampling, data
+  movement/deletion, checkpoint activation, release/deployment.
+
+## Goal-bound minimal-design review
+
+Both slices map to the confirmed Phase 1 evidence goal. Two slices are
+reasonable: inventory/capacity is independently useful, and the benchmark can
+consume its metadata without coupling runtime traversal to CPU-heavy synthetic
+work. No later optimization implementation is smuggled into the work unit.
+
+The review did not find justification for a new database, service, third-party
+benchmark dependency, or generalized observability layer. The planned Research
+CLI placement and reuse of the canonical ledger projector are the minimal local
+owners.
+
+## Assumptions tested
+
+| Assumption | Result | Evidence |
+|---|---|---|
+| Query-only SQLite aggregates can inventory ledger rows/JSON bytes without mutating the database | Supported | `read_only_evidence.py` already uses URI `mode=ro` plus `PRAGMA query_only=ON`; aggregate `COUNT`/`length` does not return payload bodies |
+| Existing manifests permit payload-free content integrity and exact logical dedup for all research data | Rejected | `shadow_replay/common.py::validate_dataset_integrity()` recomputes hashes by reading every dataset file; legacy/unmanifested files have no authoritative content identity |
+| A single filesystem observation can derive historical monthly new-unique-byte growth | Rejected | file mtime is mutable placement metadata, not immutable first-seen content history; the plan names no prior-report input or authoritative first-seen index |
+| Timing only `project_stored_trade_events_to_position_lots()` represents the existing full-replay writer | Rejected | `writer.py::rebuild_position_lots_from_trade_events()` also lists/decodes SQLite events, validates publishability, and `repository.py::replace_position_lots()` deletes and reinserts all lots |
+| Validating that declared source locators still exist proves inventory completeness | Rejected | a newly added `list_trade_events`, CSV/base64 codec, or runtime root can be undeclared while every old locator still validates |
+| Two behavior slices are appropriately sized | Supported after the findings below are fixed | separating read-only runtime observation from synthetic profiling isolates safety and resource risks without mechanical file-based slicing |
+
+## Findings
+
+### PR-P1-01-未修复-高-元数据扫描被要求给出只有读取内容才能证明的完整性与去重结论
+- **位置**: Public contracts and schemas / `research_storage`; Slice 1 invariants and validation
+- **问题类型**: 契约缺失 / 测试缺口 / 最佳实践偏离
+- **当前写法**: collector promises logical referenced bytes, unique physical bytes, dedup ratio, orphan bytes, restore/integrity status, corrupt-manifest handling, while also promising zero payload-content reads.
+- **反例/失败场景**: A Shadow Replay manifest advertises SHA-256 and byte size but its referenced JSONL is modified in-place to different bytes of the same length. A metadata-only scan cannot detect the corruption. An unmanifested CSV with the same size as another file cannot safely be counted as duplicate or unique without reading/hash authority.
+- **为什么有问题**: The report can silently label corrupt evidence verified or present a false exact dedup ratio. That would make a later tier/delete decision rely on evidence Phase 1 did not actually establish.
+- **直接证据**: `src/application/shadow_replay/common.py::validate_dataset_integrity()` calls `dataset_integrity_payload()`, which reads each dataset file and recomputes SHA-256. Legacy datasets explicitly return `legacy_unverified` when an integrity receipt is absent. The design contract also distinguishes metadata-only status from later restore verification.
+- **影响**: false safety signal, incorrect capacity forecast, unsafe later storage decisions, and an implementation agent forced to choose between violating payload-free scope or lying about integrity.
+- **建议改法和验证点**: Split `declared` from `verified`: use manifest-declared hash/bytes for logical-reference accounting, filesystem stat for physical bytes/presence, and report `content_verification=not_performed`. Exact dedup applies only within authoritative declared hashes; unmanifested bytes remain `unknown_unique_bytes`. Same-size tampering must remain `unverified`, not `verified` or `corrupt`; missing/size mismatch may be critical. Add tests for same-size tamper, missing object, and unmanifested copies.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-P1-02-未修复-高-一次性快照没有可审计的数据来源来计算月增长和90天预测
+- **位置**: Read-only CLI; `research_storage`; Slice 1 data flow and error handling
+- **问题类型**: 契约缺失 / 不可直接实施
+- **当前写法**: CLI accepts `--history-months 6`, and one run is expected to report monthly new unique bytes, trailing growth, and a 90-day forecast.
+- **反例/失败场景**: Existing blobs were copied or restored yesterday, so their mtime says “new” although their content has existed for a year. Conversely, old files newly referenced by a generation have old mtimes. A single scan cannot distinguish either case.
+- **为什么有问题**: `--history-months` selects a window but supplies no historical observations or authoritative first-seen timestamp. Any implementation would invent a heuristic and present it as storage growth.
+- **直接证据**: The current plan defines no persisted observation store (correctly, by non-goal) and no previous-report input. Existing Shadow Replay manifests can expose generation/integrity metadata but do not form a complete first-seen history for every runtime artifact.
+- **影响**: non-reproducible forecasts, false warning/critical status, or goal drift into a new history database.
+- **建议改法和验证点**: Replace the ambiguous option with repeatable `--history-report <storage_runtime_baseline.v1>` inputs. Validate root identity and monotonic observation time; derive physical/declared-unique deltas only between reports. With fewer than two compatible observations, emit `insufficient_history` and a null forecast. Immutable manifest timestamps may be descriptive only, not the forecast authority. Test incompatible roots, out-of-order reports, two/three-point forecasts, and no-history behavior.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-P1-03-未修复-高-只测纯投影函数无法回答已确认的完整 writer 成本
+- **位置**: Benchmark artifacts; Slice 2 exact changes and gate decision
+- **问题类型**: 测试缺口 / 不可直接实施 / 非最优方案
+- **当前写法**: Synthetic scenarios call `project_stored_trade_events_to_position_lots()` and use that result for the full-replay performance component; diff publication is separately `not_implemented`.
+- **反例/失败场景**: Projection itself completes in 1.4 seconds, but SQLite JSON loading plus publishability checks plus global lot deletion/reinsert makes the actual writer take 2.5 seconds and create large WAL. The report says replay passes even though the current writer path fails.
+- **为什么有问题**: Goal confirmation explicitly requires evidence for the existing full-replay writer. The pure projector excludes material work and the known O(all lots) write path.
+- **直接证据**: `writer.py::rebuild_position_lots_from_trade_events()` calls `list_trade_events()`, the canonical projector, `ensure_projection_publishable()`, and `replace_position_lots()`. `repository.py::replace_position_lots()` begins with `DELETE FROM position_lots` and reinserts all records.
+- **影响**: wrong optimization decision and a false basis for deciding whether checkpoint review is necessary.
+- **建议改法和验证点**: Benchmark two named components on synthetic temporary SQLite only: `projector_only` and `existing_full_replay_writer` through `rebuild_position_lots_from_trade_events()`. Include db/wal/shm bytes and output fingerprint equality. Mark `lot_diff_publication=not_implemented` and the combined Phase 3A gate `not_ready`; separately report whether the current writer meets wall/CPU thresholds and flag `global_replace_present=true` from observed/source-bound behavior. Never treat projector-only pass as writer pass.
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-P1-04-未修复-中-声明项存在性校验无法证明消费者与写入路径清单完整
+- **位置**: Checked-in source inventory; Slice 1 tests
+- **问题类型**: 测试缺口 / 架构边界
+- **当前写法**: A checked-in JSON lists known paths and locators; collector fails when a declared locator disappears.
+- **反例/失败场景**: A new module adds `read_csv()`, `base64.b64decode()`, `list_trade_events()`, or a literal `output_runs` root but is not added to the manifest. All declared entries remain valid, so the inventory reports success while the cutover inventory is incomplete.
+- **为什么有问题**: The design contract requires a frozen consumer/root inventory before later cutovers. Stale-entry detection only proves soundness of listed rows, not coverage of newly discovered candidates.
+- **直接证据**: The plan contains no deterministic discovery rule or assertion that every source match is classified. Existing code has many distributed ledger and required-data call sites, so omission is realistic.
+- **影响**: later hot-path or CSV/base64 cutover leaves a hidden reader/writer, causing performance regressions or broken replay.
+- **建议改法和验证点**: Make the manifest contain versioned discovery rules plus classified matches. Deterministically scan only `domain/`, `src/`, `scripts/`, and tests explicitly marked as compatibility consumers for AST calls/imports and bounded string literals. Fail inventory when a discovered production candidate is unclassified or a classified locator is stale; permit explicit ignored rows only with reason/owner. Check in a generated discovery fingerprint and test an injected unclassified fixture.
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 中
+
+### PR-P1-05-未修复-高-history_10x 的固定当前状态假设与现有关闭 lot 保留语义冲突
+- **位置**: Benchmark artifacts; Slice 2 fixture generation
+- **问题类型**: 契约缺失 / 测试缺口 / 不可直接实施
+- **当前写法**: `history_10x` promises at least 10,000 contract-valid events while current state remains fixed, but does not specify the event sequence.
+- **反例/失败场景**: The implementation creates realistic open/close pairs to grow history. The projector retains every closed `PositionLot`, and the repository republishes those rows, so output lot count grows with event history and the axis no longer isolates E. Alternatively, it fills history with only ignored events and underrepresents the retained-lot write cost.
+- **为什么有问题**: The implementation agent must choose between violating axis orthogonality and producing an unrepresentative benchmark, which changes the interpretation of the checkpoint-versus-diff decision.
+- **直接证据**: `domain/domain/ledger/projection.py` returns all lots in `lot_order`, including closed lots; it filters closed lots only when building risk views. Existing tests assert persisted/projected closed lots with `contracts_open == 0`.
+- **影响**: misleading complexity attribution and a wrong conclusion about whether replay CPU or global lot replacement is the dominant bottleneck.
+- **建议改法和验证点**: Define two explicit `history_10x` subcases, each with at least 10,000 events: `fixed_output` uses valid read-only `verification` events plus a fixed open-lot set and isolates event read/decode/sort; `retained_closed_lots` uses deterministic open/close pairs and exposes the current projection/write coupling. Report event/lot/allocation counts and separate p95 results. A comparable writer gate may pass only if both applicable subcases pass; neither result authorizes diff/checkpoint implementation.
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+## Open questions
+
+None after applying the concrete contract changes above. Reference-host identity
+and safe fixture limits are already specified sufficiently, provided a clamped
+acceptance axis becomes `not_evaluable` rather than passing.
+
+## Residual risks and tracking destination
+
+- Synthetic distributions may not reflect production: later explicitly
+  authorized read-only sampling; do not broaden this work unit.
+- Metadata-only inventory cannot prove content hashes: record verification
+  coverage now; full restore verification belongs to later Phase 7.
+- Current global lot replacement is structurally known before measurement:
+  quantify it in Slice 2; replacement with diff publication remains Phase 3A.
+- A static discovery vocabulary can miss an entirely novel codec API: retain
+  aggregate DeepReview/search coverage and assign vocabulary evolution to the
+  source-inventory owner rather than claiming mathematical completeness.
+
+## Final plan review conclusion
+
+**fail**
+
+The work-unit boundary and two-slice structure are sound, but the five findings
+above prevent safe implementation. The plan must distinguish declared metadata
+from verified content, define a real history input, measure the current writer
+instead of only its projector, detect unclassified source candidates, and make
+the history axis compatible with retained closed-lot semantics.

--- a/docs/reviews/plan-review-20260813-124834.md
+++ b/docs/reviews/plan-review-20260813-124834.md
@@ -1,0 +1,88 @@
+# Plan Re-review — data-storage-runtime-projection-p1
+
+## Reviewed target and scope
+
+- Target: revised `docs/gateflow/data-storage-runtime-projection-p1/plan.md`
+- Initial review: `docs/reviews/plan-review-20260813-123726.md`
+- Design contract amendment:
+  `docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md`
+- Scope: closure of `PR-P1-01` through `PR-P1-05`, plus regression review of
+  read-only SQLite safety, slice size, performance semantics, and goal drift.
+
+## Finding status
+
+### PR-P1-01 — 已修复
+
+The plan no longer equates metadata with current content integrity. It reports
+manifest-declared hash/bytes, physical presence/size, historical verifier status,
+and `content_verification=not_performed` separately. Unmanifested bytes stay
+unknown-unique; same-size tampering is unverified rather than falsely verified.
+
+### PR-P1-02 — 已修复
+
+`--history-months` was removed. Growth and forecast consume repeatable prior
+`storage_runtime_baseline.v1` reports with identical resolved root identity and
+monotonic observation time. Fewer than two compatible observations produces
+`insufficient_history` and a null forecast.
+
+### PR-P1-03 — 已修复
+
+The benchmark now measures both `projector_only` and
+`existing_full_replay_writer` through the real
+`rebuild_position_lots_from_trade_events()` call path on synthetic temporary
+SQLite. It records SQLite bytes and parity while keeping
+`lot_diff_publication=not_implemented`; projector-only success cannot become a
+writer pass.
+
+### PR-P1-04 — 已修复
+
+The checked-in inventory now owns bounded discovery rules as well as classified
+matches. Stale declarations and unclassified production candidates fail the
+inventory. Explicit ignores require owner/reason. The plan correctly retains
+novel APIs outside the discovery vocabulary as an aggregate-review residual
+risk rather than claiming mathematical completeness.
+
+### PR-P1-05 — 已修复
+
+`history_10x` is split into `fixed_output` using valid verification events and
+`retained_closed_lots` using open/close pairs. The first isolates event-history
+cost; the second exposes the canonical closed-lot/replace coupling. Both report
+event, lot, open-lot, view, and allocation counts and both must meet a comparable
+writer threshold for the history component to pass.
+
+## Additional safety review
+
+The revised plan recognizes that opening a live WAL database can alter shared
+reader state. It never connects to source SQLite: it copies the exact db/wal/shm
+set with bounded before/after stat validation and queries only the temporary
+copy. An unstable copy becomes `partial_data`, preserving the read-only promise
+without claiming a cross-source atomic snapshot.
+
+Two slices remain the minimum useful split. No schema, authority, runtime
+mutation, production sampling, checkpoint, blob store, storage generation, or
+cold backend has entered scope.
+
+## Open questions
+
+None.
+
+## Residual risks
+
+- Novel source APIs outside the versioned discovery vocabulary: aggregate
+  DeepReview and future inventory-owner updates.
+- Synthetic-to-production distribution drift: later separately authorized
+  read-only sampling.
+- Full content restore verification: later Phase 7 work unit; Phase 1 reports
+  coverage honestly.
+- Existing global lot replacement and closed-lot retention: quantified here;
+  changed only in later Phase 3A.
+
+All residual risks are classified and none blocks Phase 1 implementation.
+
+## Final plan review conclusion
+
+**pass-with-risks**
+
+The revised plan is code-generation-ready for the confirmed Phase 1 work unit.
+It can now measure only what its evidence can prove, preserves source/runtime
+immutability, and does not authorize later optimization paths.

--- a/docs/reviews/pr-154-review-20260813-173232.md
+++ b/docs/reviews/pr-154-review-20260813-173232.md
@@ -1,0 +1,111 @@
+# PR Review — #154
+
+## Scope
+
+- Mode: PR review
+- Pull request: `#154` — `research: add storage and projection performance baselines`
+- URL: `https://github.com/liuxie066/options-monitor/pull/154`
+- Base: `main@b940843744f74a2cf2f04070a30d9a93dd14596c`
+- Reviewed head: `perf/data-storage-runtime-projection-p1@74336f2264721dcdbd51881b072358294844119d`
+- Review time: `2026-08-13 17:32:32 +0800`
+- Changed scope: 25 files, 8,334 additions, 0 deletions
+- CI at review start: CodeQL, Guardrails, and Agent Plugin workflows were still running or queued
+
+## Findings
+
+### 1-已修复-高-Phase 1 没有测量自己冻结的 research-storage 时间和空间门槛，且代表性 history_10x 已越过时间上限
+
+- **入口/函数**: `./om research storage-baseline` ->
+  `collect_storage_runtime_baseline()` -> `_collect_runtime_storage()` ->
+  `_collect_research_storage()` -> `_extract_manifest_references()` ->
+  `_resolve_manifest_reference()`
+- **文件(行号)**:
+  `docs/plans/data-storage-runtime-projection-phase1-contract-20260813.md:663-724,728-739`;
+  `docs/gateflow/data-storage-runtime-projection-p1/plan.md:181-245,349-404`;
+  `src/application/research/performance_baseline.py:38-78,337-569,1011-1058,1480-1684`;
+  `src/application/research/storage_baseline.py:79-156,665-738,852-1034,1053-1378`;
+  `tests/test_research_performance_baseline.py:1-791`;
+  `tests/test_research_storage_baseline.py:1-859`
+- **输入场景**: 一个确定性的 `history_10x` 研究目录包含 10,000 个 1-byte
+  分区文件和一个 manifest；manifest 的 `integrity.files` 为每个分区声明
+  hash 与 size。该形态对应冻结合同要求考察的 10,000 partition/hash 规模，
+  且不读取任何 payload 内容。
+- **实际分支**: Phase 1 正式 runner 只生成并测量 trade-event projection
+  场景。五个 artifact 的 timing/CPU/allocation rows 都没有
+  `research_storage_status` component，decision 也没有合同中冻结的
+  `p95 wall <= 5 s` / `peak allocation <= 64 MiB` 结论。因此现有测试与
+  5/30 artifact 能通过，却没有执行这条 Phase 1 必须交付的性能门槛。
+- **预期行为**: 同一个 repository-local benchmark harness 应生成确定性
+  storage-status `history_10x` fixture，在无 profiler 的独立 worker 中以
+  5 warmups / 30 repetitions 记录 wall/CPU，在独立 allocation worker 中从
+  已加载的 collector 状态开始记录 Python peak allocation，并在 decision
+  中 fail closed 地判定 frozen 5 s / 64 MiB budget。fixture 创建、模块导入和
+  profiler 开销不得混入 gate。
+- **实际行为**: 独立的未分析诊断在 Apple M4 / Mac16,10 上对上述 10,001
+  个文件采集一次耗时 `5,288,635,375 ns`，超过 5 秒门槛。CPU+tracemalloc
+  诊断显示 `_extract_manifest_references()` 累计约 327.6 秒，其中
+  `_resolve_manifest_reference()` 累计约 287.4 秒（重分析放大值，不是 gate
+  timing）；主要原因是每条引用为多个候选反复调用 `Path.resolve()`，而
+  `_is_relative_to()` 又对 candidate/root 再次 resolve。分析器口径峰值
+  67.9 MiB，但其中约 34.5 MiB 来自模块导入，进一步说明正式 allocation
+  gate 必须排除 import/setup，不能直接沿用这次诊断数字。
+- **直接证据**:
+  1. 冻结合同第 10.2 节明确要求 research storage status 在
+     `history_10x` 上 p95 wall <= 5 s、peak allocation <= 64 MiB；第 11 节
+     Phase 1 要求产出 baseline JSON 与 profiles。
+  2. `PUBLIC_SCENARIOS`、`_build_scenario_specs()`、三个 worker mode、
+     `_validate_worker_artifacts()` 与 `_build_gate_decision()` 只认识
+     projection/projector/writer；测试也只断言这些组件。
+  3. `/private/tmp/om-storage-status-profile-20260813.json` 的诊断结果绑定
+     上述热点；未分析 stopwatch 结果为 `5,288,635,375 ns`。
+- **影响**: PR 可以在没有证明 storage collector 满足自身合同、甚至代表性
+  样本已越线的情况下被 Gateflow 标记为 Phase 1 完成。后续历史增长会把
+  原本用于解释超时的诊断命令本身变成新的超时/高内存路径，且没有版本化
+  artifact 能提示回归。
+- **建议改法和验证点**:
+  1. 在 manifest 路径解析边界消除每条引用的重复 canonicalization；对已由
+     no-follow 扫描得到、且通过 lexically bounded 检查的相对路径，复用
+     canonical root/manifest/reference roots，并仅对候选执行必要的 lstat/
+     symlink 边界检查。
+  2. 把 `research_storage_status.history_10x` 作为独立 component 加入现有
+     benchmark artifact set，而不是新建第二套 runner。fixture 创建与 source
+     inventory/import setup 在计时和 tracemalloc 之前完成。
+  3. decision 显式记录 frozen 5 s / 64 MiB、`pass/fail/not_evaluable`；不要求
+     reference-host fingerprint 才判断算法性 space bound，时间 gate 则遵循
+     现有 reference-host comparability。
+  4. 新增回归：10,000 references 的 fixture identity 稳定；timing/profile
+     separation；allocation setup 排除；缺场景/非 acceptance/host mismatch
+     fail closed；结果仍为 payload reads=0、mutation=0、symlink not followed。
+- **修复风险（低/中/高）**: 中
+- **严重程度（低/中/高/严重）**: 高
+- **修复结果**: `accepted; fixed`。manifest reference resolution 现在复用
+  no-follow runtime scan 的 `known_files` 索引并做 lexical bounded candidate
+  normalization，避免每条引用重复 `realpath/stat`。现有五-artifact runner
+  增加 `research_storage_status.history_10x` component，fixture setup/import 在
+  timing 与 allocation 之前完成，worker identity 与 timing distribution 均
+  fail closed 校验，decision 冻结 5 s / 64 MiB，并提供 storage-only scenario。
+- **修复后证据**:
+  - 未分析 1 warmup / 5 repetitions: p95 `3,749,353,208 ns`，相对修复前
+    单次 `5,288,635,375 ns` 降低约 29%；
+  - 正式同机 5/30: p95 wall `4,063,991,416 ns`，Python peak allocation
+    `18,966,815 bytes`，status `pass`；artifact 位于
+    `/private/tmp/om-storage-status-benchmark-acceptance-20260813`；
+  - 相关测试: `59 passed`；payload-content reads `0`，mutation operations
+    `0`，no-follow traversal 保持 `true`。
+
+## Open Questions
+
+- `history_10x` research-storage fixture 的精确增长模型在冻结合同里没有命名
+  当前文件数的基线来源。为保持可复现与保守，本 review 建议冻结为 10,000
+  manifest-declared partitions + 1 manifest；若以后要按生产基线乘十，应通过
+  新 baseline artifact 与 plan amendment 变更，而不是静默改变该 fixture。
+
+## Residual Risk
+
+- 当前 writer 的 O(E) replay 与 global replace 是已知、已测量且明确阻断
+  Phase 3A 的后续工作，不是本 finding。
+- live SQLite stable-copy 仍不是同一 stat tuple 下的原子快照；已分配给后续
+  storage-hardening work unit。
+- payload same-size tampering 仍不在 storage-status 的 payload-free 权限内；
+  需要单独 verifier，不应为性能测试而读取 payload。
+- 本次 PR review 还需在修复后复核最终 GitHub diff 与 CI；当前状态不接受。

--- a/docs/reviews/pr-154-review-20260813-175534.md
+++ b/docs/reviews/pr-154-review-20260813-175534.md
@@ -1,0 +1,102 @@
+# PR Re-review — #154
+
+## Scope
+
+- Mode: PR re-review after automatic finding fix
+- Pull request: `#154` — `research: add storage and projection performance baselines`
+- URL: `https://github.com/liuxie066/options-monitor/pull/154`
+- Base: `main@b94084374d48778a1f2d9ca95ec09ac0de4b419f`
+- Reviewed local head: `perf/data-storage-runtime-projection-p1@74336f2264721dcdbd51881b072358294844119d`
+  plus the uncommitted fix recorded below
+- Re-review time: `2026-08-13 17:55:34 +0800`
+- GitHub state: open Draft PR, mergeable, not merged, no requested reviewers
+- CI for published pre-fix head: `Agent Plugin=success`, `Guardrails=success`;
+  CodeQL checks observed in the PR UI had not yet appeared in the commit-workflow
+  API response
+
+## Finding disposition
+
+### PR-154-01 — accepted — fixed
+
+The initial PR review found that Phase 1 neither measured nor gated the frozen
+`research storage status` p95 wall / Python-allocation budgets and that a
+deterministic 10,000-partition sample exceeded the 5-second wall threshold.
+
+The fix is at both owning boundaries:
+
+- `storage_baseline.py` now builds `file_index` before manifest parsing and
+  passes its immutable `known_files` set into reference resolution. Relative
+  candidates are lexically normalized and checked against the already bounded,
+  no-follow scan rather than repeatedly resolving/statting the filesystem.
+- `performance_baseline.py` adds the independently addressable
+  `research_storage_status.history_10x` component to the existing five-artifact
+  harness. Its deterministic fixture is 10,000 one-byte partitions plus one
+  `integrity.files` manifest. Fixture construction, module import, and worker
+  setup are outside timing/tracemalloc.
+- Worker artifact validation binds the storage fixture identity, rejects setup
+  contamination, validates timing distributions, and requires the same
+  component in timing, CPU, and allocation artifacts.
+- `decision.json` now freezes p95 wall `<= 5,000,000,000 ns` and Python peak
+  allocation `<= 67,108,864 bytes`. The space bound applies on all hosts;
+  absolute timing remains subject to exact reference-host comparability.
+- `--scenario research_storage_status` runs this component without repeating
+  projection scenarios. `--scenario all` and `history_10x` include it.
+- A symlink-escape regression proves the optimized lexical lookup cannot turn
+  an unscanned symlink target into a present manifest reference.
+
+Final finding state: `已修复`.
+
+## Performance and correctness evidence
+
+- Pre-fix uninstrumented representative sample: one collection
+  `5,288,635,375 ns`.
+- Post-fix uninstrumented diagnostic, 1 warmup / 5 repetitions:
+  p95 `3,749,353,208 ns` (about 29% lower than the pre-fix single sample).
+- Post-fix CPU profile confirms repeated `Path.resolve()/realpath` is no longer
+  the dominant manifest-reference cost. Remaining major work is source-token
+  discovery plus the single bounded filesystem scan.
+- Formal storage-only acceptance, Apple M4 / Mac16,10, exact fingerprint
+  `327f740925923dfe92919e74ae630d072bacc6259298e8e0a57b8060ca056aec`,
+  5 warmups / 30 repetitions:
+  - p95 wall: `4,063,991,416 ns` — pass;
+  - Python peak allocation: `18,966,815 bytes` — pass;
+  - payload-content reads: `0`;
+  - mutation operations: `0`;
+  - artifact directory:
+    `/private/tmp/om-storage-status-benchmark-acceptance-20260813`.
+- Focused storage/performance suite: `60 passed`.
+- Aggregate research/ledger suite: `164 passed`.
+- `ruff check`, `compileall`, and `git diff --check`: pass.
+
+## Findings
+
+未发现新的实质性问题。
+
+## Open Questions
+
+- None for this work unit. The exact frozen storage fixture is now explicit;
+  changing it to production-derived cardinalities requires a new baseline
+  artifact and plan amendment.
+
+## Residual Risk
+
+- Current writer O(E) replay plus global lot replacement: `assigned to later
+  work unit`; the existing formal projection artifact still fails the
+  retained-closed-lot subcase and Phase 3A remains `not_ready`.
+- The storage collector still performs one O(files + manifest references)
+  bounded scan and retains metadata required for dedup/capacity output:
+  `accepted current contract`; its 10,000-partition gate now measures both time
+  and Python allocation so regression is visible.
+- Source-inventory discovery is rerun per collection and is now a large
+  constant fraction of CPU profile: `assigned to later work unit only if
+  repeated operator use demonstrates need`; caching it without a source-tree
+  revision key would risk stale authority.
+- Same-size payload tampering remains `not_verified`: `assigned to explicit
+  verifier`; the payload-free status command must not hash payload contents.
+- Live SQLite stable copy remains a bounded coherence check rather than atomic
+  snapshot: `assigned to storage hardening`.
+- Allocation-worker RSS remains a process cumulative high-water mark, while the
+  frozen 64-MiB decision uses the isolated Python tracemalloc peak:
+  `accepted and explicitly labeled`.
+
+All residual risks are classified. PR review status: `pass after fix`.

--- a/scripts/benchmark_data_storage_projection.py
+++ b/scripts/benchmark_data_storage_projection.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.application.research.performance_baseline import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/application/research/performance_baseline.py
+++ b/src/application/research/performance_baseline.py
@@ -1,0 +1,1801 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import cProfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import pstats
+import shutil
+import sqlite3
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from typing import Any, Callable, Iterator, Mapping, Sequence
+import zlib
+
+from domain.domain.ledger import ContractKey, TradeEvent
+from src.application.ledger.event_codec import (
+    encode_trade_event_for_storage,
+    trade_event_application_payload,
+)
+from src.application.ledger.publisher import project_stored_trade_events_to_position_lots
+from src.application.ledger.repository import SQLiteOptionPositionsRepository
+from src.application.ledger.writer import rebuild_position_lots_from_trade_events
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - unavailable on some supported platforms
+    resource = None  # type: ignore[assignment]
+
+
+FIXTURE_SCHEMA = "data_storage_projection_fixture.v1"
+TIMING_SCHEMA = "data_storage_projection_timing.v1"
+CPU_PROFILE_SCHEMA = "data_storage_projection_cpu_profile.v1"
+ALLOCATION_PROFILE_SCHEMA = "data_storage_projection_allocation_profile.v1"
+DECISION_SCHEMA = "data_storage_projection_gate_decision.v1"
+WORKER_SPEC_SCHEMA = "data_storage_projection_worker_spec.v1"
+SEED = 20260813
+DEFAULT_WARMUPS = 5
+DEFAULT_REPETITIONS = 30
+DEFAULT_CURRENT_EVENTS = 100
+DEFAULT_CURRENT_LOTS = 50
+DEFAULT_ACCOUNT_COUNT = 2
+DEFAULT_PAYLOAD_BYTES = 768
+MIN_HISTORY_EVENTS = 10_000
+MAX_HISTORY_EVENTS = 20_000
+MAX_CURRENT_EVENTS = 10_000
+MAX_CURRENT_LOTS = 500
+MAX_CURRENT_STATE_LOTS = 5_000
+MAX_ACCOUNTS = 50
+MIN_PAYLOAD_BYTES = 256
+MAX_PAYLOAD_BYTES = 4_096
+WALL_LIMIT_NS = 2_000_000_000
+CPU_LIMIT_NS = 1_500_000_000
+ARTIFACT_FILENAMES = (
+    "fixture-manifest.json",
+    "timing.json",
+    "cpu-profile.json",
+    "allocation-profile.json",
+    "decision.json",
+)
+PUBLIC_SCENARIOS = (
+    "all",
+    "current_scale",
+    "history_10x",
+    "current_state_10x",
+    "account_fanout",
+)
+
+
+@dataclass(frozen=True)
+class BaselineDimensions:
+    event_count: int
+    current_lot_count: int
+    account_count: int
+    payload_bytes: int
+    dimension_source: str
+    requested: dict[str, int]
+    clamped: dict[str, dict[str, int]]
+    metadata: dict[str, Any]
+
+
+def run_data_storage_projection_benchmark(
+    *,
+    repo_root: str | Path,
+    output_dir: str | Path,
+    baseline: str | Path | None = None,
+    scenario: str = "all",
+    warmups: int = DEFAULT_WARMUPS,
+    repetitions: int = DEFAULT_REPETITIONS,
+    seed: int = SEED,
+    reference_host_fingerprint: str | None = None,
+    worker_runner: Callable[..., dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build deterministic fixtures and publish a complete local evidence set.
+
+    The benchmark consumes only aggregate metadata from an optional Slice 1
+    report. Every SQLite file opened by the measured writer is created below a
+    private temporary directory owned by the worker process.
+    """
+
+    base = Path(repo_root).expanduser().resolve(strict=True)
+    selected = _selected_scenarios(scenario)
+    warmup_count = _bounded_nonnegative_int(warmups, name="warmups", maximum=100)
+    repetition_count = _bounded_positive_int(repetitions, name="repetitions", maximum=1_000)
+    fixture_seed = _bounded_nonnegative_int(seed, name="seed", maximum=2**31 - 1)
+    reference_fingerprint = _validated_reference_fingerprint(reference_host_fingerprint)
+    dimensions = _load_baseline_dimensions(baseline, repo_root=base)
+    scenario_specs = _build_scenario_specs(dimensions, selected=selected)
+    host = _host_profile()
+    run_label = (
+        "acceptance_5_warmups_30_repetitions"
+        if warmup_count == DEFAULT_WARMUPS and repetition_count == DEFAULT_REPETITIONS
+        else "non_acceptance_smoke"
+    )
+    fixture_manifest = _build_fixture_manifest(
+        repo_root=base,
+        dimensions=dimensions,
+        specs=scenario_specs,
+        seed=fixture_seed,
+        host=host,
+        run_label=run_label,
+    )
+    worker_spec = {
+        "schema_version": WORKER_SPEC_SCHEMA,
+        "seed": fixture_seed,
+        "warmups": warmup_count,
+        "repetitions": repetition_count,
+        "run_label": run_label,
+        "scenarios": scenario_specs,
+    }
+    run_worker = worker_runner or _run_worker_process
+    timing = run_worker(repo_root=base, mode="timing", worker_spec=worker_spec)
+    cpu_profile = run_worker(repo_root=base, mode="cpu", worker_spec=worker_spec)
+    allocation_profile = run_worker(repo_root=base, mode="allocation", worker_spec=worker_spec)
+    _validate_worker_artifacts(
+        fixture_manifest=fixture_manifest,
+        timing=timing,
+        cpu_profile=cpu_profile,
+        allocation_profile=allocation_profile,
+        expected_warmups=warmup_count,
+        expected_repetitions=repetition_count,
+        expected_run_label=run_label,
+    )
+    decision = _build_gate_decision(
+        timing=timing,
+        fixture_manifest=fixture_manifest,
+        current_host=host,
+        reference_host_fingerprint=reference_fingerprint,
+    )
+    target = _publish_artifact_set(
+        output_dir=output_dir,
+        repo_root=base,
+        artifacts={
+            "fixture-manifest.json": fixture_manifest,
+            "timing.json": timing,
+            "cpu-profile.json": cpu_profile,
+            "allocation-profile.json": allocation_profile,
+            "decision.json": decision,
+        },
+    )
+    return {
+        "status": "complete",
+        "output_dir": str(target),
+        "run_label": run_label,
+        "scenario_count": len(scenario_specs),
+        "fixture_set_sha256": fixture_manifest["fixture_set_sha256"],
+        "host_fingerprint": host["fingerprint"],
+        "existing_full_replay_writer": decision["components"]["existing_full_replay_writer"],
+        "phase_3a_combined": decision["phase_3a_combined"],
+    }
+
+
+def _selected_scenarios(value: str) -> tuple[str, ...]:
+    normalized = str(value or "").strip().lower()
+    if normalized not in PUBLIC_SCENARIOS:
+        raise ValueError(f"scenario must be one of: {', '.join(PUBLIC_SCENARIOS)}")
+    if normalized == "all":
+        return PUBLIC_SCENARIOS[1:]
+    return (normalized,)
+
+
+def _bounded_nonnegative_int(value: Any, *, name: str, maximum: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if result < 0 or result > maximum:
+        raise ValueError(f"{name} must be between 0 and {maximum}")
+    return result
+
+
+def _bounded_positive_int(value: Any, *, name: str, maximum: int) -> int:
+    result = _bounded_nonnegative_int(value, name=name, maximum=maximum)
+    if result == 0:
+        raise ValueError(f"{name} must be greater than zero")
+    return result
+
+
+def _validated_reference_fingerprint(value: str | None) -> str | None:
+    if value is None or not str(value).strip():
+        return None
+    normalized = str(value).strip().lower()
+    if len(normalized) != 64 or any(ch not in "0123456789abcdef" for ch in normalized):
+        raise ValueError("reference host fingerprint must be a 64-character lowercase SHA-256")
+    return normalized
+
+
+def _load_baseline_dimensions(
+    value: str | Path | None,
+    *,
+    repo_root: Path,
+) -> BaselineDimensions:
+    if value is None:
+        return BaselineDimensions(
+            event_count=DEFAULT_CURRENT_EVENTS,
+            current_lot_count=DEFAULT_CURRENT_LOTS,
+            account_count=DEFAULT_ACCOUNT_COUNT,
+            payload_bytes=DEFAULT_PAYLOAD_BYTES,
+            dimension_source="defaults",
+            requested={
+                "event_count": DEFAULT_CURRENT_EVENTS,
+                "current_lot_count": DEFAULT_CURRENT_LOTS,
+                "account_count": DEFAULT_ACCOUNT_COUNT,
+                "payload_bytes": DEFAULT_PAYLOAD_BYTES,
+            },
+            clamped={},
+            metadata={"baseline_schema": None, "payload_fields_consumed": 0},
+        )
+
+    raw = Path(value).expanduser()
+    path = (raw if raw.is_absolute() else repo_root / raw).resolve(strict=True)
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("baseline must be a regular JSON file")
+    if path.stat().st_size > 32 * 1024 * 1024:
+        raise ValueError("baseline exceeds the 32 MiB metadata input limit")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"baseline is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != "storage_runtime_baseline.v1":
+        raise ValueError("baseline schema must be storage_runtime_baseline.v1")
+    sqlite_payload = payload.get("sqlite")
+    tables = sqlite_payload.get("tables") if isinstance(sqlite_payload, dict) else None
+    table_rows = {
+        str(item.get("table") or ""): item
+        for item in (tables if isinstance(tables, list) else [])
+        if isinstance(item, dict)
+    }
+    event_row = table_rows.get("trade_events", {})
+    lot_row = table_rows.get("position_lots", {})
+    requested_events = _metadata_int(event_row.get("row_count"), DEFAULT_CURRENT_EVENTS)
+    requested_lots = _metadata_int(lot_row.get("row_count"), DEFAULT_CURRENT_LOTS)
+    requested_accounts = _baseline_account_count(payload)
+    event_json_bytes = _metadata_int(event_row.get("json_bytes"), 0)
+    requested_payload_bytes = (
+        max(MIN_PAYLOAD_BYTES, math.ceil(event_json_bytes / requested_events))
+        if requested_events > 0 and event_json_bytes > 0
+        else DEFAULT_PAYLOAD_BYTES
+    )
+    requested = {
+        "event_count": requested_events,
+        "current_lot_count": requested_lots,
+        "account_count": requested_accounts,
+        "payload_bytes": requested_payload_bytes,
+    }
+    effective = {
+        "event_count": _clamp(max(1, requested_events), 1, MAX_CURRENT_EVENTS),
+        "current_lot_count": _clamp(max(1, requested_lots), 1, MAX_CURRENT_LOTS),
+        "account_count": _clamp(max(1, requested_accounts), 1, MAX_ACCOUNTS),
+        "payload_bytes": _clamp(requested_payload_bytes, MIN_PAYLOAD_BYTES, MAX_PAYLOAD_BYTES),
+    }
+    if effective["event_count"] < effective["current_lot_count"]:
+        effective["event_count"] = effective["current_lot_count"]
+    clamped = {
+        key: {"requested": int(requested[key]), "effective": int(effective[key])}
+        for key in requested
+        if int(requested[key]) != int(effective[key])
+    }
+    return BaselineDimensions(
+        event_count=effective["event_count"],
+        current_lot_count=effective["current_lot_count"],
+        account_count=effective["account_count"],
+        payload_bytes=effective["payload_bytes"],
+        dimension_source="storage_runtime_baseline.v1_metadata",
+        requested=requested,
+        clamped=clamped,
+        metadata={
+            "baseline_schema": "storage_runtime_baseline.v1",
+            "sqlite_status": str(sqlite_payload.get("status") or "unknown")
+            if isinstance(sqlite_payload, dict)
+            else "missing",
+            "table_metadata_consumed": ["trade_events", "position_lots"],
+            "payload_fields_consumed": 0,
+            "paths_retained": 0,
+        },
+    )
+
+
+def _nested_metadata_value(payload: Mapping[str, Any], path: Sequence[str]) -> Any:
+    current: Any = payload
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _baseline_account_count(payload: Mapping[str, Any]) -> int:
+    explicit = _nested_metadata_value(payload, ("runtime_storage", "account_count"))
+    if explicit is not None:
+        return _metadata_int(explicit, DEFAULT_ACCOUNT_COUNT)
+    runtime_storage = payload.get("runtime_storage")
+    roots = runtime_storage.get("roots") if isinstance(runtime_storage, Mapping) else None
+    for row in roots if isinstance(roots, list) else []:
+        if isinstance(row, Mapping) and str(row.get("root") or "") == "output_accounts":
+            # Slice 1 intentionally exposes only payload-free aggregate metadata.
+            # Until it publishes an exact account count, a non-empty account root
+            # proves at least one account but cannot safely be treated as the
+            # configured cardinality.
+            return 1 if _metadata_int(row.get("file_count"), 0) > 0 else DEFAULT_ACCOUNT_COUNT
+    return DEFAULT_ACCOUNT_COUNT
+
+
+def _metadata_int(value: Any, fallback: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return int(fallback)
+    return parsed if parsed >= 0 else int(fallback)
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(maximum, int(value)))
+
+
+def _build_scenario_specs(
+    dimensions: BaselineDimensions,
+    *,
+    selected: Sequence[str],
+) -> list[dict[str, Any]]:
+    current_events = max(dimensions.event_count, dimensions.current_lot_count)
+    current_lots = dimensions.current_lot_count
+    current_accounts = dimensions.account_count
+    history_requested = max(MIN_HISTORY_EVENTS, dimensions.requested["event_count"] * 10)
+    history_events = _clamp(
+        max(MIN_HISTORY_EVENTS, current_events * 10),
+        MIN_HISTORY_EVENTS,
+        MAX_HISTORY_EVENTS,
+    )
+    history_axis_status = (
+        "evaluable"
+        if history_events >= history_requested and history_events >= MIN_HISTORY_EVENTS
+        else "not_evaluable_clamped_below_requested_10x"
+    )
+    state_requested_lots = max(10, dimensions.requested["current_lot_count"] * 10)
+    state_lots = _clamp(max(10, current_lots * 10), 10, MAX_CURRENT_STATE_LOTS)
+    state_ratio = max(1.0, current_events / max(1, current_lots))
+    state_events_requested = max(state_lots, math.ceil(state_lots * state_ratio))
+    state_events = _clamp(state_events_requested, state_lots, MAX_HISTORY_EVENTS)
+    state_axis_status = (
+        "evaluable"
+        if state_lots >= state_requested_lots and state_events >= state_events_requested
+        else "not_evaluable_clamped_below_requested_10x"
+    )
+    fanout_requested_accounts = max(10, dimensions.requested["account_count"] * 5)
+    fanout_accounts = _clamp(max(10, current_accounts * 5), 10, MAX_ACCOUNTS)
+    per_account_lots = max(1, math.ceil(current_lots / max(1, current_accounts)))
+    fanout_lots = min(MAX_CURRENT_STATE_LOTS, fanout_accounts * per_account_lots)
+    fanout_events = min(
+        MAX_HISTORY_EVENTS,
+        max(fanout_lots, math.ceil(fanout_lots * state_ratio)),
+    )
+    fanout_axis_status = (
+        "evaluable"
+        if fanout_accounts >= fanout_requested_accounts
+        else "not_evaluable_clamped_below_requested_5x"
+    )
+    specs: list[dict[str, Any]] = []
+    if "current_scale" in selected:
+        specs.append(
+            _scenario_spec(
+                key="current_scale",
+                axis="current_scale",
+                event_count=current_events,
+                lot_count=current_lots,
+                account_count=current_accounts,
+                payload_bytes=dimensions.payload_bytes,
+                shape="fixed_open_lots_with_verifications",
+                axis_status="evaluable",
+                classification="synthetic_current_scale",
+            )
+        )
+    if "history_10x" in selected:
+        specs.extend(
+            [
+                _scenario_spec(
+                    key="history_10x.fixed_output",
+                    axis="history_10x",
+                    event_count=history_events,
+                    lot_count=current_lots,
+                    account_count=current_accounts,
+                    payload_bytes=dimensions.payload_bytes,
+                    shape="fixed_open_lots_with_verifications",
+                    axis_status=history_axis_status,
+                    classification="complexity_isolation_not_production_event_mix",
+                    requested_event_count=history_requested,
+                ),
+                _scenario_spec(
+                    key="history_10x.retained_closed_lots",
+                    axis="history_10x",
+                    event_count=history_events,
+                    lot_count=history_events // 2,
+                    account_count=current_accounts,
+                    payload_bytes=dimensions.payload_bytes,
+                    shape="open_close_pairs",
+                    axis_status=history_axis_status,
+                    classification="current_retained_closed_lot_coupling",
+                    requested_event_count=history_requested,
+                ),
+            ]
+        )
+    if "current_state_10x" in selected:
+        specs.append(
+            _scenario_spec(
+                key="current_state_10x",
+                axis="current_state_10x",
+                event_count=state_events,
+                lot_count=state_lots,
+                account_count=current_accounts,
+                payload_bytes=dimensions.payload_bytes,
+                shape="fixed_open_lots_with_verifications",
+                axis_status=state_axis_status,
+                classification="current_state_growth_axis",
+                requested_event_count=state_events_requested,
+                requested_lot_count=state_requested_lots,
+            )
+        )
+    if "account_fanout" in selected:
+        specs.append(
+            _scenario_spec(
+                key="account_fanout",
+                axis="account_fanout",
+                event_count=fanout_events,
+                lot_count=fanout_lots,
+                account_count=fanout_accounts,
+                payload_bytes=dimensions.payload_bytes,
+                shape="fixed_open_lots_with_verifications",
+                axis_status=fanout_axis_status,
+                classification="account_fanout_growth_axis",
+                requested_event_count=fanout_events,
+                requested_lot_count=fanout_lots,
+                requested_account_count=fanout_requested_accounts,
+            )
+        )
+    return specs
+
+
+def _scenario_spec(
+    *,
+    key: str,
+    axis: str,
+    event_count: int,
+    lot_count: int,
+    account_count: int,
+    payload_bytes: int,
+    shape: str,
+    axis_status: str,
+    classification: str,
+    requested_event_count: int | None = None,
+    requested_lot_count: int | None = None,
+    requested_account_count: int | None = None,
+) -> dict[str, Any]:
+    if shape == "open_close_pairs":
+        projected_lots = event_count // 2
+        open_lots = 0
+        risk_views = 0
+        allocations = event_count // 2
+    else:
+        projected_lots = lot_count
+        open_lots = lot_count
+        risk_views = lot_count
+        allocations = 0
+    return {
+        "key": key,
+        "axis": axis,
+        "shape": shape,
+        "classification": classification,
+        "axis_status": axis_status,
+        "requested_dimensions": {
+            "event_count": int(requested_event_count if requested_event_count is not None else event_count),
+            "projected_lot_count": int(requested_lot_count if requested_lot_count is not None else projected_lots),
+            "account_count": int(
+                requested_account_count if requested_account_count is not None else account_count
+            ),
+            "payload_bytes": int(payload_bytes),
+        },
+        "effective_dimensions": {
+            "event_count": int(event_count),
+            "projected_lot_count": int(projected_lots),
+            "open_lot_count": int(open_lots),
+            "risk_view_count": int(risk_views),
+            "allocation_count": int(allocations),
+            "account_count": int(account_count),
+            "payload_bytes": int(payload_bytes),
+        },
+    }
+
+
+def _build_fixture_manifest(
+    *,
+    repo_root: Path,
+    dimensions: BaselineDimensions,
+    specs: Sequence[dict[str, Any]],
+    seed: int,
+    host: dict[str, Any],
+    run_label: str,
+) -> dict[str, Any]:
+    scenarios: list[dict[str, Any]] = []
+    fixture_hashes: list[str] = []
+    for spec in specs:
+        events = _build_synthetic_events(spec, seed=seed)
+        metrics = _event_payload_metrics(events)
+        fixture_hash = _events_sha256(events)
+        fixture_hashes.append(fixture_hash)
+        scenarios.append(
+            {
+                **spec,
+                "fixture_sha256": fixture_hash,
+                "payload_distribution": metrics,
+                "synthetic_only": True,
+            }
+        )
+    return {
+        "schema_version": FIXTURE_SCHEMA,
+        "fixture_seed": int(seed),
+        "fixture_set_sha256": _sha256_json(fixture_hashes),
+        "dimension_source": dimensions.dimension_source,
+        "baseline_dimensions": {
+            "requested": dimensions.requested,
+            "effective": {
+                "event_count": dimensions.event_count,
+                "current_lot_count": dimensions.current_lot_count,
+                "account_count": dimensions.account_count,
+                "payload_bytes": dimensions.payload_bytes,
+            },
+            "clamped": dimensions.clamped,
+            "metadata": dimensions.metadata,
+        },
+        "identity": {
+            "python_version": platform.python_version(),
+            "sqlite_version": sqlite3.sqlite_version,
+            "platform": platform.platform(),
+            "git_sha": _git_sha(repo_root),
+            "host_profile": host,
+            "run_label": run_label,
+            "process_condition": {
+                "worker_start": "fresh_process_per_measurement_mode",
+                "timing_repetitions": "warm_after_fixture_setup",
+                "os_page_cache": "not_flushed",
+            },
+        },
+        "safety": {
+            "synthetic_trade_events_only": True,
+            "production_sqlite_connections": 0,
+            "temporary_sqlite_only": True,
+            "runtime_mutations": 0,
+        },
+        "scenarios": scenarios,
+    }
+
+
+def _build_synthetic_events(spec: Mapping[str, Any], *, seed: int) -> list[dict[str, Any]]:
+    dims = spec.get("effective_dimensions")
+    if not isinstance(dims, Mapping):
+        raise ValueError("scenario effective_dimensions are missing")
+    event_count = _bounded_positive_int(dims.get("event_count"), name="event_count", maximum=MAX_HISTORY_EVENTS)
+    lot_count = _bounded_nonnegative_int(
+        dims.get("projected_lot_count"),
+        name="projected_lot_count",
+        maximum=MAX_CURRENT_STATE_LOTS * 2,
+    )
+    account_count = _bounded_positive_int(dims.get("account_count"), name="account_count", maximum=MAX_ACCOUNTS)
+    payload_bytes = _bounded_positive_int(dims.get("payload_bytes"), name="payload_bytes", maximum=MAX_PAYLOAD_BYTES)
+    key = str(spec.get("key") or "").strip()
+    shape = str(spec.get("shape") or "").strip()
+    if not key or shape not in {"fixed_open_lots_with_verifications", "open_close_pairs"}:
+        raise ValueError("scenario key or shape is invalid")
+    events: list[dict[str, Any]] = []
+    if shape == "open_close_pairs":
+        pair_count = event_count // 2
+        for pair_index in range(pair_count):
+            open_event = _synthetic_event(
+                scenario_key=key,
+                sequence=len(events),
+                lot_index=pair_index,
+                account_index=pair_index % account_count,
+                event_type="open",
+                target_lot_id=None,
+                payload_bytes=payload_bytes,
+                seed=seed,
+            )
+            events.append(open_event)
+            events.append(
+                _synthetic_event(
+                    scenario_key=key,
+                    sequence=len(events),
+                    lot_index=pair_index,
+                    account_index=pair_index % account_count,
+                    event_type="close",
+                    target_lot_id=str(open_event["lot_id"]),
+                    payload_bytes=payload_bytes,
+                    seed=seed,
+                )
+            )
+        if len(events) < event_count:
+            events.append(
+                _synthetic_event(
+                    scenario_key=key,
+                    sequence=len(events),
+                    lot_index=0,
+                    account_index=0,
+                    event_type="verification",
+                    target_lot_id=None,
+                    payload_bytes=payload_bytes,
+                    seed=seed,
+                )
+            )
+    else:
+        if lot_count > event_count:
+            raise ValueError("fixed-output fixture cannot have more lots than events")
+        for lot_index in range(lot_count):
+            events.append(
+                _synthetic_event(
+                    scenario_key=key,
+                    sequence=len(events),
+                    lot_index=lot_index,
+                    account_index=lot_index % account_count,
+                    event_type="open",
+                    target_lot_id=None,
+                    payload_bytes=payload_bytes,
+                    seed=seed,
+                )
+            )
+        while len(events) < event_count:
+            sequence = len(events)
+            events.append(
+                _synthetic_event(
+                    scenario_key=key,
+                    sequence=sequence,
+                    lot_index=sequence % max(1, lot_count),
+                    account_index=sequence % account_count,
+                    event_type="verification",
+                    target_lot_id=None,
+                    payload_bytes=payload_bytes,
+                    seed=seed,
+                )
+            )
+    if len(events) != event_count:
+        raise AssertionError("synthetic fixture cardinality mismatch")
+    return events
+
+
+def _synthetic_event(
+    *,
+    scenario_key: str,
+    sequence: int,
+    lot_index: int,
+    account_index: int,
+    event_type: str,
+    target_lot_id: str | None,
+    payload_bytes: int,
+    seed: int,
+) -> dict[str, Any]:
+    slug = scenario_key.replace(".", "-").replace("_", "-")
+    event_id = f"bench-{slug}-{sequence:06d}-{event_type}"
+    lot_id = f"lot-{slug}-{lot_index:06d}"
+    entropy_class = ("low", "median", "high")[sequence % 3]
+    raw_payload = {
+        "benchmark_schema": FIXTURE_SCHEMA,
+        "fixture_seed": int(seed),
+        "entropy_class": entropy_class,
+        "synthetic_filler": _deterministic_filler(
+            seed=seed,
+            scenario_key=scenario_key,
+            sequence=sequence,
+            entropy_class=entropy_class,
+            size=payload_bytes,
+        ),
+        "source_type": "synthetic_benchmark",
+        "side": "buy" if event_type == "close" else "sell",
+    }
+    if event_type == "close":
+        raw_payload["close_type"] = "buy_to_close"
+    contract_key = ContractKey.from_values(
+        broker="futu",
+        account=f"bench{account_index:02d}",
+        underlying_symbol="NVDA",
+        option_type="put",
+        position_side="short",
+        strike=10.0 + (lot_index * 0.01),
+        expiration_ymd="2028-12-15",
+    )
+    event = TradeEvent(
+        event_id=event_id,
+        event_type=event_type,
+        event_time_ms=1_800_000_000_000 + sequence,
+        contract_key=contract_key,
+        contracts=1 if event_type in {"open", "close"} else 0,
+        price=2.0 if event_type == "open" else 0.5 if event_type == "close" else 0.0,
+        currency="USD",
+        source="synthetic_benchmark",
+        multiplier=100.0,
+        fees=0.0,
+        target_lot_id=target_lot_id,
+        lot_id=lot_id if event_type == "open" else None,
+        raw_payload=raw_payload,
+    )
+    # The real writer reads canonical storage rows through the compatibility
+    # adapter before projection. Feed the projector-only component the same
+    # public stored-event shape so parity tests compare the measured components,
+    # not an incidental pre-adapter representation.
+    return trade_event_application_payload(event.to_dict())
+
+
+def _deterministic_filler(
+    *,
+    seed: int,
+    scenario_key: str,
+    sequence: int,
+    entropy_class: str,
+    size: int,
+) -> str:
+    target = max(1, int(size))
+    if entropy_class == "low":
+        return "L" * target
+    token = hashlib.sha256(f"{seed}:{scenario_key}:{sequence}".encode("utf-8")).digest()
+    if entropy_class == "median":
+        alphabet = base64.b32encode(token).decode("ascii").rstrip("=")
+        chunk = f"{alphabet[:8]}:{sequence % 97:02d}|"
+    else:
+        chunks: list[str] = []
+        produced = 0
+        block = 0
+        while produced < target:
+            digest = hashlib.sha256(token + block.to_bytes(4, "big")).digest()
+            encoded = base64.b85encode(digest).decode("ascii")
+            chunks.append(encoded)
+            produced += len(encoded)
+            block += 1
+        return "".join(chunks)[:target]
+    repeats = math.ceil(target / len(chunk))
+    return (chunk * repeats)[:target]
+
+
+def _event_payload_metrics(events: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    sizes: list[int] = []
+    ratios: list[float] = []
+    class_rows: dict[str, list[tuple[int, float]]] = {"low": [], "median": [], "high": []}
+    compressed_total = 0
+    for event in events:
+        encoded = _canonical_json_bytes(event)
+        compressed = zlib.compress(encoded, level=6)
+        size = len(encoded)
+        ratio = len(compressed) / max(1, size)
+        entropy = str((event.get("raw_payload") or {}).get("entropy_class") or "unknown")
+        sizes.append(size)
+        ratios.append(ratio)
+        compressed_total += len(compressed)
+        class_rows.setdefault(entropy, []).append((size, ratio))
+    return {
+        "uncompressed_bytes": _distribution(sizes),
+        "compressed_bytes_total_individual_rows": compressed_total,
+        "compression_ratio": _float_distribution(ratios),
+        "entropy_classes": {
+            name: {
+                "row_count": len(rows),
+                "uncompressed_bytes": _distribution([row[0] for row in rows]),
+                "compression_ratio": _float_distribution([row[1] for row in rows]),
+            }
+            for name, rows in sorted(class_rows.items())
+            if rows
+        },
+    }
+
+
+def _distribution(values: Sequence[int]) -> dict[str, int]:
+    if not values:
+        return {"count": 0, "total": 0, "min": 0, "p50": 0, "p95": 0, "p99": 0, "max": 0}
+    ordered = sorted(int(value) for value in values)
+    return {
+        "count": len(ordered),
+        "total": sum(ordered),
+        "min": ordered[0],
+        "p50": _nearest_rank(ordered, 0.50),
+        "p95": _nearest_rank(ordered, 0.95),
+        "p99": _nearest_rank(ordered, 0.99),
+        "max": ordered[-1],
+    }
+
+
+def _float_distribution(values: Sequence[float]) -> dict[str, float | int]:
+    if not values:
+        return {"count": 0, "min": 0.0, "p50": 0.0, "p95": 0.0, "p99": 0.0, "max": 0.0}
+    ordered = sorted(float(value) for value in values)
+    return {
+        "count": len(ordered),
+        "min": round(ordered[0], 6),
+        "p50": round(float(_nearest_rank(ordered, 0.50)), 6),
+        "p95": round(float(_nearest_rank(ordered, 0.95)), 6),
+        "p99": round(float(_nearest_rank(ordered, 0.99)), 6),
+        "max": round(ordered[-1], 6),
+    }
+
+
+def _nearest_rank(ordered: Sequence[Any], percentile: float) -> Any:
+    index = max(0, min(len(ordered) - 1, math.ceil(percentile * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _events_sha256(events: Sequence[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    for index, event in enumerate(events):
+        if index:
+            digest.update(b",")
+        digest.update(_canonical_json_bytes(event))
+    digest.update(b"]")
+    return digest.hexdigest()
+
+
+def _sha256_json(value: Any) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _host_profile() -> dict[str, Any]:
+    fields = {
+        "schema_version": "data_storage_projection_host_profile.v1",
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "hardware_model": _hardware_model(),
+        "physical_memory_bytes": _physical_memory_bytes(),
+        "python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version(),
+        "sqlite_version": sqlite3.sqlite_version,
+        "logical_cpu_count": int(os.cpu_count() or 0),
+    }
+    return {**fields, "fingerprint": _sha256_json(fields)}
+
+
+def _hardware_model() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        for key in ("machdep.cpu.brand_string", "hw.model"):
+            try:
+                result = subprocess.run(
+                    ["/usr/sbin/sysctl", "-n", key],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                )
+            except (OSError, subprocess.SubprocessError):
+                continue
+            value = result.stdout.strip()
+            if value:
+                return value
+    if system == "Linux":
+        try:
+            for line in Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines():
+                if line.lower().startswith(("model name", "hardware")) and ":" in line:
+                    value = line.split(":", 1)[1].strip()
+                    if value:
+                        return value
+        except (OSError, UnicodeError):
+            pass
+    return platform.processor() or "unknown"
+
+
+def _physical_memory_bytes() -> int | None:
+    try:
+        page_size = int(os.sysconf("SC_PAGE_SIZE"))
+        page_count = int(os.sysconf("SC_PHYS_PAGES"))
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+    total = page_size * page_count
+    return total if total > 0 else None
+
+
+def _git_sha(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _run_worker_process(
+    *,
+    repo_root: Path,
+    mode: str,
+    worker_spec: dict[str, Any],
+) -> dict[str, Any]:
+    if mode not in {"timing", "cpu", "allocation"}:
+        raise ValueError(f"unsupported worker mode: {mode}")
+    script = repo_root / "scripts/benchmark_data_storage_projection.py"
+    if not script.is_file():
+        raise ValueError("benchmark worker script is missing")
+    with tempfile.TemporaryDirectory(prefix="om-projection-worker-") as temp_name:
+        temp_root = Path(temp_name)
+        spec_path = temp_root / "worker-spec.json"
+        spec_path.write_bytes(_canonical_json_bytes(worker_spec) + b"\n")
+        env = os.environ.copy()
+        env["PYTHONPYCACHEPREFIX"] = str(temp_root / "pycache")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--_worker-mode",
+                mode,
+                "--_worker-spec",
+                str(spec_path),
+            ],
+            cwd=repo_root,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise RuntimeError(f"{mode} worker failed: {detail[-4_000:]}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{mode} worker returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{mode} worker returned a non-object payload")
+    return payload
+
+
+def _worker_payload(*, mode: str, worker_spec: Mapping[str, Any]) -> dict[str, Any]:
+    if worker_spec.get("schema_version") != WORKER_SPEC_SCHEMA:
+        raise ValueError("worker spec schema is invalid")
+    raw_scenarios = worker_spec.get("scenarios")
+    if not isinstance(raw_scenarios, list) or not raw_scenarios:
+        raise ValueError("worker spec scenarios are missing")
+    seed = _bounded_nonnegative_int(worker_spec.get("seed"), name="seed", maximum=2**31 - 1)
+    warmups = _bounded_nonnegative_int(worker_spec.get("warmups"), name="warmups", maximum=100)
+    repetitions = _bounded_positive_int(worker_spec.get("repetitions"), name="repetitions", maximum=1_000)
+    label = str(worker_spec.get("run_label") or "")
+    if mode == "timing":
+        rows = [
+            _measure_timing_scenario(spec, seed=seed, warmups=warmups, repetitions=repetitions)
+            for spec in raw_scenarios
+            if isinstance(spec, dict)
+        ]
+        return {
+            "schema_version": TIMING_SCHEMA,
+            "measurement_mode": "timing_without_profiler",
+            "profilers_enabled": False,
+            "tracemalloc_enabled": False,
+            "warmups": warmups,
+            "repetitions": repetitions,
+            "run_label": label,
+            "clock_authority": ["time.perf_counter_ns", "time.process_time_ns"],
+            "scenarios": rows,
+        }
+    if mode == "cpu":
+        rows = [
+            _measure_cpu_scenario(spec, seed=seed)
+            for spec in raw_scenarios
+            if isinstance(spec, dict)
+        ]
+        return {
+            "schema_version": CPU_PROFILE_SCHEMA,
+            "measurement_mode": "cprofile_separate_process",
+            "timing_threshold_eligible": False,
+            "tracemalloc_enabled": False,
+            "scenarios": rows,
+        }
+    if mode == "allocation":
+        rows = [
+            _measure_allocation_scenario(spec, seed=seed)
+            for spec in raw_scenarios
+            if isinstance(spec, dict)
+        ]
+        return {
+            "schema_version": ALLOCATION_PROFILE_SCHEMA,
+            "measurement_mode": "tracemalloc_separate_process",
+            "timing_threshold_eligible": False,
+            "cprofile_enabled": False,
+            "scenarios": rows,
+        }
+    raise ValueError(f"unsupported worker mode: {mode}")
+
+
+def _measure_timing_scenario(
+    spec: Mapping[str, Any],
+    *,
+    seed: int,
+    warmups: int,
+    repetitions: int,
+) -> dict[str, Any]:
+    events = _build_synthetic_events(spec, seed=seed)
+    fixture_hash = _events_sha256(events)
+    projector = _timed_projector(events, warmups=warmups, repetitions=repetitions)
+    writer = _timed_writer(events, warmups=warmups, repetitions=repetitions)
+    parity = _projection_parity(projector["output"], writer["output"])
+    _assert_expected_counts(spec, projector["output"])
+    if not parity["exact"]:
+        raise RuntimeError(f"writer/projector output mismatch for {spec.get('key')}: {parity}")
+    return {
+        "key": str(spec.get("key") or ""),
+        "fixture_sha256": fixture_hash,
+        "axis_status": str(spec.get("axis_status") or "unknown"),
+        "counts": _output_counts(projector["output"]),
+        "parity": parity,
+        "components": {
+            "projector_only": projector,
+            "existing_full_replay_writer": writer,
+        },
+    }
+
+
+def _timed_projector(
+    events: list[dict[str, Any]],
+    *,
+    warmups: int,
+    repetitions: int,
+) -> dict[str, Any]:
+    projection: Any = None
+    for _ in range(warmups):
+        projection = project_stored_trade_events_to_position_lots(events)
+    wall_samples: list[int] = []
+    cpu_samples: list[int] = []
+    for _ in range(repetitions):
+        wall_start = time.perf_counter_ns()
+        cpu_start = time.process_time_ns()
+        projection = project_stored_trade_events_to_position_lots(events)
+        cpu_samples.append(time.process_time_ns() - cpu_start)
+        wall_samples.append(time.perf_counter_ns() - wall_start)
+    if projection is None:
+        projection = project_stored_trade_events_to_position_lots(events)
+    return {
+        "measurement_scope": "canonical_codec_projection_no_sqlite",
+        "wall_time_ns": _timing_distribution(wall_samples),
+        "cpu_time_ns": _timing_distribution(cpu_samples),
+        "output": _projection_output(projection, event_count=len(events)),
+        "sql": {
+            "application_statement_count_per_replay": 0,
+            "rows_read_per_replay": 0,
+            "rows_written_per_replay": 0,
+        },
+    }
+
+
+def _timed_writer(
+    events: list[dict[str, Any]],
+    *,
+    warmups: int,
+    repetitions: int,
+) -> dict[str, Any]:
+    with _temporary_writer(events) as context:
+        result: Any = None
+        for _ in range(warmups):
+            result = rebuild_position_lots_from_trade_events(context["repo"])
+        wall_samples: list[int] = []
+        cpu_samples: list[int] = []
+        peak_sqlite = dict(context["before"])
+        for _ in range(repetitions):
+            wall_start = time.perf_counter_ns()
+            cpu_start = time.process_time_ns()
+            result = rebuild_position_lots_from_trade_events(context["repo"])
+            cpu_samples.append(time.process_time_ns() - cpu_start)
+            wall_samples.append(time.perf_counter_ns() - wall_start)
+            peak_sqlite = _max_sqlite_sizes(peak_sqlite, _sqlite_sizes(context["db_path"]))
+        if result is None:
+            result = rebuild_position_lots_from_trade_events(context["repo"])
+        after_replay = _sqlite_sizes(context["db_path"])
+        rows = context["repo"].list_position_lots(conn=context["keeper"])
+        output = _writer_output(result, rows=rows, event_count=len(events))
+        context["keeper"].execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        after_checkpoint = _sqlite_sizes(context["db_path"])
+        lot_count = int(output["counts"]["projected_lot_count"])
+        return {
+            "measurement_scope": "temporary_sqlite_load_decode_publishability_global_replace",
+            "wall_time_ns": _timing_distribution(wall_samples),
+            "cpu_time_ns": _timing_distribution(cpu_samples),
+            "output": output,
+            "sqlite_bytes": {
+                "before_replay": context["before"],
+                "peak_observed_after_repetition": peak_sqlite,
+                "after_replay_before_checkpoint": after_replay,
+                "steady_state_after_wal_checkpoint_truncate": after_checkpoint,
+            },
+            "sql": {
+                "count_basis": "known_current_writer_operations",
+                "application_statement_count_per_replay": 2 + lot_count,
+                "select_statements_per_replay": 1,
+                "delete_statements_per_replay": 1,
+                "insert_statements_per_replay": lot_count,
+                "trade_event_rows_read_per_replay": len(events),
+                "position_lot_rows_inserted_per_replay": lot_count,
+                "publication_behavior": "global_delete_then_insert",
+            },
+        }
+
+
+def _timing_distribution(samples: Sequence[int]) -> dict[str, Any]:
+    ordered = sorted(int(value) for value in samples)
+    if not ordered:
+        raise ValueError("timing samples are empty")
+    return {
+        "unit": "ns",
+        "sample_count": len(ordered),
+        "median": int(statistics.median(ordered)),
+        "p95": int(_nearest_rank(ordered, 0.95)),
+        "min": ordered[0],
+        "max": ordered[-1],
+        "samples": list(samples),
+    }
+
+
+@contextmanager
+def _temporary_writer(events: Sequence[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    with tempfile.TemporaryDirectory(prefix="om-synthetic-ledger-") as temp_name:
+        db_path = Path(temp_name) / "synthetic-option-positions.sqlite3"
+        repo = SQLiteOptionPositionsRepository(db_path)
+        keeper = repo._connect()
+        try:
+            now_ms = 1_800_000_000_000
+            rows = []
+            for event in events:
+                encoded = encode_trade_event_for_storage(event)
+                rows.append(
+                    (
+                        encoded.event_id,
+                        encoded.event_json,
+                        encoded.event_time_ms,
+                        now_ms,
+                        now_ms,
+                    )
+                )
+            keeper.executemany(
+                "INSERT INTO trade_events "
+                "(event_id, event_json, trade_time_ms, created_at_ms, updated_at_ms) "
+                "VALUES (?, ?, ?, ?, ?)",
+                rows,
+            )
+            keeper.commit()
+            keeper.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            before = _sqlite_sizes(db_path)
+            yield {"repo": repo, "keeper": keeper, "db_path": db_path, "before": before}
+        finally:
+            keeper.close()
+
+
+def _sqlite_sizes(db_path: Path) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for label, suffix in (("db", ""), ("wal", "-wal"), ("shm", "-shm")):
+        path = Path(str(db_path) + suffix)
+        try:
+            result[f"{label}_bytes"] = int(path.stat().st_size)
+        except FileNotFoundError:
+            result[f"{label}_bytes"] = 0
+    result["total_bytes"] = sum(result.values())
+    return result
+
+
+def _max_sqlite_sizes(left: Mapping[str, int], right: Mapping[str, int]) -> dict[str, int]:
+    return {key: max(int(left.get(key, 0)), int(right.get(key, 0))) for key in set(left) | set(right)}
+
+
+def _projection_output(projection: Any, *, event_count: int) -> dict[str, Any]:
+    lots = [lot.to_dict() for lot in projection.lots]
+    diagnostics = [item.to_dict() for item in projection.diagnostics]
+    ledger_projection = projection.ledger_projection
+    return _canonical_output(
+        events=event_count,
+        lots=lots,
+        diagnostics=diagnostics,
+        risk_view_count=len(ledger_projection.views),
+        allocation_count=len(ledger_projection.allocations),
+    )
+
+
+def _writer_output(result: Any, *, rows: Sequence[dict[str, Any]], event_count: int) -> dict[str, Any]:
+    payload = result.to_dict() if callable(getattr(result, "to_dict", None)) else dict(result)
+    return _canonical_output(
+        events=event_count,
+        lots=list(rows),
+        diagnostics=list(payload.get("projection_diagnostics") or []),
+        risk_view_count=None,
+        allocation_count=None,
+    )
+
+
+def _canonical_output(
+    *,
+    events: int,
+    lots: Sequence[dict[str, Any]],
+    diagnostics: Sequence[dict[str, Any]],
+    risk_view_count: int | None,
+    allocation_count: int | None,
+) -> dict[str, Any]:
+    canonical_lots = sorted(
+        [
+            {
+                "record_id": str(item.get("record_id") or ""),
+                "fields": dict(item.get("fields") or {}),
+            }
+            for item in lots
+        ],
+        key=lambda item: item["record_id"],
+    )
+    canonical_diagnostics = [dict(item) for item in diagnostics]
+    open_lots = sum(
+        1
+        for item in canonical_lots
+        if int((item["fields"].get("contracts_open") or 0)) > 0
+    )
+    lot_fingerprint = _sha256_json(canonical_lots)
+    diagnostic_fingerprint = _sha256_json(canonical_diagnostics)
+    return {
+        "lot_fingerprint": lot_fingerprint,
+        "diagnostic_fingerprint": diagnostic_fingerprint,
+        "combined_fingerprint": _sha256_json(
+            {"lots": canonical_lots, "diagnostics": canonical_diagnostics}
+        ),
+        "counts": {
+            "event_count": int(events),
+            "projected_lot_count": len(canonical_lots),
+            "open_lot_count": open_lots,
+            "risk_view_count": risk_view_count,
+            "allocation_count": allocation_count,
+            "diagnostic_count": len(canonical_diagnostics),
+        },
+    }
+
+
+def _projection_parity(projector: Mapping[str, Any], writer: Mapping[str, Any]) -> dict[str, Any]:
+    fields = ("lot_fingerprint", "diagnostic_fingerprint", "combined_fingerprint")
+    mismatches = [field for field in fields if projector.get(field) != writer.get(field)]
+    return {
+        "exact": not mismatches,
+        "mismatched_fingerprints": mismatches,
+        "writer_risk_and_allocation_counts": "bound_to_same_canonical_projection_not_exposed_by_writer_result",
+    }
+
+
+def _output_counts(output: Mapping[str, Any]) -> dict[str, Any]:
+    return dict(output.get("counts") or {})
+
+
+def _assert_expected_counts(spec: Mapping[str, Any], output: Mapping[str, Any]) -> None:
+    expected = spec.get("effective_dimensions")
+    counts = output.get("counts")
+    if not isinstance(expected, Mapping) or not isinstance(counts, Mapping):
+        raise RuntimeError("fixture counts are missing")
+    names = (
+        "event_count",
+        "projected_lot_count",
+        "open_lot_count",
+        "risk_view_count",
+        "allocation_count",
+    )
+    mismatches = {
+        name: {"expected": expected.get(name), "actual": counts.get(name)}
+        for name in names
+        if expected.get(name) != counts.get(name)
+    }
+    if mismatches:
+        raise RuntimeError(f"fixture output cardinality mismatch: {mismatches}")
+
+
+def _measure_cpu_scenario(spec: Mapping[str, Any], *, seed: int) -> dict[str, Any]:
+    events = _build_synthetic_events(spec, seed=seed)
+    projector_profile, projector_output = _profile_call(
+        lambda: project_stored_trade_events_to_position_lots(events),
+        output_fn=lambda result: _projection_output(result, event_count=len(events)),
+    )
+    with _temporary_writer(events) as context:
+        writer_profile, writer_output = _profile_call(
+            lambda: rebuild_position_lots_from_trade_events(context["repo"]),
+            output_fn=lambda result: _writer_output(
+                result,
+                rows=context["repo"].list_position_lots(conn=context["keeper"]),
+                event_count=len(events),
+            ),
+        )
+    parity = _projection_parity(projector_output, writer_output)
+    if not parity["exact"]:
+        raise RuntimeError(f"CPU profile parity failed for {spec.get('key')}")
+    return {
+        "key": str(spec.get("key") or ""),
+        "fixture_sha256": _events_sha256(events),
+        "parity": parity,
+        "components": {
+            "projector_only": projector_profile,
+            "existing_full_replay_writer": writer_profile,
+        },
+    }
+
+
+def _profile_call(
+    fn: Callable[[], Any],
+    *,
+    output_fn: Callable[[Any], dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    profiler = cProfile.Profile()
+    profiler.enable()
+    result = fn()
+    profiler.disable()
+    output = output_fn(result)
+    stats = pstats.Stats(profiler)
+    rows = []
+    for (filename, line, function), values in sorted(
+        stats.stats.items(),
+        key=lambda item: (-float(item[1][3]), str(item[0])),
+    )[:30]:
+        primitive_calls, total_calls, total_time, cumulative_time, _callers = values
+        rows.append(
+            {
+                "function": function,
+                "location": _profile_location(filename, line),
+                "primitive_calls": int(primitive_calls),
+                "total_calls": int(total_calls),
+                "self_seconds": round(float(total_time), 9),
+                "cumulative_seconds": round(float(cumulative_time), 9),
+            }
+        )
+    return {
+        "profiled_invocations": 1,
+        "total_calls": int(stats.total_calls),
+        "primitive_calls": int(stats.prim_calls),
+        "total_seconds": round(float(stats.total_tt), 9),
+        "top_cumulative_functions": rows,
+    }, output
+
+
+def _profile_location(filename: str, line: int) -> str:
+    path = Path(filename)
+    parts = path.parts
+    for marker in ("domain", "src", "scripts"):
+        if marker in parts:
+            index = parts.index(marker)
+            return f"{'/'.join(parts[index:])}:{line}"
+    return f"{path.name}:{line}"
+
+
+def _measure_allocation_scenario(spec: Mapping[str, Any], *, seed: int) -> dict[str, Any]:
+    events = _build_synthetic_events(spec, seed=seed)
+    projector_allocation, projector_output = _allocation_call(
+        lambda: project_stored_trade_events_to_position_lots(events),
+        output_fn=lambda result: _projection_output(result, event_count=len(events)),
+    )
+    with _temporary_writer(events) as context:
+        writer_allocation, writer_output = _allocation_call(
+            lambda: rebuild_position_lots_from_trade_events(context["repo"]),
+            output_fn=lambda result: _writer_output(
+                result,
+                rows=context["repo"].list_position_lots(conn=context["keeper"]),
+                event_count=len(events),
+            ),
+        )
+    parity = _projection_parity(projector_output, writer_output)
+    if not parity["exact"]:
+        raise RuntimeError(f"allocation profile parity failed for {spec.get('key')}")
+    return {
+        "key": str(spec.get("key") or ""),
+        "fixture_sha256": _events_sha256(events),
+        "parity": parity,
+        "components": {
+            "projector_only": projector_allocation,
+            "existing_full_replay_writer": writer_allocation,
+        },
+    }
+
+
+def _allocation_call(
+    fn: Callable[[], Any],
+    *,
+    output_fn: Callable[[Any], dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    rss_before = _peak_rss_bytes()
+    tracemalloc.start()
+    try:
+        result = fn()
+        current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+        snapshot = tracemalloc.take_snapshot()
+    finally:
+        tracemalloc.stop()
+    output = output_fn(result)
+    top_rows = []
+    for stat in snapshot.statistics("lineno")[:30]:
+        frame = stat.traceback[0]
+        top_rows.append(
+            {
+                "location": _profile_location(frame.filename, frame.lineno),
+                "size_bytes": int(stat.size),
+                "allocation_count": int(stat.count),
+            }
+        )
+    return {
+        "profiled_invocations": 1,
+        "python_current_bytes": int(current_bytes),
+        "python_peak_bytes": int(peak_bytes),
+        "peak_rss_before_bytes": rss_before,
+        "peak_rss_after_bytes": _peak_rss_bytes(),
+        "peak_rss_scope": "process_high_water_mark",
+        "top_allocation_sites": top_rows,
+    }, output
+
+
+def _peak_rss_bytes() -> int | None:
+    if resource is None:
+        return None
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def _validate_worker_artifacts(
+    *,
+    fixture_manifest: Mapping[str, Any],
+    timing: Mapping[str, Any],
+    cpu_profile: Mapping[str, Any],
+    allocation_profile: Mapping[str, Any],
+    expected_warmups: int,
+    expected_repetitions: int,
+    expected_run_label: str,
+) -> None:
+    expected_schemas = (
+        (timing, TIMING_SCHEMA, "timing_without_profiler"),
+        (cpu_profile, CPU_PROFILE_SCHEMA, "cprofile_separate_process"),
+        (allocation_profile, ALLOCATION_PROFILE_SCHEMA, "tracemalloc_separate_process"),
+    )
+    for artifact, schema, mode in expected_schemas:
+        if artifact.get("schema_version") != schema or artifact.get("measurement_mode") != mode:
+            raise RuntimeError(f"worker artifact contract failed for {schema}")
+    if (
+        timing.get("profilers_enabled") is not False
+        or timing.get("tracemalloc_enabled") is not False
+        or timing.get("warmups") != expected_warmups
+        or timing.get("repetitions") != expected_repetitions
+        or timing.get("run_label") != expected_run_label
+    ):
+        raise RuntimeError("timing worker measurement contract is invalid")
+    expected = {
+        str(item.get("key")): str(item.get("fixture_sha256"))
+        for item in fixture_manifest.get("scenarios", [])
+        if isinstance(item, Mapping)
+    }
+    for artifact in (timing, cpu_profile, allocation_profile):
+        rows = artifact.get("scenarios")
+        actual = {
+            str(item.get("key")): str(item.get("fixture_sha256"))
+            for item in (rows if isinstance(rows, list) else [])
+            if isinstance(item, Mapping)
+        }
+        if actual != expected:
+            raise RuntimeError(f"worker fixture identity mismatch for {artifact.get('schema_version')}")
+        for item in rows if isinstance(rows, list) else []:
+            parity = item.get("parity") if isinstance(item, Mapping) else None
+            if not isinstance(parity, Mapping) or parity.get("exact") is not True:
+                raise RuntimeError(f"worker parity contract failed for {artifact.get('schema_version')}")
+    for item in timing.get("scenarios", []):
+        components = item.get("components") if isinstance(item, Mapping) else None
+        if not isinstance(components, Mapping):
+            raise RuntimeError("timing scenario components are missing")
+        for component in ("projector_only", "existing_full_replay_writer"):
+            payload = components.get(component)
+            if not isinstance(payload, Mapping):
+                raise RuntimeError(f"timing component is missing: {component}")
+            _validate_timing_distribution(
+                payload.get("wall_time_ns"),
+                repetitions=expected_repetitions,
+                label=f"{component}.wall_time_ns",
+            )
+            _validate_timing_distribution(
+                payload.get("cpu_time_ns"),
+                repetitions=expected_repetitions,
+                label=f"{component}.cpu_time_ns",
+            )
+
+
+def _validate_timing_distribution(value: Any, *, repetitions: int, label: str) -> None:
+    if not isinstance(value, Mapping) or value.get("unit") != "ns":
+        raise RuntimeError(f"timing distribution is invalid: {label}")
+    samples = value.get("samples")
+    if not isinstance(samples, list) or len(samples) != repetitions:
+        raise RuntimeError(f"timing sample count is invalid: {label}")
+    if value.get("sample_count") != repetitions:
+        raise RuntimeError(f"timing sample metadata is invalid: {label}")
+    normalized: list[int] = []
+    for sample in samples:
+        if isinstance(sample, bool) or not isinstance(sample, int) or sample < 0:
+            raise RuntimeError(f"timing sample value is invalid: {label}")
+        normalized.append(sample)
+    expected = _timing_distribution(normalized)
+    for field in ("median", "p95", "min", "max"):
+        if value.get(field) != expected[field]:
+            raise RuntimeError(f"timing summary is inconsistent: {label}.{field}")
+
+
+def _build_gate_decision(
+    *,
+    timing: Mapping[str, Any],
+    fixture_manifest: Mapping[str, Any],
+    current_host: Mapping[str, Any],
+    reference_host_fingerprint: str | None,
+) -> dict[str, Any]:
+    current_fingerprint = str(current_host.get("fingerprint") or "")
+    comparable = bool(
+        reference_host_fingerprint
+        and current_fingerprint
+        and reference_host_fingerprint == current_fingerprint
+    )
+    if reference_host_fingerprint is None:
+        comparison_reason = "reference_host_fingerprint_not_supplied"
+    elif comparable:
+        comparison_reason = "exact_host_profile_fingerprint_match"
+    else:
+        comparison_reason = "host_profile_fingerprint_mismatch"
+    timing_rows = {
+        str(row.get("key")): row
+        for row in timing.get("scenarios", [])
+        if isinstance(row, Mapping)
+    }
+    manifest_rows = {
+        str(row.get("key")): row
+        for row in fixture_manifest.get("scenarios", [])
+        if isinstance(row, Mapping)
+    }
+    history_keys = (
+        "history_10x.fixed_output",
+        "history_10x.retained_closed_lots",
+    )
+    subcases: list[dict[str, Any]] = []
+    for key in history_keys:
+        timing_row = timing_rows.get(key)
+        manifest_row = manifest_rows.get(key)
+        if timing_row is None or manifest_row is None:
+            subcases.append({"key": key, "status": "not_evaluable", "reason": "scenario_not_selected"})
+            continue
+        writer = (timing_row.get("components") or {}).get("existing_full_replay_writer")
+        axis_status = str(manifest_row.get("axis_status") or "unknown")
+        run_label = str(timing.get("run_label") or "")
+        if run_label != "acceptance_5_warmups_30_repetitions":
+            status = "not_evaluable"
+            reason = "non_acceptance_smoke"
+        elif axis_status != "evaluable":
+            status = "not_evaluable"
+            reason = axis_status
+        elif not comparable:
+            status = "not_comparable"
+            reason = comparison_reason
+        else:
+            wall_p95 = int(writer["wall_time_ns"]["p95"])
+            cpu_p95 = int(writer["cpu_time_ns"]["p95"])
+            status = "pass" if wall_p95 <= WALL_LIMIT_NS and cpu_p95 <= CPU_LIMIT_NS else "fail"
+            reason = "within_frozen_limits" if status == "pass" else "frozen_limit_exceeded"
+        reported_wall_p95 = (
+            int(writer["wall_time_ns"]["p95"])
+            if isinstance(writer, Mapping)
+            and isinstance(writer.get("wall_time_ns"), Mapping)
+            and isinstance(writer["wall_time_ns"].get("p95"), int)
+            else None
+        )
+        reported_cpu_p95 = (
+            int(writer["cpu_time_ns"]["p95"])
+            if isinstance(writer, Mapping)
+            and isinstance(writer.get("cpu_time_ns"), Mapping)
+            and isinstance(writer["cpu_time_ns"].get("p95"), int)
+            else None
+        )
+        subcases.append(
+            {
+                "key": key,
+                "status": status,
+                "reason": reason,
+                "wall_p95_ns": reported_wall_p95,
+                "cpu_p95_ns": reported_cpu_p95,
+            }
+        )
+    subcase_statuses = {row["status"] for row in subcases}
+    if subcase_statuses == {"pass"}:
+        writer_status = "pass"
+    elif "fail" in subcase_statuses:
+        writer_status = "fail"
+    elif "not_evaluable" in subcase_statuses:
+        writer_status = "not_evaluable"
+    else:
+        writer_status = "not_comparable"
+    return {
+        "schema_version": DECISION_SCHEMA,
+        "reference_host": {
+            "current_profile": dict(current_host),
+            "current_fingerprint": current_fingerprint,
+            "expected_fingerprint": reference_host_fingerprint,
+            "comparable": comparable,
+            "reason": comparison_reason,
+        },
+        "thresholds": {
+            "history_10x_writer_wall_p95_ns": WALL_LIMIT_NS,
+            "history_10x_writer_cpu_p95_ns": CPU_LIMIT_NS,
+            "required_subcases": list(history_keys),
+        },
+        "components": {
+            "projector_only": {
+                "status": "diagnostic_only",
+                "reason": "projector_only_cannot_satisfy_writer_gate",
+            },
+            "existing_full_replay_writer": {
+                "status": writer_status,
+                "subcases": subcases,
+            },
+            "lot_diff_publication": {
+                "status": "not_implemented",
+                "reason": "phase_3a_diff_publication_is_out_of_scope_for_phase_1",
+            },
+        },
+        "phase_3a_combined": {
+            "status": "not_ready",
+            "reason": "lot_diff_publication_not_implemented",
+        },
+        "automatic_actions": [],
+    }
+
+
+def _resolve_output_dir(value: str | Path, *, repo_root: Path) -> tuple[Path, bool]:
+    raw = Path(value).expanduser()
+    candidate = raw if raw.is_absolute() else repo_root / raw
+    if candidate.is_symlink():
+        raise ValueError("output directory must not be a symlink")
+    parent = candidate.parent.resolve(strict=True)
+    if not parent.is_dir() or parent.is_symlink():
+        raise ValueError("output directory parent must be a real directory")
+    target = parent / candidate.name
+    existed = target.exists()
+    if existed:
+        if target.is_symlink() or not target.is_dir():
+            raise ValueError("output path must be an absent or empty directory")
+        if any(target.iterdir()):
+            raise ValueError("output directory must be empty")
+    return target, existed
+
+
+def _publish_artifact_set(
+    *,
+    output_dir: str | Path,
+    repo_root: Path,
+    artifacts: Mapping[str, Mapping[str, Any]],
+) -> Path:
+    if set(artifacts) != set(ARTIFACT_FILENAMES):
+        raise ValueError("artifact set is incomplete")
+    target, existed = _resolve_output_dir(output_dir, repo_root=repo_root)
+    stage = Path(tempfile.mkdtemp(prefix=f".{target.name}.stage-", dir=target.parent))
+    published = False
+    try:
+        for filename in ARTIFACT_FILENAMES:
+            path = stage / filename
+            with path.open("wb") as handle:
+                handle.write(_canonical_json_bytes(artifacts[filename]) + b"\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        _validate_published_files(stage)
+        directory_fd = os.open(stage, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        if existed:
+            if any(target.iterdir()):
+                raise ValueError("output directory became non-empty before publish")
+            target.rmdir()
+        os.replace(stage, target)
+        published = True
+        parent_fd = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+        return target
+    finally:
+        if not published and stage.exists():
+            shutil.rmtree(stage)
+
+
+def _validate_published_files(directory: Path) -> None:
+    actual = {path.name for path in directory.iterdir() if path.is_file()}
+    if actual != set(ARTIFACT_FILENAMES):
+        raise RuntimeError("staged artifact set is incomplete")
+    expected_schemas = {
+        "fixture-manifest.json": FIXTURE_SCHEMA,
+        "timing.json": TIMING_SCHEMA,
+        "cpu-profile.json": CPU_PROFILE_SCHEMA,
+        "allocation-profile.json": ALLOCATION_PROFILE_SCHEMA,
+        "decision.json": DECISION_SCHEMA,
+    }
+    for filename, schema in expected_schemas.items():
+        payload = json.loads((directory / filename).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("schema_version") != schema:
+            raise RuntimeError(f"staged artifact schema is invalid: {filename}")
+
+
+def _worker_main(*, mode: str, spec_path: str | Path) -> int:
+    path = Path(spec_path).expanduser().resolve(strict=True)
+    if path.is_symlink() or not path.is_file() or path.stat().st_size > 4 * 1024 * 1024:
+        raise ValueError("worker spec must be a bounded regular JSON file")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("worker spec must be a JSON object")
+    result = _worker_payload(mode=mode, worker_spec=payload)
+    sys.stdout.write(json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark canonical option-position projection on deterministic synthetic data.",
+    )
+    parser.add_argument("--baseline", help="Optional storage_runtime_baseline.v1 metadata report")
+    parser.add_argument("--scenario", choices=PUBLIC_SCENARIOS, default="all")
+    parser.add_argument("--output-dir", help="Required absent or empty local output directory")
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--repetitions", type=int, default=DEFAULT_REPETITIONS)
+    parser.add_argument("--seed", type=int, default=SEED)
+    parser.add_argument(
+        "--reference-host-fingerprint",
+        help="Exact host-profile SHA-256 required before absolute timing decisions are allowed",
+    )
+    parser.add_argument("--_worker-mode", choices=("timing", "cpu", "allocation"), help=argparse.SUPPRESS)
+    parser.add_argument("--_worker-spec", help=argparse.SUPPRESS)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args._worker_mode:
+            if not args._worker_spec:
+                parser.error("--_worker-spec is required in worker mode")
+            return _worker_main(mode=args._worker_mode, spec_path=args._worker_spec)
+        if not args.output_dir:
+            parser.error("--output-dir is required")
+        repo_root = Path(__file__).resolve().parents[3]
+        result = run_data_storage_projection_benchmark(
+            repo_root=repo_root,
+            output_dir=args.output_dir,
+            baseline=args.baseline,
+            scenario=args.scenario,
+            warmups=args.warmups,
+            repetitions=args.repetitions,
+            seed=args.seed,
+            reference_host_fingerprint=args.reference_host_fingerprint,
+        )
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+    sys.stdout.write(json.dumps(result, ensure_ascii=False, sort_keys=True) + "\n")
+    return 0
+
+
+__all__ = [
+    "ALLOCATION_PROFILE_SCHEMA",
+    "CPU_PROFILE_SCHEMA",
+    "DECISION_SCHEMA",
+    "FIXTURE_SCHEMA",
+    "TIMING_SCHEMA",
+    "build_parser",
+    "main",
+    "run_data_storage_projection_benchmark",
+]

--- a/src/application/research/performance_baseline.py
+++ b/src/application/research/performance_baseline.py
@@ -234,7 +234,11 @@ def _load_baseline_dimensions(
                 "payload_bytes": DEFAULT_PAYLOAD_BYTES,
             },
             clamped={},
-            metadata={"baseline_schema": None, "payload_fields_consumed": 0},
+            metadata={
+                "baseline_schema": None,
+                "payload_fields_consumed": 0,
+                "account_dimension_source": "safe_defaults_no_baseline",
+            },
         )
 
     raw = Path(value).expanduser()
@@ -260,7 +264,7 @@ def _load_baseline_dimensions(
     lot_row = table_rows.get("position_lots", {})
     requested_events = _metadata_int(event_row.get("row_count"), DEFAULT_CURRENT_EVENTS)
     requested_lots = _metadata_int(lot_row.get("row_count"), DEFAULT_CURRENT_LOTS)
-    requested_accounts = _baseline_account_count(payload)
+    requested_accounts, account_dimension_source = _baseline_account_count(payload)
     event_json_bytes = _metadata_int(event_row.get("json_bytes"), 0)
     requested_payload_bytes = (
         max(MIN_PAYLOAD_BYTES, math.ceil(event_json_bytes / requested_events))
@@ -300,35 +304,22 @@ def _load_baseline_dimensions(
             if isinstance(sqlite_payload, dict)
             else "missing",
             "table_metadata_consumed": ["trade_events", "position_lots"],
+            "account_dimension_source": account_dimension_source,
             "payload_fields_consumed": 0,
             "paths_retained": 0,
         },
     )
 
 
-def _nested_metadata_value(payload: Mapping[str, Any], path: Sequence[str]) -> Any:
-    current: Any = payload
-    for key in path:
-        if not isinstance(current, Mapping):
-            return None
-        current = current.get(key)
-    return current
-
-
-def _baseline_account_count(payload: Mapping[str, Any]) -> int:
-    explicit = _nested_metadata_value(payload, ("runtime_storage", "account_count"))
-    if explicit is not None:
-        return _metadata_int(explicit, DEFAULT_ACCOUNT_COUNT)
+def _baseline_account_count(payload: Mapping[str, Any]) -> tuple[int, str]:
     runtime_storage = payload.get("runtime_storage")
-    roots = runtime_storage.get("roots") if isinstance(runtime_storage, Mapping) else None
-    for row in roots if isinstance(roots, list) else []:
-        if isinstance(row, Mapping) and str(row.get("root") or "") == "output_accounts":
-            # Slice 1 intentionally exposes only payload-free aggregate metadata.
-            # Until it publishes an exact account count, a non-empty account root
-            # proves at least one account but cannot safely be treated as the
-            # configured cardinality.
-            return 1 if _metadata_int(row.get("file_count"), 0) > 0 else DEFAULT_ACCOUNT_COUNT
-    return DEFAULT_ACCOUNT_COUNT
+    if isinstance(runtime_storage, Mapping):
+        status = str(runtime_storage.get("account_count_status") or "")
+        explicit = runtime_storage.get("account_count")
+        if status == "complete" and isinstance(explicit, int) and not isinstance(explicit, bool):
+            if explicit > 0:
+                return explicit, "runtime_storage.output_accounts_immediate_directories"
+    return DEFAULT_ACCOUNT_COUNT, "safe_default_account_count_unavailable"
 
 
 def _metadata_int(value: Any, fallback: int) -> int:
@@ -381,7 +372,9 @@ def _build_scenario_specs(
         max(fanout_lots, math.ceil(fanout_lots * state_ratio)),
     )
     fanout_axis_status = (
-        "evaluable"
+        "not_evaluable_baseline_account_count_unavailable"
+        if dimensions.metadata.get("account_dimension_source") == "safe_default_account_count_unavailable"
+        else "evaluable"
         if fanout_accounts >= fanout_requested_accounts
         else "not_evaluable_clamped_below_requested_5x"
     )
@@ -499,9 +492,7 @@ def _scenario_spec(
         "requested_dimensions": {
             "event_count": int(requested_event_count if requested_event_count is not None else event_count),
             "projected_lot_count": int(requested_lot_count if requested_lot_count is not None else projected_lots),
-            "account_count": int(
-                requested_account_count if requested_account_count is not None else account_count
-            ),
+            "account_count": int(requested_account_count if requested_account_count is not None else account_count),
             "payload_bytes": int(payload_bytes),
         },
         "effective_dimensions": {
@@ -853,12 +844,14 @@ def _canonical_json_bytes(value: Any) -> bytes:
 
 
 def _host_profile() -> dict[str, Any]:
+    cpu_model, hardware_model = _hardware_identity()
     fields = {
         "schema_version": "data_storage_projection_host_profile.v1",
         "system": platform.system(),
         "release": platform.release(),
         "machine": platform.machine(),
-        "hardware_model": _hardware_model(),
+        "cpu_model": cpu_model,
+        "hardware_model": hardware_model,
         "physical_memory_bytes": _physical_memory_bytes(),
         "python_implementation": platform.python_implementation(),
         "python_version": platform.python_version(),
@@ -868,33 +861,84 @@ def _host_profile() -> dict[str, Any]:
     return {**fields, "fingerprint": _sha256_json(fields)}
 
 
-def _hardware_model() -> str:
+def _hardware_identity() -> tuple[str, str]:
     system = platform.system()
     if system == "Darwin":
-        for key in ("machdep.cpu.brand_string", "hw.model"):
-            try:
-                result = subprocess.run(
-                    ["/usr/sbin/sysctl", "-n", key],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                    timeout=2,
-                )
-            except (OSError, subprocess.SubprocessError):
-                continue
-            value = result.stdout.strip()
-            if value:
-                return value
+        cpu_model = _command_value(["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"])
+        hardware_model = _command_value(["/usr/sbin/sysctl", "-n", "hw.model"])
+        if not cpu_model or not hardware_model:
+            details = _darwin_hardware_details()
+            cpu_model = cpu_model or details.get("chip_type")
+            hardware_model = hardware_model or details.get("machine_model")
+        return (
+            cpu_model or platform.processor() or "unknown",
+            hardware_model or platform.machine() or "unknown",
+        )
     if system == "Linux":
+        cpu_model = None
         try:
             for line in Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines():
                 if line.lower().startswith(("model name", "hardware")) and ":" in line:
                     value = line.split(":", 1)[1].strip()
                     if value:
-                        return value
+                        cpu_model = value
+                        break
         except (OSError, UnicodeError):
             pass
-    return platform.processor() or "unknown"
+        hardware_model = _bounded_text_file(Path("/sys/devices/virtual/dmi/id/product_name"))
+        return (
+            cpu_model or platform.processor() or "unknown",
+            hardware_model or platform.machine() or "unknown",
+        )
+    return (
+        platform.processor() or "unknown",
+        platform.machine() or "unknown",
+    )
+
+
+def _command_value(command: Sequence[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            list(command),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _darwin_hardware_details() -> dict[str, str]:
+    try:
+        result = subprocess.run(
+            ["/usr/sbin/system_profiler", "SPHardwareDataType", "-json"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        payload = json.loads(result.stdout)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return {}
+    rows = payload.get("SPHardwareDataType") if isinstance(payload, Mapping) else None
+    row = rows[0] if isinstance(rows, list) and rows and isinstance(rows[0], Mapping) else {}
+    return {
+        key: str(row.get(key) or "").strip()
+        for key in ("chip_type", "machine_model")
+        if str(row.get(key) or "").strip()
+    }
+
+
+def _bounded_text_file(path: Path) -> str | None:
+    try:
+        if path.stat().st_size > 4_096:
+            return None
+        value = path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeError):
+        return None
+    return value or None
 
 
 def _physical_memory_bytes() -> int | None:
@@ -994,11 +1038,7 @@ def _worker_payload(*, mode: str, worker_spec: Mapping[str, Any]) -> dict[str, A
             "scenarios": rows,
         }
     if mode == "cpu":
-        rows = [
-            _measure_cpu_scenario(spec, seed=seed)
-            for spec in raw_scenarios
-            if isinstance(spec, dict)
-        ]
+        rows = [_measure_cpu_scenario(spec, seed=seed) for spec in raw_scenarios if isinstance(spec, dict)]
         return {
             "schema_version": CPU_PROFILE_SCHEMA,
             "measurement_mode": "cprofile_separate_process",
@@ -1007,11 +1047,7 @@ def _worker_payload(*, mode: str, worker_spec: Mapping[str, Any]) -> dict[str, A
             "scenarios": rows,
         }
     if mode == "allocation":
-        rows = [
-            _measure_allocation_scenario(spec, seed=seed)
-            for spec in raw_scenarios
-            if isinstance(spec, dict)
-        ]
+        rows = [_measure_allocation_scenario(spec, seed=seed) for spec in raw_scenarios if isinstance(spec, dict)]
         return {
             "schema_version": ALLOCATION_PROFILE_SCHEMA,
             "measurement_mode": "tracemalloc_separate_process",
@@ -1242,19 +1278,13 @@ def _canonical_output(
         key=lambda item: item["record_id"],
     )
     canonical_diagnostics = [dict(item) for item in diagnostics]
-    open_lots = sum(
-        1
-        for item in canonical_lots
-        if int((item["fields"].get("contracts_open") or 0)) > 0
-    )
+    open_lots = sum(1 for item in canonical_lots if int((item["fields"].get("contracts_open") or 0)) > 0)
     lot_fingerprint = _sha256_json(canonical_lots)
     diagnostic_fingerprint = _sha256_json(canonical_diagnostics)
     return {
         "lot_fingerprint": lot_fingerprint,
         "diagnostic_fingerprint": diagnostic_fingerprint,
-        "combined_fingerprint": _sha256_json(
-            {"lots": canonical_lots, "diagnostics": canonical_diagnostics}
-        ),
+        "combined_fingerprint": _sha256_json({"lots": canonical_lots, "diagnostics": canonical_diagnostics}),
         "counts": {
             "event_count": int(events),
             "projected_lot_count": len(canonical_lots),
@@ -1539,9 +1569,7 @@ def _build_gate_decision(
 ) -> dict[str, Any]:
     current_fingerprint = str(current_host.get("fingerprint") or "")
     comparable = bool(
-        reference_host_fingerprint
-        and current_fingerprint
-        and reference_host_fingerprint == current_fingerprint
+        reference_host_fingerprint and current_fingerprint and reference_host_fingerprint == current_fingerprint
     )
     if reference_host_fingerprint is None:
         comparison_reason = "reference_host_fingerprint_not_supplied"
@@ -1549,15 +1577,9 @@ def _build_gate_decision(
         comparison_reason = "exact_host_profile_fingerprint_match"
     else:
         comparison_reason = "host_profile_fingerprint_mismatch"
-    timing_rows = {
-        str(row.get("key")): row
-        for row in timing.get("scenarios", [])
-        if isinstance(row, Mapping)
-    }
+    timing_rows = {str(row.get("key")): row for row in timing.get("scenarios", []) if isinstance(row, Mapping)}
     manifest_rows = {
-        str(row.get("key")): row
-        for row in fixture_manifest.get("scenarios", [])
-        if isinstance(row, Mapping)
+        str(row.get("key")): row for row in fixture_manifest.get("scenarios", []) if isinstance(row, Mapping)
     }
     history_keys = (
         "history_10x.fixed_output",

--- a/src/application/research/performance_baseline.py
+++ b/src/application/research/performance_baseline.py
@@ -5,6 +5,7 @@ import base64
 import cProfile
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import hashlib
 import json
 import math
@@ -31,6 +32,7 @@ from src.application.ledger.event_codec import (
 from src.application.ledger.publisher import project_stored_trade_events_to_position_lots
 from src.application.ledger.repository import SQLiteOptionPositionsRepository
 from src.application.ledger.writer import rebuild_position_lots_from_trade_events
+from src.application.research.storage_baseline import collect_storage_runtime_baseline
 
 try:
     import resource
@@ -61,6 +63,11 @@ MIN_PAYLOAD_BYTES = 256
 MAX_PAYLOAD_BYTES = 4_096
 WALL_LIMIT_NS = 2_000_000_000
 CPU_LIMIT_NS = 1_500_000_000
+STORAGE_STATUS_KEY = "research_storage_status.history_10x"
+STORAGE_STATUS_PARTITION_COUNT = 10_000
+STORAGE_STATUS_WALL_LIMIT_NS = 5_000_000_000
+STORAGE_STATUS_ALLOCATION_LIMIT_BYTES = 64 * 1024 * 1024
+STORAGE_STATUS_OBSERVED_AT = datetime(2026, 8, 13, tzinfo=timezone.utc)
 ARTIFACT_FILENAMES = (
     "fixture-manifest.json",
     "timing.json",
@@ -74,6 +81,7 @@ PUBLIC_SCENARIOS = (
     "history_10x",
     "current_state_10x",
     "account_fanout",
+    "research_storage_status",
 )
 
 
@@ -115,7 +123,17 @@ def run_data_storage_projection_benchmark(
     fixture_seed = _bounded_nonnegative_int(seed, name="seed", maximum=2**31 - 1)
     reference_fingerprint = _validated_reference_fingerprint(reference_host_fingerprint)
     dimensions = _load_baseline_dimensions(baseline, repo_root=base)
-    scenario_specs = _build_scenario_specs(dimensions, selected=selected)
+    projection_scenarios = tuple(
+        item for item in selected if item != "research_storage_status"
+    )
+    scenario_specs = _build_scenario_specs(dimensions, selected=projection_scenarios)
+    storage_status_spec = (
+        _storage_status_spec(seed=fixture_seed)
+        if "history_10x" in selected or "research_storage_status" in selected
+        else None
+    )
+    if not scenario_specs and storage_status_spec is None:
+        raise ValueError("benchmark selection produced no scenarios")
     host = _host_profile()
     run_label = (
         "acceptance_5_warmups_30_repetitions"
@@ -129,6 +147,7 @@ def run_data_storage_projection_benchmark(
         seed=fixture_seed,
         host=host,
         run_label=run_label,
+        storage_status_spec=storage_status_spec,
     )
     worker_spec = {
         "schema_version": WORKER_SPEC_SCHEMA,
@@ -137,6 +156,7 @@ def run_data_storage_projection_benchmark(
         "repetitions": repetition_count,
         "run_label": run_label,
         "scenarios": scenario_specs,
+        "research_storage_status": storage_status_spec,
     }
     run_worker = worker_runner or _run_worker_process
     timing = run_worker(repo_root=base, mode="timing", worker_spec=worker_spec)
@@ -156,6 +176,7 @@ def run_data_storage_projection_benchmark(
         fixture_manifest=fixture_manifest,
         current_host=host,
         reference_host_fingerprint=reference_fingerprint,
+        allocation_profile=allocation_profile,
     )
     target = _publish_artifact_set(
         output_dir=output_dir,
@@ -176,6 +197,7 @@ def run_data_storage_projection_benchmark(
         "fixture_set_sha256": fixture_manifest["fixture_set_sha256"],
         "host_fingerprint": host["fingerprint"],
         "existing_full_replay_writer": decision["components"]["existing_full_replay_writer"],
+        "research_storage_status": decision["components"]["research_storage_status"],
         "phase_3a_combined": decision["phase_3a_combined"],
     }
 
@@ -507,6 +529,30 @@ def _scenario_spec(
     }
 
 
+def _storage_status_spec(*, seed: int) -> dict[str, Any]:
+    fixture_identity = {
+        "schema_version": "research_storage_status_history_10x_fixture.v1",
+        "seed": int(seed),
+        "partition_count": STORAGE_STATUS_PARTITION_COUNT,
+        "manifest_count": 1,
+        "bytes_per_partition": 1,
+        "manifest_shape": "integrity.files",
+    }
+    return {
+        "key": STORAGE_STATUS_KEY,
+        "axis": "history_10x",
+        "classification": "synthetic_manifest_declared_partitions",
+        "axis_status": "evaluable",
+        "effective_dimensions": {
+            "partition_count": STORAGE_STATUS_PARTITION_COUNT,
+            "manifest_count": 1,
+            "runtime_file_count": STORAGE_STATUS_PARTITION_COUNT + 1,
+        },
+        "fixture_sha256": _sha256_json(fixture_identity),
+        "fixture_identity": fixture_identity,
+    }
+
+
 def _build_fixture_manifest(
     *,
     repo_root: Path,
@@ -515,6 +561,7 @@ def _build_fixture_manifest(
     seed: int,
     host: dict[str, Any],
     run_label: str,
+    storage_status_spec: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     scenarios: list[dict[str, Any]] = []
     fixture_hashes: list[str] = []
@@ -531,10 +578,13 @@ def _build_fixture_manifest(
                 "synthetic_only": True,
             }
         )
+    fixture_set_items: list[Any] = list(fixture_hashes)
+    if storage_status_spec is not None:
+        fixture_set_items.append(str(storage_status_spec.get("fixture_sha256") or ""))
     return {
         "schema_version": FIXTURE_SCHEMA,
         "fixture_seed": int(seed),
-        "fixture_set_sha256": _sha256_json(fixture_hashes),
+        "fixture_set_sha256": _sha256_json(fixture_set_items),
         "dimension_source": dimensions.dimension_source,
         "baseline_dimensions": {
             "requested": dimensions.requested,
@@ -567,6 +617,7 @@ def _build_fixture_manifest(
             "runtime_mutations": 0,
         },
         "scenarios": scenarios,
+        "research_storage_status": dict(storage_status_spec) if storage_status_spec is not None else None,
     }
 
 
@@ -1014,18 +1065,32 @@ def _worker_payload(*, mode: str, worker_spec: Mapping[str, Any]) -> dict[str, A
     if worker_spec.get("schema_version") != WORKER_SPEC_SCHEMA:
         raise ValueError("worker spec schema is invalid")
     raw_scenarios = worker_spec.get("scenarios")
-    if not isinstance(raw_scenarios, list) or not raw_scenarios:
+    if not isinstance(raw_scenarios, list):
         raise ValueError("worker spec scenarios are missing")
     seed = _bounded_nonnegative_int(worker_spec.get("seed"), name="seed", maximum=2**31 - 1)
     warmups = _bounded_nonnegative_int(worker_spec.get("warmups"), name="warmups", maximum=100)
     repetitions = _bounded_positive_int(worker_spec.get("repetitions"), name="repetitions", maximum=1_000)
     label = str(worker_spec.get("run_label") or "")
+    storage_status_spec = worker_spec.get("research_storage_status")
+    if storage_status_spec is not None and not isinstance(storage_status_spec, Mapping):
+        raise ValueError("research storage status worker spec is invalid")
+    if not raw_scenarios and storage_status_spec is None:
+        raise ValueError("worker spec has no measurable scenarios")
     if mode == "timing":
         rows = [
             _measure_timing_scenario(spec, seed=seed, warmups=warmups, repetitions=repetitions)
             for spec in raw_scenarios
             if isinstance(spec, dict)
         ]
+        storage_status = (
+            _measure_storage_status_timing(
+                storage_status_spec,
+                warmups=warmups,
+                repetitions=repetitions,
+            )
+            if isinstance(storage_status_spec, Mapping)
+            else None
+        )
         return {
             "schema_version": TIMING_SCHEMA,
             "measurement_mode": "timing_without_profiler",
@@ -1036,26 +1101,192 @@ def _worker_payload(*, mode: str, worker_spec: Mapping[str, Any]) -> dict[str, A
             "run_label": label,
             "clock_authority": ["time.perf_counter_ns", "time.process_time_ns"],
             "scenarios": rows,
+            "research_storage_status": storage_status,
         }
     if mode == "cpu":
         rows = [_measure_cpu_scenario(spec, seed=seed) for spec in raw_scenarios if isinstance(spec, dict)]
+        storage_status = (
+            _measure_storage_status_cpu(storage_status_spec)
+            if isinstance(storage_status_spec, Mapping)
+            else None
+        )
         return {
             "schema_version": CPU_PROFILE_SCHEMA,
             "measurement_mode": "cprofile_separate_process",
             "timing_threshold_eligible": False,
             "tracemalloc_enabled": False,
             "scenarios": rows,
+            "research_storage_status": storage_status,
         }
     if mode == "allocation":
         rows = [_measure_allocation_scenario(spec, seed=seed) for spec in raw_scenarios if isinstance(spec, dict)]
+        storage_status = (
+            _measure_storage_status_allocation(storage_status_spec)
+            if isinstance(storage_status_spec, Mapping)
+            else None
+        )
         return {
             "schema_version": ALLOCATION_PROFILE_SCHEMA,
             "measurement_mode": "tracemalloc_separate_process",
             "timing_threshold_eligible": False,
             "cprofile_enabled": False,
             "scenarios": rows,
+            "research_storage_status": storage_status,
         }
     raise ValueError(f"unsupported worker mode: {mode}")
+
+
+@contextmanager
+def _temporary_storage_status_fixture(spec: Mapping[str, Any]) -> Iterator[dict[str, Any]]:
+    dimensions = spec.get("effective_dimensions")
+    if not isinstance(dimensions, Mapping):
+        raise ValueError("research storage status dimensions are missing")
+    partition_count = _bounded_positive_int(
+        dimensions.get("partition_count"),
+        name="partition_count",
+        maximum=STORAGE_STATUS_PARTITION_COUNT,
+    )
+    if partition_count != STORAGE_STATUS_PARTITION_COUNT:
+        raise ValueError("research storage status partition count must match the frozen fixture")
+    with tempfile.TemporaryDirectory(prefix="om-storage-status-history10x-") as temp_name:
+        runtime_root = Path(temp_name)
+        history_root = runtime_root / "output_shared" / "research" / "history_10x"
+        history_root.mkdir(parents=True)
+        digest = hashlib.sha256(b"x").hexdigest()
+        files: dict[str, dict[str, Any]] = {}
+        for index in range(partition_count):
+            name = f"partition-{index:05d}.bin"
+            (history_root / name).write_bytes(b"x")
+            files[name] = {"sha256": digest, "bytes": 1}
+        manifest = {
+            "schema_version": "research.history_10x.v1",
+            "integrity": {"files": files},
+        }
+        manifest_path = history_root / "manifest.json"
+        manifest_path.write_bytes(_canonical_json_bytes(manifest) + b"\n")
+        actual_identity = _sha256_json(
+            {
+                "schema_version": "research_storage_status_history_10x_fixture.v1",
+                "seed": int((spec.get("fixture_identity") or {}).get("seed") or 0),
+                "partition_count": partition_count,
+                "manifest_count": 1,
+                "bytes_per_partition": 1,
+                "manifest_shape": "integrity.files",
+            }
+        )
+        expected_identity = str(spec.get("fixture_sha256") or "")
+        if actual_identity != expected_identity:
+            raise RuntimeError("research storage status fixture identity mismatch")
+        yield {
+            "repo_root": Path.cwd(),
+            "runtime_root": runtime_root,
+            "fixture_sha256": actual_identity,
+        }
+
+
+def _collect_synthetic_storage_status(context: Mapping[str, Any]) -> dict[str, Any]:
+    return collect_storage_runtime_baseline(
+        repo_root=context["repo_root"],
+        runtime_root=context["runtime_root"],
+        now_fn=lambda: STORAGE_STATUS_OBSERVED_AT,
+    )
+
+
+def _storage_status_output(result: Mapping[str, Any]) -> dict[str, Any]:
+    runtime = result.get("runtime_storage")
+    research = result.get("research_storage")
+    safety = result.get("safety")
+    if not isinstance(runtime, Mapping) or not isinstance(research, Mapping) or not isinstance(safety, Mapping):
+        raise RuntimeError("research storage status output is incomplete")
+    output = {
+        "status": result.get("status"),
+        "runtime_file_count": runtime.get("file_count"),
+        "manifest_count": research.get("manifest_count"),
+        "declared_reference_count": research.get("declared_reference_count"),
+        "protected_reference_failure_count": len(research.get("protected_reference_failures") or []),
+        "payload_content_reads": safety.get("payload_content_reads"),
+        "mutation_operations": safety.get("mutation_operations"),
+        "no_follow_traversal": safety.get("no_follow_traversal"),
+    }
+    expected = {
+        "runtime_file_count": STORAGE_STATUS_PARTITION_COUNT + 1,
+        "manifest_count": 1,
+        "declared_reference_count": STORAGE_STATUS_PARTITION_COUNT,
+        "protected_reference_failure_count": 0,
+        "payload_content_reads": 0,
+        "mutation_operations": 0,
+        "no_follow_traversal": True,
+    }
+    mismatches = {
+        key: {"expected": value, "actual": output.get(key)}
+        for key, value in expected.items()
+        if output.get(key) != value
+    }
+    if mismatches:
+        raise RuntimeError(f"research storage status output mismatch: {mismatches}")
+    return output
+
+
+def _measure_storage_status_timing(
+    spec: Mapping[str, Any],
+    *,
+    warmups: int,
+    repetitions: int,
+) -> dict[str, Any]:
+    with _temporary_storage_status_fixture(spec) as context:
+        result: Mapping[str, Any] | None = None
+        for _ in range(warmups):
+            result = _collect_synthetic_storage_status(context)
+        wall_samples: list[int] = []
+        cpu_samples: list[int] = []
+        for _ in range(repetitions):
+            wall_start = time.perf_counter_ns()
+            cpu_start = time.process_time_ns()
+            result = _collect_synthetic_storage_status(context)
+            cpu_samples.append(time.process_time_ns() - cpu_start)
+            wall_samples.append(time.perf_counter_ns() - wall_start)
+        if result is None:
+            result = _collect_synthetic_storage_status(context)
+        return {
+            "key": STORAGE_STATUS_KEY,
+            "fixture_sha256": str(context["fixture_sha256"]),
+            "axis_status": str(spec.get("axis_status") or "unknown"),
+            "setup_included": False,
+            "measurement_scope": "payload_free_storage_status_collection",
+            "wall_time_ns": _timing_distribution(wall_samples),
+            "cpu_time_ns": _timing_distribution(cpu_samples),
+            "output": _storage_status_output(result),
+        }
+
+
+def _measure_storage_status_cpu(spec: Mapping[str, Any]) -> dict[str, Any]:
+    with _temporary_storage_status_fixture(spec) as context:
+        profile, output = _profile_call(
+            lambda: _collect_synthetic_storage_status(context),
+            output_fn=_storage_status_output,
+        )
+        return {
+            "key": STORAGE_STATUS_KEY,
+            "fixture_sha256": str(context["fixture_sha256"]),
+            "setup_included": False,
+            "component": profile,
+            "output": output,
+        }
+
+
+def _measure_storage_status_allocation(spec: Mapping[str, Any]) -> dict[str, Any]:
+    with _temporary_storage_status_fixture(spec) as context:
+        allocation, output = _allocation_call(
+            lambda: _collect_synthetic_storage_status(context),
+            output_fn=_storage_status_output,
+        )
+        return {
+            "key": STORAGE_STATUS_KEY,
+            "fixture_sha256": str(context["fixture_sha256"]),
+            "setup_included": False,
+            "component": allocation,
+            "output": output,
+        }
 
 
 def _measure_timing_scenario(
@@ -1521,6 +1752,20 @@ def _validate_worker_artifacts(
             parity = item.get("parity") if isinstance(item, Mapping) else None
             if not isinstance(parity, Mapping) or parity.get("exact") is not True:
                 raise RuntimeError(f"worker parity contract failed for {artifact.get('schema_version')}")
+        expected_storage = fixture_manifest.get("research_storage_status")
+        actual_storage = artifact.get("research_storage_status")
+        if expected_storage is None:
+            if actual_storage is not None:
+                raise RuntimeError("unexpected research storage status worker artifact")
+        else:
+            if not isinstance(expected_storage, Mapping) or not isinstance(actual_storage, Mapping):
+                raise RuntimeError("research storage status worker artifact is missing")
+            if (
+                actual_storage.get("key") != expected_storage.get("key")
+                or actual_storage.get("fixture_sha256") != expected_storage.get("fixture_sha256")
+                or actual_storage.get("setup_included") is not False
+            ):
+                raise RuntimeError("research storage status worker identity mismatch")
     for item in timing.get("scenarios", []):
         components = item.get("components") if isinstance(item, Mapping) else None
         if not isinstance(components, Mapping):
@@ -1539,6 +1784,18 @@ def _validate_worker_artifacts(
                 repetitions=expected_repetitions,
                 label=f"{component}.cpu_time_ns",
             )
+    storage_timing = timing.get("research_storage_status")
+    if isinstance(storage_timing, Mapping):
+        _validate_timing_distribution(
+            storage_timing.get("wall_time_ns"),
+            repetitions=expected_repetitions,
+            label="research_storage_status.wall_time_ns",
+        )
+        _validate_timing_distribution(
+            storage_timing.get("cpu_time_ns"),
+            repetitions=expected_repetitions,
+            label="research_storage_status.cpu_time_ns",
+        )
 
 
 def _validate_timing_distribution(value: Any, *, repetitions: int, label: str) -> None:
@@ -1566,6 +1823,7 @@ def _build_gate_decision(
     fixture_manifest: Mapping[str, Any],
     current_host: Mapping[str, Any],
     reference_host_fingerprint: str | None,
+    allocation_profile: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     current_fingerprint = str(current_host.get("fingerprint") or "")
     comparable = bool(
@@ -1641,6 +1899,19 @@ def _build_gate_decision(
         writer_status = "not_evaluable"
     else:
         writer_status = "not_comparable"
+    storage_timing = timing.get("research_storage_status")
+    storage_allocation = (
+        allocation_profile.get("research_storage_status")
+        if isinstance(allocation_profile, Mapping)
+        else None
+    )
+    storage_status, storage_reason, storage_wall_p95, storage_peak_allocation = _storage_status_gate(
+        timing=storage_timing,
+        allocation=storage_allocation,
+        run_label=str(timing.get("run_label") or ""),
+        comparable=comparable,
+        comparison_reason=comparison_reason,
+    )
     return {
         "schema_version": DECISION_SCHEMA,
         "reference_host": {
@@ -1653,6 +1924,8 @@ def _build_gate_decision(
         "thresholds": {
             "history_10x_writer_wall_p95_ns": WALL_LIMIT_NS,
             "history_10x_writer_cpu_p95_ns": CPU_LIMIT_NS,
+            "research_storage_status_wall_p95_ns": STORAGE_STATUS_WALL_LIMIT_NS,
+            "research_storage_status_python_peak_bytes": STORAGE_STATUS_ALLOCATION_LIMIT_BYTES,
             "required_subcases": list(history_keys),
         },
         "components": {
@@ -1663,6 +1936,13 @@ def _build_gate_decision(
             "existing_full_replay_writer": {
                 "status": writer_status,
                 "subcases": subcases,
+            },
+            "research_storage_status": {
+                "status": storage_status,
+                "reason": storage_reason,
+                "wall_p95_ns": storage_wall_p95,
+                "python_peak_bytes": storage_peak_allocation,
+                "fixture": STORAGE_STATUS_KEY,
             },
             "lot_diff_publication": {
                 "status": "not_implemented",
@@ -1675,6 +1955,41 @@ def _build_gate_decision(
         },
         "automatic_actions": [],
     }
+
+
+def _storage_status_gate(
+    *,
+    timing: Any,
+    allocation: Any,
+    run_label: str,
+    comparable: bool,
+    comparison_reason: str,
+) -> tuple[str, str, int | None, int | None]:
+    if not isinstance(timing, Mapping) or not isinstance(allocation, Mapping):
+        return "not_evaluable", "scenario_not_selected", None, None
+    wall = timing.get("wall_time_ns")
+    component = allocation.get("component")
+    wall_p95 = (
+        int(wall.get("p95"))
+        if isinstance(wall, Mapping) and isinstance(wall.get("p95"), int)
+        else None
+    )
+    peak = (
+        int(component.get("python_peak_bytes"))
+        if isinstance(component, Mapping) and isinstance(component.get("python_peak_bytes"), int)
+        else None
+    )
+    if run_label != "acceptance_5_warmups_30_repetitions":
+        return "not_evaluable", "non_acceptance_smoke", wall_p95, peak
+    if wall_p95 is None or peak is None:
+        return "not_evaluable", "measurement_missing", wall_p95, peak
+    if peak > STORAGE_STATUS_ALLOCATION_LIMIT_BYTES:
+        return "fail", "frozen_allocation_limit_exceeded", wall_p95, peak
+    if not comparable:
+        return "not_comparable", comparison_reason, wall_p95, peak
+    if wall_p95 > STORAGE_STATUS_WALL_LIMIT_NS:
+        return "fail", "frozen_wall_limit_exceeded", wall_p95, peak
+    return "pass", "within_frozen_limits", wall_p95, peak
 
 
 def _resolve_output_dir(value: str | Path, *, repo_root: Path) -> tuple[Path, bool]:

--- a/src/application/research/storage_baseline.py
+++ b/src/application/research/storage_baseline.py
@@ -1,0 +1,1594 @@
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from datetime import datetime, timezone
+import fnmatch
+import io
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import shutil
+import sqlite3
+import statistics
+import subprocess
+import tempfile
+import tokenize
+import heapq
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from src.application.agent_tool_contracts import AgentToolError
+from src.application.ledger.store_resolution import LEDGER_DB_RELATIVE_PATH
+
+
+SCHEMA_VERSION = "storage_runtime_baseline.v1"
+SOURCE_INVENTORY_RELATIVE_PATH = Path(
+    "docs/architecture/data-storage-runtime-source-inventory.v1.json"
+)
+RUNTIME_SUBROOTS = (
+    "output_runs",
+    "output_accounts",
+    "output_shared",
+    "output",
+    "logs",
+)
+MANIFEST_MAX_BYTES = 16 * 1024 * 1024
+LARGEST_FILE_LIMIT = 20
+SQLITE_SNAPSHOT_ATTEMPTS = 3
+GIB = 1024**3
+
+# These are reporting heuristics only. They do not authorize movement or
+# deletion. Later tiering work must replace them with a reviewed backend policy.
+RESEARCH_HOT_MAX_AGE_DAYS = 30
+COLD_CANDIDATE_MIN_AGE_DAYS = 180
+COLD_CANDIDATE_MIN_BYTES = 64 * 1024 * 1024
+
+_SQLITE_JSON_COLUMNS: dict[str, tuple[str, ...]] = {
+    "trade_events": ("event_json",),
+    "position_lots": ("fields_json",),
+    "assigned_stock_events": ("event_json",),
+    "trade_lifecycle_cases": ("raw_json",),
+    "trade_lifecycle_evidence": ("raw_json",),
+    "trade_lifecycle_source_consumptions": ("raw_json",),
+    "trade_lifecycle_allocations": ("raw_json",),
+    "trade_lifecycle_timing_policies": ("raw_json",),
+    "trade_lifecycle_migration_receipts": ("raw_json",),
+    "strategy_group_identities": ("raw_json",),
+    "combo_pair_inferences": ("evidence_json", "alternatives_json"),
+}
+
+_REFERENCE_PATH_KEYS = (
+    "relpath",
+    "path",
+    "file",
+    "file_path",
+    "payload_relpath",
+    "blob_relpath",
+    "partition_relpath",
+)
+_REFERENCE_HASH_KEYS = ("sha256", "content_sha256", "payload_sha256", "blob_sha256")
+_REFERENCE_SIZE_KEYS = (
+    "size_bytes",
+    "bytes",
+    "content_bytes",
+    "payload_size_bytes",
+    "blob_size_bytes",
+)
+
+
+def collect_storage_runtime_baseline(
+    *,
+    repo_root: str | Path,
+    runtime_root: str | Path,
+    ledger_sqlite: str | Path | None = None,
+    history_reports: Sequence[str | Path] | None = None,
+    output: str | Path | None = None,
+    allow_external_ledger: bool = False,
+    overwrite: bool = False,
+    now_fn: Callable[[], datetime] | None = None,
+    source_inventory_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Collect a payload-free, read-only storage and capacity baseline."""
+
+    base = Path(repo_root).expanduser().resolve()
+    root = _required_runtime_root(runtime_root)
+    ledger_path, ledger_source = _resolve_ledger_path(
+        root=root,
+        repo_root=base,
+        value=ledger_sqlite,
+        allow_external=allow_external_ledger,
+    )
+    observed_at = _utc_now(now_fn)
+    inventory_path = (
+        _resolve_input_path(source_inventory_path, base=base)
+        if source_inventory_path is not None
+        else base / SOURCE_INVENTORY_RELATIVE_PATH
+    )
+    resolved_history_reports = [
+        _resolve_input_path(item, base=base) for item in (history_reports or ())
+    ]
+    source_inventory = _collect_source_inventory(repo_root=base, manifest_path=inventory_path)
+    runtime_storage, research_file_rows = _collect_runtime_storage(root=root, observed_at=observed_at)
+    sqlite_payload = _collect_sqlite_metadata(ledger_path)
+    research_storage = _collect_research_storage(
+        root=root,
+        observed_at=observed_at,
+        file_rows=research_file_rows,
+        history_reports=resolved_history_reports,
+    )
+    disk = shutil.disk_usage(root)
+    thresholds = _capacity_thresholds(
+        disk_total_bytes=int(disk.total),
+        disk_free_bytes=int(disk.free),
+        research_storage=research_storage,
+    )
+    source_statuses = {
+        str(sqlite_payload.get("status")),
+        str(research_storage.get("status")),
+    }
+    overall_status = "complete"
+    if "data_unavailable" in source_statuses or "partial_data" in source_statuses:
+        overall_status = "partial_data"
+    elif "missing" in source_statuses:
+        overall_status = "partial_data"
+
+    result: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": overall_status,
+        "identity": {
+            "observed_at_utc": observed_at.isoformat(),
+            "runtime_root": str(root),
+            "ledger_sqlite": _display_runtime_path(ledger_path, root=root),
+            "ledger_source": ledger_source,
+            "python_version": platform.python_version(),
+            "sqlite_version": sqlite3.sqlite_version,
+            "platform": platform.platform(),
+            "git_sha": _git_sha(base),
+            "collection_options": {
+                "allow_external_ledger": bool(allow_external_ledger),
+                "history_report_count": len(resolved_history_reports),
+                "sqlite_snapshot_attempts": SQLITE_SNAPSHOT_ATTEMPTS,
+                "runtime_subroots": list(RUNTIME_SUBROOTS),
+            },
+        },
+        "source_inventory": source_inventory,
+        "sqlite": sqlite_payload,
+        "runtime_storage": runtime_storage,
+        "research_storage": research_storage,
+        "thresholds": thresholds,
+        "safety": {
+            "query_only_sqlite": True,
+            "source_sqlite_connections": 0,
+            "no_follow_traversal": True,
+            "payload_content_reads": 0,
+            "content_verification": "not_performed",
+            "mutation_operations": 0,
+            "automatic_actions": [],
+        },
+    }
+    if output is not None:
+        output_path = _resolve_output_path(output, base=base)
+        result["identity"]["output"] = str(output_path)
+        _write_report(
+            output_path,
+            result,
+            runtime_root=root,
+            overwrite=overwrite,
+        )
+    return result
+
+
+def _required_runtime_root(value: str | Path) -> Path:
+    raw = Path(value).expanduser()
+    try:
+        root = raw.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise AgentToolError(code="INPUT_ERROR", message=f"runtime root not found: {raw}") from exc
+    if not root.is_dir():
+        raise AgentToolError(code="INPUT_ERROR", message=f"runtime root is not a directory: {root}")
+    return root
+
+
+def _resolve_input_path(value: str | Path, *, base: Path) -> Path:
+    path = Path(value).expanduser()
+    return (path if path.is_absolute() else base / path).resolve()
+
+
+def _resolve_output_path(value: str | Path, *, base: Path) -> Path:
+    path = Path(value).expanduser()
+    candidate = path if path.is_absolute() else base / path
+    if candidate.is_symlink():
+        raise AgentToolError(code="INPUT_ERROR", message=f"baseline output must not be a symlink: {candidate}")
+    return candidate.resolve()
+
+
+def _resolve_ledger_path(
+    *,
+    root: Path,
+    repo_root: Path,
+    value: str | Path | None,
+    allow_external: bool,
+) -> tuple[Path, str]:
+    if value is None or not str(value).strip():
+        candidate = root / LEDGER_DB_RELATIVE_PATH
+        path = candidate.resolve()
+        if _path_or_parent_is_symlink(candidate, stop=root):
+            raise AgentToolError(
+                code="INPUT_ERROR",
+                message="default ledger path must not traverse a symlink",
+            )
+        return path, "runtime_default"
+    candidate = Path(value).expanduser()
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    path = candidate.resolve()
+    if _path_or_parent_is_symlink(candidate, stop=root if _is_relative_to(path, root) else None):
+        raise AgentToolError(code="INPUT_ERROR", message=f"explicit ledger path must not traverse a symlink: {candidate}")
+    if not _is_relative_to(path, root) and not allow_external:
+        raise AgentToolError(
+            code="INPUT_ERROR",
+            message="explicit ledger path must be inside runtime root unless --allow-external-ledger is set",
+        )
+    if not path.exists() or not path.is_file() or path.is_symlink():
+        raise AgentToolError(code="INPUT_ERROR", message=f"explicit ledger path must be a regular file: {path}")
+    return path, "explicit_external" if not _is_relative_to(path, root) else "explicit_runtime"
+
+
+def _utc_now(now_fn: Callable[[], datetime] | None) -> datetime:
+    now = now_fn() if now_fn is not None else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return now.astimezone(timezone.utc)
+
+
+def _git_sha(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _collect_source_inventory(*, repo_root: Path, manifest_path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message="source inventory manifest is missing") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message=f"source inventory manifest is invalid: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != "data_storage_runtime_source_inventory.v1":
+        raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message="source inventory schema is invalid")
+    rules = payload.get("discovery_rules")
+    roots = payload.get("scan_roots")
+    declarations = payload.get("declared_locators")
+    if not isinstance(rules, list) or not isinstance(roots, list) or not isinstance(declarations, list):
+        raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message="source inventory lists are invalid")
+
+    validated_rules: list[tuple[str, Mapping[str, Any], Sequence[Any]]] = []
+    rule_ids: set[str] = set()
+    for raw_rule in rules:
+        if not isinstance(raw_rule, dict):
+            raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message="source inventory rule is invalid")
+        rule_id = str(raw_rule.get("id") or "").strip()
+        classifiers = raw_rule.get("classifiers")
+        if not rule_id or rule_id in rule_ids or not isinstance(classifiers, list) or not classifiers:
+            raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message=f"source inventory rule is incomplete: {rule_id}")
+        rule_ids.add(rule_id)
+        validated_rules.append((rule_id, raw_rule, classifiers))
+
+    call_symbols = {
+        str(symbol)
+        for _rule_id, rule, _classifiers in validated_rules
+        if rule.get("kind") == "call"
+        for symbol in (rule.get("symbols") or [])
+    }
+    literal_values = {
+        str(value)
+        for _rule_id, rule, _classifiers in validated_rules
+        if rule.get("kind") == "literal"
+        for value in (rule.get("values") or [])
+    }
+    parse_errors: list[dict[str, str]] = []
+    matches: list[dict[str, Any]] = []
+    unclassified: list[dict[str, str]] = []
+    classifier_hits = {
+        rule_id: [0 for _ in classifiers]
+        for rule_id, _rule, classifiers in validated_rules
+    }
+    for root_name in roots:
+        root_rel = str(root_name or "").strip()
+        root = (repo_root / root_rel).resolve()
+        if not _is_relative_to(root, repo_root) or not root.is_dir():
+            raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message=f"source scan root is invalid: {root_rel}")
+        for path in _iter_python_files(root):
+            relpath = path.relative_to(repo_root).as_posix()
+            try:
+                text = path.read_text(encoding="utf-8")
+                calls, literals = _token_discoveries(
+                    text,
+                    call_symbols=call_symbols,
+                    literal_values=literal_values,
+                )
+            except (OSError, UnicodeError, IndentationError, tokenize.TokenError) as exc:
+                text = ""
+                calls = {}
+                literals = {}
+                parse_errors.append({"path": relpath, "error_type": type(exc).__name__})
+            for rule_id, raw_rule, classifiers in validated_rules:
+                discovered = _discover_rule_matches(
+                    raw_rule,
+                    text=text,
+                    calls=calls,
+                    literals=literals,
+                )
+                for locator, count in sorted(discovered.items()):
+                    classifier_index = _classifier_index(relpath, classifiers)
+                    if classifier_index is None:
+                        unclassified.append({"rule_id": rule_id, "path": relpath, "locator": locator})
+                        continue
+                    classifier_hits[rule_id][classifier_index] += count
+                    classifier = classifiers[classifier_index]
+                    matches.append(
+                        {
+                            "rule_id": rule_id,
+                            "path": relpath,
+                            "locator": locator,
+                            "match_count": count,
+                            "owner": str(classifier.get("owner") or ""),
+                            "operation": str(classifier.get("operation") or ""),
+                            "history_dimension": str(classifier.get("history_dimension") or ""),
+                            "path_class": str(classifier.get("path_class") or ""),
+                            "later_phase": str(classifier.get("later_phase") or ""),
+                        }
+                    )
+
+    stale_classifiers: list[dict[str, str]] = []
+    for rule_id, _raw_rule, classifiers in validated_rules:
+        for index, count in enumerate(classifier_hits[rule_id]):
+            if count == 0:
+                classifier = classifiers[index]
+                stale_classifiers.append(
+                    {
+                        "rule_id": rule_id,
+                        "path_glob": str(classifier.get("path_glob") or ""),
+                    }
+                )
+
+    stale_locators: list[dict[str, str]] = []
+    for item in declarations:
+        if not isinstance(item, dict):
+            stale_locators.append({"path": "", "locator": "invalid_declaration"})
+            continue
+        relpath = str(item.get("path") or "").strip()
+        locator = str(item.get("locator") or "").strip()
+        path = (repo_root / relpath).resolve()
+        if (
+            not relpath
+            or not locator
+            or not _is_relative_to(path, repo_root)
+            or not path.is_file()
+            or path.is_symlink()
+        ):
+            stale_locators.append({"path": relpath, "locator": locator})
+            continue
+        try:
+            present = locator in path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            present = False
+        if not present:
+            stale_locators.append({"path": relpath, "locator": locator})
+
+    if parse_errors or stale_classifiers or stale_locators or unclassified:
+        raise AgentToolError(
+            code="SOURCE_INVENTORY_ERROR",
+            message="source inventory has stale or unclassified production matches",
+            details={
+                "parse_errors": parse_errors,
+                "stale_classifiers": stale_classifiers,
+                "stale_locators": stale_locators,
+                "unclassified": unclassified,
+            },
+        )
+    return {
+        "schema_version": str(payload["schema_version"]),
+        "status": "complete",
+        "manifest_path": manifest_path.relative_to(repo_root).as_posix(),
+        "scan_roots": [str(item) for item in roots],
+        "rule_count": len(rules),
+        "declared_locator_count": len(declarations),
+        "classified_match_count": len(matches),
+        "matches": sorted(matches, key=lambda item: (item["rule_id"], item["path"], item["locator"])),
+        "stale_classifiers": [],
+        "stale_locators": [],
+        "unclassified_matches": [],
+        "ignored_matches": list(payload.get("ignores") or []),
+    }
+
+
+def _iter_python_files(root: Path) -> Iterable[Path]:
+    stack = [root]
+    while stack:
+        directory = stack.pop()
+        with os.scandir(directory) as entries:
+            for entry in sorted(entries, key=lambda item: item.name, reverse=True):
+                if entry.is_symlink():
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    if entry.name not in {"__pycache__", ".venv"}:
+                        stack.append(Path(entry.path))
+                elif entry.is_file(follow_symlinks=False) and entry.name.endswith(".py"):
+                    yield Path(entry.path)
+
+
+def _token_discoveries(
+    text: str,
+    *,
+    call_symbols: set[str],
+    literal_values: set[str],
+) -> tuple[dict[str, int], dict[str, int]]:
+    calls: dict[str, int] = defaultdict(int)
+    literals: dict[str, int] = defaultdict(int)
+    tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+    significant = [
+        token
+        for token in tokens
+        if token.type
+        not in {
+            tokenize.ENCODING,
+            tokenize.NL,
+            tokenize.NEWLINE,
+            tokenize.INDENT,
+            tokenize.DEDENT,
+            tokenize.COMMENT,
+            tokenize.ENDMARKER,
+        }
+    ]
+    for index, token in enumerate(significant):
+        if token.type == tokenize.NAME and token.string in call_symbols:
+            previous = significant[index - 1].string if index else ""
+            following = significant[index + 1].string if index + 1 < len(significant) else ""
+            if previous != "def" and following == "(":
+                calls[token.string] += 1
+        elif token.type == tokenize.STRING and literal_values:
+            try:
+                value = ast.literal_eval(token.string)
+            except (SyntaxError, ValueError):
+                continue
+            if isinstance(value, str) and value in literal_values:
+                literals[value] += 1
+    return dict(calls), dict(literals)
+
+
+def _discover_rule_matches(
+    rule: Mapping[str, Any],
+    *,
+    text: str,
+    calls: Mapping[str, int],
+    literals: Mapping[str, int],
+) -> dict[str, int]:
+    kind = str(rule.get("kind") or "")
+    out: dict[str, int] = defaultdict(int)
+    if kind == "text":
+        for pattern in rule.get("patterns") or []:
+            value = str(pattern or "")
+            if value:
+                out[value] += text.count(value)
+        return {key: count for key, count in out.items() if count}
+    if kind == "call":
+        wanted = {str(item) for item in rule.get("symbols") or []}
+        return {name: int(calls[name]) for name in wanted if calls.get(name)}
+    if kind == "literal":
+        wanted = {str(item) for item in rule.get("values") or []}
+        return {value: int(literals[value]) for value in wanted if literals.get(value)}
+    raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message=f"unsupported discovery rule kind: {kind}")
+
+
+def _classifier_index(relpath: str, classifiers: Sequence[Any]) -> int | None:
+    for index, raw in enumerate(classifiers):
+        if isinstance(raw, dict) and fnmatch.fnmatch(relpath, str(raw.get("path_glob") or "")):
+            return index
+    return None
+
+
+def _collect_sqlite_metadata(path: Path) -> dict[str, Any]:
+    source_files = _sqlite_source_files(path)
+    if not path.exists():
+        return {
+            "status": "missing",
+            "source_files": source_files,
+            "snapshot_attempts": 0,
+            "tables": [],
+            "unknown_tables": [],
+            "query_mode": "stable_copy_mode_ro_query_only",
+        }
+    if path.is_symlink() or not path.is_file():
+        return {
+            "status": "data_unavailable",
+            "reason": "ledger_not_regular_file",
+            "source_files": source_files,
+            "snapshot_attempts": 0,
+            "tables": [],
+            "unknown_tables": [],
+            "query_mode": "stable_copy_mode_ro_query_only",
+        }
+    try:
+        with tempfile.TemporaryDirectory(prefix="om-storage-baseline-sqlite-") as temp_name:
+            copied_path, attempts, stable_state = _copy_stable_sqlite_set(path, Path(temp_name))
+            query = _query_sqlite_copy(copied_path)
+        return {
+            "status": "complete",
+            "source_files": _source_file_rows(stable_state),
+            "snapshot_attempts": attempts,
+            "query_mode": "stable_copy_mode_ro_query_only",
+            **query,
+        }
+    except Exception as exc:
+        return {
+            "status": "data_unavailable",
+            "reason": "stable_copy_or_query_failed",
+            "error_type": type(exc).__name__,
+            "source_files": _sqlite_source_files(path),
+            "snapshot_attempts": SQLITE_SNAPSHOT_ATTEMPTS,
+            "tables": [],
+            "unknown_tables": [],
+            "query_mode": "stable_copy_mode_ro_query_only",
+        }
+
+
+def _sqlite_paths(path: Path) -> tuple[Path, Path, Path]:
+    return path, path.with_name(path.name + "-wal"), path.with_name(path.name + "-shm")
+
+
+def _stat_tuple(path: Path) -> tuple[bool, int | None, int | None, int | None]:
+    try:
+        stat = path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return False, None, None, None
+    return True, int(stat.st_size), int(stat.st_mtime_ns), int(stat.st_ino)
+
+
+def _sqlite_state(path: Path) -> dict[str, tuple[bool, int | None, int | None, int | None]]:
+    return {item.name: _stat_tuple(item) for item in _sqlite_paths(path)}
+
+
+def _source_file_rows(
+    state: Mapping[str, tuple[bool, int | None, int | None, int | None]],
+) -> list[dict[str, Any]]:
+    rows = []
+    for name, values in state.items():
+        exists, size, mtime_ns, inode = values
+        role = "db"
+        if name.endswith("-wal"):
+            role = "wal"
+        elif name.endswith("-shm"):
+            role = "shm"
+        rows.append(
+            {
+                "role": role,
+                "exists": exists,
+                "size_bytes": size,
+                "mtime_ns": mtime_ns,
+                "inode": inode,
+            }
+        )
+    return rows
+
+
+def _sqlite_source_files(path: Path) -> list[dict[str, Any]]:
+    return _source_file_rows(_sqlite_state(path))
+
+
+def _copy_stable_sqlite_set(
+    source: Path,
+    destination_dir: Path,
+) -> tuple[Path, int, dict[str, tuple[bool, int | None, int | None, int | None]]]:
+    destination = destination_dir / source.name
+    for attempt in range(1, SQLITE_SNAPSHOT_ATTEMPTS + 1):
+        before = _sqlite_state(source)
+        for item in destination_dir.iterdir():
+            if item.is_file() or item.is_symlink():
+                item.unlink()
+        for source_path in _sqlite_paths(source):
+            if before[source_path.name][0]:
+                shutil.copyfile(source_path, destination_dir / source_path.name)
+        after = _sqlite_state(source)
+        if before == after:
+            return destination, attempt, after
+    raise RuntimeError("sqlite source changed during all snapshot attempts")
+
+
+def _query_sqlite_copy(path: Path) -> dict[str, Any]:
+    uri = f"file:{path.as_posix()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA query_only=ON")
+        table_rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+        ).fetchall()
+        table_names = [str(row["name"]) for row in table_rows]
+        tables: list[dict[str, Any]] = []
+        for table, json_columns in _SQLITE_JSON_COLUMNS.items():
+            if table not in table_names:
+                tables.append(
+                    {
+                        "table": table,
+                        "status": "missing",
+                        "row_count": None,
+                        "json_bytes": None,
+                    }
+                )
+                continue
+            column_rows = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+            present_columns = {str(row["name"]) for row in column_rows}
+            selected_columns = [column for column in json_columns if column in present_columns]
+            byte_expression = " + ".join(
+                f'COALESCE(length("{column}"), 0)' for column in selected_columns
+            )
+            if selected_columns:
+                row = conn.execute(
+                    f'SELECT COUNT(*) AS row_count, COALESCE(SUM({byte_expression}), 0) AS json_bytes FROM "{table}"'
+                ).fetchone()
+                json_bytes: int | None = int(row["json_bytes"] or 0)
+            else:
+                row = conn.execute(f'SELECT COUNT(*) AS row_count FROM "{table}"').fetchone()
+                json_bytes = None
+            tables.append(
+                {
+                    "table": table,
+                    "status": "complete" if selected_columns else "json_column_missing",
+                    "row_count": int(row["row_count"] or 0),
+                    "json_columns": selected_columns,
+                    "json_bytes": json_bytes,
+                }
+            )
+        allowed = set(_SQLITE_JSON_COLUMNS)
+        unknown = [name for name in table_names if name not in allowed and not name.startswith("sqlite_")]
+        return {
+            "page": {
+                "page_size_bytes": int(conn.execute("PRAGMA page_size").fetchone()[0]),
+                "page_count": int(conn.execute("PRAGMA page_count").fetchone()[0]),
+                "freelist_count": int(conn.execute("PRAGMA freelist_count").fetchone()[0]),
+            },
+            "tables": tables,
+            "unknown_tables": unknown,
+        }
+    finally:
+        conn.close()
+
+
+def _collect_runtime_storage(*, root: Path, observed_at: datetime) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    aggregates = _RuntimeAggregates()
+    research_files: list[dict[str, Any]] = []
+    symlinks: list[dict[str, Any]] = []
+    roots: list[dict[str, Any]] = []
+    for name in RUNTIME_SUBROOTS:
+        path = root / name
+        if path.is_symlink():
+            symlinks.append({"path": name, "kind": "root"})
+            roots.append({"root": name, "status": "symlink_not_followed", "file_count": 0, "size_bytes": 0})
+            continue
+        if not path.exists():
+            roots.append({"root": name, "status": "missing", "file_count": 0, "size_bytes": 0})
+            continue
+        if not path.is_dir():
+            roots.append({"root": name, "status": "not_directory", "file_count": 0, "size_bytes": 0})
+            continue
+        before_count = aggregates.file_count
+        before_bytes = aggregates.size_bytes
+        _scan_runtime_directory(
+            path,
+            root=root,
+            observed_at=observed_at,
+            aggregates=aggregates,
+            research_files=research_files,
+            symlinks=symlinks,
+        )
+        roots.append(
+            {
+                "root": name,
+                "status": "complete",
+                "file_count": aggregates.file_count - before_count,
+                "size_bytes": aggregates.size_bytes - before_bytes,
+            }
+        )
+    largest = [item for _size, _path, item in sorted(aggregates.largest, key=lambda row: (-row[0], row[1]))]
+    payload = {
+        "status": "complete",
+        "file_count": aggregates.file_count,
+        "size_bytes": aggregates.size_bytes,
+        "roots": roots,
+        "by_class": _aggregate_groups(aggregates.by_class, "storage_class"),
+        "by_suffix": _aggregate_groups(aggregates.by_suffix, "suffix"),
+        "by_month": _aggregate_groups(aggregates.by_month, "month"),
+        "by_tier": _aggregate_groups(aggregates.by_tier, "tier"),
+        "largest_files": [
+            {
+                "path": item["path"],
+                "size_bytes": item["size_bytes"],
+                "storage_class": item["storage_class"],
+                "tier": item["tier"],
+            }
+            for item in largest
+        ],
+        "symlinks_not_followed": sorted(symlinks, key=lambda item: item["path"]),
+    }
+    return payload, research_files
+
+
+class _RuntimeAggregates:
+    def __init__(self) -> None:
+        self.file_count = 0
+        self.size_bytes = 0
+        self.by_class: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+        self.by_suffix: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+        self.by_month: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+        self.by_tier: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+        self.largest: list[tuple[int, str, dict[str, Any]]] = []
+
+    def add(self, item: dict[str, Any]) -> None:
+        size = int(item["size_bytes"])
+        self.file_count += 1
+        self.size_bytes += size
+        for values, key in (
+            (self.by_class, "storage_class"),
+            (self.by_suffix, "suffix"),
+            (self.by_month, "month"),
+            (self.by_tier, "tier"),
+        ):
+            bucket = values[str(item[key])]
+            bucket[0] += 1
+            bucket[1] += size
+        summary = {
+            "path": item["path"],
+            "size_bytes": size,
+            "storage_class": item["storage_class"],
+            "tier": item["tier"],
+        }
+        heapq.heappush(self.largest, (size, str(item["path"]), summary))
+        if len(self.largest) > LARGEST_FILE_LIMIT:
+            heapq.heappop(self.largest)
+
+
+def _aggregate_groups(values: Mapping[str, Sequence[int]], key: str) -> list[dict[str, Any]]:
+    return [
+        {key: value, "file_count": int(counts[0]), "size_bytes": int(counts[1])}
+        for value, counts in sorted(values.items())
+    ]
+
+
+def _scan_runtime_directory(
+    directory: Path,
+    *,
+    root: Path,
+    observed_at: datetime,
+    aggregates: _RuntimeAggregates,
+    research_files: list[dict[str, Any]],
+    symlinks: list[dict[str, Any]],
+) -> None:
+    stack = [directory]
+    while stack:
+        current = stack.pop()
+        with os.scandir(current) as entries:
+            for entry in sorted(entries, key=lambda item: item.name, reverse=True):
+                path = Path(entry.path)
+                relpath = path.relative_to(root).as_posix()
+                if entry.is_symlink():
+                    symlinks.append({"path": relpath, "kind": "entry"})
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    stack.append(path)
+                    continue
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                stat = entry.stat(follow_symlinks=False)
+                storage_class = _storage_class(relpath)
+                age_days = max(0.0, (observed_at.timestamp() - stat.st_mtime) / 86400.0)
+                tier = _storage_tier(storage_class=storage_class, age_days=age_days)
+                item = {
+                        "path": relpath,
+                        "size_bytes": int(stat.st_size),
+                        "mtime_ns": int(stat.st_mtime_ns),
+                        "age_days": round(age_days, 3),
+                        "suffix": path.suffix.lower() or "[none]",
+                        "month": datetime.fromtimestamp(stat.st_mtime, timezone.utc).strftime("%Y-%m"),
+                        "storage_class": storage_class,
+                        "tier": tier,
+                    }
+                aggregates.add(item)
+                if storage_class in {"research_artifact", "immutable_shared_partition", "sealed_run_artifact"}:
+                    research_files.append(item)
+
+
+def _storage_class(relpath: str) -> str:
+    parts = Path(relpath).parts
+    if not parts:
+        return "other"
+    if parts[0] == "output_runs":
+        return "sealed_run_artifact"
+    if parts[0] in {"output_accounts", "output"}:
+        return "compatibility_runtime_output"
+    if parts[0] == "logs":
+        return "runtime_log"
+    if parts[:2] == ("output_shared", "state"):
+        return "operational_state"
+    if parts[:2] == ("output_shared", "required_data"):
+        return "immutable_shared_partition"
+    if parts[:2] == ("output_shared", "research"):
+        return "research_artifact"
+    return "shared_runtime_artifact" if parts[0] == "output_shared" else "other"
+
+
+def _storage_tier(*, storage_class: str, age_days: float) -> str:
+    if storage_class != "research_artifact":
+        return "hot"
+    return "hot" if age_days <= RESEARCH_HOT_MAX_AGE_DAYS else "warm"
+
+
+def _collect_research_storage(
+    *,
+    root: Path,
+    observed_at: datetime,
+    file_rows: list[dict[str, Any]],
+    history_reports: Sequence[str | Path],
+) -> dict[str, Any]:
+    manifests = [row for row in file_rows if _is_manifest_relpath(str(row["path"]))]
+    manifest_results: list[dict[str, Any]] = []
+    references: list[dict[str, Any]] = []
+    generations: set[str] = set()
+    parse_failures: list[dict[str, str]] = []
+    for row in manifests:
+        relpath = str(row["path"])
+        path = root / relpath
+        if int(row["size_bytes"]) > MANIFEST_MAX_BYTES:
+            parse_failures.append({"path": relpath, "reason": "manifest_too_large"})
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            parse_failures.append({"path": relpath, "reason": type(exc).__name__})
+            continue
+        if not isinstance(payload, dict):
+            parse_failures.append({"path": relpath, "reason": "manifest_not_object"})
+            continue
+        generation = _first_text(payload, ("generation_id", "dataset_id", "run_id"))
+        if generation:
+            generations.add(generation)
+        extracted = _extract_manifest_references(
+            payload,
+            manifest_path=path,
+            root=root,
+        )
+        references.extend(extracted)
+        manifest_results.append(
+            {
+                "path": relpath,
+                "schema_version": str(payload.get("schema_version") or payload.get("schema") or "unknown"),
+                "reference_count": len(extracted),
+                "historical_verifier_receipt_present": _has_historical_verifier_receipt(payload),
+            }
+        )
+
+    file_index = {str(row["path"]): row for row in file_rows}
+    referenced_paths: set[str] = set()
+    protected_failures: list[dict[str, Any]] = []
+    hash_sizes: dict[str, int] = {}
+    hash_physical: dict[str, dict[str, Any]] = {}
+    logical_bytes = 0
+    declared_reference_count = 0
+    bytes_by_class: dict[str, int] = defaultdict(int)
+    bytes_by_tier: dict[str, int] = defaultdict(int)
+    bytes_by_market: dict[str, int] = defaultdict(int)
+    for reference in references:
+        size = reference.get("declared_size_bytes")
+        digest = reference.get("declared_sha256")
+        relpath = reference.get("resolved_relpath")
+        storage_class = str(reference.get("artifact_class") or "unclassified_manifest_reference")
+        market = str(reference.get("market") or "unknown").lower()
+        if isinstance(size, int) and size >= 0:
+            logical_bytes += size
+            bytes_by_class[storage_class] += size
+            bytes_by_market[market] += size
+        if digest:
+            declared_reference_count += 1
+            if isinstance(size, int) and digest in hash_sizes and hash_sizes[digest] != size:
+                protected_failures.append(
+                    {"manifest": reference["manifest"], "reference": reference["display_path"], "reason": "declared_hash_size_conflict"}
+                )
+            elif isinstance(size, int):
+                hash_sizes[digest] = size
+        if relpath:
+            referenced_paths.add(str(relpath))
+            actual = file_index.get(str(relpath))
+            if actual is None:
+                protected_failures.append(
+                    {"manifest": reference["manifest"], "reference": reference["display_path"], "reason": "missing"}
+                )
+                reference["presence_status"] = "missing"
+                continue
+            actual_size = int(actual["size_bytes"])
+            reference["actual_size_bytes"] = actual_size
+            if isinstance(size, int) and size != actual_size:
+                protected_failures.append(
+                    {"manifest": reference["manifest"], "reference": reference["display_path"], "reason": "declared_size_mismatch"}
+                )
+                reference["presence_status"] = "declared_size_mismatch"
+            else:
+                reference["presence_status"] = "present_size_match" if isinstance(size, int) else "present_size_undeclared"
+            if digest and digest not in hash_physical:
+                hash_physical[digest] = actual
+        elif reference.get("path_value"):
+            protected_failures.append(
+                {"manifest": reference["manifest"], "reference": reference["display_path"], "reason": "unresolved_path"}
+            )
+
+    unique_declared_bytes = sum(hash_sizes.values())
+    unknown_hash_size_count = len({str(ref["declared_sha256"]) for ref in references if ref.get("declared_sha256") and not isinstance(ref.get("declared_size_bytes"), int)})
+    manifest_paths = {str(row["path"]) for row in manifests}
+    research_files = [
+        row
+        for row in file_rows
+        if str(row["storage_class"]) in {"research_artifact", "immutable_shared_partition", "sealed_run_artifact"}
+    ]
+    unmanifested = [row for row in research_files if str(row["path"]) not in referenced_paths | manifest_paths]
+    physical_bytes = sum(int(row["size_bytes"]) for row in research_files)
+    unknown_unique_bytes = sum(int(row["size_bytes"]) for row in unmanifested)
+    cold_candidates: list[dict[str, Any]] = []
+    for digest, row in hash_physical.items():
+        if (
+            float(row["age_days"]) >= COLD_CANDIDATE_MIN_AGE_DAYS
+            and int(row["size_bytes"]) >= COLD_CANDIDATE_MIN_BYTES
+        ):
+            cold_candidates.append(
+                {
+                    "path": row["path"],
+                    "declared_sha256": digest,
+                    "size_bytes": row["size_bytes"],
+                    "age_days": row["age_days"],
+                    "action": "preview_only",
+                }
+            )
+            bytes_by_tier["cold_candidate"] += int(row["size_bytes"])
+        elif float(row["age_days"]) <= RESEARCH_HOT_MAX_AGE_DAYS:
+            bytes_by_tier["hot"] += int(row["size_bytes"])
+        else:
+            bytes_by_tier["warm"] += int(row["size_bytes"])
+
+    growth = _growth_and_forecast(
+        root=root,
+        observed_at=observed_at,
+        current_unique_bytes=unique_declared_bytes,
+        history_reports=history_reports,
+    )
+    if parse_failures or protected_failures:
+        status = "data_unavailable"
+    else:
+        status = "complete"
+    dedup_ratio = (
+        round(logical_bytes / unique_declared_bytes, 6)
+        if unique_declared_bytes > 0
+        else None
+    )
+    return {
+        "status": status,
+        "content_verification": "not_performed",
+        "manifest_count": len(manifests),
+        "parsed_manifest_count": len(manifest_results),
+        "manifest_parse_failures": parse_failures,
+        "manifests": manifest_results,
+        "root_count": sum(1 for rel in ("output_runs", "output_shared/research", "output_shared/required_data") if (root / rel).is_dir()),
+        "generation_count": len(generations),
+        "declared_reference_count": len(references),
+        "declared_hash_reference_count": declared_reference_count,
+        "logical_referenced_bytes": logical_bytes,
+        "unique_declared_bytes": unique_declared_bytes,
+        "declared_hash_unknown_size_count": unknown_hash_size_count,
+        "dedup_ratio": dedup_ratio,
+        "physical_bytes": physical_bytes,
+        "unmanifested_file_count": len(unmanifested),
+        "unknown_unique_bytes": unknown_unique_bytes,
+        "protected_reference_failures": protected_failures,
+        "same_size_content_status": "not_verified",
+        "bytes_by_class": _byte_groups(bytes_by_class, "storage_class"),
+        "bytes_by_market": _byte_groups(bytes_by_market, "market"),
+        "bytes_by_tier": _byte_groups(bytes_by_tier, "tier"),
+        "tier_policy": {
+            "status": "reporting_heuristic_only",
+            "hot_max_age_days": RESEARCH_HOT_MAX_AGE_DAYS,
+            "cold_candidate_min_age_days": COLD_CANDIDATE_MIN_AGE_DAYS,
+            "cold_candidate_min_bytes": COLD_CANDIDATE_MIN_BYTES,
+            "backend": "not_implemented",
+            "automatic_actions": [],
+        },
+        "cold_candidates": sorted(cold_candidates, key=lambda item: (-int(item["size_bytes"]), str(item["path"]))),
+        "growth": growth,
+    }
+
+
+def _is_manifest_relpath(relpath: str) -> bool:
+    path = Path(relpath)
+    if path.suffix.lower() != ".json":
+        return False
+    name = path.name.lower()
+    return "manifest" in name or name.startswith("inventory")
+
+
+def _extract_manifest_references(payload: Mapping[str, Any], *, manifest_path: Path, root: Path) -> list[dict[str, Any]]:
+    if payload.get("schema_version") == "research_archive.v2" and payload.get("action") == "verify":
+        return _extract_research_archive_references(
+            payload,
+            manifest_path=manifest_path,
+            root=root,
+        )
+
+    out: list[dict[str, Any]] = []
+
+    manifest_reference_roots = _manifest_reference_roots(
+        payload,
+        manifest_path=manifest_path,
+        root=root,
+    )
+
+    def visit(
+        value: Any,
+        context: Mapping[str, Any] | None = None,
+        path_hint: str | None = None,
+    ) -> None:
+        if isinstance(value, dict):
+            reference = _reference_from_mapping(
+                value,
+                manifest_path=manifest_path,
+                root=root,
+                context=context,
+                reference_roots=manifest_reference_roots,
+                path_hint=path_hint,
+            )
+            if reference is not None:
+                out.append(reference)
+            for child_key, child in value.items():
+                child_path_hint = str(child_key) if _mapping_looks_like_file_index(value) else None
+                visit(child, context=value, path_hint=child_path_hint)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child, context=context, path_hint=None)
+
+    visit(dict(payload))
+    out.extend(
+        _extract_parallel_file_map_references(
+            payload,
+            manifest_path=manifest_path,
+            root=root,
+        )
+    )
+    unique: dict[tuple[str, str | None, int | None], dict[str, Any]] = {}
+    for item in out:
+        key = (
+            str(item.get("path_value") or ""),
+            str(item.get("declared_sha256")) if item.get("declared_sha256") else None,
+            item.get("declared_size_bytes") if isinstance(item.get("declared_size_bytes"), int) else None,
+        )
+        unique.setdefault(key, item)
+    return list(unique.values())
+
+
+def _extract_research_archive_references(
+    payload: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+    root: Path,
+) -> list[dict[str, Any]]:
+    declared_root = Path(str(payload.get("archive_root") or "")).expanduser()
+    archive_root = declared_root.resolve() if declared_root.is_absolute() else manifest_path.parent.parent.resolve()
+    if not _is_relative_to(archive_root, root):
+        archive_root = manifest_path.parent.parent.resolve()
+    references: list[dict[str, Any]] = []
+    runs = payload.get("runs")
+    if not isinstance(runs, list):
+        return references
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+        run_id = str(run.get("run_id") or "").strip()
+        file_manifest = run.get("file_manifest")
+        if not run_id or not isinstance(file_manifest, list):
+            continue
+        reference_root = archive_root / "output_runs" / run_id
+        for item in file_manifest:
+            if not isinstance(item, Mapping):
+                continue
+            relpath = str(item.get("path") or "").strip()
+            if not relpath:
+                continue
+            references.append(
+                _explicit_manifest_reference(
+                    manifest_path=manifest_path,
+                    root=root,
+                    reference_root=reference_root,
+                    path_value=relpath,
+                    digest=item.get("sha256"),
+                    size=item.get("size_bytes"),
+                    artifact_class="immutable_replay_authority",
+                    market=_first_text(run, ("market",)),
+                )
+            )
+    return references
+
+
+def _extract_parallel_file_map_references(
+    payload: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+    root: Path,
+) -> list[dict[str, Any]]:
+    references: list[dict[str, Any]] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, Mapping):
+            files = value.get("files")
+            hashes = value.get("file_sha256")
+            sizes = value.get("file_size_bytes")
+            if isinstance(files, Mapping) and isinstance(hashes, Mapping):
+                for name, raw_path in files.items():
+                    if not isinstance(raw_path, str) or not raw_path.strip():
+                        continue
+                    references.append(
+                        _explicit_manifest_reference(
+                            manifest_path=manifest_path,
+                            root=root,
+                            reference_root=manifest_path.parent,
+                            path_value=raw_path,
+                            digest=hashes.get(name),
+                            size=sizes.get(name) if isinstance(sizes, Mapping) else None,
+                            artifact_class="experiment_or_research_artifact",
+                            market=_first_text(value, ("market",)),
+                        )
+                    )
+            for child in value.values():
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(payload)
+    return references
+
+
+def _explicit_manifest_reference(
+    *,
+    manifest_path: Path,
+    root: Path,
+    reference_root: Path,
+    path_value: str,
+    digest: Any,
+    size: Any,
+    artifact_class: str,
+    market: str | None,
+) -> dict[str, Any]:
+    digest_value = str(digest or "").strip().lower() or None
+    if digest_value is not None and (
+        len(digest_value) != 64
+        or any(char not in "0123456789abcdef" for char in digest_value)
+    ):
+        digest_value = None
+    size_value = size if isinstance(size, int) and not isinstance(size, bool) and size >= 0 else None
+    return {
+        "manifest": manifest_path.relative_to(root).as_posix(),
+        "display_path": path_value,
+        "path_key": "adapter_path",
+        "path_value": path_value,
+        "resolved_relpath": _resolve_manifest_reference(
+            path_value,
+            manifest_path=manifest_path,
+            root=root,
+            reference_roots=(reference_root,),
+        ),
+        "declared_sha256": digest_value,
+        "declared_size_bytes": size_value,
+        "hash_key": "adapter_sha256",
+        "size_key": "adapter_size_bytes" if size_value is not None else None,
+        "artifact_class": artifact_class,
+        "market": market,
+    }
+
+
+def _reference_from_mapping(
+    value: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+    root: Path,
+    context: Mapping[str, Any] | None,
+    reference_roots: Sequence[Path],
+    path_hint: str | None,
+) -> dict[str, Any] | None:
+    path_key, path_value = _first_key_value(value, _REFERENCE_PATH_KEYS)
+    if path_value is None:
+        for key, raw in value.items():
+            if (
+                str(key).endswith("_relpath")
+                and not str(key).endswith("_root_relpath")
+                and isinstance(raw, str)
+                and raw.strip()
+            ):
+                path_key, path_value = str(key), raw
+                break
+    if path_value is None and path_hint:
+        path_key, path_value = "mapping_key", path_hint
+    hash_key, digest_value = _first_key_value(value, _REFERENCE_HASH_KEYS)
+    if digest_value is None and path_key and path_key.endswith("_relpath"):
+        hash_key = path_key.removesuffix("_relpath") + "_sha256"
+        digest_value = value.get(hash_key)
+    size_key, size_value = _first_key_value(value, _REFERENCE_SIZE_KEYS)
+    if path_value is None and digest_value is None:
+        return None
+    if (
+        path_value is not None
+        and not str(path_key or "").endswith("relpath")
+        and digest_value is None
+        and size_value is None
+    ):
+        return None
+    if path_value is not None and not isinstance(path_value, str):
+        return None
+    digest = str(digest_value or "").strip().lower() or None
+    if digest is not None and (len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest)):
+        digest = None
+    size: int | None = None
+    if isinstance(size_value, int) and not isinstance(size_value, bool) and size_value >= 0:
+        size = size_value
+    resolved_relpath = _resolve_manifest_reference(
+        str(path_value or ""),
+        manifest_path=manifest_path,
+        root=root,
+        reference_roots=reference_roots,
+    )
+    context_map = context or value
+    artifact_class = _first_text(value, ("artifact_class", "storage_class", "class")) or _first_text(
+        context_map, ("artifact_class", "storage_class", "class")
+    )
+    market = _first_text(value, ("market",)) or _first_text(context_map, ("market",))
+    return {
+        "manifest": manifest_path.relative_to(root).as_posix(),
+        "display_path": str(path_value or "[hash-only]"),
+        "path_key": path_key,
+        "path_value": str(path_value or ""),
+        "resolved_relpath": resolved_relpath,
+        "declared_sha256": digest,
+        "declared_size_bytes": size,
+        "hash_key": hash_key,
+        "size_key": size_key,
+        "artifact_class": artifact_class or _artifact_class_for_reference(resolved_relpath),
+        "market": market,
+    }
+
+
+def _mapping_looks_like_file_index(value: Mapping[str, Any]) -> bool:
+    if not value:
+        return False
+    for child in value.values():
+        if not isinstance(child, Mapping):
+            continue
+        if any(key in child for key in (*_REFERENCE_HASH_KEYS, *_REFERENCE_SIZE_KEYS)):
+            return True
+    return False
+
+
+def _manifest_reference_roots(
+    payload: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+    root: Path,
+) -> list[Path]:
+    roots: list[Path] = []
+    for key, raw in payload.items():
+        if not str(key).endswith("_root_relpath") or not isinstance(raw, str) or not raw.strip():
+            continue
+        candidate = (manifest_path.parent / raw).resolve()
+        if _is_relative_to(candidate, root):
+            roots.append(candidate)
+    integrity = payload.get("integrity")
+    if isinstance(integrity, dict) and isinstance(integrity.get("files"), dict):
+        roots.append(manifest_path.parent.resolve())
+    return list(dict.fromkeys(roots))
+
+
+def _resolve_manifest_reference(
+    value: str,
+    *,
+    manifest_path: Path,
+    root: Path,
+    reference_roots: Sequence[Path],
+) -> str | None:
+    raw = value.strip()
+    if not raw:
+        return None
+    path = Path(raw)
+    if path.is_absolute():
+        candidate = path.resolve()
+        return candidate.relative_to(root).as_posix() if _is_relative_to(candidate, root) else None
+    candidates: list[Path] = []
+    if path.parts and path.parts[0] in RUNTIME_SUBROOTS:
+        candidates.append((root / path).resolve())
+    candidates.extend((reference_root / path).resolve() for reference_root in reference_roots)
+    candidates.extend(((manifest_path.parent / path).resolve(), (root / path).resolve()))
+    valid = [candidate for candidate in candidates if _is_relative_to(candidate, root)]
+    for candidate in valid:
+        if candidate.exists() and candidate.is_file() and not candidate.is_symlink():
+            return candidate.relative_to(root).as_posix()
+    return valid[0].relative_to(root).as_posix() if valid else None
+
+
+def _artifact_class_for_reference(relpath: str | None) -> str:
+    if not relpath:
+        return "unclassified_manifest_reference"
+    storage_class = _storage_class(relpath)
+    if storage_class == "sealed_run_artifact":
+        return "immutable_replay_authority"
+    if storage_class == "immutable_shared_partition":
+        return storage_class
+    if storage_class == "research_artifact":
+        return "experiment_or_research_artifact"
+    return "unclassified_manifest_reference"
+
+
+def _first_key_value(value: Mapping[str, Any], keys: Sequence[str]) -> tuple[str | None, Any]:
+    for key in keys:
+        if key in value and value.get(key) is not None:
+            return key, value.get(key)
+    return None, None
+
+
+def _first_text(value: Mapping[str, Any], keys: Sequence[str]) -> str | None:
+    for key in keys:
+        raw = value.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return None
+
+
+def _has_historical_verifier_receipt(payload: Mapping[str, Any]) -> bool:
+    for key in ("verifier_receipt", "verification_receipt", "verified_at_utc", "verification"):
+        if payload.get(key):
+            return True
+    return False
+
+
+def _byte_groups(values: Mapping[str, int], key: str) -> list[dict[str, Any]]:
+    return [{key: name, "bytes": int(size)} for name, size in sorted(values.items())]
+
+
+def _growth_and_forecast(
+    *,
+    root: Path,
+    observed_at: datetime,
+    current_unique_bytes: int,
+    history_reports: Sequence[str | Path],
+) -> dict[str, Any]:
+    observations: list[dict[str, Any]] = []
+    rejected: list[dict[str, str]] = []
+    previous_time: datetime | None = None
+    for raw_path in history_reports:
+        path = Path(raw_path).expanduser().resolve()
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            rejected.append({"report": path.name, "reason": type(exc).__name__})
+            continue
+        if isinstance(payload, dict) and payload.get("tool_name") == "research.storage-baseline":
+            payload = payload.get("data")
+        if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+            rejected.append({"report": path.name, "reason": "schema_mismatch"})
+            continue
+        identity = payload.get("identity")
+        research = payload.get("research_storage")
+        if not isinstance(identity, dict) or not isinstance(research, dict):
+            rejected.append({"report": path.name, "reason": "shape_invalid"})
+            continue
+        try:
+            report_root = Path(str(identity.get("runtime_root") or "")).resolve()
+            timestamp = datetime.fromisoformat(str(identity.get("observed_at_utc") or "").replace("Z", "+00:00"))
+            timestamp = timestamp.astimezone(timezone.utc)
+            unique_bytes = int(research["unique_declared_bytes"])
+        except (KeyError, TypeError, ValueError, OSError):
+            rejected.append({"report": path.name, "reason": "identity_or_measure_invalid"})
+            continue
+        if report_root != root:
+            rejected.append({"report": path.name, "reason": "runtime_root_mismatch"})
+            continue
+        if timestamp >= observed_at or (previous_time is not None and timestamp <= previous_time):
+            rejected.append({"report": path.name, "reason": "out_of_order"})
+            continue
+        observations.append(
+            {
+                "observed_at_utc": timestamp.isoformat(),
+                "unique_declared_bytes": unique_bytes,
+                "source": path.name,
+            }
+        )
+        previous_time = timestamp
+    observations.append(
+        {
+            "observed_at_utc": observed_at.isoformat(),
+            "unique_declared_bytes": int(current_unique_bytes),
+            "source": "current",
+        }
+    )
+    intervals: list[dict[str, Any]] = []
+    for previous, current in zip(observations, observations[1:]):
+        previous_time_value = datetime.fromisoformat(str(previous["observed_at_utc"]))
+        current_time_value = datetime.fromisoformat(str(current["observed_at_utc"]))
+        days = (current_time_value - previous_time_value).total_seconds() / 86400.0
+        if days <= 0:
+            continue
+        delta = int(current["unique_declared_bytes"]) - int(previous["unique_declared_bytes"])
+        intervals.append(
+            {
+                "from_utc": previous["observed_at_utc"],
+                "to_utc": current["observed_at_utc"],
+                "days": round(days, 6),
+                "new_unique_bytes": delta,
+                "monthly_rate_bytes": int(round(delta * 30.0 / days)),
+            }
+        )
+    if len(observations) < 2 or not intervals:
+        return {
+            "status": "insufficient_history",
+            "observations": observations,
+            "rejected_reports": rejected,
+            "intervals": intervals,
+            "monthly_unique_growth_bytes": None,
+            "forecast_90d_additional_bytes": None,
+            "rapid_growth_two_consecutive_months": False,
+        }
+    recent_rates = [int(item["monthly_rate_bytes"]) for item in intervals[-3:]]
+    monthly_growth = int(round(statistics.median(recent_rates)))
+    additional = max(0, monthly_growth * 3)
+    rapid = _has_two_consecutive_growth_spikes(intervals)
+    return {
+        "status": "complete",
+        "observations": observations,
+        "rejected_reports": rejected,
+        "intervals": intervals,
+        "monthly_unique_growth_bytes": monthly_growth,
+        "forecast_90d_additional_bytes": additional,
+        "rapid_growth_two_consecutive_months": rapid,
+    }
+
+
+def _has_two_consecutive_growth_spikes(intervals: Sequence[Mapping[str, Any]]) -> bool:
+    rates = [int(item.get("monthly_rate_bytes") or 0) for item in intervals]
+    if len(rates) < 5:
+        return False
+    flags: list[bool] = []
+    for index in range(3, len(rates)):
+        median = statistics.median(rates[index - 3 : index])
+        flags.append(median > 0 and rates[index] > 2 * median)
+    return any(first and second for first, second in zip(flags, flags[1:]))
+
+
+def _capacity_thresholds(
+    *,
+    disk_total_bytes: int,
+    disk_free_bytes: int,
+    research_storage: Mapping[str, Any],
+) -> dict[str, Any]:
+    growth = research_storage.get("growth") if isinstance(research_storage.get("growth"), dict) else {}
+    forecast_additional = growth.get("forecast_90d_additional_bytes")
+    forecast_free = (
+        max(0, disk_free_bytes - int(forecast_additional))
+        if isinstance(forecast_additional, int)
+        else None
+    )
+    warning_floor = max(math.ceil(disk_total_bytes * 0.10), 20 * GIB)
+    critical_floor = max(math.ceil(disk_total_bytes * 0.05), 10 * GIB)
+    protected_failures = list(research_storage.get("protected_reference_failures") or [])
+    critical_reasons: list[str] = []
+    warning_reasons: list[str] = []
+    if disk_free_bytes < critical_floor:
+        critical_reasons.append("current_free_space_below_critical_floor")
+    if protected_failures:
+        critical_reasons.append("protected_object_missing_or_unresolved")
+    if research_storage.get("manifest_parse_failures"):
+        critical_reasons.append("generation_manifest_unresolved")
+    if forecast_free is not None and forecast_free < warning_floor:
+        warning_reasons.append("forecast_free_space_below_warning_floor")
+    if growth.get("rapid_growth_two_consecutive_months") is True:
+        warning_reasons.append("monthly_unique_growth_above_two_times_trailing_median")
+    if critical_reasons:
+        status = "critical"
+    elif warning_reasons:
+        status = "warning"
+    elif forecast_free is None:
+        status = "insufficient_history"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "filesystem_capacity_bytes": disk_total_bytes,
+        "current_free_bytes": disk_free_bytes,
+        "warning_floor_bytes": warning_floor,
+        "critical_floor_bytes": critical_floor,
+        "forecast_90d_free_bytes": forecast_free,
+        "warning_reasons": warning_reasons,
+        "critical_reasons": critical_reasons,
+        "operator_decision_required": bool(warning_reasons or critical_reasons),
+        "preview": {
+            "cold_candidate_count": len(research_storage.get("cold_candidates") or []),
+            "unmanifested_file_count": int(research_storage.get("unmanifested_file_count") or 0),
+            "actions": [],
+        },
+        "automatic_actions": [],
+    }
+
+
+def _display_runtime_path(path: Path, *, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return f"external:{path.name}"
+
+
+def _write_report(path: Path, payload: Mapping[str, Any], *, runtime_root: Path, overwrite: bool) -> None:
+    if _path_or_parent_is_symlink(path, stop=path.parent):
+        raise AgentToolError(code="INPUT_ERROR", message=f"baseline output must not be a symlink: {path}")
+    if _is_relative_to(path, runtime_root):
+        raise AgentToolError(code="INPUT_ERROR", message="baseline output must be outside the inventoried runtime root")
+    if not path.parent.exists() or not path.parent.is_dir():
+        raise AgentToolError(code="INPUT_ERROR", message=f"baseline output parent directory not found: {path.parent}")
+    if path.exists() and not overwrite:
+        raise AgentToolError(code="INPUT_ERROR", message=f"baseline output already exists: {path}")
+    if path.exists() and (not path.is_file() or path.is_symlink()):
+        raise AgentToolError(code="INPUT_ERROR", message=f"baseline output is not a regular file: {path}")
+    data = (json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Exception:
+        try:
+            temp_path.unlink(missing_ok=True)
+        finally:
+            raise
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _path_or_parent_is_symlink(path: Path, *, stop: Path | None) -> bool:
+    current = path.absolute()
+    stop_path = stop.absolute() if stop is not None else None
+    while True:
+        if current.is_symlink():
+            return True
+        if stop_path is not None and current == stop_path:
+            return False
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+
+
+__all__ = ["SCHEMA_VERSION", "collect_storage_runtime_baseline"]

--- a/src/application/research/storage_baseline.py
+++ b/src/application/research/storage_baseline.py
@@ -17,7 +17,7 @@ import subprocess
 import tempfile
 import tokenize
 import heapq
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import AbstractSet, Any, Callable, Iterable, Mapping, Sequence
 
 from src.application.agent_tool_contracts import AgentToolError
 from src.application.ledger.store_resolution import LEDGER_DB_RELATIVE_PATH
@@ -857,6 +857,8 @@ def _collect_research_storage(
     history_reports: Sequence[str | Path],
 ) -> dict[str, Any]:
     manifests = [row for row in file_rows if _is_manifest_relpath(str(row["path"]))]
+    file_index = {str(row["path"]): row for row in file_rows}
+    known_files = frozenset(file_index)
     manifest_results: list[dict[str, Any]] = []
     references: list[dict[str, Any]] = []
     generations: set[str] = set()
@@ -882,6 +884,7 @@ def _collect_research_storage(
             payload,
             manifest_path=path,
             root=root,
+            known_files=known_files,
         )
         references.extend(extracted)
         manifest_results.append(
@@ -893,7 +896,6 @@ def _collect_research_storage(
             }
         )
 
-    file_index = {str(row["path"]): row for row in file_rows}
     referenced_paths: set[str] = set()
     protected_failures: list[dict[str, Any]] = []
     hash_sizes: dict[str, int] = {}
@@ -1051,13 +1053,18 @@ def _is_manifest_relpath(relpath: str) -> bool:
 
 
 def _extract_manifest_references(
-    payload: Mapping[str, Any], *, manifest_path: Path, root: Path
+    payload: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+    root: Path,
+    known_files: AbstractSet[str],
 ) -> list[dict[str, Any]]:
     if payload.get("schema_version") == "research_archive.v2" and payload.get("action") == "verify":
         return _extract_research_archive_references(
             payload,
             manifest_path=manifest_path,
             root=root,
+            known_files=known_files,
         )
 
     out: list[dict[str, Any]] = []
@@ -1081,6 +1088,7 @@ def _extract_manifest_references(
                 context=context,
                 reference_roots=manifest_reference_roots,
                 path_hint=path_hint,
+                known_files=known_files,
             )
             if reference is not None:
                 out.append(reference)
@@ -1094,10 +1102,11 @@ def _extract_manifest_references(
     visit(dict(payload))
     out.extend(
         _extract_parallel_file_map_references(
-            payload,
-            manifest_path=manifest_path,
-            root=root,
-        )
+        payload,
+        manifest_path=manifest_path,
+        root=root,
+        known_files=known_files,
+    )
     )
     unique: dict[tuple[str, str | None, int | None], dict[str, Any]] = {}
     for item in out:
@@ -1115,6 +1124,7 @@ def _extract_research_archive_references(
     *,
     manifest_path: Path,
     root: Path,
+    known_files: AbstractSet[str],
 ) -> list[dict[str, Any]]:
     declared_root = Path(str(payload.get("archive_root") or "")).expanduser()
     archive_root = declared_root.resolve() if declared_root.is_absolute() else manifest_path.parent.parent.resolve()
@@ -1148,6 +1158,7 @@ def _extract_research_archive_references(
                     size=item.get("size_bytes"),
                     artifact_class="immutable_replay_authority",
                     market=_first_text(run, ("market",)),
+                    known_files=known_files,
                 )
             )
     return references
@@ -1158,6 +1169,7 @@ def _extract_parallel_file_map_references(
     *,
     manifest_path: Path,
     root: Path,
+    known_files: AbstractSet[str],
 ) -> list[dict[str, Any]]:
     references: list[dict[str, Any]] = []
 
@@ -1180,6 +1192,7 @@ def _extract_parallel_file_map_references(
                             size=sizes.get(name) if isinstance(sizes, Mapping) else None,
                             artifact_class="experiment_or_research_artifact",
                             market=_first_text(value, ("market",)),
+                            known_files=known_files,
                         )
                     )
             for child in value.values():
@@ -1202,6 +1215,7 @@ def _explicit_manifest_reference(
     size: Any,
     artifact_class: str,
     market: str | None,
+    known_files: AbstractSet[str],
 ) -> dict[str, Any]:
     digest_value = str(digest or "").strip().lower() or None
     if digest_value is not None and (
@@ -1219,6 +1233,7 @@ def _explicit_manifest_reference(
             manifest_path=manifest_path,
             root=root,
             reference_roots=(reference_root,),
+            known_files=known_files,
         ),
         "declared_sha256": digest_value,
         "declared_size_bytes": size_value,
@@ -1237,6 +1252,7 @@ def _reference_from_mapping(
     context: Mapping[str, Any] | None,
     reference_roots: Sequence[Path],
     path_hint: str | None,
+    known_files: AbstractSet[str],
 ) -> dict[str, Any] | None:
     path_key, path_value = _first_key_value(value, _REFERENCE_PATH_KEYS)
     if path_value is None:
@@ -1278,6 +1294,7 @@ def _reference_from_mapping(
         manifest_path=manifest_path,
         root=root,
         reference_roots=reference_roots,
+        known_files=known_files,
     )
     context_map = context or value
     artifact_class = _first_text(value, ("artifact_class", "storage_class", "class")) or _first_text(
@@ -1335,24 +1352,60 @@ def _resolve_manifest_reference(
     manifest_path: Path,
     root: Path,
     reference_roots: Sequence[Path],
+    known_files: AbstractSet[str],
 ) -> str | None:
     raw = value.strip()
     if not raw:
         return None
     path = Path(raw)
     if path.is_absolute():
-        candidate = path.resolve()
-        return candidate.relative_to(root).as_posix() if _is_relative_to(candidate, root) else None
+        return _select_runtime_relative_candidate(
+            (path,),
+            root=root,
+            known_files=known_files,
+        )
     candidates: list[Path] = []
     if path.parts and path.parts[0] in RUNTIME_SUBROOTS:
-        candidates.append((root / path).resolve())
-    candidates.extend((reference_root / path).resolve() for reference_root in reference_roots)
-    candidates.extend(((manifest_path.parent / path).resolve(), (root / path).resolve()))
-    valid = [candidate for candidate in candidates if _is_relative_to(candidate, root)]
-    for candidate in valid:
-        if candidate.exists() and candidate.is_file() and not candidate.is_symlink():
-            return candidate.relative_to(root).as_posix()
-    return valid[0].relative_to(root).as_posix() if valid else None
+        candidates.append(root / path)
+    candidates.extend(reference_root / path for reference_root in reference_roots)
+    candidates.extend((manifest_path.parent / path, root / path))
+    return _select_runtime_relative_candidate(
+        candidates,
+        root=root,
+        known_files=known_files,
+    )
+
+
+def _select_runtime_relative_candidate(
+    candidates: Iterable[Path],
+    *,
+    root: Path,
+    known_files: AbstractSet[str],
+) -> str | None:
+    """Resolve a declared path against the no-follow scan without filesystem walks.
+
+    ``root`` and every reference root are canonicalized once before this hot
+    path. Candidate normalization is lexical; a candidate is considered present
+    only when its runtime-relative path was already produced by the bounded
+    ``os.scandir(..., follow_symlinks=False)`` inventory. This avoids repeated
+    ``realpath``/``stat`` calls while preserving the no-symlink authority.
+    """
+
+    valid: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        normalized = Path(os.path.normpath(os.fspath(candidate)))
+        try:
+            relpath = normalized.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        if relpath == "." or relpath in seen:
+            continue
+        seen.add(relpath)
+        valid.append(relpath)
+        if relpath in known_files:
+            return relpath
+    return valid[0] if valid else None
 
 
 def _artifact_class_for_reference(relpath: str | None) -> str:

--- a/src/application/research/storage_baseline.py
+++ b/src/application/research/storage_baseline.py
@@ -24,9 +24,7 @@ from src.application.ledger.store_resolution import LEDGER_DB_RELATIVE_PATH
 
 
 SCHEMA_VERSION = "storage_runtime_baseline.v1"
-SOURCE_INVENTORY_RELATIVE_PATH = Path(
-    "docs/architecture/data-storage-runtime-source-inventory.v1.json"
-)
+SOURCE_INVENTORY_RELATIVE_PATH = Path("docs/architecture/data-storage-runtime-source-inventory.v1.json")
 RUNTIME_SUBROOTS = (
     "output_runs",
     "output_accounts",
@@ -106,9 +104,7 @@ def collect_storage_runtime_baseline(
         if source_inventory_path is not None
         else base / SOURCE_INVENTORY_RELATIVE_PATH
     )
-    resolved_history_reports = [
-        _resolve_input_path(item, base=base) for item in (history_reports or ())
-    ]
+    resolved_history_reports = [_resolve_input_path(item, base=base) for item in (history_reports or ())]
     source_inventory = _collect_source_inventory(repo_root=base, manifest_path=inventory_path)
     runtime_storage, research_file_rows = _collect_runtime_storage(root=root, observed_at=observed_at)
     sqlite_payload = _collect_sqlite_metadata(ledger_path)
@@ -225,7 +221,9 @@ def _resolve_ledger_path(
         candidate = repo_root / candidate
     path = candidate.resolve()
     if _path_or_parent_is_symlink(candidate, stop=root if _is_relative_to(path, root) else None):
-        raise AgentToolError(code="INPUT_ERROR", message=f"explicit ledger path must not traverse a symlink: {candidate}")
+        raise AgentToolError(
+            code="INPUT_ERROR", message=f"explicit ledger path must not traverse a symlink: {candidate}"
+        )
     if not _is_relative_to(path, root) and not allow_external:
         raise AgentToolError(
             code="INPUT_ERROR",
@@ -265,7 +263,9 @@ def _collect_source_inventory(*, repo_root: Path, manifest_path: Path) -> dict[s
     except FileNotFoundError as exc:
         raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message="source inventory manifest is missing") from exc
     except (OSError, json.JSONDecodeError) as exc:
-        raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message=f"source inventory manifest is invalid: {exc}") from exc
+        raise AgentToolError(
+            code="SOURCE_INVENTORY_ERROR", message=f"source inventory manifest is invalid: {exc}"
+        ) from exc
     if not isinstance(payload, dict) or payload.get("schema_version") != "data_storage_runtime_source_inventory.v1":
         raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message="source inventory schema is invalid")
     rules = payload.get("discovery_rules")
@@ -282,7 +282,9 @@ def _collect_source_inventory(*, repo_root: Path, manifest_path: Path) -> dict[s
         rule_id = str(raw_rule.get("id") or "").strip()
         classifiers = raw_rule.get("classifiers")
         if not rule_id or rule_id in rule_ids or not isinstance(classifiers, list) or not classifiers:
-            raise AgentToolError(code="SOURCE_INVENTORY_ERROR", message=f"source inventory rule is incomplete: {rule_id}")
+            raise AgentToolError(
+                code="SOURCE_INVENTORY_ERROR", message=f"source inventory rule is incomplete: {rule_id}"
+            )
         rule_ids.add(rule_id)
         validated_rules.append((rule_id, raw_rule, classifiers))
 
@@ -301,10 +303,7 @@ def _collect_source_inventory(*, repo_root: Path, manifest_path: Path) -> dict[s
     parse_errors: list[dict[str, str]] = []
     matches: list[dict[str, Any]] = []
     unclassified: list[dict[str, str]] = []
-    classifier_hits = {
-        rule_id: [0 for _ in classifiers]
-        for rule_id, _rule, classifiers in validated_rules
-    }
+    classifier_hits = {rule_id: [0 for _ in classifiers] for rule_id, _rule, classifiers in validated_rules}
     for root_name in roots:
         root_rel = str(root_name or "").strip()
         root = (repo_root / root_rel).resolve()
@@ -613,9 +612,7 @@ def _query_sqlite_copy(path: Path) -> dict[str, Any]:
     conn.row_factory = sqlite3.Row
     try:
         conn.execute("PRAGMA query_only=ON")
-        table_rows = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
-        ).fetchall()
+        table_rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").fetchall()
         table_names = [str(row["name"]) for row in table_rows]
         tables: list[dict[str, Any]] = []
         for table, json_columns in _SQLITE_JSON_COLUMNS.items():
@@ -632,9 +629,7 @@ def _query_sqlite_copy(path: Path) -> dict[str, Any]:
             column_rows = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
             present_columns = {str(row["name"]) for row in column_rows}
             selected_columns = [column for column in json_columns if column in present_columns]
-            byte_expression = " + ".join(
-                f'COALESCE(length("{column}"), 0)' for column in selected_columns
-            )
+            byte_expression = " + ".join(f'COALESCE(length("{column}"), 0)' for column in selected_columns)
             if selected_columns:
                 row = conn.execute(
                     f'SELECT COUNT(*) AS row_count, COALESCE(SUM({byte_expression}), 0) AS json_bytes FROM "{table}"'
@@ -672,18 +667,29 @@ def _collect_runtime_storage(*, root: Path, observed_at: datetime) -> tuple[dict
     research_files: list[dict[str, Any]] = []
     symlinks: list[dict[str, Any]] = []
     roots: list[dict[str, Any]] = []
+    account_count: int | None = None
+    account_count_status = "output_accounts_not_collected"
     for name in RUNTIME_SUBROOTS:
         path = root / name
         if path.is_symlink():
             symlinks.append({"path": name, "kind": "root"})
             roots.append({"root": name, "status": "symlink_not_followed", "file_count": 0, "size_bytes": 0})
+            if name == "output_accounts":
+                account_count_status = "symlink_not_followed"
             continue
         if not path.exists():
             roots.append({"root": name, "status": "missing", "file_count": 0, "size_bytes": 0})
+            if name == "output_accounts":
+                account_count_status = "missing"
             continue
         if not path.is_dir():
             roots.append({"root": name, "status": "not_directory", "file_count": 0, "size_bytes": 0})
+            if name == "output_accounts":
+                account_count_status = "not_directory"
             continue
+        if name == "output_accounts":
+            account_count = _count_immediate_directories(path)
+            account_count_status = "complete"
         before_count = aggregates.file_count
         before_bytes = aggregates.size_bytes
         _scan_runtime_directory(
@@ -707,6 +713,9 @@ def _collect_runtime_storage(*, root: Path, observed_at: datetime) -> tuple[dict
         "status": "complete",
         "file_count": aggregates.file_count,
         "size_bytes": aggregates.size_bytes,
+        "account_count": account_count,
+        "account_count_status": account_count_status,
+        "account_count_basis": "immediate_non_symlink_output_accounts_directories",
         "roots": roots,
         "by_class": _aggregate_groups(aggregates.by_class, "storage_class"),
         "by_suffix": _aggregate_groups(aggregates.by_suffix, "suffix"),
@@ -724,6 +733,11 @@ def _collect_runtime_storage(*, root: Path, observed_at: datetime) -> tuple[dict
         "symlinks_not_followed": sorted(symlinks, key=lambda item: item["path"]),
     }
     return payload, research_files
+
+
+def _count_immediate_directories(path: Path) -> int:
+    with os.scandir(path) as entries:
+        return sum(1 for entry in entries if not entry.is_symlink() and entry.is_dir(follow_symlinks=False))
 
 
 class _RuntimeAggregates:
@@ -796,15 +810,15 @@ def _scan_runtime_directory(
                 age_days = max(0.0, (observed_at.timestamp() - stat.st_mtime) / 86400.0)
                 tier = _storage_tier(storage_class=storage_class, age_days=age_days)
                 item = {
-                        "path": relpath,
-                        "size_bytes": int(stat.st_size),
-                        "mtime_ns": int(stat.st_mtime_ns),
-                        "age_days": round(age_days, 3),
-                        "suffix": path.suffix.lower() or "[none]",
-                        "month": datetime.fromtimestamp(stat.st_mtime, timezone.utc).strftime("%Y-%m"),
-                        "storage_class": storage_class,
-                        "tier": tier,
-                    }
+                    "path": relpath,
+                    "size_bytes": int(stat.st_size),
+                    "mtime_ns": int(stat.st_mtime_ns),
+                    "age_days": round(age_days, 3),
+                    "suffix": path.suffix.lower() or "[none]",
+                    "month": datetime.fromtimestamp(stat.st_mtime, timezone.utc).strftime("%Y-%m"),
+                    "storage_class": storage_class,
+                    "tier": tier,
+                }
                 aggregates.add(item)
                 if storage_class in {"research_artifact", "immutable_shared_partition", "sealed_run_artifact"}:
                     research_files.append(item)
@@ -903,7 +917,11 @@ def _collect_research_storage(
             declared_reference_count += 1
             if isinstance(size, int) and digest in hash_sizes and hash_sizes[digest] != size:
                 protected_failures.append(
-                    {"manifest": reference["manifest"], "reference": reference["display_path"], "reason": "declared_hash_size_conflict"}
+                    {
+                        "manifest": reference["manifest"],
+                        "reference": reference["display_path"],
+                        "reason": "declared_hash_size_conflict",
+                    }
                 )
             elif isinstance(size, int):
                 hash_sizes[digest] = size
@@ -920,11 +938,17 @@ def _collect_research_storage(
             reference["actual_size_bytes"] = actual_size
             if isinstance(size, int) and size != actual_size:
                 protected_failures.append(
-                    {"manifest": reference["manifest"], "reference": reference["display_path"], "reason": "declared_size_mismatch"}
+                    {
+                        "manifest": reference["manifest"],
+                        "reference": reference["display_path"],
+                        "reason": "declared_size_mismatch",
+                    }
                 )
                 reference["presence_status"] = "declared_size_mismatch"
             else:
-                reference["presence_status"] = "present_size_match" if isinstance(size, int) else "present_size_undeclared"
+                reference["presence_status"] = (
+                    "present_size_match" if isinstance(size, int) else "present_size_undeclared"
+                )
             if digest and digest not in hash_physical:
                 hash_physical[digest] = actual
         elif reference.get("path_value"):
@@ -933,7 +957,13 @@ def _collect_research_storage(
             )
 
     unique_declared_bytes = sum(hash_sizes.values())
-    unknown_hash_size_count = len({str(ref["declared_sha256"]) for ref in references if ref.get("declared_sha256") and not isinstance(ref.get("declared_size_bytes"), int)})
+    unknown_hash_size_count = len(
+        {
+            str(ref["declared_sha256"])
+            for ref in references
+            if ref.get("declared_sha256") and not isinstance(ref.get("declared_size_bytes"), int)
+        }
+    )
     manifest_paths = {str(row["path"]) for row in manifests}
     research_files = [
         row
@@ -945,10 +975,7 @@ def _collect_research_storage(
     unknown_unique_bytes = sum(int(row["size_bytes"]) for row in unmanifested)
     cold_candidates: list[dict[str, Any]] = []
     for digest, row in hash_physical.items():
-        if (
-            float(row["age_days"]) >= COLD_CANDIDATE_MIN_AGE_DAYS
-            and int(row["size_bytes"]) >= COLD_CANDIDATE_MIN_BYTES
-        ):
+        if float(row["age_days"]) >= COLD_CANDIDATE_MIN_AGE_DAYS and int(row["size_bytes"]) >= COLD_CANDIDATE_MIN_BYTES:
             cold_candidates.append(
                 {
                     "path": row["path"],
@@ -974,11 +1001,7 @@ def _collect_research_storage(
         status = "data_unavailable"
     else:
         status = "complete"
-    dedup_ratio = (
-        round(logical_bytes / unique_declared_bytes, 6)
-        if unique_declared_bytes > 0
-        else None
-    )
+    dedup_ratio = round(logical_bytes / unique_declared_bytes, 6) if unique_declared_bytes > 0 else None
     return {
         "status": status,
         "content_verification": "not_performed",
@@ -986,7 +1009,11 @@ def _collect_research_storage(
         "parsed_manifest_count": len(manifest_results),
         "manifest_parse_failures": parse_failures,
         "manifests": manifest_results,
-        "root_count": sum(1 for rel in ("output_runs", "output_shared/research", "output_shared/required_data") if (root / rel).is_dir()),
+        "root_count": sum(
+            1
+            for rel in ("output_runs", "output_shared/research", "output_shared/required_data")
+            if (root / rel).is_dir()
+        ),
         "generation_count": len(generations),
         "declared_reference_count": len(references),
         "declared_hash_reference_count": declared_reference_count,
@@ -1023,7 +1050,9 @@ def _is_manifest_relpath(relpath: str) -> bool:
     return "manifest" in name or name.startswith("inventory")
 
 
-def _extract_manifest_references(payload: Mapping[str, Any], *, manifest_path: Path, root: Path) -> list[dict[str, Any]]:
+def _extract_manifest_references(
+    payload: Mapping[str, Any], *, manifest_path: Path, root: Path
+) -> list[dict[str, Any]]:
     if payload.get("schema_version") == "research_archive.v2" and payload.get("action") == "verify":
         return _extract_research_archive_references(
             payload,
@@ -1176,8 +1205,7 @@ def _explicit_manifest_reference(
 ) -> dict[str, Any]:
     digest_value = str(digest or "").strip().lower() or None
     if digest_value is not None and (
-        len(digest_value) != 64
-        or any(char not in "0123456789abcdef" for char in digest_value)
+        len(digest_value) != 64 or any(char not in "0123456789abcdef" for char in digest_value)
     ):
         digest_value = None
     size_value = size if isinstance(size, int) and not isinstance(size, bool) and size >= 0 else None
@@ -1483,11 +1511,7 @@ def _capacity_thresholds(
 ) -> dict[str, Any]:
     growth = research_storage.get("growth") if isinstance(research_storage.get("growth"), dict) else {}
     forecast_additional = growth.get("forecast_90d_additional_bytes")
-    forecast_free = (
-        max(0, disk_free_bytes - int(forecast_additional))
-        if isinstance(forecast_additional, int)
-        else None
-    )
+    forecast_free = max(0, disk_free_bytes - int(forecast_additional)) if isinstance(forecast_additional, int) else None
     warning_floor = max(math.ceil(disk_total_bytes * 0.10), 20 * GIB)
     critical_floor = max(math.ceil(disk_total_bytes * 0.05), 10 * GIB)
     protected_failures = list(research_storage.get("protected_reference_failures") or [])

--- a/src/interfaces/cli/research.py
+++ b/src/interfaces/cli/research.py
@@ -93,6 +93,22 @@ def add_research_commands(subparsers: Any) -> argparse.ArgumentParser:
     research_collect.add_argument("--write-outputs", action="store_true")
     research_collect.add_argument("--no-write-outputs", action="store_true")
     research_collect.add_argument("--confirm", action="store_true")
+    storage_baseline = research_sub.add_parser(
+        "storage-baseline",
+        help="collect a payload-free read-only runtime storage and capacity baseline",
+    )
+    storage_baseline.add_argument("--runtime-root", required=True)
+    storage_baseline.add_argument("--ledger-sqlite", default=None)
+    storage_baseline.add_argument(
+        "--history-report",
+        dest="history_reports",
+        action="append",
+        default=None,
+        help="prior compatible storage baseline JSON; repeat in chronological order",
+    )
+    storage_baseline.add_argument("--output", default=None)
+    storage_baseline.add_argument("--allow-external-ledger", action="store_true")
+    storage_baseline.add_argument("--overwrite", action="store_true")
     research_handoff = research_sub.add_parser("handoff", help="render handoff from a collected bundle")
     research_handoff.add_argument("--bundle", required=True)
     research_archive = research_sub.add_parser("archive", help="mirror remote Research evidence for local replay")
@@ -840,6 +856,22 @@ def handle_research_command(
     research_collect_fn: ResearchCollectFn | None = None,
     repo_base_fn: Callable[[], Path] = repo_base,
 ) -> dict[str, Any]:
+    if args.research_command == "storage-baseline":
+        from src.application.research.storage_baseline import (
+            collect_storage_runtime_baseline,
+        )
+
+        data = collect_storage_runtime_baseline(
+            repo_root=repo_base_fn(),
+            runtime_root=args.runtime_root,
+            ledger_sqlite=args.ledger_sqlite,
+            history_reports=args.history_reports,
+            output=args.output,
+            allow_external_ledger=bool(args.allow_external_ledger),
+            overwrite=bool(args.overwrite),
+        )
+        return build_response(tool_name="research.storage-baseline", ok=True, data=data)
+
     if args.research_command == "collect":
         collect = research_collect_fn or (lambda payload: run_research_collect(payload, repo_base_fn=repo_base_fn))
         return collect(_research_collect_payload(args))

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -139,6 +139,59 @@ def _seal_combo_diagnostic_fixture(
     )
 
 
+def test_storage_baseline_cli_dispatches_read_only_options(monkeypatch, tmp_path: Path) -> None:
+    from src.application.research import storage_baseline
+    from src.interfaces.cli.main import parse_args
+    from src.interfaces.cli.research import handle_research_command
+
+    calls: list[dict[str, Any]] = []
+
+    def _collect_storage_runtime_baseline(**kwargs):
+        calls.append(kwargs)
+        return {"schema_version": "storage_runtime_baseline.v1", "status": "complete"}
+
+    monkeypatch.setattr(
+        storage_baseline,
+        "collect_storage_runtime_baseline",
+        _collect_storage_runtime_baseline,
+    )
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    output = tmp_path / "baseline.json"
+    args = parse_args(
+        [
+            "research",
+            "storage-baseline",
+            "--runtime-root",
+            str(runtime),
+            "--history-report",
+            "before-1.json",
+            "--history-report",
+            "before-2.json",
+            "--output",
+            str(output),
+            "--allow-external-ledger",
+            "--overwrite",
+        ]
+    )
+
+    response = handle_research_command(args, repo_base_fn=lambda: tmp_path)
+
+    assert response["ok"] is True
+    assert response["tool_name"] == "research.storage-baseline"
+    assert calls == [
+        {
+            "repo_root": tmp_path,
+            "runtime_root": str(runtime),
+            "ledger_sqlite": None,
+            "history_reports": ["before-1.json", "before-2.json"],
+            "output": str(output),
+            "allow_external_ledger": True,
+            "overwrite": True,
+        }
+    ]
+
+
 class _ToolKwargs(TypedDict):
     load_runtime_config: Callable[..., tuple[Path, dict[str, Any]]]
     repo_base: Callable[[], Path]

--- a/tests/test_research_performance_baseline.py
+++ b/tests/test_research_performance_baseline.py
@@ -144,9 +144,7 @@ def _fake_workers(
     scenarios = []
     for spec in worker_spec["scenarios"]:
         events = module._build_synthetic_events(spec, seed=worker_spec["seed"])
-        timing_distribution = module._timing_distribution(
-            [100] * worker_spec["repetitions"]
-        )
+        timing_distribution = module._timing_distribution([100] * worker_spec["repetitions"])
         scenarios.append(
             {
                 "key": spec["key"],
@@ -403,21 +401,15 @@ def test_reference_host_gate_fails_when_either_history_subcase_exceeds_limit() -
         run_label="acceptance_5_warmups_30_repetitions",
     )
     timing = _timing_artifact(manifest)
-    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["p95"] = (
-        module.CPU_LIMIT_NS + 1
-    )
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["p95"] = module.CPU_LIMIT_NS + 1
     timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["samples"] = [
         module.CPU_LIMIT_NS + 1
     ] * 30
     timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["median"] = (
         module.CPU_LIMIT_NS + 1
     )
-    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["min"] = (
-        module.CPU_LIMIT_NS + 1
-    )
-    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["max"] = (
-        module.CPU_LIMIT_NS + 1
-    )
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["min"] = module.CPU_LIMIT_NS + 1
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["max"] = module.CPU_LIMIT_NS + 1
 
     decision = module._build_gate_decision(
         timing=timing,
@@ -451,7 +443,11 @@ def test_hostile_baseline_metadata_is_clamped_and_payload_paths_are_discarded(tm
                         {"table": "position_lots", "row_count": 10**9, "fields_json": "ignored"},
                     ],
                 },
-                "runtime_storage": {"account_count": 10**6, "largest_files": ["private"]},
+                "runtime_storage": {
+                    "account_count": 10**6,
+                    "account_count_status": "complete",
+                    "largest_files": ["private"],
+                },
             }
         ),
         encoding="utf-8",
@@ -485,9 +481,9 @@ def test_baseline_account_dimension_uses_payload_free_aggregate_only(tmp_path: P
                     ],
                 },
                 "runtime_storage": {
-                    "roots": [
-                        {"root": "output_accounts", "status": "complete", "file_count": 3, "size_bytes": 100}
-                    ],
+                    "account_count": 3,
+                    "account_count_status": "complete",
+                    "roots": [{"root": "output_accounts", "status": "complete", "file_count": 3, "size_bytes": 100}],
                     "largest_files": ["must not be retained"],
                 },
             }
@@ -497,9 +493,137 @@ def test_baseline_account_dimension_uses_payload_free_aggregate_only(tmp_path: P
 
     dimensions = module._load_baseline_dimensions(baseline, repo_root=tmp_path)
 
-    assert dimensions.account_count == 1
+    fanout = module._build_scenario_specs(dimensions, selected=["account_fanout"])[0]
+
+    assert dimensions.account_count == 3
+    assert dimensions.metadata["account_dimension_source"] == ("runtime_storage.output_accounts_immediate_directories")
+    assert fanout["effective_dimensions"]["account_count"] == 15
+    assert fanout["axis_status"] == "evaluable"
     assert dimensions.metadata["payload_fields_consumed"] == 0
     assert "must not be retained" not in json.dumps(dimensions.metadata)
+
+
+def test_legacy_baseline_without_exact_account_count_is_fail_closed_for_fanout(
+    tmp_path: Path,
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "schema_version": "storage_runtime_baseline.v1",
+                "sqlite": {"status": "complete", "tables": []},
+                "runtime_storage": {"roots": [{"root": "output_accounts", "status": "complete", "file_count": 12}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dimensions = module._load_baseline_dimensions(baseline, repo_root=tmp_path)
+    fanout = module._build_scenario_specs(dimensions, selected=["account_fanout"])[0]
+
+    assert dimensions.account_count == module.DEFAULT_ACCOUNT_COUNT
+    assert dimensions.metadata["account_dimension_source"] == ("safe_default_account_count_unavailable")
+    assert fanout["axis_status"] == "not_evaluable_baseline_account_count_unavailable"
+
+
+def test_empty_observed_account_root_is_not_treated_as_configured_cardinality(
+    tmp_path: Path,
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "schema_version": "storage_runtime_baseline.v1",
+                "sqlite": {"status": "complete", "tables": []},
+                "runtime_storage": {
+                    "account_count": 0,
+                    "account_count_status": "complete",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dimensions = module._load_baseline_dimensions(baseline, repo_root=tmp_path)
+    fanout = module._build_scenario_specs(dimensions, selected=["account_fanout"])[0]
+
+    assert dimensions.account_count == module.DEFAULT_ACCOUNT_COUNT
+    assert dimensions.metadata["account_dimension_source"] == ("safe_default_account_count_unavailable")
+    assert fanout["axis_status"] == "not_evaluable_baseline_account_count_unavailable"
+
+
+@pytest.mark.parametrize("invalid_count", [True, 3.5, "3", -1])
+def test_malformed_account_count_is_not_coerced_into_an_exact_dimension(
+    tmp_path: Path,
+    invalid_count: object,
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "schema_version": "storage_runtime_baseline.v1",
+                "sqlite": {"status": "complete", "tables": []},
+                "runtime_storage": {
+                    "account_count": invalid_count,
+                    "account_count_status": "complete",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dimensions = module._load_baseline_dimensions(baseline, repo_root=tmp_path)
+
+    assert dimensions.account_count == module.DEFAULT_ACCOUNT_COUNT
+    assert dimensions.metadata["account_dimension_source"] == (
+        "safe_default_account_count_unavailable"
+    )
+
+
+def test_darwin_hardware_identity_collects_cpu_and_machine_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_command_value(command: list[str]) -> str | None:
+        calls.append(command[-1])
+        return {
+            "machdep.cpu.brand_string": "arm",
+            "hw.model": "Mac16,10",
+        }[command[-1]]
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(module, "_command_value", fake_command_value)
+
+    assert module._hardware_identity() == ("arm", "Mac16,10")
+    assert calls == ["machdep.cpu.brand_string", "hw.model"]
+
+
+def test_darwin_hardware_identity_falls_back_to_bounded_system_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(module, "_command_value", lambda _command: None)
+    monkeypatch.setattr(
+        module,
+        "_darwin_hardware_details",
+        lambda: {"chip_type": "Apple M4", "machine_model": "Mac16,10"},
+    )
+
+    assert module._hardware_identity() == ("Apple M4", "Mac16,10")
+
+
+def test_host_fingerprint_binds_cpu_and_hardware_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(module, "_hardware_identity", lambda: ("Apple M4", "Mac16,10"))
+    first = module._host_profile()
+    monkeypatch.setattr(module, "_hardware_identity", lambda: ("Apple M4", "Mac16,11"))
+    second = module._host_profile()
+
+    assert first["cpu_model"] == "Apple M4"
+    assert first["hardware_model"] == "Mac16,10"
+    assert first["fingerprint"] != second["fingerprint"]
 
 
 def test_parent_publishes_all_five_artifacts_atomically_and_labels_smoke(
@@ -603,15 +727,13 @@ def test_worker_artifact_validation_rejects_fixture_identity_drift() -> None:
     ("mutate", "message"),
     [
         (
-            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"].pop(
-                "wall_time_ns"
-            ),
+            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"].pop("wall_time_ns"),
             "timing distribution is invalid",
         ),
         (
-            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"][
-                "wall_time_ns"
-            ]["samples"].pop(),
+            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"]["wall_time_ns"][
+                "samples"
+            ].pop(),
             "timing sample count is invalid",
         ),
         (
@@ -624,9 +746,9 @@ def test_worker_artifact_validation_rejects_fixture_identity_drift() -> None:
             "timing summary is inconsistent",
         ),
         (
-            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"][
-                "wall_time_ns"
-            ]["samples"].__setitem__(0, -1),
+            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"]["wall_time_ns"][
+                "samples"
+            ].__setitem__(0, -1),
             "timing sample value is invalid",
         ),
     ],

--- a/tests/test_research_performance_baseline.py
+++ b/tests/test_research_performance_baseline.py
@@ -1,0 +1,669 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.application.research import performance_baseline as module
+
+
+def _dimensions(**overrides: int) -> module.BaselineDimensions:
+    values = {
+        "event_count": 12,
+        "current_lot_count": 3,
+        "account_count": 2,
+        "payload_bytes": 256,
+    }
+    values.update(overrides)
+    return module.BaselineDimensions(
+        **values,
+        dimension_source="test",
+        requested=dict(values),
+        clamped={},
+        metadata={"payload_fields_consumed": 0},
+    )
+
+
+def _small_spec(
+    *,
+    key: str = "current_scale",
+    shape: str = "fixed_open_lots_with_verifications",
+    event_count: int = 6,
+    lot_count: int = 2,
+    account_count: int = 2,
+) -> dict[str, Any]:
+    if shape == "open_close_pairs":
+        projected_lots = event_count // 2
+        open_lots = 0
+        risk_views = 0
+        allocations = event_count // 2
+    else:
+        projected_lots = lot_count
+        open_lots = lot_count
+        risk_views = lot_count
+        allocations = 0
+    return {
+        "key": key,
+        "axis": key.split(".", 1)[0],
+        "shape": shape,
+        "classification": "test_fixture",
+        "axis_status": "evaluable",
+        "requested_dimensions": {
+            "event_count": event_count,
+            "projected_lot_count": projected_lots,
+            "account_count": account_count,
+            "payload_bytes": 256,
+        },
+        "effective_dimensions": {
+            "event_count": event_count,
+            "projected_lot_count": projected_lots,
+            "open_lot_count": open_lots,
+            "risk_view_count": risk_views,
+            "allocation_count": allocations,
+            "account_count": account_count,
+            "payload_bytes": 256,
+        },
+    }
+
+
+def _timing_artifact(
+    fixture_manifest: dict[str, Any],
+    *,
+    wall_p95: int = 100,
+    cpu_p95: int = 100,
+) -> dict[str, Any]:
+    wall_samples = [wall_p95] * 30
+    cpu_samples = [cpu_p95] * 30
+    return {
+        "schema_version": module.TIMING_SCHEMA,
+        "measurement_mode": "timing_without_profiler",
+        "profilers_enabled": False,
+        "tracemalloc_enabled": False,
+        "warmups": 5,
+        "repetitions": 30,
+        "run_label": "acceptance_5_warmups_30_repetitions",
+        "clock_authority": ["time.perf_counter_ns", "time.process_time_ns"],
+        "scenarios": [
+            {
+                "key": row["key"],
+                "fixture_sha256": row["fixture_sha256"],
+                "axis_status": row["axis_status"],
+                "counts": row["effective_dimensions"],
+                "parity": {"exact": True, "mismatched_fingerprints": []},
+                "components": {
+                    "projector_only": {
+                        "wall_time_ns": module._timing_distribution(wall_samples),
+                        "cpu_time_ns": module._timing_distribution(cpu_samples),
+                    },
+                    "existing_full_replay_writer": {
+                        "wall_time_ns": module._timing_distribution(wall_samples),
+                        "cpu_time_ns": module._timing_distribution(cpu_samples),
+                    },
+                },
+            }
+            for row in fixture_manifest["scenarios"]
+        ],
+    }
+
+
+def _profile_artifact(
+    fixture_manifest: dict[str, Any],
+    *,
+    schema: str,
+    mode: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": schema,
+        "measurement_mode": mode,
+        "timing_threshold_eligible": False,
+        "scenarios": [
+            {
+                "key": row["key"],
+                "fixture_sha256": row["fixture_sha256"],
+                "parity": {"exact": True, "mismatched_fingerprints": []},
+                "components": {
+                    "projector_only": {},
+                    "existing_full_replay_writer": {},
+                },
+            }
+            for row in fixture_manifest["scenarios"]
+        ],
+    }
+
+
+def _fake_workers(
+    *,
+    repo_root: Path,
+    mode: str,
+    worker_spec: dict[str, Any],
+) -> dict[str, Any]:
+    del repo_root
+    scenarios = []
+    for spec in worker_spec["scenarios"]:
+        events = module._build_synthetic_events(spec, seed=worker_spec["seed"])
+        timing_distribution = module._timing_distribution(
+            [100] * worker_spec["repetitions"]
+        )
+        scenarios.append(
+            {
+                "key": spec["key"],
+                "fixture_sha256": module._events_sha256(events),
+                "axis_status": spec["axis_status"],
+                "parity": {"exact": True, "mismatched_fingerprints": []},
+                "components": {
+                    "projector_only": {
+                        "wall_time_ns": timing_distribution,
+                        "cpu_time_ns": timing_distribution,
+                    },
+                    "existing_full_replay_writer": {
+                        "wall_time_ns": timing_distribution,
+                        "cpu_time_ns": timing_distribution,
+                    },
+                },
+            }
+        )
+    schemas = {
+        "timing": (module.TIMING_SCHEMA, "timing_without_profiler"),
+        "cpu": (module.CPU_PROFILE_SCHEMA, "cprofile_separate_process"),
+        "allocation": (module.ALLOCATION_PROFILE_SCHEMA, "tracemalloc_separate_process"),
+    }
+    schema, measurement_mode = schemas[mode]
+    return {
+        "schema_version": schema,
+        "measurement_mode": measurement_mode,
+        "profilers_enabled": False if mode == "timing" else None,
+        "tracemalloc_enabled": False if mode in {"timing", "cpu"} else None,
+        "timing_threshold_eligible": False if mode != "timing" else None,
+        "warmups": worker_spec["warmups"] if mode == "timing" else None,
+        "repetitions": worker_spec["repetitions"] if mode == "timing" else None,
+        "run_label": worker_spec["run_label"],
+        "scenarios": scenarios,
+    }
+
+
+def test_history_specs_freeze_output_and_retain_closed_lot_coupling() -> None:
+    specs = module._build_scenario_specs(_dimensions(), selected=["history_10x"])
+
+    assert [spec["key"] for spec in specs] == [
+        "history_10x.fixed_output",
+        "history_10x.retained_closed_lots",
+    ]
+    fixed, retained = specs
+    assert fixed["effective_dimensions"]["event_count"] >= module.MIN_HISTORY_EVENTS
+    assert fixed["effective_dimensions"]["projected_lot_count"] == 3
+    assert fixed["effective_dimensions"]["open_lot_count"] == 3
+    assert fixed["effective_dimensions"]["allocation_count"] == 0
+    assert retained["effective_dimensions"]["projected_lot_count"] == 5_000
+    assert retained["effective_dimensions"]["open_lot_count"] == 0
+    assert retained["effective_dimensions"]["allocation_count"] == 5_000
+
+
+def test_fixture_hash_is_repeatable_and_changes_with_seed() -> None:
+    spec = _small_spec()
+
+    first = module._build_synthetic_events(spec, seed=1)
+    second = module._build_synthetic_events(spec, seed=1)
+    third = module._build_synthetic_events(spec, seed=2)
+
+    assert first == second
+    assert module._events_sha256(first) == module._events_sha256(second)
+    assert module._events_sha256(first) != module._events_sha256(third)
+    assert {row["raw_payload"]["entropy_class"] for row in first} == {
+        "low",
+        "median",
+        "high",
+    }
+    metrics = module._event_payload_metrics(first)
+    assert (
+        metrics["entropy_classes"]["high"]["compression_ratio"]["p50"]
+        > metrics["entropy_classes"]["median"]["compression_ratio"]["p50"]
+        > metrics["entropy_classes"]["low"]["compression_ratio"]["p50"]
+    )
+
+
+def test_fixed_output_history_growth_does_not_change_projected_output() -> None:
+    small = _small_spec(event_count=6, lot_count=2)
+    large = _small_spec(event_count=60, lot_count=2)
+
+    small_projection = module.project_stored_trade_events_to_position_lots(
+        module._build_synthetic_events(small, seed=module.SEED)
+    )
+    large_projection = module.project_stored_trade_events_to_position_lots(
+        module._build_synthetic_events(large, seed=module.SEED)
+    )
+    small_output = module._projection_output(small_projection, event_count=6)
+    large_output = module._projection_output(large_projection, event_count=60)
+
+    assert small_output["lot_fingerprint"] == large_output["lot_fingerprint"]
+    assert small_output["counts"]["projected_lot_count"] == 2
+    assert large_output["counts"]["projected_lot_count"] == 2
+    assert small_output["counts"]["risk_view_count"] == 2
+    assert large_output["counts"]["risk_view_count"] == 2
+
+
+def test_retained_closed_lot_fixture_projects_one_allocation_per_pair() -> None:
+    spec = _small_spec(
+        key="history_10x.retained_closed_lots",
+        shape="open_close_pairs",
+        event_count=10,
+        lot_count=5,
+    )
+    events = module._build_synthetic_events(spec, seed=module.SEED)
+    projection = module.project_stored_trade_events_to_position_lots(events)
+    output = module._projection_output(projection, event_count=len(events))
+
+    assert output["counts"] == {
+        "event_count": 10,
+        "projected_lot_count": 5,
+        "open_lot_count": 0,
+        "risk_view_count": 0,
+        "allocation_count": 5,
+        "diagnostic_count": 0,
+    }
+
+
+def test_real_writer_and_projector_have_exact_canonical_parity_and_byte_accounting() -> None:
+    spec = _small_spec(event_count=8, lot_count=3)
+    events = module._build_synthetic_events(spec, seed=module.SEED)
+
+    projector = module._timed_projector(events, warmups=0, repetitions=1)
+    writer = module._timed_writer(events, warmups=0, repetitions=1)
+
+    assert module._projection_parity(projector["output"], writer["output"])["exact"] is True
+    assert writer["sql"]["publication_behavior"] == "global_delete_then_insert"
+    assert writer["sql"]["trade_event_rows_read_per_replay"] == 8
+    assert writer["sql"]["position_lot_rows_inserted_per_replay"] == 3
+    for stage in (
+        "before_replay",
+        "peak_observed_after_repetition",
+        "after_replay_before_checkpoint",
+        "steady_state_after_wal_checkpoint_truncate",
+    ):
+        assert set(writer["sqlite_bytes"][stage]) == {
+            "db_bytes",
+            "wal_bytes",
+            "shm_bytes",
+            "total_bytes",
+        }
+        assert writer["sqlite_bytes"][stage]["total_bytes"] >= 0
+
+
+def test_timing_cpu_and_allocation_modes_are_contractually_separate() -> None:
+    worker_spec = {
+        "schema_version": module.WORKER_SPEC_SCHEMA,
+        "seed": module.SEED,
+        "warmups": 0,
+        "repetitions": 1,
+        "run_label": "non_acceptance_smoke",
+        "scenarios": [_small_spec(event_count=3, lot_count=1)],
+    }
+
+    timing = module._worker_payload(mode="timing", worker_spec=worker_spec)
+    cpu = module._worker_payload(mode="cpu", worker_spec=worker_spec)
+    allocation = module._worker_payload(mode="allocation", worker_spec=worker_spec)
+
+    assert timing["profilers_enabled"] is False
+    assert timing["tracemalloc_enabled"] is False
+    assert cpu["measurement_mode"] == "cprofile_separate_process"
+    assert cpu["timing_threshold_eligible"] is False
+    assert allocation["measurement_mode"] == "tracemalloc_separate_process"
+    assert allocation["timing_threshold_eligible"] is False
+
+
+def test_reference_host_gate_requires_exact_fingerprint_and_both_history_subcases(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    host = {
+        "schema_version": "data_storage_projection_host_profile.v1",
+        "fingerprint": "a" * 64,
+    }
+    specs = module._build_scenario_specs(_dimensions(), selected=["history_10x"])
+    manifest = module._build_fixture_manifest(
+        repo_root=Path.cwd(),
+        dimensions=_dimensions(),
+        specs=specs,
+        seed=module.SEED,
+        host=host,
+        run_label="acceptance_5_warmups_30_repetitions",
+    )
+    timing = _timing_artifact(manifest)
+
+    absent = module._build_gate_decision(
+        timing=timing,
+        fixture_manifest=manifest,
+        current_host=host,
+        reference_host_fingerprint=None,
+    )
+    mismatch = module._build_gate_decision(
+        timing=timing,
+        fixture_manifest=manifest,
+        current_host=host,
+        reference_host_fingerprint="b" * 64,
+    )
+    matching = module._build_gate_decision(
+        timing=timing,
+        fixture_manifest=manifest,
+        current_host=host,
+        reference_host_fingerprint="a" * 64,
+    )
+
+    assert absent["components"]["existing_full_replay_writer"]["status"] == "not_comparable"
+    assert mismatch["components"]["existing_full_replay_writer"]["status"] == "not_comparable"
+    assert matching["components"]["existing_full_replay_writer"]["status"] == "pass"
+    assert matching["components"]["projector_only"]["status"] == "diagnostic_only"
+    assert matching["components"]["lot_diff_publication"]["status"] == "not_implemented"
+    assert matching["phase_3a_combined"] == {
+        "status": "not_ready",
+        "reason": "lot_diff_publication_not_implemented",
+    }
+
+
+def test_matching_host_never_turns_smoke_measurements_into_a_pass() -> None:
+    host = {"fingerprint": "a" * 64}
+    specs = module._build_scenario_specs(_dimensions(), selected=["history_10x"])
+    manifest = module._build_fixture_manifest(
+        repo_root=Path.cwd(),
+        dimensions=_dimensions(),
+        specs=specs,
+        seed=module.SEED,
+        host=host,
+        run_label="non_acceptance_smoke",
+    )
+    timing = _timing_artifact(manifest)
+    timing["run_label"] = "non_acceptance_smoke"
+    timing["warmups"] = 1
+    timing["repetitions"] = 2
+
+    decision = module._build_gate_decision(
+        timing=timing,
+        fixture_manifest=manifest,
+        current_host=host,
+        reference_host_fingerprint="a" * 64,
+    )
+
+    assert decision["components"]["existing_full_replay_writer"]["status"] == "not_evaluable"
+    assert {row["reason"] for row in decision["components"]["existing_full_replay_writer"]["subcases"]} == {
+        "non_acceptance_smoke"
+    }
+
+
+def test_reference_host_gate_fails_when_either_history_subcase_exceeds_limit() -> None:
+    host = {"fingerprint": "a" * 64}
+    specs = module._build_scenario_specs(_dimensions(), selected=["history_10x"])
+    manifest = module._build_fixture_manifest(
+        repo_root=Path.cwd(),
+        dimensions=_dimensions(),
+        specs=specs,
+        seed=module.SEED,
+        host=host,
+        run_label="acceptance_5_warmups_30_repetitions",
+    )
+    timing = _timing_artifact(manifest)
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["p95"] = (
+        module.CPU_LIMIT_NS + 1
+    )
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["samples"] = [
+        module.CPU_LIMIT_NS + 1
+    ] * 30
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["median"] = (
+        module.CPU_LIMIT_NS + 1
+    )
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["min"] = (
+        module.CPU_LIMIT_NS + 1
+    )
+    timing["scenarios"][1]["components"]["existing_full_replay_writer"]["cpu_time_ns"]["max"] = (
+        module.CPU_LIMIT_NS + 1
+    )
+
+    decision = module._build_gate_decision(
+        timing=timing,
+        fixture_manifest=manifest,
+        current_host=host,
+        reference_host_fingerprint="a" * 64,
+    )
+
+    assert decision["components"]["existing_full_replay_writer"]["status"] == "fail"
+
+
+def test_hostile_baseline_metadata_is_clamped_and_payload_paths_are_discarded(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "schema_version": "storage_runtime_baseline.v1",
+                "identity": {
+                    "runtime_root": "/do/not/retain",
+                    "ledger_sqlite": "/do/not/open.sqlite3",
+                },
+                "sqlite": {
+                    "status": "complete",
+                    "tables": [
+                        {
+                            "table": "trade_events",
+                            "row_count": 10**12,
+                            "json_bytes": 10**18,
+                            "payload": {"secret": "must not be consumed"},
+                        },
+                        {"table": "position_lots", "row_count": 10**9, "fields_json": "ignored"},
+                    ],
+                },
+                "runtime_storage": {"account_count": 10**6, "largest_files": ["private"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dimensions = module._load_baseline_dimensions(baseline, repo_root=tmp_path)
+    specs = module._build_scenario_specs(dimensions, selected=["history_10x"])
+
+    assert dimensions.event_count == module.MAX_CURRENT_EVENTS
+    assert dimensions.current_lot_count == module.MAX_CURRENT_LOTS
+    assert dimensions.account_count == module.MAX_ACCOUNTS
+    assert dimensions.payload_bytes == module.MAX_PAYLOAD_BYTES
+    assert dimensions.metadata["payload_fields_consumed"] == 0
+    assert dimensions.metadata["paths_retained"] == 0
+    assert specs[0]["effective_dimensions"]["event_count"] == module.MAX_HISTORY_EVENTS
+    assert specs[0]["axis_status"] == "not_evaluable_clamped_below_requested_10x"
+    assert "/do/not/retain" not in json.dumps(dimensions.metadata)
+
+
+def test_baseline_account_dimension_uses_payload_free_aggregate_only(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "schema_version": "storage_runtime_baseline.v1",
+                "sqlite": {
+                    "status": "complete",
+                    "tables": [
+                        {"table": "trade_events", "row_count": 20, "json_bytes": 20_000},
+                        {"table": "position_lots", "row_count": 4, "json_bytes": 4_000},
+                    ],
+                },
+                "runtime_storage": {
+                    "roots": [
+                        {"root": "output_accounts", "status": "complete", "file_count": 3, "size_bytes": 100}
+                    ],
+                    "largest_files": ["must not be retained"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dimensions = module._load_baseline_dimensions(baseline, repo_root=tmp_path)
+
+    assert dimensions.account_count == 1
+    assert dimensions.metadata["payload_fields_consumed"] == 0
+    assert "must not be retained" not in json.dumps(dimensions.metadata)
+
+
+def test_parent_publishes_all_five_artifacts_atomically_and_labels_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        module,
+        "_host_profile",
+        lambda: {"schema_version": "data_storage_projection_host_profile.v1", "fingerprint": "a" * 64},
+    )
+    output = tmp_path / "benchmark-output"
+
+    result = module.run_data_storage_projection_benchmark(
+        repo_root=Path.cwd(),
+        output_dir=output,
+        scenario="current_scale",
+        warmups=1,
+        repetitions=2,
+        worker_runner=_fake_workers,
+    )
+
+    assert result["run_label"] == "non_acceptance_smoke"
+    assert {path.name for path in output.iterdir()} == set(module.ARTIFACT_FILENAMES)
+    decision = json.loads((output / "decision.json").read_text(encoding="utf-8"))
+    assert decision["components"]["lot_diff_publication"]["status"] == "not_implemented"
+    assert decision["phase_3a_combined"]["status"] == "not_ready"
+
+
+def test_parent_failure_leaves_absent_output_unmodified(tmp_path: Path) -> None:
+    output = tmp_path / "benchmark-output"
+
+    def fail_worker(**_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("synthetic worker failure")
+
+    with pytest.raises(RuntimeError, match="synthetic worker failure"):
+        module.run_data_storage_projection_benchmark(
+            repo_root=Path.cwd(),
+            output_dir=output,
+            scenario="current_scale",
+            warmups=0,
+            repetitions=1,
+            worker_runner=fail_worker,
+        )
+
+    assert not output.exists()
+
+
+def test_parent_refuses_nonempty_or_symlink_output(tmp_path: Path) -> None:
+    nonempty = tmp_path / "nonempty"
+    nonempty.mkdir()
+    (nonempty / "existing.txt").write_text("keep", encoding="utf-8")
+    symlink = tmp_path / "linked-output"
+    symlink.symlink_to(nonempty, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="empty"):
+        module._resolve_output_dir(nonempty, repo_root=tmp_path)
+    with pytest.raises(ValueError, match="symlink"):
+        module._resolve_output_dir(symlink, repo_root=tmp_path)
+    assert (nonempty / "existing.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_worker_artifact_validation_rejects_fixture_identity_drift() -> None:
+    specs = [_small_spec()]
+    host = {"fingerprint": "a" * 64}
+    manifest = module._build_fixture_manifest(
+        repo_root=Path.cwd(),
+        dimensions=_dimensions(),
+        specs=specs,
+        seed=module.SEED,
+        host=host,
+        run_label="non_acceptance_smoke",
+    )
+    timing = _timing_artifact(manifest)
+    cpu = _profile_artifact(
+        manifest,
+        schema=module.CPU_PROFILE_SCHEMA,
+        mode="cprofile_separate_process",
+    )
+    allocation = _profile_artifact(
+        manifest,
+        schema=module.ALLOCATION_PROFILE_SCHEMA,
+        mode="tracemalloc_separate_process",
+    )
+    cpu = copy.deepcopy(cpu)
+    cpu["scenarios"][0]["fixture_sha256"] = "0" * 64
+
+    with pytest.raises(RuntimeError, match="fixture identity mismatch"):
+        module._validate_worker_artifacts(
+            fixture_manifest=manifest,
+            timing=timing,
+            cpu_profile=cpu,
+            allocation_profile=allocation,
+            expected_warmups=5,
+            expected_repetitions=30,
+            expected_run_label="acceptance_5_warmups_30_repetitions",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"].pop(
+                "wall_time_ns"
+            ),
+            "timing distribution is invalid",
+        ),
+        (
+            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"][
+                "wall_time_ns"
+            ]["samples"].pop(),
+            "timing sample count is invalid",
+        ),
+        (
+            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"].update(
+                wall_time_ns={
+                    **timing["scenarios"][0]["components"]["existing_full_replay_writer"]["wall_time_ns"],
+                    "p95": 0,
+                }
+            ),
+            "timing summary is inconsistent",
+        ),
+        (
+            lambda timing: timing["scenarios"][0]["components"]["existing_full_replay_writer"][
+                "wall_time_ns"
+            ]["samples"].__setitem__(0, -1),
+            "timing sample value is invalid",
+        ),
+    ],
+)
+def test_worker_artifact_validation_fails_closed_on_invalid_timing(
+    mutate: Any,
+    message: str,
+) -> None:
+    specs = [_small_spec()]
+    manifest = module._build_fixture_manifest(
+        repo_root=Path.cwd(),
+        dimensions=_dimensions(),
+        specs=specs,
+        seed=module.SEED,
+        host={"fingerprint": "a" * 64},
+        run_label="acceptance_5_warmups_30_repetitions",
+    )
+    timing = _timing_artifact(manifest)
+    cpu = _profile_artifact(
+        manifest,
+        schema=module.CPU_PROFILE_SCHEMA,
+        mode="cprofile_separate_process",
+    )
+    allocation = _profile_artifact(
+        manifest,
+        schema=module.ALLOCATION_PROFILE_SCHEMA,
+        mode="tracemalloc_separate_process",
+    )
+    mutate(timing)
+
+    with pytest.raises(RuntimeError, match=message):
+        module._validate_worker_artifacts(
+            fixture_manifest=manifest,
+            timing=timing,
+            cpu_profile=cpu,
+            allocation_profile=allocation,
+            expected_warmups=5,
+            expected_repetitions=30,
+            expected_run_label="acceptance_5_warmups_30_repetitions",
+        )

--- a/tests/test_research_performance_baseline.py
+++ b/tests/test_research_performance_baseline.py
@@ -77,7 +77,7 @@ def _timing_artifact(
 ) -> dict[str, Any]:
     wall_samples = [wall_p95] * 30
     cpu_samples = [cpu_p95] * 30
-    return {
+    payload = {
         "schema_version": module.TIMING_SCHEMA,
         "measurement_mode": "timing_without_profiler",
         "profilers_enabled": False,
@@ -107,6 +107,18 @@ def _timing_artifact(
             for row in fixture_manifest["scenarios"]
         ],
     }
+    storage = fixture_manifest.get("research_storage_status")
+    if isinstance(storage, dict):
+        payload["research_storage_status"] = {
+            "key": storage["key"],
+            "fixture_sha256": storage["fixture_sha256"],
+            "setup_included": False,
+            "wall_time_ns": module._timing_distribution(wall_samples),
+            "cpu_time_ns": module._timing_distribution(cpu_samples),
+        }
+    else:
+        payload["research_storage_status"] = None
+    return payload
 
 
 def _profile_artifact(
@@ -115,7 +127,7 @@ def _profile_artifact(
     schema: str,
     mode: str,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "schema_version": schema,
         "measurement_mode": mode,
         "timing_threshold_eligible": False,
@@ -132,6 +144,17 @@ def _profile_artifact(
             for row in fixture_manifest["scenarios"]
         ],
     }
+    storage = fixture_manifest.get("research_storage_status")
+    if isinstance(storage, dict):
+        payload["research_storage_status"] = {
+            "key": storage["key"],
+            "fixture_sha256": storage["fixture_sha256"],
+            "setup_included": False,
+            "component": {"python_peak_bytes": 1_024},
+        }
+    else:
+        payload["research_storage_status"] = None
+    return payload
 
 
 def _fake_workers(
@@ -169,6 +192,27 @@ def _fake_workers(
         "allocation": (module.ALLOCATION_PROFILE_SCHEMA, "tracemalloc_separate_process"),
     }
     schema, measurement_mode = schemas[mode]
+    storage_spec = worker_spec.get("research_storage_status")
+    storage_status = None
+    if isinstance(storage_spec, dict):
+        storage_status = {
+            "key": storage_spec["key"],
+            "fixture_sha256": storage_spec["fixture_sha256"],
+            "setup_included": False,
+        }
+        if mode == "timing":
+            storage_status.update(
+                wall_time_ns=module._timing_distribution(
+                    [100] * worker_spec["repetitions"]
+                ),
+                cpu_time_ns=module._timing_distribution(
+                    [100] * worker_spec["repetitions"]
+                ),
+            )
+        elif mode == "allocation":
+            storage_status["component"] = {"python_peak_bytes": 1_024}
+        else:
+            storage_status["component"] = {}
     return {
         "schema_version": schema,
         "measurement_mode": measurement_mode,
@@ -179,6 +223,7 @@ def _fake_workers(
         "repetitions": worker_spec["repetitions"] if mode == "timing" else None,
         "run_label": worker_spec["run_label"],
         "scenarios": scenarios,
+        "research_storage_status": storage_status,
     }
 
 
@@ -309,6 +354,149 @@ def test_timing_cpu_and_allocation_modes_are_contractually_separate() -> None:
     assert cpu["timing_threshold_eligible"] is False
     assert allocation["measurement_mode"] == "tracemalloc_separate_process"
     assert allocation["timing_threshold_eligible"] is False
+
+
+def test_storage_status_fixture_identity_is_repeatable() -> None:
+    first = module._storage_status_spec(seed=module.SEED)
+    second = module._storage_status_spec(seed=module.SEED)
+    third = module._storage_status_spec(seed=module.SEED + 1)
+
+    assert first == second
+    assert first["fixture_sha256"] != third["fixture_sha256"]
+    assert first["effective_dimensions"] == {
+        "partition_count": 10_000,
+        "manifest_count": 1,
+        "runtime_file_count": 10_001,
+    }
+
+
+def test_research_storage_status_can_run_without_projection_scenarios(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        module,
+        "_host_profile",
+        lambda: {
+            "schema_version": "data_storage_projection_host_profile.v1",
+            "fingerprint": "a" * 64,
+        },
+    )
+    output = tmp_path / "storage-only"
+
+    result = module.run_data_storage_projection_benchmark(
+        repo_root=Path.cwd(),
+        output_dir=output,
+        scenario="research_storage_status",
+        warmups=1,
+        repetitions=2,
+        worker_runner=_fake_workers,
+    )
+
+    assert result["scenario_count"] == 0
+    assert result["research_storage_status"]["status"] == "not_evaluable"
+    fixture = json.loads((output / "fixture-manifest.json").read_text(encoding="utf-8"))
+    assert fixture["scenarios"] == []
+    assert fixture["research_storage_status"]["key"] == module.STORAGE_STATUS_KEY
+
+
+def test_storage_status_workers_exclude_setup_and_preserve_payload_free_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = module._storage_status_spec(seed=module.SEED)
+    result = {
+        "status": "partial_data",
+        "runtime_storage": {"file_count": 10_001},
+        "research_storage": {
+            "manifest_count": 1,
+            "declared_reference_count": 10_000,
+            "protected_reference_failures": [],
+        },
+        "safety": {
+            "payload_content_reads": 0,
+            "mutation_operations": 0,
+            "no_follow_traversal": True,
+        },
+    }
+    setup_calls = 0
+    collect_calls = 0
+
+    @module.contextmanager
+    def fake_fixture(_spec: dict[str, Any]):
+        nonlocal setup_calls
+        setup_calls += 1
+        yield {"fixture_sha256": spec["fixture_sha256"]}
+
+    def fake_collect(_context: dict[str, Any]) -> dict[str, Any]:
+        nonlocal collect_calls
+        collect_calls += 1
+        return result
+
+    monkeypatch.setattr(module, "_temporary_storage_status_fixture", fake_fixture)
+    monkeypatch.setattr(module, "_collect_synthetic_storage_status", fake_collect)
+
+    timing = module._measure_storage_status_timing(spec, warmups=1, repetitions=2)
+    allocation = module._measure_storage_status_allocation(spec)
+
+    assert setup_calls == 2
+    assert collect_calls == 4
+    assert timing["setup_included"] is False
+    assert timing["output"]["payload_content_reads"] == 0
+    assert timing["output"]["mutation_operations"] == 0
+    assert allocation["setup_included"] is False
+
+
+def test_storage_status_gate_checks_space_on_any_host_and_time_on_reference_host() -> None:
+    timing = {
+        "wall_time_ns": module._timing_distribution([100] * 30),
+    }
+    allocation = {"component": {"python_peak_bytes": 1_024}}
+
+    mismatch = module._storage_status_gate(
+        timing=timing,
+        allocation=allocation,
+        run_label="acceptance_5_warmups_30_repetitions",
+        comparable=False,
+        comparison_reason="host_profile_fingerprint_mismatch",
+    )
+    too_large = module._storage_status_gate(
+        timing=timing,
+        allocation={
+            "component": {
+                "python_peak_bytes": module.STORAGE_STATUS_ALLOCATION_LIMIT_BYTES + 1,
+            }
+        },
+        run_label="acceptance_5_warmups_30_repetitions",
+        comparable=False,
+        comparison_reason="host_profile_fingerprint_mismatch",
+    )
+    passing = module._storage_status_gate(
+        timing=timing,
+        allocation=allocation,
+        run_label="acceptance_5_warmups_30_repetitions",
+        comparable=True,
+        comparison_reason="exact_host_profile_fingerprint_match",
+    )
+
+    assert mismatch[:2] == ("not_comparable", "host_profile_fingerprint_mismatch")
+    assert too_large[:2] == ("fail", "frozen_allocation_limit_exceeded")
+    assert passing[:2] == ("pass", "within_frozen_limits")
+
+
+def test_storage_status_gate_is_not_comparable_when_allocation_measurement_is_missing() -> None:
+    timing = {
+        "wall_time_ns": module._timing_distribution([100] * 30),
+    }
+
+    result = module._storage_status_gate(
+        timing=timing,
+        allocation=None,
+        run_label="acceptance_5_warmups_30_repetitions",
+        comparable=True,
+        comparison_reason="exact_host_profile_fingerprint_match",
+    )
+
+    assert result[:2] == ("not_evaluable", "scenario_not_selected")
 
 
 def test_reference_host_gate_requires_exact_fingerprint_and_both_history_subcases(

--- a/tests/test_research_storage_baseline.py
+++ b/tests/test_research_storage_baseline.py
@@ -1,0 +1,820 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import sqlite3
+from typing import Any
+
+import pytest
+
+from src.application.agent_tool_contracts import AgentToolError
+from src.application.research import storage_baseline as module
+
+
+NOW = datetime(2026, 8, 13, 5, 0, tzinfo=timezone.utc)
+
+
+def _make_runtime(tmp_path: Path, *, with_ledger: bool = True) -> Path:
+    root = tmp_path / "runtime"
+    for relpath in (
+        "output_runs",
+        "output_accounts",
+        "output_shared/state",
+        "output_shared/research",
+        "output_shared/required_data",
+        "logs",
+    ):
+        (root / relpath).mkdir(parents=True, exist_ok=True)
+    if with_ledger:
+        _write_ledger(root / "output_shared/state/option_positions.sqlite3")
+    return root
+
+
+def _write_ledger(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE trade_events ("
+            "event_id TEXT PRIMARY KEY, event_json TEXT NOT NULL, "
+            "trade_time_ms INTEGER NOT NULL, created_at_ms INTEGER NOT NULL, "
+            "updated_at_ms INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE position_lots ("
+            "record_id TEXT PRIMARY KEY, fields_json TEXT NOT NULL)"
+        )
+        conn.execute("CREATE TABLE future_table (payload TEXT)")
+        conn.execute(
+            "INSERT INTO trade_events VALUES (?, ?, ?, ?, ?)",
+            ("event-1", '{"account":"lx","contracts":1}', 1, 1, 1),
+        )
+        conn.execute(
+            "INSERT INTO position_lots VALUES (?, ?)",
+            ("lot-1", '{"account":"lx","status":"open"}'),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _stub_source_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        module,
+        "_collect_source_inventory",
+        lambda **_kwargs: {
+            "schema_version": "data_storage_runtime_source_inventory.v1",
+            "status": "complete",
+            "classified_match_count": 1,
+            "stale_locators": [],
+            "unclassified_matches": [],
+        },
+    )
+
+
+def _collect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    root: Path | None = None,
+    history_reports: list[Path] | None = None,
+    output: Path | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    _stub_source_inventory(monkeypatch)
+    runtime = root or _make_runtime(tmp_path)
+    return module.collect_storage_runtime_baseline(
+        repo_root=Path.cwd(),
+        runtime_root=runtime,
+        history_reports=history_reports,
+        output=output,
+        overwrite=overwrite,
+        now_fn=lambda: NOW,
+    )
+
+
+def _tree_identity(root: Path) -> list[tuple[str, str, int, int, bytes | None]]:
+    rows: list[tuple[str, str, int, int, bytes | None]] = []
+    for path in sorted(root.rglob("*")):
+        stat = path.lstat()
+        kind = "symlink" if path.is_symlink() else "dir" if path.is_dir() else "file"
+        content = path.read_bytes() if kind == "file" else None
+        rows.append((path.relative_to(root).as_posix(), kind, stat.st_size, stat.st_mtime_ns, content))
+    return rows
+
+
+def _write_research_manifest(
+    root: Path,
+    *,
+    entries: list[dict[str, Any]],
+    name: str = "manifest.json",
+) -> Path:
+    dataset = root / "output_shared/research/dataset"
+    dataset.mkdir(parents=True, exist_ok=True)
+    path = dataset / name
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "shadow_fixture.v1",
+                "generation_id": "generation-1",
+                "market": "us",
+                "files": entries,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _history_report(path: Path, *, root: Path, observed_at: str, unique_bytes: int) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": module.SCHEMA_VERSION,
+                "identity": {
+                    "runtime_root": str(root.resolve()),
+                    "observed_at_utc": observed_at,
+                },
+                "research_storage": {"unique_declared_bytes": unique_bytes},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_collect_returns_deterministic_schema_and_aggregate_sqlite_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    assert result["schema_version"] == module.SCHEMA_VERSION
+    assert result["status"] == "complete"
+    assert result["identity"]["ledger_sqlite"] == "output_shared/state/option_positions.sqlite3"
+    assert result["sqlite"]["status"] == "complete"
+    assert result["sqlite"]["query_mode"] == "stable_copy_mode_ro_query_only"
+    tables = {row["table"]: row for row in result["sqlite"]["tables"]}
+    assert tables["trade_events"]["row_count"] == 1
+    assert tables["trade_events"]["json_bytes"] == len('{"account":"lx","contracts":1}')
+    assert tables["position_lots"]["row_count"] == 1
+    assert "future_table" in result["sqlite"]["unknown_tables"]
+    assert result["safety"] == {
+        "query_only_sqlite": True,
+        "source_sqlite_connections": 0,
+        "no_follow_traversal": True,
+        "payload_content_reads": 0,
+        "content_verification": "not_performed",
+        "mutation_operations": 0,
+        "automatic_actions": [],
+    }
+
+
+def test_collection_leaves_runtime_tree_and_sqlite_sidecars_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path, with_ledger=False)
+    db = root / "output_shared/state/option_positions.sqlite3"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            "CREATE TABLE trade_events (event_id TEXT PRIMARY KEY, event_json TEXT, "
+            "trade_time_ms INTEGER, created_at_ms INTEGER, updated_at_ms INTEGER)"
+        )
+        conn.execute("INSERT INTO trade_events VALUES ('e', '{}', 1, 1, 1)")
+        conn.commit()
+        assert db.with_name(db.name + "-wal").exists()
+        assert db.with_name(db.name + "-shm").exists()
+        before = _tree_identity(root)
+
+        result = _collect(monkeypatch, tmp_path, root=root)
+
+        after = _tree_identity(root)
+        assert result["sqlite"]["status"] == "complete"
+        assert before == after
+    finally:
+        conn.close()
+
+
+def test_runtime_scan_does_not_follow_root_or_nested_symlinks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.bin").write_bytes(b"do-not-count")
+    (root / "output_runs/link").symlink_to(outside, target_is_directory=True)
+    (root / "output").symlink_to(outside, target_is_directory=True)
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    assert all(row["path"] != "outside/secret.bin" for row in result["runtime_storage"]["largest_files"])
+    assert {row["path"] for row in result["runtime_storage"]["symlinks_not_followed"]} == {
+        "output",
+        "output_runs/link",
+    }
+    roots = {row["root"]: row for row in result["runtime_storage"]["roots"]}
+    assert roots["output"]["status"] == "symlink_not_followed"
+
+
+def test_missing_default_ledger_is_partial_data_not_fabricated_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result = _collect(monkeypatch, tmp_path, root=_make_runtime(tmp_path, with_ledger=False))
+
+    assert result["status"] == "partial_data"
+    assert result["sqlite"]["status"] == "missing"
+    assert result["sqlite"]["tables"] == []
+
+
+def test_external_ledger_requires_explicit_allow_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _stub_source_inventory(monkeypatch)
+    root = _make_runtime(tmp_path)
+    external = tmp_path / "external.sqlite3"
+    _write_ledger(external)
+
+    with pytest.raises(AgentToolError, match="inside runtime root"):
+        module.collect_storage_runtime_baseline(
+            repo_root=Path.cwd(),
+            runtime_root=root,
+            ledger_sqlite=external,
+        )
+
+    result = module.collect_storage_runtime_baseline(
+        repo_root=Path.cwd(),
+        runtime_root=root,
+        ledger_sqlite=external,
+        allow_external_ledger=True,
+        now_fn=lambda: NOW,
+    )
+    assert result["identity"]["ledger_sqlite"] == "external:external.sqlite3"
+
+
+def test_ledger_path_rejects_symlink_leaf_and_parent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _stub_source_inventory(monkeypatch)
+    root = _make_runtime(tmp_path)
+    external = tmp_path / "external.sqlite3"
+    _write_ledger(external)
+    leaf = root / "output_shared/state/linked.sqlite3"
+    leaf.symlink_to(external)
+
+    with pytest.raises(AgentToolError, match="symlink"):
+        module.collect_storage_runtime_baseline(
+            repo_root=Path.cwd(),
+            runtime_root=root,
+            ledger_sqlite=leaf,
+            allow_external_ledger=True,
+        )
+
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(root / "output_shared/state", target_is_directory=True)
+    with pytest.raises(AgentToolError, match="symlink"):
+        module.collect_storage_runtime_baseline(
+            repo_root=Path.cwd(),
+            runtime_root=root,
+            ledger_sqlite=linked_parent / "option_positions.sqlite3",
+        )
+
+
+def test_stable_copy_retries_when_source_tuple_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    db = root / "output_shared/state/option_positions.sqlite3"
+    real_state = module._sqlite_state
+    calls = 0
+
+    def changing_once(path: Path):
+        nonlocal calls
+        calls += 1
+        state = real_state(path)
+        if calls == 2:
+            db_state = state[db.name]
+            state[db.name] = (db_state[0], db_state[1], int(db_state[2] or 0) + 1, db_state[3])
+        return state
+
+    monkeypatch.setattr(module, "_sqlite_state", changing_once)
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    assert result["sqlite"]["status"] == "complete"
+    assert result["sqlite"]["snapshot_attempts"] == 2
+
+
+def test_stable_copy_exhaustion_is_partial_data(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    real_state = module._sqlite_state
+    calls = 0
+
+    def always_changing(path: Path):
+        nonlocal calls
+        calls += 1
+        state = real_state(path)
+        key = path.name
+        db_state = state[key]
+        state[key] = (db_state[0], db_state[1], int(db_state[2] or 0) + calls, db_state[3])
+        return state
+
+    monkeypatch.setattr(module, "_sqlite_state", always_changing)
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    assert result["status"] == "partial_data"
+    assert result["sqlite"]["status"] == "data_unavailable"
+    assert result["sqlite"]["reason"] == "stable_copy_or_query_failed"
+
+
+def test_manifest_declared_hash_dedup_does_not_read_or_verify_payload_content(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    dataset = root / "output_shared/research/dataset"
+    dataset.mkdir(parents=True)
+    (dataset / "payload-a.bin").write_bytes(b"AAAA")
+    (dataset / "payload-b.bin").write_bytes(b"BBBB")
+    digest = "f" * 64
+    _write_research_manifest(
+        root,
+        entries=[
+            {"relpath": "payload-a.bin", "size_bytes": 4, "sha256": digest},
+            {"relpath": "payload-b.bin", "size_bytes": 4, "sha256": digest},
+        ],
+    )
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+    research = result["research_storage"]
+
+    assert research["status"] == "complete"
+    assert research["logical_referenced_bytes"] == 8
+    assert research["unique_declared_bytes"] == 4
+    assert research["dedup_ratio"] == 2.0
+    assert research["content_verification"] == "not_performed"
+    assert research["same_size_content_status"] == "not_verified"
+    assert research["protected_reference_failures"] == []
+
+
+def test_required_data_root_relpath_resolves_manifest_references(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    payload = root / "output_shared/required_data/NVDA.csv"
+    payload.write_bytes(b"data")
+    manifest_dir = root / "output_runs/run-1/state"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "required_data_snapshot_manifest.v1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "required_data_snapshot_manifest.v1",
+                "required_data_root_relpath": "../../../output_shared/required_data",
+                "symbols": {
+                    "NVDA": {
+                        "payload_relpath": "NVDA.csv",
+                        "payload_sha256": "d" * 64,
+                        "payload_size_bytes": 4,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    assert result["research_storage"]["protected_reference_failures"] == []
+    assert result["research_storage"]["logical_referenced_bytes"] == 4
+
+
+def test_shadow_replay_integrity_file_map_counts_keyed_references(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    dataset = root / "output_shared/research/shadow_replay/dataset-1"
+    dataset.mkdir(parents=True)
+    (dataset / "candidate_snapshots.jsonl").write_bytes(b"{}\n")
+    (dataset / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "shadow_replay_dataset.v1",
+                "dataset_id": "dataset-1",
+                "integrity": {
+                    "generation_id": "generation-1",
+                    "files": {
+                        "candidate_snapshots.jsonl": {
+                            "sha256": "e" * 64,
+                            "bytes": 3,
+                            "row_count": 1,
+                        }
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    research = result["research_storage"]
+    assert research["protected_reference_failures"] == []
+    assert research["logical_referenced_bytes"] == 3
+    assert research["unique_declared_bytes"] == 3
+
+
+def test_combo_facet_parallel_file_and_hash_maps_are_joined(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    dataset = root / "output_shared/research/shadow_replay/dataset-1"
+    dataset.mkdir(parents=True)
+    facet_file = dataset / "combo_pair_decisions.jsonl"
+    facet_file.write_bytes(b"{}\n")
+    (dataset / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "shadow_replay_dataset.v1",
+                "combo_pair_facet": {
+                    "files": {
+                        facet_file.name: str(facet_file),
+                    },
+                    "file_sha256": {
+                        facet_file.name: "f" * 64,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+    research = result["research_storage"]
+
+    assert research["protected_reference_failures"] == []
+    assert research["declared_hash_reference_count"] == 1
+    assert research["declared_hash_unknown_size_count"] == 1
+    assert research["unmanifested_file_count"] == 0
+
+
+def test_research_archive_inventory_binds_file_manifest_to_run_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    archive = root / "output_shared/research/remote_archive/prod"
+    run_file = archive / "output_runs/run-1/state/tick_metrics.json"
+    run_file.parent.mkdir(parents=True)
+    run_file.write_bytes(b"{}\n")
+    manifests = archive / "manifests"
+    manifests.mkdir()
+    (manifests / "inventory.latest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "research_archive.v2",
+                "action": "verify",
+                "archive_root": str(archive),
+                "runs": [
+                    {
+                        "run_id": "run-1",
+                        "file_manifest": [
+                            {
+                                "path": "state/tick_metrics.json",
+                                "size_bytes": 3,
+                                "sha256": "1" * 64,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+    research = result["research_storage"]
+
+    assert research["protected_reference_failures"] == []
+    assert research["logical_referenced_bytes"] == 3
+    assert research["unique_declared_bytes"] == 3
+    assert research["unmanifested_file_count"] == 0
+
+
+def test_research_archive_inventory_missing_run_file_is_critical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    archive = root / "output_shared/research/remote_archive/prod"
+    manifests = archive / "manifests"
+    manifests.mkdir(parents=True)
+    (manifests / "inventory.latest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "research_archive.v2",
+                "action": "verify",
+                "archive_root": str(archive),
+                "runs": [
+                    {
+                        "run_id": "run-1",
+                        "file_manifest": [
+                            {
+                                "path": "state/missing.json",
+                                "size_bytes": 3,
+                                "sha256": "2" * 64,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    failures = result["research_storage"]["protected_reference_failures"]
+    assert failures == [
+        {
+            "manifest": "output_shared/research/remote_archive/prod/manifests/inventory.latest.json",
+            "reference": "state/missing.json",
+            "reason": "missing",
+        }
+    ]
+    assert result["thresholds"]["status"] == "critical"
+
+
+@pytest.mark.parametrize(
+    ("entry", "reason"),
+    [
+        ({"relpath": "missing.bin", "size_bytes": 4, "sha256": "a" * 64}, "missing"),
+        ({"relpath": "payload.bin", "size_bytes": 99, "sha256": "b" * 64}, "declared_size_mismatch"),
+    ],
+)
+def test_manifest_missing_or_declared_size_mismatch_is_critical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    entry: dict[str, Any],
+    reason: str,
+) -> None:
+    root = _make_runtime(tmp_path)
+    dataset = root / "output_shared/research/dataset"
+    dataset.mkdir(parents=True)
+    (dataset / "payload.bin").write_bytes(b"data")
+    _write_research_manifest(root, entries=[entry])
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    assert result["status"] == "partial_data"
+    assert result["research_storage"]["status"] == "data_unavailable"
+    assert result["research_storage"]["protected_reference_failures"][0]["reason"] == reason
+    assert result["thresholds"]["status"] == "critical"
+    assert result["thresholds"]["automatic_actions"] == []
+    assert result["thresholds"]["preview"]["actions"] == []
+
+
+def test_forecast_requires_compatible_ordered_history_and_uses_observed_deltas(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    dataset = root / "output_shared/research/dataset"
+    dataset.mkdir(parents=True)
+    (dataset / "payload.bin").write_bytes(b"x" * 300)
+    _write_research_manifest(
+        root,
+        entries=[{"relpath": "payload.bin", "size_bytes": 300, "sha256": "c" * 64}],
+    )
+    no_history = _collect(monkeypatch, tmp_path, root=root)
+    assert no_history["research_storage"]["growth"]["status"] == "insufficient_history"
+    assert no_history["research_storage"]["growth"]["forecast_90d_additional_bytes"] is None
+
+    prior = tmp_path / "prior.json"
+    _history_report(
+        prior,
+        root=root,
+        observed_at="2026-07-14T05:00:00+00:00",
+        unique_bytes=200,
+    )
+    with_history = _collect(monkeypatch, tmp_path, root=root, history_reports=[prior])
+    growth = with_history["research_storage"]["growth"]
+    assert growth["status"] == "complete"
+    assert growth["monthly_unique_growth_bytes"] == 100
+    assert growth["forecast_90d_additional_bytes"] == 300
+
+    wrong_root = tmp_path / "wrong-root.json"
+    _history_report(
+        wrong_root,
+        root=tmp_path / "other-runtime",
+        observed_at="2026-06-14T05:00:00+00:00",
+        unique_bytes=100,
+    )
+    rejected = _collect(monkeypatch, tmp_path, root=root, history_reports=[wrong_root])
+    assert rejected["research_storage"]["growth"]["status"] == "insufficient_history"
+    assert rejected["research_storage"]["growth"]["rejected_reports"][0]["reason"] == "runtime_root_mismatch"
+
+
+def test_out_of_order_prior_reports_are_rejected_without_fabricating_growth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    earlier = tmp_path / "earlier.json"
+    later = tmp_path / "later.json"
+    _history_report(later, root=root, observed_at="2026-08-01T05:00:00+00:00", unique_bytes=20)
+    _history_report(earlier, root=root, observed_at="2026-07-01T05:00:00+00:00", unique_bytes=10)
+
+    result = _collect(monkeypatch, tmp_path, root=root, history_reports=[later, earlier])
+    growth = result["research_storage"]["growth"]
+
+    assert any(row["reason"] == "out_of_order" for row in growth["rejected_reports"])
+    assert growth["status"] == "complete"
+    assert len(growth["observations"]) == 2
+
+
+def test_warning_and_critical_thresholds_never_create_actions() -> None:
+    warning = module._capacity_thresholds(
+        disk_total_bytes=100 * module.GIB,
+        disk_free_bytes=25 * module.GIB,
+        research_storage={
+            "growth": {
+                "forecast_90d_additional_bytes": 10 * module.GIB,
+                "rapid_growth_two_consecutive_months": False,
+            },
+            "protected_reference_failures": [],
+            "manifest_parse_failures": [],
+            "cold_candidates": [{"path": "p"}],
+            "unmanifested_file_count": 3,
+        },
+    )
+    critical = module._capacity_thresholds(
+        disk_total_bytes=100 * module.GIB,
+        disk_free_bytes=4 * module.GIB,
+        research_storage={
+            "growth": {
+                "forecast_90d_additional_bytes": 0,
+                "rapid_growth_two_consecutive_months": False,
+            },
+            "protected_reference_failures": [],
+            "manifest_parse_failures": [],
+            "cold_candidates": [],
+            "unmanifested_file_count": 0,
+        },
+    )
+
+    assert warning["status"] == "warning"
+    assert warning["automatic_actions"] == []
+    assert warning["preview"]["actions"] == []
+    assert critical["status"] == "critical"
+    assert critical["automatic_actions"] == []
+
+
+def test_output_is_atomic_external_and_collision_guarded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    output = tmp_path / "baseline.json"
+
+    result = _collect(monkeypatch, tmp_path, root=root, output=output)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == result
+    assert list(tmp_path.glob(".baseline.json.*.tmp")) == []
+    with pytest.raises(AgentToolError, match="already exists"):
+        _collect(monkeypatch, tmp_path, root=root, output=output)
+    overwritten = _collect(monkeypatch, tmp_path, root=root, output=output, overwrite=True)
+    assert json.loads(output.read_text(encoding="utf-8")) == overwritten
+
+    inside = root / "output_shared/research/baseline.json"
+    with pytest.raises(AgentToolError, match="outside"):
+        _collect(monkeypatch, tmp_path, root=root, output=inside)
+
+    real_output = tmp_path / "real-baseline.json"
+    linked_output = tmp_path / "linked-baseline.json"
+    linked_output.symlink_to(real_output)
+    with pytest.raises(AgentToolError, match="symlink"):
+        _collect(monkeypatch, tmp_path, root=root, output=linked_output, overwrite=True)
+
+
+def test_checked_in_source_inventory_is_complete() -> None:
+    result = module._collect_source_inventory(
+        repo_root=Path.cwd(),
+        manifest_path=Path("docs/architecture/data-storage-runtime-source-inventory.v1.json").resolve(),
+    )
+
+    assert result["status"] == "complete"
+    assert result["classified_match_count"] > 0
+    assert result["stale_locators"] == []
+    assert result["unclassified_matches"] == []
+
+
+def test_source_inventory_rejects_unclassified_discovery(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src/owned.py").write_text("list_trade_events()\n", encoding="utf-8")
+    (repo / "src/unowned.py").write_text("list_trade_events()\n", encoding="utf-8")
+    manifest = repo / "inventory.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "data_storage_runtime_source_inventory.v1",
+                "scan_roots": ["src"],
+                "discovery_rules": [
+                    {
+                        "id": "events",
+                        "kind": "call",
+                        "symbols": ["list_trade_events"],
+                        "classifiers": [
+                            {
+                                "path_glob": "src/owned.py",
+                                "owner": "ledger",
+                                "operation": "read",
+                                "history_dimension": "events",
+                                "path_class": "hot",
+                                "later_phase": "phase_3",
+                            }
+                        ],
+                    }
+                ],
+                "declared_locators": [
+                    {"path": "src/owned.py", "locator": "list_trade_events"}
+                ],
+                "ignores": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AgentToolError) as raised:
+        module._collect_source_inventory(repo_root=repo, manifest_path=manifest)
+
+    assert raised.value.details is not None
+    assert raised.value.details["unclassified"] == [
+        {"rule_id": "events", "path": "src/unowned.py", "locator": "list_trade_events"}
+    ]
+
+
+def test_source_inventory_rejects_stale_locator(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src/owned.py").write_text("list_trade_events()\n", encoding="utf-8")
+    manifest = repo / "inventory.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "data_storage_runtime_source_inventory.v1",
+                "scan_roots": ["src"],
+                "discovery_rules": [
+                    {
+                        "id": "events",
+                        "kind": "call",
+                        "symbols": ["list_trade_events"],
+                        "classifiers": [
+                            {
+                                "path_glob": "src/*.py",
+                                "owner": "ledger",
+                                "operation": "read",
+                                "history_dimension": "events",
+                                "path_class": "hot",
+                                "later_phase": "phase_3",
+                            }
+                        ],
+                    }
+                ],
+                "declared_locators": [
+                    {"path": "src/owned.py", "locator": "removed_symbol"}
+                ],
+                "ignores": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AgentToolError) as raised:
+        module._collect_source_inventory(repo_root=repo, manifest_path=manifest)
+
+    assert raised.value.details is not None
+    assert raised.value.details["stale_locators"] == [
+        {"path": "src/owned.py", "locator": "removed_symbol"}
+    ]
+
+
+def test_tier_classification_is_preview_only() -> None:
+    assert module._storage_tier(storage_class="sealed_run_artifact", age_days=999) == "hot"
+    assert module._storage_tier(storage_class="research_artifact", age_days=30) == "hot"
+    assert module._storage_tier(storage_class="research_artifact", age_days=31) == "warm"

--- a/tests/test_research_storage_baseline.py
+++ b/tests/test_research_storage_baseline.py
@@ -218,6 +218,47 @@ def test_runtime_scan_does_not_follow_root_or_nested_symlinks(
     assert roots["output"]["status"] == "symlink_not_followed"
 
 
+def test_manifest_reference_cannot_escape_through_unscanned_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    outside = tmp_path / "outside-research"
+    outside.mkdir()
+    (outside / "payload.bin").write_bytes(b"data")
+    dataset = root / "output_shared/research/dataset"
+    dataset.mkdir(parents=True)
+    (dataset / "linked").symlink_to(outside, target_is_directory=True)
+    (dataset / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "research.dataset.v1",
+                "entries": [
+                    {
+                        "relpath": "linked/payload.bin",
+                        "size_bytes": 4,
+                        "sha256": "a" * 64,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    assert result["research_storage"]["protected_reference_failures"] == [
+        {
+            "manifest": "output_shared/research/dataset/manifest.json",
+            "reference": "linked/payload.bin",
+            "reason": "missing",
+        }
+    ]
+    assert "output_shared/research/dataset/linked" in {
+        row["path"] for row in result["runtime_storage"]["symlinks_not_followed"]
+    }
+
+
 def test_runtime_scan_counts_immediate_non_symlink_account_directories(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_research_storage_baseline.py
+++ b/tests/test_research_storage_baseline.py
@@ -41,10 +41,7 @@ def _write_ledger(path: Path) -> None:
             "trade_time_ms INTEGER NOT NULL, created_at_ms INTEGER NOT NULL, "
             "updated_at_ms INTEGER NOT NULL)"
         )
-        conn.execute(
-            "CREATE TABLE position_lots ("
-            "record_id TEXT PRIMARY KEY, fields_json TEXT NOT NULL)"
-        )
+        conn.execute("CREATE TABLE position_lots (record_id TEXT PRIMARY KEY, fields_json TEXT NOT NULL)")
         conn.execute("CREATE TABLE future_table (payload TEXT)")
         conn.execute(
             "INSERT INTO trade_events VALUES (?, ?, ?, ?, ?)",
@@ -219,6 +216,54 @@ def test_runtime_scan_does_not_follow_root_or_nested_symlinks(
     }
     roots = {row["root"]: row for row in result["runtime_storage"]["roots"]}
     assert roots["output"]["status"] == "symlink_not_followed"
+
+
+def test_runtime_scan_counts_immediate_non_symlink_account_directories(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _make_runtime(tmp_path)
+    for account in ("lx", "sy", "qa"):
+        account_root = root / "output_accounts" / account
+        account_root.mkdir()
+        (account_root / "report.json").write_text("{}", encoding="utf-8")
+    outside = tmp_path / "outside-account"
+    outside.mkdir()
+    (root / "output_accounts" / "linked").symlink_to(outside, target_is_directory=True)
+
+    result = _collect(monkeypatch, tmp_path, root=root)
+
+    runtime_storage = result["runtime_storage"]
+    assert runtime_storage["account_count"] == 3
+    assert runtime_storage["account_count_status"] == "complete"
+    assert runtime_storage["account_count_basis"] == "immediate_non_symlink_output_accounts_directories"
+    assert "output_accounts/linked" in {row["path"] for row in runtime_storage["symlinks_not_followed"]}
+
+
+def test_runtime_account_count_distinguishes_empty_missing_and_symlink_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    empty_root = _make_runtime(tmp_path / "empty")
+    empty = _collect(monkeypatch, tmp_path, root=empty_root)["runtime_storage"]
+
+    missing_root = _make_runtime(tmp_path / "missing")
+    (missing_root / "output_accounts").rmdir()
+    missing = _collect(monkeypatch, tmp_path, root=missing_root)["runtime_storage"]
+
+    symlink_root = _make_runtime(tmp_path / "symlink")
+    (symlink_root / "output_accounts").rmdir()
+    target = tmp_path / "linked-accounts"
+    target.mkdir()
+    (symlink_root / "output_accounts").symlink_to(target, target_is_directory=True)
+    linked = _collect(monkeypatch, tmp_path, root=symlink_root)["runtime_storage"]
+
+    assert (empty["account_count"], empty["account_count_status"]) == (0, "complete")
+    assert (missing["account_count"], missing["account_count_status"]) == (None, "missing")
+    assert (linked["account_count"], linked["account_count_status"]) == (
+        None,
+        "symlink_not_followed",
+    )
 
 
 def test_missing_default_ledger_is_partial_data_not_fabricated_zero(
@@ -751,9 +796,7 @@ def test_source_inventory_rejects_unclassified_discovery(tmp_path: Path) -> None
                         ],
                     }
                 ],
-                "declared_locators": [
-                    {"path": "src/owned.py", "locator": "list_trade_events"}
-                ],
+                "declared_locators": [{"path": "src/owned.py", "locator": "list_trade_events"}],
                 "ignores": [],
             }
         ),
@@ -796,9 +839,7 @@ def test_source_inventory_rejects_stale_locator(tmp_path: Path) -> None:
                         ],
                     }
                 ],
-                "declared_locators": [
-                    {"path": "src/owned.py", "locator": "removed_symbol"}
-                ],
+                "declared_locators": [{"path": "src/owned.py", "locator": "removed_symbol"}],
                 "ignores": [],
             }
         ),
@@ -809,9 +850,7 @@ def test_source_inventory_rejects_stale_locator(tmp_path: Path) -> None:
         module._collect_source_inventory(repo_root=repo, manifest_path=manifest)
 
     assert raised.value.details is not None
-    assert raised.value.details["stale_locators"] == [
-        {"path": "src/owned.py", "locator": "removed_symbol"}
-    ]
+    assert raised.value.details["stale_locators"] == [{"path": "src/owned.py", "locator": "removed_symbol"}]
 
 
 def test_tier_classification_is_preview_only() -> None:


### PR DESCRIPTION
## Summary

- Add a payload-free, read-only storage baseline for SQLite and retained runtime artifacts.
- Add a deterministic synthetic benchmark that separates wall time, CPU time, and allocation evidence for both canonical projection and research-storage status.
- Optimize manifest-reference lookup by reusing the bounded no-follow file index instead of repeatedly resolving/statting each declared path.
- Fail closed when historical account fanout is not exactly known, bind timing acceptance to an exact host fingerprint, and preserve zero payload reads/runtime mutations.
- Record the Phase 1 contract, Gateflow evidence, slice reviews, aggregate DeepReview, PR review/fix/re-review, and operating documentation.

## Validation

- `164 passed` across the final aggregate research/ledger suite.
- `60 passed` in the focused storage/performance suite.
- Ruff checks, compile checks, and diff hygiene passed.
- Projection and storage acceptance runs used 5 warmups and 30 measured repetitions on Apple M4 / Mac16,10.

## Performance evidence

- Fixed-output replay: p95 wall 0.357 s, p95 CPU 0.357 s — passes the Phase 1 reference threshold.
- 5,000 retained closed lots: p95 wall 2.849 s, p95 CPU 2.739 s — fails, confirming retained-history/write amplification remains material.
- Research-storage status, 10,000 declared partitions: p95 wall 4.064 s and Python peak allocation 18.97 MB — passes the frozen 5 s / 64 MiB budget.
- Manifest-reference optimization reduced the representative uninstrumented sample from about 5.29 s to 3.75 s p95 in a 1-warmup/5-repetition diagnostic.
- Existing full-replay writer remains ineligible for Phase 3A; lot-diff publication is not implemented, so the combined readiness decision is `not_ready`.

## Safety and scope

This PR is Phase 1 instrumentation, contract, and read-only collector optimization only. It does not mutate production data, change schemas or runtime configuration, send notifications, deploy services, release a version, or alter ledger authority. The storage benchmark reads metadata/manifests/filesystem sizes only and records zero payload-content reads and zero runtime mutations.