### PR TITLE
feat: capture official Sell Put recommendation points

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 928 (`src`: 498, `domain`: 75, `scripts`: 9, `tests`: 346)
-- Internal import edges: 6016 total, 2509 production/script edges excluding tests
+- Python files scanned: 931 (`src`: 500, `domain`: 75, `scripts`: 9, `tests`: 347)
+- Internal import edges: 6038 total, 2519 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,7 +31,7 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|387| domain
+  application -->|388| domain
   application -->|4| domain_services
   application -->|132| infrastructure
   application -->|41| storage
@@ -45,8 +45,8 @@ flowchart LR
   scripts -->|13| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2618| application
-  tests -->|427| domain
+  tests -->|2627| application
+  tests -->|429| domain
   tests -->|2| domain_services
   tests -->|167| infrastructure
   tests -->|221| interfaces
@@ -58,7 +58,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 387 |
+| application | domain | 388 |
 | interfaces | application | 140 |
 | application | infrastructure | 132 |
 | application | storage | 41 |
@@ -77,8 +77,8 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2618 |
-| tests | domain | 427 |
+| tests | application | 2627 |
+| tests | domain | 429 |
 | tests | interfaces | 221 |
 | tests | infrastructure | 167 |
 | tests | storage | 18 |
@@ -91,7 +91,7 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 
 | from | to | imports |
 |---|---|---|
-| src.application | domain.domain | 199 |
+| src.application | domain.domain | 200 |
 | src.interfaces | src.application | 113 |
 | src.application | src.infrastructure | 93 |
 | src.application.ledger | domain.domain | 49 |
@@ -128,6 +128,7 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 | src.application.setup | src.application | 5 |
 | src.interfaces | src.application.ledger | 5 |
 | domain.services | domain.domain | 5 |
+| src.application.ledger | src.application | 4 |
 | src.application.positions | src.application.ledger | 4 |
 | src.application.settings | src.application | 4 |
 | src.interfaces | src.application.settings | 4 |
@@ -135,7 +136,6 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 | domain.domain | domain.domain.engine | 4 |
 | src.application | src.application.research | 3 |
 | src.application.inbound | src.infrastructure | 3 |
-| src.application.ledger | src.application | 3 |
 | src.application | domain.services | 3 |
 | src.application.research | src.application.ledger | 3 |
 | src.infrastructure | domain.domain | 3 |
@@ -190,8 +190,8 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | src.application.settings | 23 |
 | domain.domain.trade_contract_identity | 23 |
 | src.application.agent_tools.runtime_helpers | 22 |
+| domain.domain.decision_state_fingerprint | 22 |
 | src.application.config_sections | 21 |
-| domain.domain.decision_state_fingerprint | 21 |
 
 ### Highest Fan-Out Production Modules
 
@@ -205,13 +205,13 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | src.interfaces.cli.option_positions | 25 |
 | src.application.ledger.queries | 24 |
 | src.application.ledger.writer | 24 |
+| src.application.tick_notification_flow | 24 |
 | src.application.agent_tools.diagnostics | 23 |
 | src.application.channels.wechat_clawbot.inbound | 23 |
 | src.application.multi_tick.required_data_prefetch | 23 |
 | src.application.close_advice_runner | 22 |
 | src.application.daily_decision_brief_service | 22 |
 | src.application.ledger.api | 22 |
-| src.application.pipeline_runtime | 22 |
 
 ## Reading
 

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  src_application["src.application"] -->|199| domain_domain["domain.domain"]
+  src_application["src.application"] -->|200| domain_domain["domain.domain"]
   src_interfaces["src.interfaces"] -->|113| src_application["src.application"]
   src_application["src.application"] -->|93| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|49| domain_domain["domain.domain"]
@@ -37,6 +37,7 @@ flowchart LR
   src_application_setup["src.application.setup"] -->|5| src_application["src.application"]
   src_interfaces["src.interfaces"] -->|5| src_application_ledger["src.application.ledger"]
   domain_domain["domain.domain"] -->|4| domain_domain_engine["domain.domain.engine"]
+  src_application_ledger["src.application.ledger"] -->|4| src_application["src.application"]
   src_application_positions["src.application.positions"] -->|4| src_application_ledger["src.application.ledger"]
   src_application_settings["src.application.settings"] -->|4| src_application["src.application"]
   src_interfaces["src.interfaces"] -->|4| src_application_research["src.application.research"]
@@ -44,7 +45,6 @@ flowchart LR
   src_application["src.application"] -->|3| domain_services["domain.services"]
   src_application["src.application"] -->|3| src_application_research["src.application.research"]
   src_application_inbound["src.application.inbound"] -->|3| src_infrastructure["src.infrastructure"]
-  src_application_ledger["src.application.ledger"] -->|3| src_application["src.application"]
   src_application_research["src.application.research"] -->|3| src_application_ledger["src.application.ledger"]
   src_infrastructure["src.infrastructure"] -->|3| domain_domain["domain.domain"]
   src_interfaces["src.interfaces"] -->|3| src_application_positions["src.application.positions"]

--- a/docs/gateflow/sell-put-top1-w2/aggregate-review.md
+++ b/docs/gateflow/sell-put-top1-w2/aggregate-review.md
@@ -1,0 +1,23 @@
+# Gateflow Aggregate DeepReview — Sell Put Top1 W2
+
+- Gate: `aggregate review`
+- Work unit: `sell-put-top1-w2`
+- Reviewed range: `origin/main...2d00aab3`
+- Review artifact: `docs/reviews/code-review-20260815-105101.md`
+- Status: pass; no unresolved finding; ready for Draft PR gate
+
+## Result
+
+Kimi independently reviewed the committed W2 slice against the accepted plan and found no substantive issue. The committed implementation and initial-review target are equivalent, and no code or test fix was required.
+
+## Verification
+
+- Focused W2 suite: `145 passed`.
+- Regression suite: `88 passed` from the implementation gate.
+- Ruff: pass.
+- The two new modules have zero BasedPyright errors; W2 adds no error to the touched notification-flow baseline.
+- Dependency graph: current, `production_modules=584`, `cycles=0`.
+- Full sandbox run: `4864 passed, 10 skipped`; all nine environment-only failures were separately reproduced as passing under the required worktree/loopback conditions.
+- Aggregate review: no plan drift, review-artifact drift, overdesign, or unresolved finding.
+
+No release, deployment, service/config change, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed by this gate.

--- a/docs/gateflow/sell-put-top1-w2/draft-pr-pass.md
+++ b/docs/gateflow/sell-put-top1-w2/draft-pr-pass.md
@@ -1,0 +1,37 @@
+# Gateflow Draft PR Pass — Sell Put Top1 W2
+
+## Gate
+
+- Work unit: `sell-put-top1-w2`
+- Gate: `draft-PR-pass`
+- Date: `2026-08-15`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/159`
+- Base: `main@c626e965`
+- Accepted PR-review head: `e570abb866e6a1e46e212c2e2eb9da825cc72ddf`
+- PR review: `docs/reviews/code-review-20260815-105608.md`
+- State: `OPEN`, `DRAFT`, `MERGEABLE`, merge state `CLEAN`
+
+## Entry criteria
+
+- [x] PR commits and 21-file payload exactly match the Gateflow-accepted W2 sequence; Kimi found no push drift.
+- [x] Recommendation-point identity, binding, write-once publication, observer ordering/exclusion/failure isolation, and source extraction remain within the accepted scope.
+- [x] Initial, aggregate, and PR-level Kimi DeepReviews passed with no unresolved finding.
+- [x] Focused W2 suite passed: `145 passed`; regression suite passed: `88 passed`.
+- [x] Ruff, type-baseline, and dependency-graph checks passed.
+- [x] Agent Plugin, Guardrails, CodeQL Actions, CodeQL Python, and CodeQL summary checks passed on the accepted PR-review head.
+
+## Residual risks and owners
+
+- The outside-sandbox full-suite wait near 87% remains a repository-level environment diagnosis and is not represented as a pass; the complete sandbox run and each environment-only failure were separately closed.
+- `official_point_missing` consumption remains W4 ownership; env service/profile rendering remains W7 ownership.
+- W2 is default-off and cannot start an experiment, modify strategy parameters, or affect provider/delivery success.
+
+## Safety boundary
+
+No release, deployment, service/configuration change, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed.
+
+## Conclusion
+
+`draft-PR-pass`.
+
+Current gate / next entry point: final closeout, final CI, then merge under the user's explicit authorization.

--- a/docs/gateflow/sell-put-top1-w2/final-closeout.md
+++ b/docs/gateflow/sell-put-top1-w2/final-closeout.md
@@ -1,0 +1,45 @@
+# Gateflow Final Closeout — Sell Put Top1 W2
+
+## Gate
+
+- Work unit: `sell-put-top1-w2`
+- Gate: `final closeout`
+- Date: `2026-08-15`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/159`
+- Base: `main@c626e965`
+- Accepted plan: `8723571f`
+- Accepted implementation: `2d00aab3`
+- Accepted aggregate review: `a1276de6`
+- Draft-PR readiness: `e570abb8`
+- Verified draft-PR-pass: `d3fa6de0`
+
+## What changed
+
+1. W2 publishes a canonical, write-once `recommendation_point.v1` artifact for each eligible official scheduled Sell Put account/run point.
+2. The point is bound to scheduler target, terminal manifest bytes, opening snapshot, config/policy hashes, clean source commit, and the W1A producer accepted-candidate ordering.
+3. A default-off best-effort observer runs only after the existing scheduler-target commit and before notification delivery; observer failures cannot change the existing production result or provider path.
+4. The existing release-aware source-commit resolver is shared with the ledger migration without changing its compatibility behavior.
+
+## What was verified
+
+- Focused W2 suite: `145 passed`; regression suite: `88 passed`.
+- Ruff, type-baseline comparison, dependency graph, and `git diff --check`: passed.
+- Full sandbox suite completed with `4864 passed, 10 skipped`; nine environment-only failures were individually closed under their required worktree/loopback conditions.
+- Initial, aggregate, and PR-level Kimi DeepReviews passed with zero open finding and no push drift.
+- PR payload and local accepted slice are blob-identical.
+- Agent Plugin, Guardrails, CodeQL Actions, CodeQL Python, and CodeQL summary passed on both the accepted PR-review head and the draft-PR-pass head.
+
+## Remaining modules and risks
+
+- Persistent experiment lifecycle/account opt-in, corpus/outcome consumption, 40-day research, 20-day hidden validation, product experiment switch, Agent tools, and LLM hypothesis loop remain later work units.
+- `official_point_missing` after a committed watermark remains an intentional immutable gap for W4; W2 performs no retry or backfill.
+- W2 remains default-off until W7 owns service/profile rendering. It cannot start an experiment, alter a strategy parameter, select a winner, or affect delivery success.
+
+## Safety and workspace status
+
+- No release, tag, deployment, remote upgrade, service/configuration mutation, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed.
+- Unrelated user changes in the root worktree were not touched.
+
+## Completion and merge authorization
+
+W2 is complete at `final closeout pass`, subject only to the final mechanical GitHub checks for this documentation commit. The user explicitly authorized merge; after those checks pass, PR #159 may be marked Ready and merged. Release and deployment remain separate and unauthorized.

--- a/docs/gateflow/sell-put-top1-w2/goal-confirmation.md
+++ b/docs/gateflow/sell-put-top1-w2/goal-confirmation.md
@@ -1,0 +1,74 @@
+# Gateflow Goal Confirmation — Sell Put Top1 W2
+
+- Gate: `goal confirmation`
+- Work unit: `sell-put-top1-w2`
+- Branch: `feat/sell-put-top1-w2`
+- Base: `origin/main@9b29e05b`
+- Design documents:
+  - `docs/plans/sell-put-top1-optimization-loop-mvp-20260814.md`
+  - `docs/plans/sell-put-top1-modular-technical-implementation-plan-20260814.md`
+  - `docs/plans/sell-put-top1-modular-implementation-control-20260814.md`
+- Confirmation: the user approved the modular implementation documents and explicitly requested sequential Gateflow implementation with Kimi DeepReview after every module.
+- Artifact path: `docs/gateflow/sell-put-top1-w2/goal-confirmation.md`
+
+## Goal and motivation
+
+Publish one immutable `recommendation_point.v1` audit fact for each official scheduled Sell Put recommendation decision. This gives later corpus and experiment modules a producer-owned point identity without making the production tick depend on an experiment database or experiment state.
+
+## Success signals
+
+- A scheduled account pipeline with a committed scheduler watermark, valid terminal candidate manifest, and valid current opening snapshot publishes the canonical run/account point artifact.
+- Repeating the same point is idempotent; different bytes at the same run/account path fail closed.
+- The point binds the canonical scheduler target, terminal manifest, opening snapshot, producer accepted Sell Put IDs, policy/config hashes, decision clock, and source commit.
+- W1A validates the clean point-to-opening-snapshot binding and accepted candidate IDs immediately.
+- Manual, force, smoke, replay, delivery-only, missing-target, failed-pipeline, or maintainer-disabled paths do not publish.
+- Any observer failure occurs only after a successful watermark commit and cannot change tick, watermark, or notification behavior.
+- Focused tests, architecture guard, Ruff, dependency graph, and available type checks pass before Kimi DeepReview.
+
+## Scope boundary
+
+### Included
+
+- `recommendation_point.v1` builder, strict validator, binding projection, loader, and run/account-scoped write-once publisher.
+- Exact `OM_STRATEGY_LAB_TOP1_AVAILABLE == "1"` process-environment read.
+- Minimal best-effort observer between scheduler watermark commit and notification delivery.
+- Reuse of the existing terminal candidate bundle loader, opening snapshot contract, W1A projection contract, and safe write-once state writer.
+- A shared production source-commit resolver only if the existing ledger-owned implementation must be reused by W2 without importing ledger migration code.
+
+### Excluded
+
+- Experiment SQLite, account opt-in, corpus capture, research, validation, outcomes, timers, CLI, Agent tools, LLM, and Prompt work.
+- A generic feature-flag service, observer framework, event bus, repository interface, registry, or retry/backfill mechanism.
+- Candidate Engine changes, filtering/ranking changes, production configuration changes, release, deployment, service installation, notification sends, or real experiments.
+
+## Direct code evidence
+
+- `src/application/tick_notification_flow.py::run_tick_notification_flow()` already commits scheduler scan targets through `_commit_scan_targets_before_delivery()` before provider delivery; this is the single required observer seam.
+- `src/application/tick_account_execution.py` already exposes the accounts whose pipelines ran and their account-scoped scheduled targets.
+- `src/application/candidate_snapshot_manifest.py::load_candidate_snapshot_bundle()` validates the terminal manifest, status index, exact owner files, and opening snapshot bindings.
+- `src/application/tick_run_workspace.py::write_account_run_state_bytes_once_safely()` already provides byte-level write-once/adopt/conflict semantics at the required run/account state path.
+- `src/application/strategy_lab/top1/ranking.py::build_ranking_projection()` already validates the W1A point binding, current opening snapshot, producer accepted IDs, and baseline parity.
+- The only existing release-aware clean source-commit resolver is private to ledger migration, so W2 must either extract that exact behavior to a narrow shared helper or fail to publish in installed release directories.
+
+## First-principles and overdesign judgment
+
+The point must exist because later modules cannot reconstruct an official scheduler decision after the source run is retained or deleted. One audit file and one observer call are sufficient. No persistent point database, automatic retry, backfill, generic flag system, or experiment orchestration is needed in W2.
+
+## Dirty-worktree ownership
+
+The primary worktree and all unrelated worktrees remain untouched. W2 owns only the isolated worktree `/private/tmp/options-monitor-sell-put-top1-w2-20260815` and its branch.
+
+## Blocking open questions
+
+None.
+
+## Residual risks
+
+- Source-run retention and long-lived corpus copying are assigned to W4.
+- Account opt-in and effective two-layer feature gating are assigned to W3 and later feature surfaces; the producer observer reads only the maintainer availability gate.
+- Runtime service/profile rendering of the new availability variable is assigned to W7; W2 only consumes the already-loaded process environment.
+- Real pilot/provider readiness remains governed by W0R and does not block this synthetic producer seam.
+
+## Decision
+
+`goal-confirmation-pass`; next gate: `plan`.

--- a/docs/gateflow/sell-put-top1-w2/implementation.md
+++ b/docs/gateflow/sell-put-top1-w2/implementation.md
@@ -1,0 +1,36 @@
+# Gateflow Implementation — Sell Put Top1 W2
+
+- Gate: `implementation`
+- Work unit: `sell-put-top1-w2`
+- Accepted plan commit: `8723571f`
+- Implementation base: `origin/main@c626e965`
+- Branch: `feat/sell-put-top1-w2`
+- Status: implementation verified; initial Kimi DeepReview passed; ready for accepted-slice commit
+
+## Implemented scope
+
+- Added the strict `recommendation_point.v1` identity, validation, source binding, canonical byte encoding, and write-once publication contract for official scheduled Sell Put points.
+- Added one default-off, best-effort observer immediately after the existing scheduler-target commit and before notification delivery. Manual, force, delivery-only, failed, and identity-incomplete paths do not publish.
+- Reused the terminal candidate bundle, opening snapshot, W1A ranking projection, and safe run-state writer. No experiment store, lifecycle, scheduler, Candidate Engine, provider, or production config behavior was added.
+- Extracted the existing release-aware source-commit resolver into one shared module; the ledger migration retains its compatibility wrapper and behavior.
+
+## Validation evidence
+
+- Focused W2 suite: `145 passed` in Kimi's independent run; the implementation-owner planned run passed before review.
+- Regression suite: `88 passed`.
+- Ruff over all changed production/test files: pass.
+- BasedPyright error-level check for the two new modules: `0 errors, 0 warnings, 0 notes`; the touched notification-flow file has the same 24 pre-existing errors as `origin/main` and W2 adds none.
+- Dependency graph: current, `production_modules=584`, `cycles=0`.
+- Full repository sandbox run: `4864 passed, 10 skipped`; nine environment-only failures were classified as one denied loopback bind and eight missing worktree-local `.venv` entrypoint failures. The complete entrypoint file then passed with a temporary verified `.venv` symlink (`10 passed`), and the exact loopback test passed outside the sandbox (`1 passed`). The temporary symlink was removed.
+- A redundant outside-sandbox full-suite attempt made progress without failure to the repository's known slow point near 87% and was interrupted without a summary; it is not claimed as a pass.
+- `git diff --check`: pass.
+
+## Kimi review closure
+
+- Initial report: `docs/reviews/code-review-20260815-103446.md`.
+- Result: pass with no finding after independent source-flow, contract, concurrency, failure-isolation, architecture, test, lint, type-baseline, and dependency-graph review.
+- No implementation fix was required.
+
+## Remaining gate boundary
+
+The implementation is ready for an accepted-slice commit. A separate aggregate Kimi DeepReview must pass before Draft PR creation. Release, deployment, service/config changes, runtime writes, and real experiment execution remain outside this work unit.

--- a/docs/gateflow/sell-put-top1-w2/plan-fix.md
+++ b/docs/gateflow/sell-put-top1-w2/plan-fix.md
@@ -1,0 +1,52 @@
+# Gateflow Plan Fix — Sell Put Top1 W2
+
+- Gate: `plan review -> fix`
+- Work unit: `sell-put-top1-w2`
+- Plan: `docs/gateflow/sell-put-top1-w2/plan.md`
+- Review: `docs/reviews/plan-review-20260815-100136.md`
+- Artifact path: `docs/gateflow/sell-put-top1-w2/plan-fix.md`
+
+## Finding decision
+
+### PR-W2-01 — accepted — fixed
+
+The plan no longer assumes that `partial_data` or `data_unavailable` implies an empty producer accepted set.
+
+Changes:
+
+- Every point now preserves the ordered accepted Sell Put IDs from the validated opening snapshot.
+- Clean `candidates_found/no_candidate` points must pass W1A projection and match its accepted IDs exactly.
+- Incomplete `partial_data/data_unavailable` points must remain non-evaluable by W1A, but may still retain accepted IDs from usable sibling scopes.
+- The point validator only derives hard cardinality rules for clean statuses: `candidates_found` is non-empty and `no_candidate` is empty.
+- Added an explicit mixed-scope fixture: one successful Sell Put scope with a candidate plus one failed sibling scope must publish an incomplete point, retain the accepted ID, and fail W1A projection.
+- Clarified that the builder recomputes the terminal manifest byte hash from its canonical payload.
+
+Final status: `已修复`.
+
+## Validation
+
+- The correction maps directly to the confirmed goal of preserving every official scheduled producer decision.
+- It adds no schema key, state, store, workflow, or later-module behavior.
+- W1A remains the evaluability boundary and does not become the point publisher.
+
+### PR-W2-02 — accepted — fixed
+
+The plan now keeps candidate rankability and Sell Put universe completeness separate:
+
+- It reuses `candidate_universe_summary()` and filters affected scopes to `strategy_mode=put`.
+- Aggregate `data_unavailable` remains the strongest status; otherwise any affected Sell Put scope forces point `partial_data`.
+- Every point attempts the W1A seam and compares IDs whenever W1A succeeds.
+- Only clean statuses require W1A success; an incomplete point stays non-evaluable even when its usable accepted subset can be projected.
+- Added a completed/`partial_data` scope with an accepted candidate fixture so W1A success cannot erase the incomplete point status.
+
+Final status: `已修复`.
+
+## Residual risks
+
+- Cross-run duplicate reconciliation: assigned to W4.
+- Post-watermark crash gap: assigned to W4 consumption semantics.
+- Service/profile delivery and account opt-in: assigned to W7 and W3.
+
+## Decision
+
+`fix complete`; next gate: `plan re-review`.

--- a/docs/gateflow/sell-put-top1-w2/plan.md
+++ b/docs/gateflow/sell-put-top1-w2/plan.md
@@ -1,0 +1,297 @@
+# Gateflow Plan — Sell Put Top1 W2
+
+- Gate: `plan`
+- Work unit: `sell-put-top1-w2`
+- Branch: `feat/sell-put-top1-w2`
+- Base: `origin/main@c626e965`
+- Goal contract: `docs/gateflow/sell-put-top1-w2/goal-confirmation.md`
+- Artifact path: `docs/gateflow/sell-put-top1-w2/plan.md`
+- Current gate: `accepted plan commit`
+
+## 1. Goal, motivation, and success signal
+
+Implement the producer-owned `recommendation_point.v1` seam for official scheduled Sell Put decisions. The production tick must publish at most one canonical run/account artifact after its scheduler target watermark is committed and before notification delivery, while all experiment and later corpus/lifecycle concerns remain absent.
+
+Completion is proven when scheduled eligible points publish idempotently, source conflicts fail closed, excluded triggers never publish, W1A validates the clean point/snapshot accepted set, and injected observer failures leave the existing tick result, scheduler commit, and provider path unchanged.
+
+## 2. Non-goals and scope boundary
+
+### Included
+
+- Strict point identity, payload, source-binding, load, and byte-level write-once contracts.
+- Exact maintainer availability read from the already-loaded process environment.
+- One best-effort notification-flow observer immediately after scheduler-target commit.
+- Narrow extraction of the existing release-aware source-commit resolver so W2 and the existing ledger migration share one implementation.
+- Focused contract, seam, architecture, and regression tests.
+
+### Excluded
+
+- SQLite, account opt-in, effective two-layer feature status, corpus, research, validation, outcomes, timers, CLI/tools, LLM, Prompt, backfill, retry queues, or permanent point storage.
+- Candidate Engine, filters, ranks, production config, scheduler rules, watermark semantics, notification policy/provider behavior, release, deployment, or service changes.
+- Generic observer, feature-flag, provenance, repository, workflow, or event abstractions.
+
+## 3. Goal alignment
+
+| Decision or validation | Confirmed goal / success signal |
+|---|---|
+| One run/account point file | Producer-owned official recommendation identity without a new database |
+| Observer after watermark and before delivery | Point means the official target was committed but is independent of provider delivery |
+| W1A projection call during clean-point build | Validate snapshot binding and producer accepted IDs now, not first in W4 |
+| Exact process env gate | Default-off and removable experimental feature without a flag platform |
+| Shared source-commit extraction | Preserve the already-tested installed-release behavior without importing ledger migration or duplicating it |
+| Broad exception containment at observer boundary | Production tick, watermark, and notification remain authoritative |
+
+## 4. Design-document alignment
+
+- MVP §4.3: only `OM_STRATEGY_LAB_TOP1_AVAILABLE == "1"` enables the producer observer; it does not read account opt-in or experiment state.
+- MVP §7.1: identity is market/account/strategy/target based; only scheduled, actually-run, watermark-committed account pipelines can publish; notification delivery is not a precondition.
+- Modular technical plan M2: point is run/account-scoped, write-once, best-effort, and forbidden from M3–M8 dependencies.
+- Modular control W2: builder/validator/publisher, scheduled identity, manifest/opening bindings, excluded triggers, and W1A seam are all included; nothing from W3 or W4 is pulled forward.
+
+## 5. First-principles judgment and direct code evidence
+
+- `run_tick_notification_flow()` already has the only correct ordering boundary: `_commit_scan_targets_before_delivery(request)` completes before any provider execution. One call immediately after it is enough.
+- `ran_pipeline_accounts`, `scheduler_decisions_by_account`, and `scheduled_scan_targets_by_account` already carry the account execution/identity facts. No new tick DTO or event bus is needed.
+- `load_candidate_snapshot_bundle()` already verifies the terminal manifest, status index, exact owner set, file hashes, opening snapshot current contract, config hash, and policy hash. W2 must consume it rather than reimplement those checks.
+- `write_account_run_state_bytes_once_safely()` already provides no-follow, atomic link, same-byte adoption, and different-byte conflict semantics. W2 only supplies canonical bytes and a domain error mapping.
+- `build_ranking_projection()` already validates the point binding against the opening snapshot and derives the ordered accepted Sell Put IDs with baseline parity. W2 calls it for evaluable `candidates_found` / `no_candidate` points and records its accepted IDs.
+- The private ledger `_source_commit()` already supports both Git worktrees and installed release directories backed by the upgrade cache, and rejects dirty production source. Extracting those exact lines is smaller and safer than a second resolver.
+
+## 6. Contract and schema
+
+### 6.1 Constants
+
+```text
+RECOMMENDATION_POINT_SCHEMA = "recommendation_point.v1"
+RECOMMENDATION_POINT_FILE = "recommendation_point.sell_put.json"
+STRATEGY_FAMILY = "sell_put"
+AVAILABILITY_ENV = "OM_STRATEGY_LAB_TOP1_AVAILABLE"
+```
+
+### 6.2 Canonical identity
+
+`build_recommendation_point_id(market, account, scheduled_scan_target_market)` first canonicalizes the timezone-aware target to UTC ISO-8601 `Z`, then returns `canonical_sha256()` of exactly:
+
+```json
+{
+  "schema_version": "recommendation_point.v1",
+  "market": "HK|US",
+  "account": "lowercase",
+  "strategy_family": "sell_put",
+  "scheduled_scan_target_market": "<UTC ISO-8601 Z>"
+}
+```
+
+Run ID, execution time, source commit, candidate rows, and notification state are deliberately absent, so a retry/catch-up for the same official target has the same identity.
+
+### 6.3 Exact point fields
+
+`recommendation_point.v1` has no optional or extra top-level keys:
+
+```text
+schema_version
+recommendation_point_id
+strategy_family
+market
+account
+run_id
+scheduled_scan_target_market
+decision_at_utc
+terminal_sell_put_status
+account_config_sha256
+strategy_policy_sha256
+terminal_manifest_ref
+terminal_manifest_sha256
+opening_snapshot_ref
+opening_snapshot_sha256
+source_commit_sha
+producer_accepted_candidate_ids
+content_sha256
+```
+
+Semantics:
+
+- target and decision time are canonical UTC `Z` values; target comes from account scheduler `scheduled_scan_target_market`, decision time from scheduler `now_utc`;
+- `terminal_sell_put_status` is exactly one of `candidates_found`, `no_candidate`, `partial_data`, `data_unavailable`;
+- `producer_accepted_candidate_ids` always preserves the opening snapshot's ordered accepted Sell Put IDs, including incomplete points that retain usable candidates from some scopes;
+- `candidates_found` requires at least one accepted ID and `no_candidate` requires an empty list; `partial_data/data_unavailable` may have zero or more accepted IDs and are never inferred from list length;
+- status combines the existing aggregate Sell Put result with `candidate_universe_summary()` completeness: an aggregate `data_unavailable` remains `data_unavailable`; otherwise any affected `strategy_mode=put` scope forces `partial_data`; only an unaffected Sell Put universe may remain clean `candidates_found/no_candidate`;
+- `terminal_manifest_ref` is exactly `output_runs/<run_id>/accounts/<account>/state/candidate_snapshot_manifest.v1.json` and its hash is the SHA-256 of canonical file bytes; the builder recomputes the supplied hash from the exact canonical manifest payload so a valid dict cannot be paired with an unrelated file hash;
+- `opening_snapshot_ref` is exactly `output_runs/<run_id>/accounts/<account>/state/opening_candidate_snapshot.json` and its hash is the opening snapshot `content_sha256`, matching W1A;
+- config/policy hashes must match both terminal manifest and opening snapshot;
+- source commit is exactly 40 lowercase hex characters;
+- `content_sha256` is `canonical_sha256(payload_without_content_sha256)`;
+- persisted bytes are sorted, indented, no-NaN UTF-8 JSON plus one newline.
+
+### 6.4 Public functions
+
+`src/application/recommendation_point.py` adds:
+
+```text
+strategy_lab_top1_available(environ=None) -> bool
+build_recommendation_point_id(market, account, scheduled_scan_target_market) -> str
+build_recommendation_point(scheduler_decision, terminal_manifest, opening_snapshot, *, terminal_manifest_sha256, source_commit_sha) -> dict
+validate_recommendation_point(payload) -> dict
+point_binding_from_recommendation_point(payload) -> dict
+publish_recommendation_point(base, payload) -> "published" | "idempotent"
+load_recommendation_point(base, run_id, account) -> dict
+capture_scheduled_recommendation_point(base, run_id, account, scheduler_decision, *, source_commit_sha) -> (status, payload)
+```
+
+`RecommendationPointError.reason_code` is limited to current boundary failures such as `official_point_invalid`, `official_point_identity_missing`, `official_point_source_unavailable`, `official_point_unavailable`, and `official_point_conflict`. Conflict is raised, not returned as a successful publication state.
+
+## 7. Source and binding validation
+
+`capture_scheduled_recommendation_point()`:
+
+1. loads `load_candidate_snapshot_bundle(base, run_id, account)`;
+2. reads and hashes the exact terminal manifest bytes through the safe run-state reader;
+3. requires the bundle's `opening` owner;
+4. calls the strict builder;
+5. publishes/adopts canonical point bytes and returns status plus payload.
+
+The builder:
+
+1. requires scheduler `should_run_scan is True`, a timezone-aware scheduled scan target, and a timezone-aware decision clock;
+2. validates the terminal manifest and current opening snapshot contracts;
+3. requires run/account/market/config/policy and manifest opening-owner bindings to agree;
+4. requires at least one terminal Sell Put scope and exactly one Sell Put strategy result, combines that result with existing `candidate_universe_summary()` affected Sell Put scopes to derive the point status, then derives ordered accepted Sell Put IDs from the validated opening snapshot;
+5. attempts W1A `build_ranking_projection()` with the point binding for every point; whenever it succeeds, its ordered accepted IDs must match exactly;
+6. clean `candidates_found` / `no_candidate` requires W1A success; `partial_data` / `data_unavailable` remains non-evaluable by point status whether W1A succeeds on the usable accepted subset or fails closed, and still publishes all producer facts;
+7. validates the final strict point before returning it.
+
+The point's binding projection contains exactly W1A's existing keys: point ID, market, account, run ID, opening ref/hash, decision time, and source commit.
+
+## 8. Observer state transition and error handling
+
+`run_tick_notification_flow()` keeps its current preparation and commit behavior, then performs:
+
+```text
+_commit_scan_targets_before_delivery(request)  # existing, authoritative; may raise
+_observe_recommendation_points_best_effort(request)  # new, never raises out
+existing notification branch/provider behavior
+```
+
+Observer eligibility is the conjunction of:
+
+- `trigger_kind == "scheduled"`;
+- not `delivery_only`;
+- maintainer availability is exactly enabled;
+- account is in `ran_pipeline_accounts`;
+- account has a non-empty committed target in `scheduled_scan_targets_by_account`;
+- account scheduler decision exists, has `should_run_scan is True`, and its canonical target equals the committed target;
+- one clean source commit SHA is resolvable.
+
+Manual, force, replay-like unknown trigger kinds, smoke/failed pipelines (no ran account), delivery-only, disabled availability, or missing identity are skipped or recorded as a point gap and never call the publisher. Each account is isolated: one account failure does not block another. Audit attempts are themselves exception-contained. No retry/backfill occurs because a post-watermark missing point is a meaningful `official_point_missing` gap.
+
+## 9. Source identity extraction
+
+Add `src/application/source_identity.py::source_commit_sha(root=None, run_cmd=None)` by moving the existing algorithm unchanged:
+
+- Git worktree: resolve `HEAD`, require no tracked or untracked changes under `domain`, `src`, or `scripts`;
+- installed release: resolve `v<VERSION>^{commit}` from the existing upgrade cache with a temporary index and apply the same clean-source check;
+- timeout/command/source failure: return `None`.
+
+`position_projection_migration._source_commit()` remains as a compatibility wrapper passing its module `subprocess.run`, preserving existing monkeypatch tests and callers. No ledger behavior changes.
+
+## 10. Affected files
+
+### Production
+
+- New `src/application/recommendation_point.py`.
+- New `src/application/source_identity.py`.
+- Modify `src/application/ledger/position_projection_migration.py` only to delegate its private compatibility function to the shared resolver and remove moved imports.
+- Modify `src/application/tick_notification_flow.py` only for imports, one post-commit observer call, and a narrow private best-effort helper.
+
+### Tests and generated documentation
+
+- New `tests/test_recommendation_point.py`.
+- Modify `tests/test_daily_decision_brief_notification_flow.py` for observer ordering/exclusion/failure isolation.
+- Modify `tests/test_strategy_lab_top1_architecture.py` to forbid M2 dependencies on experiment stores and M3–M8 modules.
+- Existing `tests/test_position_projection_migration.py` remains the regression authority for source identity behavior; change only if extraction requires import-path alignment not covered by the compatibility wrapper.
+- Regenerate `docs/DEPENDENCY_GRAPH.md` and `docs/dependency_graph.mmd` only if the repository graph check reports the expected new import edges.
+- Add Gateflow/review artifacts; do not edit product design documents or public operator docs because W2 adds no public command/config surface.
+
+## 11. Implementation slice
+
+One slice is sufficient because the artifact contract and its observer call form one deployable behavior; splitting by file would add review gates without producing an independently useful product increment.
+
+### S1 — Official scheduled point publication seam
+
+- Objective: publish a strict point after successful official target commit without changing production control flow.
+- Allowed production files: the four production paths listed in §10.
+- Allowed test/docs files: the test, generated dependency graph, Gateflow, and review artifacts listed in §10.
+- Prerequisites: merged W1A contracts on `origin/main`; valid terminal candidate bundle fixtures.
+- Exact changes: §§6–9 only.
+- Non-goals: all §2 exclusions.
+- Completion signal: every expected assertion in §12 passes, Kimi code/aggregate/PR reviews have no unresolved accepted finding, and the accepted slice/deepreview/PR review commits exist.
+- Stop condition: any required change to Candidate Engine, scheduler/watermark semantics, experiment DB/schema, account opt-in, public config, service rendering, release/deployment, or actual notification/experiment execution requires a new user decision.
+
+## 12. Tests and validation
+
+### Contract and publisher tests
+
+`tests/test_recommendation_point.py` must prove:
+
+- offset-equivalent targets produce the same UTC target and point ID; account/market/target changes alter the ID;
+- a valid manifest-bound candidates-found point has exact keys, expected refs/hashes/status/accepted IDs, valid content hash, and a W1A projection whose accepted IDs equal the point;
+- clean no-candidate is valid; unavailable/partial evidence may preserve accepted IDs but remains non-evaluable by point status even if W1A can project its usable subset;
+- one successful Sell Put scope with an accepted candidate plus one failed sibling scope publishes an incomplete point, preserves the accepted ID, and is rejected by W1A projection rather than dropped;
+- a completed Sell Put scope carrying `reason=partial_data` plus an accepted candidate is normalized to point status `partial_data`; its IDs are retained and any successful W1A subset projection cannot make the point clean;
+- scheduler false/missing/naive target, naive decision clock, wrong source hash, point/snapshot/manifest/config/policy mismatch, unsafe/tampered refs, unexpected keys, content-hash drift, and inconsistent IDs fail closed;
+- first publish returns `published`, exact replay returns `idempotent`, different canonical bytes at the same path raise `official_point_conflict`, and load rejects non-canonical/tampered bytes;
+- availability is true only for exact value `1`;
+- capture uses the exact terminal bundle and does not depend on an experiment store.
+
+### Tick seam tests
+
+`tests/test_daily_decision_brief_notification_flow.py` must prove:
+
+- order is `watermark commit -> observer -> provider`;
+- observer success and observer exception both preserve the pre-existing return code and provider execution;
+- commit failure prevents observer and provider exactly as before;
+- disabled availability, manual, force, delivery-only, empty `ran_pipeline_accounts`, and missing/mismatched target never call capture;
+- a failing account does not prevent a second eligible account from being observed.
+
+### Regression and architecture commands
+
+Run from the W2 worktree with the existing project Python 3.12 environment:
+
+```text
+python -m pytest -q tests/test_recommendation_point.py tests/test_daily_decision_brief_notification_flow.py tests/test_position_projection_migration.py tests/test_strategy_lab_top1.py tests/test_strategy_lab_top1_architecture.py
+python -m pytest -q tests/test_candidate_snapshot_manifest.py tests/test_opening_candidate_snapshot.py tests/test_multi_account_tick.py tests/test_tick_account_execution_barrier.py
+ruff check src/application/recommendation_point.py src/application/source_identity.py src/application/ledger/position_projection_migration.py src/application/tick_notification_flow.py tests/test_recommendation_point.py tests/test_daily_decision_brief_notification_flow.py tests/test_strategy_lab_top1_architecture.py
+basedpyright src/application/recommendation_point.py src/application/source_identity.py src/application/tick_notification_flow.py
+python scripts/generate_dependency_graph.py --check
+python -m pytest -q
+```
+
+Expected: focused tests and static checks pass; dependency graph has no cycle; full-suite failures, if any, are classified with exact evidence and cannot be used to claim a broad pass without completion.
+
+## 13. Docs decision
+
+No public documentation or config example changes in W2. The env variable is already the accepted product contract but service/profile authoring belongs to W7. Gateflow artifacts record the internal schema and seam; generated dependency graph changes are mechanical only.
+
+## 14. Risks, open questions, and residual ownership
+
+- Git/source resolution latency or unavailability: current slice fails open for production behavior and records a point gap; no cache or fallback identity is added. Owner: W2 behavior, tested synthetically.
+- Point lost after watermark due crash/failure: intentional `official_point_missing`; W4 treats it as an immutable denominator gap. No backfill. Owner: W4 consumption.
+- Source `output_runs` retention: W4 copies the minimal projection before deletion. W2 adds no global store.
+- Availability service/profile rendering and account opt-in: W7 and W3 respectively.
+- Runtime provider/pilot readiness: W0R.
+- Blocking open questions: none.
+
+## 15. No-overdesign / no-goal-drift check
+
+The plan adds one artifact owner, one existing-flow call, and one shared extraction required by two current callers. It reuses every existing validation/write primitive and introduces no generic framework or future module. All other accepted product features remain assigned to their named later work units.
+
+## 16. Completion report format
+
+Final closeout will report:
+
+- changed production/test/generated-doc files and accepted commit hashes;
+- exact focused/full validation results and any environment-only limitations;
+- code, aggregate Kimi DeepReview, and PR review findings with final status;
+- Draft PR URL and CI state;
+- residual risks with W3/W4/W7/W0R ownership;
+- next entry point: merge authorization for W2, then W3 only after its dependency base is available.

--- a/docs/gateflow/sell-put-top1-w2/ready-to-open-draft-pr.md
+++ b/docs/gateflow/sell-put-top1-w2/ready-to-open-draft-pr.md
@@ -1,0 +1,35 @@
+# Gateflow Readiness — Sell Put Top1 W2 Draft PR
+
+- Gate: `ready-to-open-draft-PR`
+- Work unit: `sell-put-top1-w2`
+- Branch: `feat/sell-put-top1-w2`
+- Base: `origin/main@c626e965`
+- Accepted plan: `8723571f`
+- Accepted implementation: `2d00aab3`
+- Accepted aggregate review: `a1276de6`
+- Status: ready to publish branch and open Draft PR
+
+## Scope check
+
+- `origin/main...HEAD` contains only the accepted W2 goal/plan, recommendation-point seam, shared source identity extraction, focused tests, generated dependency graph, and review evidence.
+- W2 adds no experiment store, lifecycle, scheduling policy, Candidate Engine policy, account opt-in, CLI, Agent, Prompt/LLM, production config/service change, or experiment execution.
+- `origin/main` was refreshed immediately before this gate; it remains `c626e965`, equal to the branch merge base.
+- The worktree was clean and `git diff --check origin/main...HEAD` passed.
+
+## Validation
+
+- Focused W2 suite: `145 passed`.
+- Regression suite: `88 passed`.
+- Ruff: pass.
+- Two new modules: zero BasedPyright errors; W2 adds no error to the touched notification-flow baseline.
+- Dependency graph: current, `584` production modules, `0` cycles.
+- Initial and aggregate Kimi DeepReviews: pass, no unresolved finding.
+- Full sandbox suite: `4864 passed, 10 skipped`, with nine classified environment-only failures; the complete entrypoint file and exact loopback test passed under their required conditions.
+
+## Authority boundary
+
+Publishing the branch and opening a Draft PR are source-review actions only. The user's merge authorization applies only after PR-level Kimi DeepReview and required CI pass. This gate does not authorize release, deployment, service/configuration changes, runtime writes, real experiments, notifications, market-data reads, ledger writes, or broker actions.
+
+## Next transition
+
+Commit this readiness artifact, push the accepted branch, open a Draft PR, wait for CI, and run PR-level Kimi DeepReview before merge.

--- a/docs/reviews/code-review-20260815-103446.md
+++ b/docs/reviews/code-review-20260815-103446.md
@@ -1,0 +1,52 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Branch or PR: `feat/sell-put-top1-w2`（本地 worktree，未提交实现）
+- Base: `origin/main@c626e965`
+- Worktree: `/private/tmp/options-monitor-sell-put-top1-w2-20260815`
+- Output file: `docs/reviews/code-review-20260815-103446.md`
+- Included scope: 相对基线的全部 W2 改动 — 已提交 Gateflow plan（`8723571f`，含 plan/plan-fix/goal-confirmation/三份 plan-review）+ 未提交实现（新增 `src/application/recommendation_point.py` 534 行、`src/application/source_identity.py` 94 行、`tests/test_recommendation_point.py` 479 行；修改 `tick_notification_flow.py` +156、`position_projection_migration.py` 净 -69、`tests/test_daily_decision_brief_notification_flow.py` +162、`tests/test_strategy_lab_top1_architecture.py` +20；依赖图文档机械再生）
+- Excluded scope: W0R 运行时实证、W3+ 后续模块、生产 config/service/notify 行为变更（本切片未触碰）
+- Parallel review coverage: 无；端到端独立审查实现与计划的一致性、真实调用链、契约与失败语义
+- 计划依据: `docs/gateflow/sell-put-top1-w2/{plan.md,plan-fix.md}`（两轮 plan re-review 均 pass）
+
+## Verified Facts（本轮实际执行）
+
+- 聚焦套件（计划 §12 第一组）：`145 passed`（test_recommendation_point + test_daily_decision_brief_notification_flow + test_position_projection_migration + test_strategy_lab_top1 + test_strategy_lab_top1_architecture）。
+- 回归套件（计划 §12 第二组）：`88 passed`（candidate_snapshot_manifest / opening_candidate_snapshot / multi_account_tick / tick_account_execution_barrier）。
+- Ruff（计划列出的 7 个文件）：`All checks passed!`。
+- `scripts/generate_dependency_graph.py --check`：OK，`production_modules=584 cycles=0`；已提交的 DEPENDENCY_GRAPH.md 与当前代码一致（机械再生）。
+- basedpyright 1.39.3 对 3 个生产文件：`recommendation_point.py` / `source_identity.py` 为 0 error；`tick_notification_flow.py` 有 24 个 `reportArgumentType` error，但基线 `c626e965` 同文件独立检查同样为 24 error（同一批 confirm/record delivery 调用，行号随 W2 插入平移）——**W2 未新增类型错误**。
+- `source_identity.py` 与基线 `position_projection_migration._source_commit()` 删除的 73 行逐行比对：算法完全一致；compat wrapper 传 `run_cmd=subprocess.run`，`monkeypatch.setattr(module.subprocess, "run", fake_run)` 对模块属性的打桩经 wrapper 继续生效，`test_position_projection_migration.py` 全套未改且通过。
+- 新架构守卫精确覆盖 `recommendation_point.py` 的全部 14 个 import，且不含任何 M3–M8 / experiment store 依赖。
+- 真实调用链核实：`multi_account_tick.main` 以 `repo_root = Path(__file__).resolve().parents[2]`（真实源码根）构造请求；observer 中 `source_commit_sha((request.repo_root or request.base).resolve())` 正确优先 repo_root；observer 调用点位于 `_commit_scan_targets_before_delivery(request)` 之后、scheduled 分支与 provider 执行之前，与计划 §8 状态机一致。
+- 顺序证明测试：`order == ["commit", "observer", "provider"]`；commit 失败时 observer 与 provider 均不执行；observer 抛错不改变返回码与 provider 执行。
+- write-once 语义核实：底层 `_write_once_or_adopt_at` 为 O_NOFOLLOW 临时文件 + `os.link` 原子 publish + FileExistsError 时同字节 adopt / 异字节 conflict + 发布后回读校验；`publish_recommendation_point` 的同字节幂等、异字节 `official_point_conflict`、写失败补救读取语义均与该原语对齐。
+- 幂等/并发：两个并发发布者产生同一 canonical bytes 时一方 `os.link` 失败→同字节 adopt→`idempotent`；异字节→conflict 上抛，不做重试/回填，符合计划 §8 "post-watermark missing point 是有意义的 gap"。
+- Scheduler eligibility 核实：`trigger_kind=="scheduled"` ∧ 非 delivery_only ∧ env 精确等于 `"1"` ∧ account ∈ ran_pipeline_accounts ∧ committed target 非空 ∧ decision.should_run_scan is True ∧ decision target 与 committed target 规范化后相等；8 个排除路径（disabled/manual/force/delivery_only/not_run/target_missing/target_mismatch/source_unavailable）均有测试且 capture 零调用；账户间隔离（lx 失败不影响 sy）有测试。
+- partial/data_unavailable 保守语义（plan-fix PR-W2-01/02）核实：聚合 `data_unavailable` 最强优先；否则任何 affected `strategy_mode=put` scope → `partial_data`；clean 状态必须 W1A `build_ranking_projection` 成功且 accepted IDs 精确一致；incomplete 状态保留 accepted IDs 但 W1A 失败不影响发布、W1A 成功也不能把点变 clean（`partial-completed` fixture 证明）；`candidates_found` 要求非空、`no_candidate` 要求为空的基数规则仅在 clean 状态强制。
+- manifest/opening snapshot 绑定核实：`capture_scheduled_recommendation_point` 复用 `load_candidate_snapshot_bundle`（自身已校验 manifest 链、owner 集合、文件 hash、opening current contract、config/policy hash），另回读 manifest 原始字节并断言与 canonical bytes 逐字节相等；builder 重算 manifest payload 的 canonical SHA-256 与传入 `terminal_manifest_sha256` 比对（防止合法 dict 配无关文件 hash）；opening owner 的 relpath/content_sha256、config/policy 双 hash 一致性均强校验。
+- 不影响生产 provider/delivery：observer 双层 `except Exception`（账户级 + 顶层），audit 自身也被 try/except 包裹（计划 §8 "Audit attempts are themselves exception-contained"）；observer 只新增 `output_runs/<run>/accounts/<account>/state/recommendation_point.sell_put.json` 的 write-once 写入，不触碰 state/config/provider。
+
+## Findings
+
+未发现实质性问题。
+
+残留观察（均不构成 finding，列出以备后续 gate 参考）：
+
+1. 账户 scheduler decision 的 `now_utc` 未经 per-account 伪造防护（理论上同一 decision dict 可被调用方替换时间戳），但生产来源是 `scan_decision_by_account` 中由 scheduler 流程产生的决策，且 point 的 `decision_at_utc` 不参与身份 hash（身份仅由 market/account/target 决定），属观测字段；计划已明确 target 身份才是官方语义。
+2. observer 在 `_observe_recommendation_points` 内对每个 ineligible 账户写 `official_point_identity_missing` degraded audit；disabled/manual/force/delivery-only 直接静默 return（计划语义：这些不是 gap）。一致，无歧义。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 全仓套件未在本轮重跑（遵守 12 分钟上限与既有超时中断诊断）；focused 145 + 回归 88 + 静态检查全部通过，类型错误与基线等价。
+- `official_point_missing`（watermark 后崩溃/失败导致的点缺失）按计划不做重试/回填，消费语义归 W4。
+- Git/source 解析不可用或超时（5s×3 命令）时 fail-open 记录 `official_point_source_unavailable` gap，不加缓存/兜底身份——计划已声明，W2 合成测试覆盖。
+- env flag `OM_STRATEGY_LAB_TOP1_AVAILABLE` 的 service/profile 渲染归 W7；本切片默认关闭。
+- 本审查为只读源码级审查，未授权任何 commit/push/merge/部署/生产写入。

--- a/docs/reviews/code-review-20260815-105101.md
+++ b/docs/reviews/code-review-20260815-105101.md
@@ -1,0 +1,39 @@
+# Code Review
+
+## Scope
+
+- Mode: aggregate deepreview（committed range）
+- Branch or PR: `feat/sell-put-top1-w2`
+- Base: `origin/main@c626e965`
+- Range: `origin/main...2d00aab3`（`8723571f` accepted plan + `2d00aab3` accepted slice；HEAD == `2d00aab3`，工作树干净）
+- Worktree: `/private/tmp/options-monitor-sell-put-top1-w2-20260815`
+- Output file: `docs/reviews/code-review-20260815-105101.md`
+- Included scope: 完整提交切片（17 文件，+2137/-91）：Gateflow plan/plan-fix/goal-confirmation/三份 plan-review/implementation、初审报告，以及实现与测试、依赖图机械再生
+- Excluded scope: W0R 运行时实证、W3+ 后续模块、生产 config/service/notify 行为变更（切片未触碰）
+- Parallel review coverage: 无；对提交内容做独立复核，承接但不照抄初审结论
+
+## Verified Facts（本轮实际执行）
+
+- 提交结构：`8723571f`（plan 接受）→ `2d00aab3`（accepted slice）；HEAD == `2d00aab3`，`git status` 干净；无额外/改写提交。
+- Review-artifact 漂移检查：`git show 2d00aab3:docs/reviews/code-review-20260815-103446.md` 与工作区初审报告逐字节一致（`diff` 为空）；implementation.md 所载验证声明与初审报告一致，无夸大（145/88/Ruff/basedpyright/依赖图数字均吻合）。
+- 提交切片与初审对象等价性：切片 diffstat 与初审时工作区逐文件一致（recommendation_point.py 534、source_identity.py 94、tick_notification_flow.py +156、position_projection_migration.py 净 -69、test_recommendation_point.py 479、test_daily_decision_brief_notification_flow.py +162、test_strategy_lab_top1_architecture.py +20、两份依赖图文档机械再生）；初审后无未提交改动被遗漏在外。
+- 在提交树上重跑聚焦套件：**145 passed**；Ruff 7 文件 `All checks passed!`；`scripts/generate_dependency_graph.py --check` OK（`production_modules=584 cycles=0`，与提交的 DEPENDENCY_GRAPH.md 一致）。
+- 真实调用链、契约/write-once/幂等/并发、partial/data_unavailable 保守语义、manifest 字节回读与 canonical 重算、config/policy 双 hash 绑定、W1A 投影仅约束 clean 状态、scheduler eligibility 8 条排除路径、账户失败隔离、observer 双层异常包容、source_identity 提取与 `_source_commit()` 逐行等价、新架构守卫精确锁死 14 个允许 import：均在初审（同 range 内 `code-review-20260815-103446.md`）逐项核实并有测试佐证，本轮复核未发现提交引入任何漂移。
+- 计划符合性：plan §10 允许文件清单与实际改动逐一对应；§2 排除项（SQLite/opt-in/feature status/corpus/CLI/LLM/重试队列/持久点存储/scheduler 规则/notify 策略/provider 行为）无一混入；§8 状态机（commit → observer → provider）与 §9 提取边界均按文执行；plan-fix 两项（PR-W2-01/02）的保守语义在实现与测试中存在且被证明。
+- 过度设计检查：无新增抽象层/注册表/事件总线/通用 observer 框架；`RecommendationPointError.reason_code` 集合与计划列举一致；observer 为单一私有 helper，不暴露公共面。
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 全仓套件：implementation.md 记录沙箱跑 `4864 passed, 10 skipped` + 9 项环境性失败（1 loopback bind + 8 缺 worktree 本地 `.venv`，且两类均已用临时 `.venv`/沙箱外单测单独证明通过，临时符号链接已删除）；沙箱外全套件在已知 ~87% 慢点被中断、无 summary，未计为通过。本轮未重跑全仓套件（遵守既有超时诊断约束）。
+- `official_point_missing`（watermark 后崩溃/失败）按计划不重试/回填，消费语义归 W4。
+- Git/source 解析不可用或超时时 fail-open 记 `official_point_source_unavailable` gap——计划声明行为，合成测试已覆盖。
+- env flag `OM_STRATEGY_LAB_TOP1_AVAILABLE` service/profile 渲染归 W7；本切片默认关闭。
+- 本审查只读，未授权 commit/push/Draft PR/merge/部署/生产写入；下一步 Draft PR 门禁需单独授权。

--- a/docs/reviews/code-review-20260815-105608.md
+++ b/docs/reviews/code-review-20260815-105608.md
@@ -1,0 +1,53 @@
+# Code Review
+
+## Scope
+
+- Mode: PR deepreview（Draft PR #159）
+- PR: https://github.com/liuxie066/options-monitor/pull/159 — `feat: capture official Sell Put recommendation points`
+- PR state: OPEN, Draft=true, base `main`, head `feat/sell-put-top1-w2` @ `e570abb866e6a1e46e212c2e2eb9da825cc72ddf`, mergeStateStatus `CLEAN`
+- Worktree: `/private/tmp/options-monitor-sell-put-top1-w2-20260815`（本地 HEAD 为 `e570abb8`，与 PR head 一致；`2d00aab3` 为 accepted slice 提交）
+- Plan basis: `docs/gateflow/sell-put-top1-w2/{plan.md,plan-fix.md,implementation.md,aggregate-review.md,ready-to-open-draft-pr.md}`
+- Output file: `docs/reviews/code-review-20260815-105608.md`
+- Read-only: 未修改/回退任何既有文件；唯一新增为本报告
+
+## PR Consistency（push-drift 核对）
+
+- PR commits: `8723571f`（accept plan）→ `2d00aab3`（accepted slice）→ `a1276de6`（aggregate review 记录）→ `e570abb8`（draft-pr readiness）；后两个为 docs-only Gateflow 记录提交，与计划 §16 / readiness 门禁完全一致，无额外或改写提交。
+- PR 文件清单（21 个）与本地 `c626e965..2d00aab3` diffstat（17 文件，+2137/-91）加两个 docs-only 提交（aggregate-review.md、ready-to-open-draft-pr.md、code-review-20260815-105101.md）精确对应；PR 端逐文件行数与本地一致。
+- Blob SHA 比对（PR head 树 vs 本地 `2d00aab3` 树）：全部 8 个代码/测试路径逐一相同 — `recommendation_point.py` 02e5f49、`source_identity.py` 847612c、`tick_notification_flow.py` 813f0e0、`position_projection_migration.py` 425c619、`test_recommendation_point.py` 07e17b9、`test_daily_decision_brief_notification_flow.py` 86b974c、`test_strategy_lab_top1_architecture.py` c35f5aa、`test_position_projection_migration.py` 3b8c0bc。**无 push drift。**
+- 切片中无 workflow/持久化/调度/Candidate Engine 策略/CLI/Agent/Prompt/LLM/provider/生产 config 文件。
+
+## 完整调用链与契约复核
+
+- 生产调用链：`multi_account_tick.main`（`repo_root = Path(__file__).resolve().parents[2]`）→ `run_tick_notification_flow` → `_commit_scan_targets_before_delivery`（既有权威边界，可能上抛）→ `_observe_recommendation_points_best_effort`（新增，永不上抛）→ 既有 scheduled 分支与 provider 执行。顺序有测试证明（`["commit","observer","provider"]`）；commit 失败时 observer/provider 均不执行。
+- 点身份与 write-once：身份仅由 market/account/canonical-UTC-target 决定（run_id/时间/通知状态不参与，retry/catch-up 同 target 同身份）；底层 `os.link` 原子 publish + 同字节 adopt（`idempotent`）+ 异字节 `official_point_conflict` 上抛 + 发布后回读校验；`load_recommendation_point` 拒绝非 canonical/被篡改字节。
+- manifest/opening 绑定：`load_candidate_snapshot_bundle` 复用其全部既有校验；capture 另回读 manifest 原始字节并断言与 canonical bytes 逐字节相等；builder 重算 canonical SHA-256 与传入 hash 比对；config/policy 双 hash、opening owner relpath/content_sha256 强校验。
+- W1A 投影一致性：clean（`candidates_found`/`no_candidate`）必须 `build_ranking_projection` 成功且 accepted IDs 精确一致；`partial_data`/`data_unavailable` 保留 accepted IDs 但永不被 W1A 成功"洗净"（`partial-completed` fixture 证明）；聚合 `data_unavailable` 最强优先；`candidate_universe_summary()` affected put scope → `partial_data`。符合 plan-fix PR-W2-01/02。
+- Scheduler eligibility：`scheduled` ∧ 非 delivery_only ∧ env 精确 `"1"` ∧ ∈ ran_pipeline_accounts ∧ committed target 非空 ∧ should_run_scan is True ∧ decision/committed target 规范化相等；8 条排除路径测试均证明 capture 零调用；账户级失败隔离（lx 失败不阻断 sy）有测试。
+- 生产边界：observer 双层 `except Exception` + audit 自身异常包容；仅新增 run/account state 目录下一个 write-once 文件；不触碰 scheduler 状态、provider、delivery、config。
+- source 提取：`source_identity.py` 与基线 `_source_commit()` 逐行等价；compat wrapper 保留 monkeypatch 入口，`test_position_projection_migration.py` 未改且通过。
+- 过度设计：无 experiment store / M3–M8 依赖（架构守卫精确锁死 14 个允许 import）；无通用 observer/flag/事件框架；`reason_code` 集合与计划一致。
+
+## Test Evidence（aggregate 轮在提交树上实际执行，本轮未重跑）
+
+- 聚焦套件 145 passed；回归套件 88 passed（implementation 门禁）；Ruff 7 文件全过；依赖图 `--check` OK（584 模块 0 环）；两个新模块 basedpyright 0 error，`tick_notification_flow.py` 24 个 error 与基线完全等价（W2 零新增）。
+- 测试缺口评估：身份 canonical 化（offset-equivalent target 同 ID）、publish 幂等/冲突、load 拒绝非 canonical、availability 精确匹配、builder/validator 各 fail-closed 分支、observer 顺序/排除/隔离均有直接断言；未发现关键路径缺测。
+
+## CI 状态（gh 实测，全部通过）
+
+- `Analyze (actions)` pass（39s）、`Analyze (python)` pass（1m24s）、`CodeQL` pass（3s）、`agent-plugin` pass（47s）、`guardrails` pass（1m27s）。
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- CI 五项检查已全部通过；merge 授权仍是独立动作，本报告不构成授权。
+- 全仓套件沙箱外运行曾在 ~87% 已知慢点中断（无 summary，不计通过）；沙箱跑 `4864 passed, 10 skipped` + 9 项环境性失败已分别证明在所需条件下通过。
+- `official_point_missing` gap 语义归 W4；env flag service/profile 渲染归 W7；source 解析 fail-open 为计划声明行为。
+- 本审查只读，未改变 Draft/Ready/merge 状态，未授权 release/deploy/生产写入。

--- a/docs/reviews/plan-re-review-20260815-100302.md
+++ b/docs/reviews/plan-re-review-20260815-100302.md
@@ -1,0 +1,52 @@
+# Plan Re-Review — Sell Put Top1 W2
+
+- Reviewed target: `docs/gateflow/sell-put-top1-w2/plan.md`
+- Prior review: `docs/reviews/plan-review-20260815-100136.md`
+- Fix artifact: `docs/gateflow/sell-put-top1-w2/plan-fix.md`
+- Reviewed base: `origin/main@9b29e05b`
+- Artifact path: `docs/reviews/plan-re-review-20260815-100302.md`
+
+## Prior finding status
+
+### PR-W2-01 — 已修复
+
+- The revised plan always preserves ordered producer accepted Sell Put IDs.
+- Clean points require exact W1A accepted-ID parity.
+- Incomplete points are no longer dropped merely because accepted IDs exist.
+- A mixed successful/failed same-mode fixture is now required.
+
+## New finding
+
+### PR-W2-02-未修复-中-仅看 aggregate strategy status 会把有 partial scope 的候选点误标为 clean
+
+- **位置**: §6.3 `terminal_sell_put_status`、§7 builder 第 4–6 步、§12 incomplete tests。
+- **问题类型**: 契约缺失 / 状态机漏洞 / 测试缺口。
+- **当前写法**: 修订计划要求 exactly one Sell Put strategy result，并把 clean/incomplete 分支绑定到 `candidates_found/no_candidate` 与 `partial_data/data_unavailable`；但没有规定必须检查 `candidate_universe_summary()` 的 Sell Put affected scopes，且要求 incomplete status 下 W1A 必须失败。
+- **反例/失败场景**: 一个 Sell Put scope 以 `status=completed, reason=partial_data` 封存，同时仍有一个完整 accepted candidate。现有 opening snapshot aggregate result 会返回 `strategy_status=candidates_found`，W1A 也可能成功构造 accepted-set projection；但 `candidate_universe_summary()` 会把该 Sell Put scope 标为 affected/partial。按产品合同，这个 point 应保留事实但必须 `not_evaluable`，不能被标为 clean candidates-found point。
+- **为什么有问题**: aggregate strategy result 优先表达“是否有候选”，而 candidate-universe summary 表达“候选宇宙是否完整”；两者不是同一个维度。W2 只有一个 terminal status 字段，必须把 Sell Put affected scope 提升为 `partial_data`，否则 W4 会把不完整宇宙纳入 40/20 日有效样本。反过来，W1A 的成功只证明 accepted facts 可重排，不证明全部 Sell Put scopes 完整，因此 incomplete point 不能要求 W1A 必然失败。
+- **直接证据**: `opening_candidate_snapshot._strategy_results()` 对 completed scope 的 `reason=partial_data` 且 `candidate_count>0` 明确返回 `candidates_found`；`candidate_universe_summary()` 对同一 completed/non-clean reason 明确加入 `affected_scopes` 并返回 `status=partial`。W1A `build_ranking_projection()`只检查 aggregate Sell Put `strategy_status` 与 accepted candidate count，不检查 universe summary。产品合同 §7.2/§7.3 要求任一 Sell Put scope 不完整时 point `not_evaluable`。
+- **影响**: partial evidence 被误纳入研究/隐藏验证，样本完整性和胜者结论失真；W1A parity 被错误当成 completeness proof。
+- **建议改法和验证点**: 定义 status derivation：先读取 aggregate Sell Put result；若 `candidate_universe_summary().affected_scopes` 中存在 `strategy_mode=put`，则无论是否有 accepted IDs，都把 point status 归为 `partial_data`（已有 aggregate `data_unavailable` 可保留更强状态）；否则使用 clean aggregate status。所有点都尝试 W1A seam：成功时必须核对 IDs；clean point 要求成功，incomplete point 允许成功或 fail closed，但始终由 point status 判定不可评估。增加 completed/partial_data + accepted candidate fixture，断言 point status 为 partial、IDs 保留、即使 W1A 成功也不能转为 clean。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 中。
+
+## Open questions
+
+None.
+
+## Residual risks
+
+- Cross-run corpus conflict, retention, feature-service rendering, account opt-in, and real pilot readiness remain assigned to W4/W7/W3/W0R.
+
+## Special lens verdicts
+
+- Goal-bound minimal design: fail only on PR-W2-02; the required fix uses an existing completeness projection and adds no new state.
+- Architecture boundary: pass.
+- Best practice: fail until availability/completeness and rankability are not conflated.
+- Optimal solution: use the existing `candidate_universe_summary()` rather than inventing a second completeness algorithm.
+- Overengineering: pass.
+- Overcoupling: fail only where W1A success is currently over-coupled to point evaluability.
+
+## Conclusion
+
+`fail` until PR-W2-02 is fixed and re-reviewed.

--- a/docs/reviews/plan-re-review-20260815-100915.md
+++ b/docs/reviews/plan-re-review-20260815-100915.md
@@ -1,0 +1,59 @@
+# Plan Re-Review — Sell Put Top1 W2
+
+- Reviewed target: `docs/gateflow/sell-put-top1-w2/plan.md`
+- Prior reviews:
+  - `docs/reviews/plan-review-20260815-100136.md`
+  - `docs/reviews/plan-re-review-20260815-100302.md`
+- Fix artifact: `docs/gateflow/sell-put-top1-w2/plan-fix.md`
+- Reviewed base: `origin/main@c626e965`
+- Artifact path: `docs/reviews/plan-re-review-20260815-100915.md`
+
+## Base refresh
+
+The branch was fast-forwarded from `9b29e05b` to `c626e965` after PR #158 merged. The added W1B contracts, economics, and statistics modules do not change the W2 notification seam, candidate bundle contracts, ranking projection, scheduler target contract, safe run-state writer, or source-identity implementation being extracted. The revised W2 plan remains code-generation-ready on the current base.
+
+## Prior finding status
+
+### PR-W2-01 — 已修复
+
+- Every point preserves ordered accepted Sell Put IDs from the validated opening snapshot.
+- Only clean `candidates_found` and `no_candidate` points require W1A projection success and exact accepted-ID parity.
+- Incomplete points retain usable producer facts instead of becoming false point gaps.
+- The required mixed successful/failed Sell Put scope fixture covers the counterexample.
+
+### PR-W2-02 — 已修复
+
+- Status derivation now combines the aggregate Sell Put result with `candidate_universe_summary()`.
+- Aggregate `data_unavailable` remains strongest; otherwise any affected Sell Put scope forces `partial_data`.
+- W1A rankability is checked for every point but cannot override incomplete universe status.
+- The required completed/`partial_data` scope with accepted candidate fixture covers the counterexample.
+
+## New findings
+
+None.
+
+## Open questions
+
+None.
+
+## Residual risks and ownership
+
+- Cross-run duplicate reconciliation, immutable denominator gaps, and source-run retention are intentionally assigned to W4.
+- Account opt-in and effective two-layer feature state remain W3.
+- Service/profile rendering of the availability gate remains W7.
+- Real provider and pilot readiness remain W0R.
+
+These are explicit later-module responsibilities and do not require W2 state, storage, retries, or abstractions.
+
+## Special lens verdicts
+
+- Goal-bound minimal design: pass; one producer artifact and one existing-flow call satisfy the current work unit.
+- Architecture boundary: pass; W2 has no experiment-store or later-use-case dependency.
+- Best practice: pass; completeness and rankability are separate and both reuse existing validated projections.
+- Optimal solution: pass; existing bundle, snapshot, W1A, write-once, and source-resolution primitives are reused.
+- Overengineering: pass; no generic flag, observer, event, repository, retry, or workflow layer is introduced.
+- Overcoupling: pass; the notification observer is best-effort and W1A remains validation rather than point ownership.
+
+## Conclusion
+
+`pass`; both prior findings are fixed, no new findings remain, and the plan is accepted for implementation on `origin/main@c626e965`.

--- a/docs/reviews/plan-review-20260815-100136.md
+++ b/docs/reviews/plan-review-20260815-100136.md
@@ -1,0 +1,55 @@
+# Plan Review — Sell Put Top1 W2
+
+- Reviewed target: `docs/gateflow/sell-put-top1-w2/plan.md`
+- Goal contract: `docs/gateflow/sell-put-top1-w2/goal-confirmation.md`
+- Reviewed base: `origin/main@9b29e05b`
+- Scope: recommendation-point schema, source bindings, W1A seam, source-identity extraction, observer ordering/failure isolation, implementation slice, and validation plan
+- Artifact path: `docs/reviews/plan-review-20260815-100136.md`
+
+## Assumptions tested
+
+- The notification flow has one stable post-watermark/pre-provider insertion point.
+- The terminal candidate bundle already proves the manifest/opening/config/policy bindings required by W2.
+- Every non-clean Sell Put status necessarily has an empty accepted set.
+- W1A can validate every point that W2 is required to publish.
+- The existing source-commit implementation can be shared without changing ledger behavior.
+- One implementation slice is sufficient and does not pull W3/W4 work forward.
+
+## Findings
+
+### PR-W2-01-未修复-中-不完整 Sell Put scope 仍可能封存已接受候选，计划会错误拒绝正式 point
+
+- **位置**: §6.3 的 `partial_data/data_unavailable` 空列表不变量、§7 builder 第 5–6 步、§12 contract tests。
+- **问题类型**: 契约缺失 / 状态机漏洞 / 测试缺口。
+- **当前写法**: 计划规定 `candidates_found` 必须有 accepted IDs，而 `no_candidate`、`partial_data`、`data_unavailable` 全部必须为空；只有 clean status 调 W1A，其他状态要求没有 accepted Sell Put ID。
+- **反例/失败场景**: 同一 Sell Put 推荐点中，NVDA scope 成功并产生一个已接受候选，AMD scope 因行情或 required-data 不可用而失败。opening snapshot 可以同时保留 NVDA 的 ranked/accepted candidate 和一个不完整 sibling scope；aggregate Sell Put `strategy_status` 会是 `data_unavailable`，W1A 会正确拒绝将其作为可评估 projection，但 producer point 仍必须封存这次正式决策及已实际产生的 accepted IDs。
+- **为什么有问题**: W2 的职责是记录正式推荐点，包括 `partial_data/data_unavailable`，而不是只记录可评估点。把 incomplete status 强制绑定空 accepted set 会让 observer 抛错并制造 `official_point_missing`，丢掉原本可审计的正式决策；或者实现者会被迫删掉真实 accepted IDs，破坏 point 与 opening snapshot 的绑定。W1A 拒绝 projection 表示 `not_evaluable`，不表示 producer point 不应存在。
+- **直接证据**: `opening_candidate_snapshot._strategy_results()` 在同一 mode 的 scope states 不全属于 completed/not_applicable 时落到 `strategy_status="data_unavailable"`，但不会删除 `ranked_candidates`；`_opening_status()` 只要任一 result 的 `candidate_count > 0` 仍保留 `opening_status="candidates_found"`。W1A `build_ranking_projection()` 明确要求有 candidates 时 Sell Put result status 为 `candidates_found`，因此会对该 mixed-scope point fail closed。产品合同 §7.1 同时允许 point 记录 `partial_data/data_unavailable`，§7.2/§7.3 只把 scope 不完整判为 `not_evaluable`，没有授权省略正式 point 或已接受候选身份。
+- **影响**: 合法 scheduled point 被错误漏记；W4 分母出现不可恢复的假 gap；point/snapshot audit 丢失真实 producer accepted set；实现与 W1A 的 fail-closed 语义混淆。
+- **建议改法和验证点**: 所有 status 都从 validated opening snapshot 的正式 ranked Sell Put decisions 提取并保存有序 accepted IDs。只对 clean `candidates_found/no_candidate` 要求 W1A projection 成功且 IDs 精确一致；对 `partial_data/data_unavailable` 要求 W1A fail closed，并允许有或没有 accepted IDs。validator 只约束 `candidates_found` 非空、`no_candidate` 为空；incomplete statuses 不从列表长度推断。增加一个“一个 Sell Put scope 成功有候选、一个 sibling scope 失败”的 manifest-bound fixture，断言 point 发布、accepted ID 保留、W1A 拒绝 projection、point 明确不可评估。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 中。
+
+## Open questions
+
+None.
+
+## Residual risks and tracking destination
+
+- Cross-run duplicate point IDs are intentionally reconciled by W4 corpus content conflicts; W2 only owns run/account write-once state.
+- Post-watermark crash before point publication remains an explicit `official_point_missing` gap for W4.
+- Source identity unavailability remains best-effort and cannot alter production tick behavior.
+- Service/profile delivery and account opt-in remain W7 and W3 respectively.
+
+## Special lens verdicts
+
+- Goal-bound minimal design: pass except PR-W2-01; fixing the incomplete-point invariant restores the confirmed producer-audit goal without adding scope.
+- Architecture boundary: pass; no experiment store or later use-case dependency is planned.
+- Best practice: fail until incomplete-but-partially-useful producer evidence is preserved rather than collapsed.
+- Optimal solution: pass; reuse of existing bundle/write/source/W1A contracts is the smallest credible path.
+- Overengineering: pass; one artifact and one observer seam, no framework.
+- Overcoupling: pass; source identity extraction is a current two-consumer reuse, and W1A remains pure validation rather than point ownership.
+
+## Conclusion
+
+`fail` until PR-W2-01 is fixed and re-reviewed.

--- a/src/application/ledger/position_projection_migration.py
+++ b/src/application/ledger/position_projection_migration.py
@@ -4,12 +4,10 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 import hashlib
 import json
-import os
 from pathlib import Path
 import sqlite3
 import stat
 import subprocess
-import tempfile
 import time
 from typing import Any, Callable, Iterator, Mapping
 
@@ -43,6 +41,7 @@ from src.application.ledger.repository import (
     initialize_ledger_connection,
 )
 from src.application.ledger.sqlite_row_codec import position_lot_row_to_record
+from src.application.source_identity import source_commit_sha
 from src.infrastructure.private_storage import (
     connect_private_sqlite,
     private_path,
@@ -622,80 +621,7 @@ def _load_lots(conn: sqlite3.Connection) -> list[dict[str, Any]]:
 
 
 def _source_commit(root: Path | None = None) -> str | None:
-    root = root or Path(__file__).resolve().parents[3]
-    git_prefix = ["git"]
-    git_env: dict[str, str] | None = None
-    commit_ref = "HEAD"
-    temp_index: tempfile.TemporaryDirectory[str] | None = None
-    if not (root / ".git").exists():
-        configured_cache = str(os.environ.get("OM_UPGRADE_CACHE_ROOT") or "").strip()
-        cache_root = (
-            Path(configured_cache).expanduser()
-            if configured_cache
-            else root.parent.parent / "_cache"
-        )
-        cache_repo = cache_root / "git" / "options-monitor.git"
-        try:
-            version = (root / "VERSION").read_text(encoding="utf-8").strip()
-        except OSError:
-            return None
-        if root.parent.name != "releases" or not cache_repo.is_dir() or not version:
-            return None
-        git_prefix = [
-            "git",
-            f"--git-dir={cache_repo}",
-            f"--work-tree={root}",
-        ]
-        commit_ref = f"refs/tags/v{version}^{{commit}}"
-        temp_index = tempfile.TemporaryDirectory(prefix="om-source-identity-")
-        git_env = {**os.environ, "GIT_INDEX_FILE": str(Path(temp_index.name) / "index")}
-    try:
-        result = subprocess.run(
-            [*git_prefix, "rev-parse", "--verify", commit_ref],
-            cwd=root,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=5,
-            env=git_env,
-        )
-        commit = result.stdout.strip()
-        if temp_index is not None:
-            subprocess.run(
-                [*git_prefix, "read-tree", commit],
-                cwd=root,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=5,
-                env=git_env,
-            )
-        source_status = subprocess.run(
-            [
-                *git_prefix,
-                "status",
-                "--porcelain=v1",
-                "--untracked-files=all",
-                "--",
-                "domain",
-                "src",
-                "scripts",
-            ],
-            cwd=root,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=5,
-            env=git_env,
-        )
-        if source_status.stdout.strip():
-            return None
-    except (OSError, subprocess.SubprocessError):
-        return None
-    finally:
-        if temp_index is not None:
-            temp_index.cleanup()
-    return commit or None
+    return source_commit_sha(root, run_cmd=subprocess.run)
 
 
 def _verify_from_conn(

--- a/src/application/recommendation_point.py
+++ b/src/application/recommendation_point.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, NoReturn
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from src.application.candidate_snapshot_contract import (
+    CandidateSnapshotContractError,
+    utc_timestamp,
+)
+from src.application.candidate_snapshot_manifest import (
+    CANDIDATE_SNAPSHOT_MANIFEST_FILE,
+    CandidateSnapshotManifestError,
+    load_candidate_snapshot_bundle,
+    validate_candidate_snapshot_manifest,
+)
+from src.application.opening_candidate_snapshot import (
+    OPENING_CANDIDATE_SNAPSHOT_FILE,
+    OpeningCandidateSnapshotError,
+    candidate_universe_summary,
+    ranked_opening_candidate_decisions,
+    validate_opening_candidate_snapshot,
+)
+from src.application.strategy_lab.top1.ranking import (
+    Top1RankingError,
+    build_ranking_projection,
+)
+from src.application.tick_run_workspace import (
+    AccountRunConfigError,
+    read_account_run_state_bytes_safely,
+    write_account_run_state_bytes_once_safely,
+)
+
+
+RECOMMENDATION_POINT_SCHEMA = "recommendation_point.v1"
+RECOMMENDATION_POINT_FILE = "recommendation_point.sell_put.json"
+STRATEGY_FAMILY = "sell_put"
+AVAILABILITY_ENV = "OM_STRATEGY_LAB_TOP1_AVAILABLE"
+
+_POINT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "recommendation_point_id",
+        "strategy_family",
+        "market",
+        "account",
+        "run_id",
+        "scheduled_scan_target_market",
+        "decision_at_utc",
+        "terminal_sell_put_status",
+        "account_config_sha256",
+        "strategy_policy_sha256",
+        "terminal_manifest_ref",
+        "terminal_manifest_sha256",
+        "opening_snapshot_ref",
+        "opening_snapshot_sha256",
+        "source_commit_sha",
+        "producer_accepted_candidate_ids",
+        "content_sha256",
+    }
+)
+_POINT_BINDING_FIELDS = (
+    "recommendation_point_id",
+    "market",
+    "account",
+    "run_id",
+    "opening_snapshot_ref",
+    "opening_snapshot_sha256",
+    "decision_at_utc",
+    "source_commit_sha",
+)
+_TERMINAL_STATUSES = frozenset(
+    {"candidates_found", "no_candidate", "partial_data", "data_unavailable"}
+)
+_CLEAN_STATUSES = frozenset({"candidates_found", "no_candidate"})
+_HASH_64 = re.compile(r"[0-9a-f]{64}\Z")
+_HASH_40 = re.compile(r"[0-9a-f]{40}\Z")
+
+
+class RecommendationPointError(RuntimeError):
+    """Stable fail-closed error at the official recommendation-point boundary."""
+
+    reason_code: str
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        self.reason_code = str(reason_code)
+        super().__init__(message)
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise RecommendationPointError(reason_code, message)
+
+
+def _canonical_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(
+            dict(payload),
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("official_point_invalid", f"{label} must be canonical text")
+    return value
+
+
+def _identity(value: Any, label: str) -> str:
+    text = _text(value, label)
+    if text in {".", ".."} or "/" in text or "\\" in text:
+        _fail("official_point_invalid", f"{label} is invalid")
+    return text
+
+
+def _account(value: Any) -> str:
+    account = _identity(value, "account")
+    if account != account.lower():
+        _fail("official_point_invalid", "account must be lowercase")
+    return account
+
+
+def _market(value: Any) -> str:
+    market = _text(value, "market")
+    if market not in {"US", "HK"}:
+        _fail("official_point_invalid", "market must be US or HK")
+    return market
+
+
+def _hash(value: Any, label: str, pattern: re.Pattern[str]) -> str:
+    text = _text(value, label)
+    if pattern.fullmatch(text) is None:
+        _fail("official_point_invalid", f"{label} is invalid")
+    return text
+
+
+def _canonical_timestamp(value: Any, label: str) -> str:
+    try:
+        return utc_timestamp(value, label)
+    except CandidateSnapshotContractError as exc:
+        _fail("official_point_identity_missing", str(exc))
+
+
+def _strict_timestamp(value: Any, label: str) -> str:
+    text = _text(value, label)
+    try:
+        canonical = utc_timestamp(text, label)
+    except CandidateSnapshotContractError as exc:
+        _fail("official_point_invalid", str(exc))
+    if text != canonical:
+        _fail("official_point_invalid", f"{label} must be canonical UTC")
+    return text
+
+
+def _terminal_manifest_ref(run_id: str, account: str) -> str:
+    return (
+        f"output_runs/{run_id}/accounts/{account}/state/"
+        f"{CANDIDATE_SNAPSHOT_MANIFEST_FILE}"
+    )
+
+
+def _opening_snapshot_ref(run_id: str, account: str) -> str:
+    return (
+        f"output_runs/{run_id}/accounts/{account}/state/"
+        f"{OPENING_CANDIDATE_SNAPSHOT_FILE}"
+    )
+
+
+def strategy_lab_top1_available(environ: Mapping[str, str] | None = None) -> bool:
+    source = os.environ if environ is None else environ
+    return source.get(AVAILABILITY_ENV) == "1"
+
+
+def build_recommendation_point_id(
+    market: str,
+    account: str,
+    scheduled_scan_target_market: Any,
+) -> str:
+    target = _canonical_timestamp(
+        scheduled_scan_target_market,
+        "scheduled_scan_target_market",
+    )
+    return canonical_sha256(
+        {
+            "schema_version": RECOMMENDATION_POINT_SCHEMA,
+            "market": _market(market),
+            "account": _account(account),
+            "strategy_family": STRATEGY_FAMILY,
+            "scheduled_scan_target_market": target,
+        }
+    )
+
+
+def point_binding_from_recommendation_point(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    item = validate_recommendation_point(payload)
+    return {field: item[field] for field in _POINT_BINDING_FIELDS}
+
+
+def build_recommendation_point(
+    scheduler_decision: Mapping[str, Any],
+    terminal_manifest: Mapping[str, Any],
+    opening_snapshot: Mapping[str, Any],
+    *,
+    terminal_manifest_sha256: str,
+    source_commit_sha: str,
+) -> dict[str, Any]:
+    if not isinstance(scheduler_decision, Mapping):
+        _fail("official_point_identity_missing", "scheduler decision is missing")
+    if scheduler_decision.get("should_run_scan") is not True:
+        _fail("official_point_identity_missing", "scheduler decision did not run")
+    target = _canonical_timestamp(
+        scheduler_decision.get("scheduled_scan_target_market"),
+        "scheduled_scan_target_market",
+    )
+    decision_at = _canonical_timestamp(
+        scheduler_decision.get("now_utc"),
+        "decision_at_utc",
+    )
+    try:
+        source_sha = _hash(source_commit_sha, "source_commit_sha", _HASH_40)
+    except RecommendationPointError as exc:
+        _fail("official_point_source_unavailable", str(exc))
+
+    if not isinstance(opening_snapshot, Mapping):
+        _fail("official_point_invalid", "opening snapshot must be an object")
+    opening = dict(opening_snapshot)
+    run_id = _identity(opening.get("run_id"), "run_id")
+    account = _account(opening.get("account"))
+    market = _market(opening.get("market"))
+    try:
+        validate_opening_candidate_snapshot(
+            opening,
+            expected_run_id=run_id,
+            expected_account=account,
+            require_current_contract=True,
+        )
+    except (KeyError, TypeError, ValueError, OpeningCandidateSnapshotError) as exc:
+        _fail("official_point_invalid", f"opening snapshot is invalid: {exc}")
+
+    if not isinstance(terminal_manifest, Mapping):
+        _fail("official_point_invalid", "terminal manifest must be an object")
+    manifest = dict(terminal_manifest)
+    try:
+        validate_candidate_snapshot_manifest(
+            manifest,
+            expected_run_id=run_id,
+            expected_account=account,
+        )
+    except (KeyError, TypeError, ValueError, CandidateSnapshotManifestError) as exc:
+        _fail("official_point_invalid", f"terminal manifest is invalid: {exc}")
+    manifest_sha = _hash(
+        terminal_manifest_sha256,
+        "terminal_manifest_sha256",
+        _HASH_64,
+    )
+    if hashlib.sha256(_canonical_json_bytes(manifest)).hexdigest() != manifest_sha:
+        _fail("official_point_invalid", "terminal manifest byte hash does not match")
+
+    for field in ("account_config_sha256", "strategy_policy_sha256"):
+        if manifest.get(field) != opening.get(field):
+            _fail("official_point_invalid", f"{field} binding does not match")
+    opening_entries = [
+        row
+        for row in manifest.get("owner_snapshots") or []
+        if isinstance(row, Mapping) and row.get("candidate_owner") == "opening"
+    ]
+    if len(opening_entries) != 1:
+        _fail("official_point_unavailable", "opening owner is unavailable")
+    opening_entry = dict(opening_entries[0])
+    if (
+        opening_entry.get("relpath") != f"state/{OPENING_CANDIDATE_SNAPSHOT_FILE}"
+        or opening_entry.get("content_sha256") != opening.get("content_sha256")
+    ):
+        _fail("official_point_invalid", "opening owner binding does not match")
+    sell_put_scopes = [
+        row
+        for row in manifest.get("expected_scopes") or []
+        if isinstance(row, Mapping)
+        and row.get("strategy_family") == STRATEGY_FAMILY
+        and row.get("strategy_mode") == "put"
+        and row.get("candidate_owner") == "opening"
+    ]
+    if not sell_put_scopes:
+        _fail("official_point_unavailable", "terminal Sell Put scope is unavailable")
+    if any(row.get("market") != market for row in sell_put_scopes):
+        _fail("official_point_invalid", "Sell Put scope market does not match")
+
+    put_results = [
+        row
+        for row in opening.get("strategy_results") or []
+        if isinstance(row, Mapping) and row.get("strategy_mode") == "put"
+    ]
+    if len(put_results) != 1:
+        _fail("official_point_invalid", "Sell Put strategy result is invalid")
+    aggregate_status = str(put_results[0].get("strategy_status") or "")
+    try:
+        incomplete_put = any(
+            row.get("strategy_mode") == "put"
+            for row in candidate_universe_summary(opening)["affected_scopes"]
+        )
+        accepted_ids = [
+            _text(row.get("candidate_id"), "candidate_id")
+            for row in ranked_opening_candidate_decisions(opening)
+            if row.get("strategy_mode") == "put"
+        ]
+    except (KeyError, TypeError, ValueError, OpeningCandidateSnapshotError) as exc:
+        _fail("official_point_invalid", f"Sell Put producer facts are invalid: {exc}")
+    if len(accepted_ids) != len(set(accepted_ids)):
+        _fail("official_point_invalid", "Sell Put candidate IDs are duplicated")
+    if aggregate_status == "data_unavailable":
+        point_status = "data_unavailable"
+    elif incomplete_put:
+        point_status = "partial_data"
+    elif aggregate_status in _TERMINAL_STATUSES:
+        point_status = aggregate_status
+    else:
+        _fail("official_point_invalid", "Sell Put terminal status is unsupported")
+
+    point_id = build_recommendation_point_id(market, account, target)
+    payload: dict[str, Any] = {
+        "schema_version": RECOMMENDATION_POINT_SCHEMA,
+        "recommendation_point_id": point_id,
+        "strategy_family": STRATEGY_FAMILY,
+        "market": market,
+        "account": account,
+        "run_id": run_id,
+        "scheduled_scan_target_market": target,
+        "decision_at_utc": decision_at,
+        "terminal_sell_put_status": point_status,
+        "account_config_sha256": opening["account_config_sha256"],
+        "strategy_policy_sha256": opening["strategy_policy_sha256"],
+        "terminal_manifest_ref": _terminal_manifest_ref(run_id, account),
+        "terminal_manifest_sha256": manifest_sha,
+        "opening_snapshot_ref": _opening_snapshot_ref(run_id, account),
+        "opening_snapshot_sha256": opening["content_sha256"],
+        "source_commit_sha": source_sha,
+        "producer_accepted_candidate_ids": accepted_ids,
+    }
+
+    projection: dict[str, Any] | None = None
+    try:
+        projection = build_ranking_projection(
+            opening,
+            point_binding={field: payload[field] for field in _POINT_BINDING_FIELDS},
+        )
+    except Top1RankingError as exc:
+        if point_status in _CLEAN_STATUSES:
+            _fail("official_point_invalid", f"clean point is not rankable: {exc}")
+    if (
+        projection is not None
+        and projection.get("producer_accepted_candidate_ids") != accepted_ids
+    ):
+        _fail("official_point_invalid", "W1A accepted candidate IDs do not match")
+
+    payload["content_sha256"] = canonical_sha256(payload)
+    return validate_recommendation_point(payload)
+
+
+def validate_recommendation_point(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        _fail("official_point_invalid", "recommendation point must be an object")
+    item = dict(payload)
+    if set(item) != _POINT_FIELDS:
+        _fail("official_point_invalid", "recommendation point keys are incomplete or unexpected")
+    if item["schema_version"] != RECOMMENDATION_POINT_SCHEMA:
+        _fail("official_point_invalid", "recommendation point schema is invalid")
+    if item["strategy_family"] != STRATEGY_FAMILY:
+        _fail("official_point_invalid", "strategy family is invalid")
+    market = _market(item["market"])
+    account = _account(item["account"])
+    run_id = _identity(item["run_id"], "run_id")
+    target = _strict_timestamp(
+        item["scheduled_scan_target_market"],
+        "scheduled_scan_target_market",
+    )
+    _strict_timestamp(item["decision_at_utc"], "decision_at_utc")
+    point_id = _hash(item["recommendation_point_id"], "recommendation_point_id", _HASH_64)
+    if point_id != build_recommendation_point_id(market, account, target):
+        _fail("official_point_invalid", "recommendation point identity does not match")
+    status = item["terminal_sell_put_status"]
+    if status not in _TERMINAL_STATUSES:
+        _fail("official_point_invalid", "terminal Sell Put status is invalid")
+    for field in (
+        "account_config_sha256",
+        "strategy_policy_sha256",
+        "terminal_manifest_sha256",
+        "opening_snapshot_sha256",
+        "content_sha256",
+    ):
+        _hash(item[field], field, _HASH_64)
+    _hash(item["source_commit_sha"], "source_commit_sha", _HASH_40)
+    if item["terminal_manifest_ref"] != _terminal_manifest_ref(run_id, account):
+        _fail("official_point_invalid", "terminal manifest ref is invalid")
+    if item["opening_snapshot_ref"] != _opening_snapshot_ref(run_id, account):
+        _fail("official_point_invalid", "opening snapshot ref is invalid")
+    candidate_ids = item["producer_accepted_candidate_ids"]
+    if not isinstance(candidate_ids, list):
+        _fail("official_point_invalid", "producer candidate IDs must be a list")
+    canonical_ids = [_text(value, "candidate_id") for value in candidate_ids]
+    if len(canonical_ids) != len(set(canonical_ids)):
+        _fail("official_point_invalid", "producer candidate IDs are duplicated")
+    if status == "candidates_found" and not canonical_ids:
+        _fail("official_point_invalid", "candidates_found requires an accepted candidate")
+    if status == "no_candidate" and canonical_ids:
+        _fail("official_point_invalid", "no_candidate cannot contain accepted candidates")
+    content = {key: value for key, value in item.items() if key != "content_sha256"}
+    if canonical_sha256(content) != item["content_sha256"]:
+        _fail("official_point_invalid", "recommendation point content hash does not match")
+    return item
+
+
+def _decode_point_bytes(encoded: bytes) -> dict[str, Any]:
+    try:
+        payload = json.loads(encoded.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        _fail("official_point_invalid", f"recommendation point bytes are invalid: {exc}")
+    if not isinstance(payload, dict):
+        _fail("official_point_invalid", "recommendation point must be an object")
+    item = validate_recommendation_point(payload)
+    if encoded != _canonical_json_bytes(item):
+        _fail("official_point_invalid", "recommendation point bytes are not canonical")
+    return item
+
+
+def publish_recommendation_point(
+    base: Path,
+    payload: Mapping[str, Any],
+) -> str:
+    item = validate_recommendation_point(payload)
+    encoded = _canonical_json_bytes(item)
+    identity = {
+        "run_id": item["run_id"],
+        "account": item["account"],
+        "name": RECOMMENDATION_POINT_FILE,
+    }
+    try:
+        existing = read_account_run_state_bytes_safely(base=Path(base), **identity)
+    except AccountRunConfigError:
+        existing = None
+    if existing is not None:
+        if existing != encoded:
+            _fail("official_point_conflict", "recommendation point already exists with different bytes")
+        _decode_point_bytes(existing)
+        return "idempotent"
+    try:
+        write_account_run_state_bytes_once_safely(
+            base=Path(base),
+            payload=encoded,
+            **identity,
+        )
+    except AccountRunConfigError as exc:
+        try:
+            adopted = read_account_run_state_bytes_safely(base=Path(base), **identity)
+        except AccountRunConfigError:
+            adopted = None
+        if adopted is not None and adopted == encoded:
+            _decode_point_bytes(adopted)
+            return "idempotent"
+        reason = (
+            "official_point_conflict"
+            if exc.code == "ACCOUNT_RUN_STATE_CONFLICT"
+            else "official_point_unavailable"
+        )
+        _fail(reason, "recommendation point cannot be published")
+    return "published"
+
+
+def load_recommendation_point(
+    base: Path,
+    run_id: str,
+    account: str,
+) -> dict[str, Any]:
+    try:
+        encoded = read_account_run_state_bytes_safely(
+            base=Path(base),
+            run_id=_identity(run_id, "run_id"),
+            account=_account(account),
+            name=RECOMMENDATION_POINT_FILE,
+        )
+    except AccountRunConfigError as exc:
+        _fail("official_point_unavailable", f"recommendation point is unavailable: {exc}")
+    return _decode_point_bytes(encoded)
+
+
+def capture_scheduled_recommendation_point(
+    base: Path,
+    run_id: str,
+    account: str,
+    scheduler_decision: Mapping[str, Any],
+    *,
+    source_commit_sha: str,
+) -> tuple[str, dict[str, Any]]:
+    try:
+        bundle = load_candidate_snapshot_bundle(
+            base=Path(base),
+            run_id=run_id,
+            account=account,
+        )
+        manifest_bytes = read_account_run_state_bytes_safely(
+            base=Path(base),
+            run_id=run_id,
+            account=account,
+            name=CANDIDATE_SNAPSHOT_MANIFEST_FILE,
+        )
+    except (AccountRunConfigError, CandidateSnapshotManifestError) as exc:
+        _fail("official_point_unavailable", f"terminal candidate bundle is unavailable: {exc}")
+    manifest = dict(bundle["manifest"])
+    if manifest_bytes != _canonical_json_bytes(manifest):
+        _fail("official_point_invalid", "terminal manifest bytes are not canonical")
+    owners = bundle.get("owners")
+    opening = owners.get("opening") if isinstance(owners, Mapping) else None
+    if not isinstance(opening, Mapping):
+        _fail("official_point_unavailable", "opening owner is unavailable")
+    point = build_recommendation_point(
+        scheduler_decision,
+        manifest,
+        opening,
+        terminal_manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        source_commit_sha=source_commit_sha,
+    )
+    return publish_recommendation_point(Path(base), point), point

--- a/src/application/source_identity.py
+++ b/src/application/source_identity.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Any, Callable
+
+
+RunCommand = Callable[..., Any]
+
+
+def source_commit_sha(
+    root: Path | None = None,
+    *,
+    run_cmd: RunCommand | None = None,
+) -> str | None:
+    """Resolve the clean production source commit for a worktree or release."""
+
+    root = root or Path(__file__).resolve().parents[2]
+    runner = run_cmd or subprocess.run
+    git_prefix = ["git"]
+    git_env: dict[str, str] | None = None
+    commit_ref = "HEAD"
+    temp_index: tempfile.TemporaryDirectory[str] | None = None
+    if not (root / ".git").exists():
+        configured_cache = str(os.environ.get("OM_UPGRADE_CACHE_ROOT") or "").strip()
+        cache_root = (
+            Path(configured_cache).expanduser()
+            if configured_cache
+            else root.parent.parent / "_cache"
+        )
+        cache_repo = cache_root / "git" / "options-monitor.git"
+        try:
+            version = (root / "VERSION").read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        if root.parent.name != "releases" or not cache_repo.is_dir() or not version:
+            return None
+        git_prefix = [
+            "git",
+            f"--git-dir={cache_repo}",
+            f"--work-tree={root}",
+        ]
+        commit_ref = f"refs/tags/v{version}^{{commit}}"
+        temp_index = tempfile.TemporaryDirectory(prefix="om-source-identity-")
+        git_env = {**os.environ, "GIT_INDEX_FILE": str(Path(temp_index.name) / "index")}
+    try:
+        result = runner(
+            [*git_prefix, "rev-parse", "--verify", commit_ref],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=git_env,
+        )
+        commit = result.stdout.strip()
+        if temp_index is not None:
+            runner(
+                [*git_prefix, "read-tree", commit],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                env=git_env,
+            )
+        source_status = runner(
+            [
+                *git_prefix,
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "--",
+                "domain",
+                "src",
+                "scripts",
+            ],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=git_env,
+        )
+        if source_status.stdout.strip():
+            return None
+    except (OSError, subprocess.SubprocessError):
+        return None
+    finally:
+        if temp_index is not None:
+            temp_index.cleanup()
+    return commit or None

--- a/src/application/tick_notification_flow.py
+++ b/src/application/tick_notification_flow.py
@@ -52,11 +52,18 @@ from src.application.notification_delivery_adapter import (
     notification_target_reference,
     select_notification_delivery_adapter,
 )
+from src.application.candidate_snapshot_contract import utc_timestamp
+from src.application.recommendation_point import (
+    RecommendationPointError,
+    capture_scheduled_recommendation_point,
+    strategy_lab_top1_available,
+)
 from src.application.scheduled_notification import (
     PreparedPerAccountMessages,
     build_per_account_delivery_batch,
     execute_per_account_delivery,
 )
+from src.application.source_identity import source_commit_sha
 from src.infrastructure.io_utils import read_json, utc_now
 
 
@@ -151,6 +158,7 @@ def run_tick_notification_flow(request: TickNotificationRequest) -> int:
     results_count = len(request.results)
 
     _commit_scan_targets_before_delivery(request)
+    _observe_recommendation_points_best_effort(request)
 
     if str(request.trigger_kind or "manual").strip().lower() != "scheduled":
         reason = "non_scheduled_ordinary_notification_disabled"
@@ -665,6 +673,154 @@ def _commit_scan_targets_before_delivery(request: TickNotificationRequest) -> No
             extra={"targets": targets},
         )
         raise
+
+
+def _observe_recommendation_points_best_effort(
+    request: TickNotificationRequest,
+) -> None:
+    """Capture official scheduled points without changing production control flow."""
+
+    try:
+        _observe_recommendation_points(request)
+    except Exception as exc:
+        _audit_recommendation_point(
+            request,
+            "recommendation_point_gap",
+            status="degraded",
+            reason_code="official_point_observer_failed",
+            message=str(exc),
+        )
+
+
+def _observe_recommendation_points(request: TickNotificationRequest) -> None:
+    if (
+        request.delivery_only
+        or str(request.trigger_kind or "manual").strip().lower() != "scheduled"
+        or not strategy_lab_top1_available()
+    ):
+        return
+    decisions = request.scheduler_decisions_by_account or {}
+    targets = request.scheduled_scan_targets_by_account or {}
+    eligible: list[tuple[str, Mapping[str, Any]]] = []
+    ran_accounts = dict.fromkeys(
+        str(raw_account or "").strip().lower()
+        for raw_account in request.ran_pipeline_accounts
+    )
+    for account in ran_accounts:
+        decision = decisions.get(account)
+        committed_target = _canonical_recommendation_target(targets.get(account))
+        scheduler_target = _canonical_recommendation_target(
+            decision.get("scheduled_scan_target_market")
+            if isinstance(decision, Mapping)
+            else None
+        )
+        if (
+            not account
+            or not isinstance(decision, Mapping)
+            or decision.get("should_run_scan") is not True
+            or committed_target is None
+            or scheduler_target != committed_target
+        ):
+            _audit_recommendation_point(
+                request,
+                "recommendation_point_gap",
+                status="degraded",
+                account=account or None,
+                reason_code="official_point_identity_missing",
+            )
+            continue
+        eligible.append((account, decision))
+    if not eligible:
+        return
+    source_sha = source_commit_sha((request.repo_root or request.base).resolve())
+    if source_sha is None:
+        for account, _decision in eligible:
+            _audit_recommendation_point(
+                request,
+                "recommendation_point_gap",
+                status="degraded",
+                account=account,
+                reason_code="official_point_source_unavailable",
+            )
+        return
+    for account, decision in eligible:
+        try:
+            publication, point = capture_scheduled_recommendation_point(
+                request.base,
+                request.run_id,
+                account,
+                decision,
+                source_commit_sha=source_sha,
+            )
+        except RecommendationPointError as exc:
+            _audit_recommendation_point(
+                request,
+                "recommendation_point_gap",
+                status="degraded",
+                account=account,
+                reason_code=exc.reason_code,
+                message=str(exc),
+            )
+            continue
+        except Exception as exc:
+            _audit_recommendation_point(
+                request,
+                "recommendation_point_gap",
+                status="degraded",
+                account=account,
+                reason_code="official_point_observer_failed",
+                message=str(exc),
+            )
+            continue
+        _audit_recommendation_point(
+            request,
+            "recommendation_point_captured",
+            status="ok",
+            account=account,
+            publication=publication,
+            recommendation_point_id=point.get("recommendation_point_id"),
+        )
+
+
+def _canonical_recommendation_target(value: Any) -> str | None:
+    try:
+        return utc_timestamp(value, "scheduled_scan_target_market")
+    except Exception:
+        return None
+
+
+def _audit_recommendation_point(
+    request: TickNotificationRequest,
+    action: str,
+    *,
+    status: str,
+    account: str | None = None,
+    reason_code: str | None = None,
+    message: str | None = None,
+    publication: str | None = None,
+    recommendation_point_id: Any = None,
+) -> None:
+    extra = {
+        key: value
+        for key, value in {
+            "account": account,
+            "reason_code": reason_code,
+            "publication": publication,
+            "recommendation_point_id": recommendation_point_id,
+        }.items()
+        if value is not None
+    }
+    try:
+        request.audit_helper.audit(
+            "strategy_lab",
+            action,
+            run_id=request.run_id,
+            status=status,
+            message=message,
+            extra=extra,
+        )
+    except Exception:
+        return
 
 
 def _daily_brief_limits(config: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_daily_decision_brief_notification_flow.py
+++ b/tests/test_daily_decision_brief_notification_flow.py
@@ -164,6 +164,10 @@ def _request(
     scheduler_by_account = {
         account: {
             "in_run_window": True,
+            "should_run_scan": not delivery_only,
+            "now_utc": (
+                "2026-07-21T14:00:30Z" if fixed else "2026-07-21T14:30:30Z"
+            ),
             "now_market": "2026-07-21T10:10:00-04:00" if delivery_only else target,
             "scheduled_scan_target_market": None if delivery_only else target,
             "scheduled_target_market": None if delivery_only or not fixed else target,
@@ -212,10 +216,18 @@ def _patch_assembler(monkeypatch, *, blocked: bool = False, candidate: bool = Tr
     )
 
 
-def _patch_sender(monkeypatch, *, result: dict | None = None, calls: list[dict] | None = None) -> None:
+def _patch_sender(
+    monkeypatch,
+    *,
+    result: dict | None = None,
+    calls: list[dict] | None = None,
+    order: list[str] | None = None,
+) -> None:
     import src.application.tick_notification_flow as mod
 
     def send(**kwargs):
+        if order is not None:
+            order.append("provider")
         if calls is not None:
             calls.append(dict(kwargs))
         return result or {
@@ -724,11 +736,20 @@ def test_commit_failure_prevents_provider_call_and_keeps_envelope(monkeypatch, t
     _patch_assembler(monkeypatch)
     calls: list[dict] = []
     _patch_sender(monkeypatch, calls=calls)
+    observer_calls: list[str] = []
+    monkeypatch.setattr(mod, "strategy_lab_top1_available", lambda: True)
+    monkeypatch.setattr(mod, "source_commit_sha", lambda _root: "c" * 40)
+    monkeypatch.setattr(
+        mod,
+        "capture_scheduled_recommendation_point",
+        lambda *_args, **_kwargs: observer_calls.append("observer"),
+    )
     bundle = _request(tmp_path, run_id="commit-fail")
     bundle.request = replace(bundle.request, commit_scan_targets_fn=lambda _targets: (_ for _ in ()).throw(OSError("state write failed")))
     with pytest.raises(OSError, match="state write failed"):
         mod.run_tick_notification_flow(bundle.request)
     assert calls == []
+    assert observer_calls == []
     pending = read_retryable_daily_decision_brief_delivery(
         base=tmp_path,
         account="lx",
@@ -752,6 +773,145 @@ def test_commit_failure_prevents_provider_call_and_keeps_envelope(monkeypatch, t
     assert confirmed["delivery_key"] == pending["delivery_key"]
     assert confirmed["message_sha256"] == pending["message_sha256"]
     assert confirmed["status"] == "confirmed"
+
+
+@pytest.mark.parametrize("observer_fails", (False, True))
+def test_recommendation_point_observer_runs_after_commit_before_provider_and_is_best_effort(
+    monkeypatch,
+    tmp_path: Path,
+    observer_fails: bool,
+) -> None:
+    import src.application.tick_notification_flow as mod
+
+    _patch_assembler(monkeypatch)
+    order: list[str] = []
+    _patch_sender(monkeypatch, order=order)
+    monkeypatch.setattr(mod, "strategy_lab_top1_available", lambda: True)
+    monkeypatch.setattr(mod, "source_commit_sha", lambda _root: "c" * 40)
+
+    def capture(*_args, **_kwargs):
+        order.append("observer")
+        if observer_fails:
+            raise mod.RecommendationPointError(
+                "official_point_unavailable",
+                "injected observer failure",
+            )
+        return "published", {"recommendation_point_id": "p" * 64}
+
+    monkeypatch.setattr(mod, "capture_scheduled_recommendation_point", capture)
+    bundle = _request(tmp_path, run_id=f"observer-{observer_fails}")
+    bundle.request = replace(
+        bundle.request,
+        commit_scan_targets_fn=lambda _targets: order.append("commit"),
+    )
+
+    assert mod.run_tick_notification_flow(bundle.request) == 0
+    assert order == ["commit", "observer", "provider"]
+    actions = [event["action"] for event in bundle.request.audit_helper.events]
+    assert (
+        "recommendation_point_gap"
+        if observer_fails
+        else "recommendation_point_captured"
+    ) in actions
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "disabled",
+        "manual",
+        "force",
+        "delivery_only",
+        "not_run",
+        "target_missing",
+        "target_mismatch",
+        "source_unavailable",
+    ),
+)
+def test_recommendation_point_observer_excludes_ineligible_paths(
+    monkeypatch,
+    tmp_path: Path,
+    case: str,
+) -> None:
+    import src.application.tick_notification_flow as mod
+
+    bundle = _request(
+        tmp_path,
+        run_id=f"observer-excluded-{case}",
+        delivery_only=case == "delivery_only",
+        trigger_kind=case if case in {"manual", "force"} else "scheduled",
+    )
+    if case == "not_run":
+        bundle.request = replace(bundle.request, ran_pipeline_accounts=())
+    if case == "target_mismatch":
+        bundle.request = replace(
+            bundle.request,
+            scheduled_scan_targets_by_account={"lx": HALF_TARGET},
+        )
+    if case == "target_missing":
+        bundle.request = replace(
+            bundle.request,
+            scheduled_scan_targets_by_account={},
+        )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        mod,
+        "strategy_lab_top1_available",
+        lambda: case != "disabled",
+    )
+    monkeypatch.setattr(
+        mod,
+        "source_commit_sha",
+        lambda _root: None if case == "source_unavailable" else "c" * 40,
+    )
+    monkeypatch.setattr(
+        mod,
+        "capture_scheduled_recommendation_point",
+        lambda *_args, **_kwargs: calls.append("capture"),
+    )
+
+    mod._observe_recommendation_points_best_effort(bundle.request)
+
+    assert calls == []
+
+
+def test_recommendation_point_observer_isolates_accounts(monkeypatch, tmp_path: Path) -> None:
+    import src.application.tick_notification_flow as mod
+
+    bundle = _request(
+        tmp_path,
+        run_id="observer-account-isolation",
+        accounts=("lx", "sy"),
+    )
+    bundle.request = replace(
+        bundle.request,
+        ran_pipeline_accounts=("lx", "lx", "sy"),
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(mod, "strategy_lab_top1_available", lambda: True)
+    monkeypatch.setattr(mod, "source_commit_sha", lambda _root: "c" * 40)
+
+    def capture(_base, _run_id, account, _decision, **_kwargs):
+        calls.append(account)
+        if account == "lx":
+            raise mod.RecommendationPointError(
+                "official_point_unavailable",
+                "injected account failure",
+            )
+        return "published", {"recommendation_point_id": "p" * 64}
+
+    monkeypatch.setattr(mod, "capture_scheduled_recommendation_point", capture)
+
+    mod._observe_recommendation_points_best_effort(bundle.request)
+
+    assert calls == ["lx", "sy"]
+    point_events = [
+        event
+        for event in bundle.request.audit_helper.events
+        if event["action"].startswith("recommendation_point_")
+    ]
+    assert [event["extra"]["account"] for event in point_events] == ["lx", "sy"]
+    assert [event["status"] for event in point_events] == ["degraded", "ok"]
 
 
 def test_provider_definite_failure_stays_pending_for_exact_delivery_only_retry(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_recommendation_point.py
+++ b/tests/test_recommendation_point.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.engine import build_candidate_decision
+from src.application.candidate_snapshot_manifest import (
+    CANDIDATE_SNAPSHOT_MANIFEST_FILE,
+    load_candidate_snapshot_bundle,
+    publish_candidate_snapshot_manifest,
+)
+from src.application.opening_candidate_snapshot import (
+    dependency_from_hash,
+    seal_opening_candidate_snapshot,
+)
+from src.application.recommendation_point import (
+    AVAILABILITY_ENV,
+    RECOMMENDATION_POINT_FILE,
+    RecommendationPointError,
+    build_recommendation_point,
+    build_recommendation_point_id,
+    capture_scheduled_recommendation_point,
+    load_recommendation_point,
+    point_binding_from_recommendation_point,
+    publish_recommendation_point,
+    strategy_lab_top1_available,
+    validate_recommendation_point,
+)
+from src.application.strategy_lab.top1.ranking import (
+    Top1RankingError,
+    build_ranking_projection,
+)
+from src.application.strategy_scan_status import (
+    publish_strategy_scan_status,
+    publish_strategy_scan_status_index_v2,
+)
+from src.application.tick_run_workspace import read_account_run_state_bytes_safely
+from tests.candidate_evidence_helpers import (
+    CONFIG_HASH,
+    POLICY_HASH,
+    _normalized_row,
+    seal_opening_candidate_fixture,
+)
+
+
+SOURCE_SHA = "c" * 40
+TARGET = "2026-07-21T10:00:00-04:00"
+TARGET_UTC = "2026-07-21T14:00:00Z"
+
+
+def _candidate(symbol: str = "NVDA") -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "contract_symbol": f"{symbol}260821P00100000",
+        "expiration": "2026-08-21",
+        "strike": 100,
+        "open_interest": 500,
+        "period_net_return_on_cash_basis": 0.01,
+        "net_assignment_discount_pct": 0.08,
+        "symbol_concentration_after": 0.20,
+        "sell_limit": 1.10,
+        "net_premium": 105.0,
+        "net_cash_basis": 9_895.0,
+        "stock_owner": "none",
+        "fee_schedule_version": "fixture.v1",
+        "fee_basis": "fixture",
+        "fee_schedule_url": "https://example.test/fees",
+    }
+
+
+def _scheduler(
+    *,
+    target: str = TARGET,
+    now_utc: str = "2026-07-21T14:00:30Z",
+    should_run_scan: bool = True,
+) -> dict[str, Any]:
+    return {
+        "should_run_scan": should_run_scan,
+        "scheduled_scan_target_market": target,
+        "now_utc": now_utc,
+    }
+
+
+def _canonical_bytes(payload: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(
+            dict(payload),
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _build_from_bundle(
+    base: Path,
+    run_id: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    bundle = load_candidate_snapshot_bundle(base=base, run_id=run_id, account="lx")
+    manifest_bytes = read_account_run_state_bytes_safely(
+        base=base,
+        run_id=run_id,
+        account="lx",
+        name=CANDIDATE_SNAPSHOT_MANIFEST_FILE,
+    )
+    point = build_recommendation_point(
+        _scheduler(),
+        bundle["manifest"],
+        bundle["owners"]["opening"],
+        terminal_manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        source_commit_sha=SOURCE_SHA,
+    )
+    return point, bundle["owners"]["opening"]
+
+
+def _seal_partial_fixture(
+    base: Path,
+    *,
+    run_id: str,
+    sibling_failed: bool,
+) -> None:
+    accepted = _normalized_row(_candidate(), accepted=True)
+    scopes = [
+        {
+            "symbol": "NVDA",
+            "status": "completed",
+            "reason": None if sibling_failed else "partial_data",
+            "candidate_count": 1,
+        }
+    ]
+    if sibling_failed:
+        scopes.append(
+            {
+                "symbol": "AMD",
+                "status": "failed",
+                "reason": "quote_unavailable",
+                "candidate_count": None,
+            }
+        )
+    account_dir = base / "output_runs" / run_id / "accounts" / "lx"
+    account_dir.mkdir(parents=True)
+    statuses: list[dict[str, Any]] = []
+    expected: list[dict[str, str]] = []
+    for scope in scopes:
+        symbol = str(scope["symbol"])
+        publish_strategy_scan_status(
+            report_dir=account_dir,
+            run_id=run_id,
+            account="lx",
+            market="US",
+            symbol=symbol,
+            strategy_family="sell_put",
+            status=str(scope["status"]),
+            candidate_count=scope["candidate_count"],
+            reason=str(scope["reason"] or "") or None,
+            snapshot_id=f"fixture-{symbol}-put",
+            receipt_relpath=f"quotes/{symbol}/put/receipt.json",
+        )
+        statuses.append(
+            {
+                "symbol": symbol,
+                "strategy_mode": "put",
+                "status": scope["status"],
+                "reason": scope["reason"],
+                "quote_snapshot_id": f"fixture-{symbol}-put",
+                "quote_receipt_relpath": f"quotes/{symbol}/put/receipt.json",
+            }
+        )
+        expected.append(
+            {
+                "market": "US",
+                "symbol": symbol,
+                "strategy_family": "sell_put",
+                "strategy_mode": "put",
+                "candidate_owner": "opening",
+                "account_config_sha256": CONFIG_HASH,
+            }
+        )
+    seal_opening_candidate_snapshot(
+        base=base,
+        run_id=run_id,
+        account="lx",
+        market="US",
+        physical_account={
+            "status": "available",
+            "logical_account": "lx",
+            "futu_account_id": "fixture-account",
+            "trd_env": "REAL",
+            "market": "US",
+            "source": "opend",
+        },
+        account_config_sha256=CONFIG_HASH,
+        strategy_policy_sha256=POLICY_HASH,
+        dependencies=[
+            dependency_from_hash(kind=kind, sha256=char * 64)
+            for kind, char in (
+                ("required_data", "1"),
+                ("portfolio", "2"),
+                ("ledger", "3"),
+                ("fx", "4"),
+                ("earnings_rv", "5"),
+            )
+        ],
+        scan_statuses=statuses,
+        final_candidates={"put": [accepted]},
+        candidate_evaluations={
+            "put": [
+                {
+                    "normalized_input": accepted,
+                    "opening_decision": build_candidate_decision(
+                        mode="put",
+                        symbol="NVDA",
+                        contract_symbol=str(accepted["contract_symbol"]),
+                        accepted=True,
+                        normalized_input=accepted,
+                    ),
+                }
+            ]
+        },
+        sealed_at="2026-07-21T14:00:00Z",
+    )
+    publish_strategy_scan_status_index_v2(
+        report_dir=account_dir,
+        run_id=run_id,
+        account="lx",
+        account_config_sha256=CONFIG_HASH,
+        expected=expected,
+    )
+    publish_candidate_snapshot_manifest(
+        base=base,
+        run_id=run_id,
+        account="lx",
+        strategy_policy_sha256=POLICY_HASH,
+        sealed_at="2026-07-21T14:00:01Z",
+    )
+
+
+def test_point_identity_canonicalizes_target_and_availability_is_exact() -> None:
+    assert build_recommendation_point_id("US", "lx", TARGET) == (
+        build_recommendation_point_id("US", "lx", TARGET_UTC)
+    )
+    assert build_recommendation_point_id("US", "lx", TARGET) != (
+        build_recommendation_point_id("HK", "lx", TARGET)
+    )
+    assert build_recommendation_point_id("US", "lx", TARGET) != (
+        build_recommendation_point_id("US", "sy", TARGET)
+    )
+    assert build_recommendation_point_id("US", "lx", TARGET) != (
+        build_recommendation_point_id("US", "lx", "2026-07-21T14:30:00Z")
+    )
+    assert strategy_lab_top1_available({AVAILABILITY_ENV: "1"}) is True
+    for value in ("", "0", "true", " 1", "1 "):
+        assert strategy_lab_top1_available({AVAILABILITY_ENV: value}) is False
+    assert strategy_lab_top1_available({}) is False
+
+
+def test_clean_point_capture_is_manifest_bound_rankable_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    run_id = "clean-point"
+    seal_opening_candidate_fixture(
+        tmp_path,
+        run_id=run_id,
+        accepted_rows=[_candidate()],
+    )
+
+    publication, point = capture_scheduled_recommendation_point(
+        tmp_path,
+        run_id,
+        "lx",
+        _scheduler(),
+        source_commit_sha=SOURCE_SHA,
+    )
+
+    assert publication == "published"
+    assert point["scheduled_scan_target_market"] == TARGET_UTC
+    assert point["terminal_sell_put_status"] == "candidates_found"
+    assert len(point["producer_accepted_candidate_ids"]) == 1
+    assert load_recommendation_point(tmp_path, run_id, "lx") == point
+    bundle = load_candidate_snapshot_bundle(base=tmp_path, run_id=run_id, account="lx")
+    projection = build_ranking_projection(
+        bundle["owners"]["opening"],
+        point_binding=point_binding_from_recommendation_point(point),
+    )
+    assert projection["producer_accepted_candidate_ids"] == point[
+        "producer_accepted_candidate_ids"
+    ]
+    assert capture_scheduled_recommendation_point(
+        tmp_path,
+        run_id,
+        "lx",
+        _scheduler(),
+        source_commit_sha=SOURCE_SHA,
+    )[0] == "idempotent"
+
+    conflict = dict(point)
+    conflict["decision_at_utc"] = "2026-07-21T14:00:31Z"
+    conflict["content_sha256"] = canonical_sha256(
+        {key: value for key, value in conflict.items() if key != "content_sha256"}
+    )
+    with pytest.raises(RecommendationPointError) as raised:
+        publish_recommendation_point(tmp_path, conflict)
+    assert raised.value.reason_code == "official_point_conflict"
+
+
+def test_clean_no_candidate_point_is_valid(tmp_path: Path) -> None:
+    run_id = "no-candidate"
+    seal_opening_candidate_fixture(tmp_path, run_id=run_id)
+
+    point, opening = _build_from_bundle(tmp_path, run_id)
+
+    assert point["terminal_sell_put_status"] == "no_candidate"
+    assert point["producer_accepted_candidate_ids"] == []
+    assert build_ranking_projection(
+        opening,
+        point_binding=point_binding_from_recommendation_point(point),
+    )["producer_accepted_candidate_ids"] == []
+
+
+def test_failed_sibling_preserves_candidate_but_is_not_rankable(tmp_path: Path) -> None:
+    run_id = "failed-sibling"
+    _seal_partial_fixture(tmp_path, run_id=run_id, sibling_failed=True)
+
+    point, opening = _build_from_bundle(tmp_path, run_id)
+
+    assert point["terminal_sell_put_status"] == "data_unavailable"
+    assert len(point["producer_accepted_candidate_ids"]) == 1
+    with pytest.raises(Top1RankingError):
+        build_ranking_projection(
+            opening,
+            point_binding=point_binding_from_recommendation_point(point),
+        )
+
+
+def test_partial_completed_scope_stays_partial_when_subset_is_rankable(
+    tmp_path: Path,
+) -> None:
+    run_id = "partial-completed"
+    _seal_partial_fixture(tmp_path, run_id=run_id, sibling_failed=False)
+
+    point, opening = _build_from_bundle(tmp_path, run_id)
+
+    assert point["terminal_sell_put_status"] == "partial_data"
+    assert len(point["producer_accepted_candidate_ids"]) == 1
+    projection = build_ranking_projection(
+        opening,
+        point_binding=point_binding_from_recommendation_point(point),
+    )
+    assert projection["producer_accepted_candidate_ids"] == point[
+        "producer_accepted_candidate_ids"
+    ]
+
+
+def test_builder_rejects_missing_scheduler_identity_and_manifest_hash(
+    tmp_path: Path,
+) -> None:
+    run_id = "invalid-builder"
+    seal_opening_candidate_fixture(tmp_path, run_id=run_id)
+    bundle = load_candidate_snapshot_bundle(base=tmp_path, run_id=run_id, account="lx")
+    manifest = bundle["manifest"]
+    opening = bundle["owners"]["opening"]
+    manifest_bytes = read_account_run_state_bytes_safely(
+        base=tmp_path,
+        run_id=run_id,
+        account="lx",
+        name=CANDIDATE_SNAPSHOT_MANIFEST_FILE,
+    )
+    manifest_sha = hashlib.sha256(manifest_bytes).hexdigest()
+
+    for scheduler in (
+        _scheduler(should_run_scan=False),
+        _scheduler(now_utc="2026-07-21T14:00:30"),
+        _scheduler(target=""),
+    ):
+        with pytest.raises(RecommendationPointError) as raised:
+            build_recommendation_point(
+                scheduler,
+                manifest,
+                opening,
+                terminal_manifest_sha256=manifest_sha,
+                source_commit_sha=SOURCE_SHA,
+            )
+        assert raised.value.reason_code == "official_point_identity_missing"
+    with pytest.raises(RecommendationPointError) as raised:
+        build_recommendation_point(
+            _scheduler(),
+            manifest,
+            opening,
+            terminal_manifest_sha256="d" * 64,
+            source_commit_sha=SOURCE_SHA,
+        )
+    assert raised.value.reason_code == "official_point_invalid"
+    with pytest.raises(RecommendationPointError) as raised:
+        build_recommendation_point(
+            _scheduler(),
+            manifest,
+            opening,
+            terminal_manifest_sha256=manifest_sha,
+            source_commit_sha="not-a-commit",
+        )
+    assert raised.value.reason_code == "official_point_source_unavailable"
+    for field in ("account_config_sha256", "strategy_policy_sha256"):
+        mismatched_manifest = dict(manifest)
+        mismatched_manifest[field] = "e" * 64
+        mismatched_manifest["content_sha256"] = canonical_sha256(
+            {
+                key: value
+                for key, value in mismatched_manifest.items()
+                if key != "content_sha256"
+            }
+        )
+        with pytest.raises(RecommendationPointError) as raised:
+            build_recommendation_point(
+                _scheduler(),
+                mismatched_manifest,
+                opening,
+                terminal_manifest_sha256=hashlib.sha256(
+                    _canonical_bytes(mismatched_manifest)
+                ).hexdigest(),
+                source_commit_sha=SOURCE_SHA,
+            )
+        assert raised.value.reason_code == "official_point_invalid"
+
+
+def test_validator_rejects_contract_and_content_drift(tmp_path: Path) -> None:
+    run_id = "invalid-point"
+    seal_opening_candidate_fixture(tmp_path, run_id=run_id, accepted_rows=[_candidate()])
+    point, _opening = _build_from_bundle(tmp_path, run_id)
+
+    extra = {**point, "unexpected": True}
+    bad_ref = {**point, "opening_snapshot_ref": "../opening_candidate_snapshot.json"}
+    bad_ref["content_sha256"] = canonical_sha256(
+        {key: value for key, value in bad_ref.items() if key != "content_sha256"}
+    )
+    bad_status = {**point, "terminal_sell_put_status": "no_candidate"}
+    bad_status["content_sha256"] = canonical_sha256(
+        {key: value for key, value in bad_status.items() if key != "content_sha256"}
+    )
+    bad_identity = {**point, "recommendation_point_id": "e" * 64}
+    bad_identity["content_sha256"] = canonical_sha256(
+        {
+            key: value
+            for key, value in bad_identity.items()
+            if key != "content_sha256"
+        }
+    )
+    drift = {**point, "content_sha256": "d" * 64}
+    for invalid in (extra, bad_ref, bad_status, bad_identity, drift):
+        with pytest.raises(RecommendationPointError) as raised:
+            validate_recommendation_point(invalid)
+        assert raised.value.reason_code == "official_point_invalid"
+
+
+def test_load_rejects_noncanonical_persisted_bytes(tmp_path: Path) -> None:
+    run_id = "noncanonical-load"
+    seal_opening_candidate_fixture(tmp_path, run_id=run_id)
+    point, _opening = _build_from_bundle(tmp_path, run_id)
+    assert publish_recommendation_point(tmp_path, point) == "published"
+    path = (
+        tmp_path
+        / "output_runs"
+        / run_id
+        / "accounts"
+        / "lx"
+        / "state"
+        / RECOMMENDATION_POINT_FILE
+    )
+    path.write_text(json.dumps(point), encoding="utf-8")
+
+    with pytest.raises(RecommendationPointError) as raised:
+        load_recommendation_point(tmp_path, run_id, "lx")
+    assert raised.value.reason_code == "official_point_invalid"

--- a/tests/test_strategy_lab_top1_architecture.py
+++ b/tests/test_strategy_lab_top1_architecture.py
@@ -9,6 +9,7 @@ RANKING_MODULE = ROOT / "src/application/strategy_lab/top1/ranking.py"
 CONTRACTS_MODULE = ROOT / "src/application/strategy_lab/top1/contracts.py"
 ECONOMICS_MODULE = ROOT / "src/application/strategy_lab/top1/economics.py"
 STATISTICS_MODULE = ROOT / "src/application/strategy_lab/top1/statistics.py"
+RECOMMENDATION_POINT_MODULE = ROOT / "src/application/recommendation_point.py"
 CANDIDATE_ENGINE = ROOT / "domain/domain/engine/candidate_engine.py"
 
 
@@ -76,4 +77,23 @@ def test_top1_core_imports_only_approved_pure_owners() -> None:
         "datetime",
         "typing",
         "scipy.stats",
+    }
+
+
+def test_recommendation_point_imports_only_producer_evidence_owners() -> None:
+    assert _imports(RECOMMENDATION_POINT_MODULE) <= {
+        "__future__",
+        "collections.abc",
+        "hashlib",
+        "json",
+        "os",
+        "pathlib",
+        "re",
+        "typing",
+        "domain.domain.decision_state_fingerprint",
+        "src.application.candidate_snapshot_contract",
+        "src.application.candidate_snapshot_manifest",
+        "src.application.opening_candidate_snapshot",
+        "src.application.strategy_lab.top1.ranking",
+        "src.application.tick_run_workspace",
     }


### PR DESCRIPTION
## Summary
- capture canonical write-once recommendation_point.v1 artifacts for eligible scheduled Sell Put scans
- bind each point to scheduler target, terminal manifest, opening snapshot, config/policy hashes, source commit, and W1A accepted candidates
- keep the observer default-off and best-effort so production watermark and notification behavior remain authoritative

## Validation
- focused W2 suite: 145 passed
- regression suite: 88 passed
- Ruff: pass
- dependency graph: 584 modules, 0 cycles
- initial and aggregate Kimi DeepReviews: pass, 0 unresolved findings
- full sandbox suite: 4864 passed, 10 skipped; 9 environment-only failures individually closed

## Safety
- no release, deploy, service/config change, runtime experiment, notification, market-data read, ledger write, or broker action