### PR TITLE
feat: add Sell Put Top1 experiment lifecycle store

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 931 (`src`: 500, `domain`: 75, `scripts`: 9, `tests`: 347)
-- Internal import edges: 6038 total, 2519 production/script edges excluding tests
+- Python files scanned: 936 (`src`: 504, `domain`: 75, `scripts`: 9, `tests`: 348)
+- Internal import edges: 6056 total, 2529 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,9 +31,9 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|388| domain
+  application -->|389| domain
   application -->|4| domain_services
-  application -->|132| infrastructure
+  application -->|135| infrastructure
   application -->|41| storage
   domain_services -->|5| domain
   domain_services -->|2| storage
@@ -45,10 +45,10 @@ flowchart LR
   scripts -->|13| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2627| application
-  tests -->|429| domain
+  tests -->|2632| application
+  tests -->|431| domain
   tests -->|2| domain_services
-  tests -->|167| infrastructure
+  tests -->|168| infrastructure
   tests -->|221| interfaces
   tests -->|15| scripts
   tests -->|18| storage
@@ -58,9 +58,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 388 |
+| application | domain | 389 |
 | interfaces | application | 140 |
-| application | infrastructure | 132 |
+| application | infrastructure | 135 |
 | application | storage | 41 |
 | infrastructure | application | 13 |
 | scripts | application | 13 |
@@ -77,10 +77,10 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2627 |
-| tests | domain | 429 |
+| tests | application | 2632 |
+| tests | domain | 431 |
 | tests | interfaces | 221 |
-| tests | infrastructure | 167 |
+| tests | infrastructure | 168 |
 | tests | storage | 18 |
 | tests | scripts | 15 |
 | tests | domain_services | 2 |
@@ -91,9 +91,9 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 
 | from | to | imports |
 |---|---|---|
-| src.application | domain.domain | 200 |
+| src.application | domain.domain | 201 |
 | src.interfaces | src.application | 113 |
-| src.application | src.infrastructure | 93 |
+| src.application | src.infrastructure | 96 |
 | src.application.ledger | domain.domain | 49 |
 | src.application.ledger | domain.domain.ledger | 38 |
 | src.application | domain.storage | 32 |
@@ -185,12 +185,12 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | domain.domain.ledger.position_fields | 43 |
 | domain.domain.option_position_identity | 40 |
 | src.application.account_config | 38 |
+| src.application.shadow_replay.common | 27 |
 | domain.domain.engine | 25 |
-| src.application.shadow_replay.common | 25 |
 | src.application.settings | 23 |
 | domain.domain.trade_contract_identity | 23 |
+| domain.domain.decision_state_fingerprint | 23 |
 | src.application.agent_tools.runtime_helpers | 22 |
-| domain.domain.decision_state_fingerprint | 22 |
 | src.application.config_sections | 21 |
 
 ### Highest Fan-Out Production Modules

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,7 +1,7 @@
 flowchart LR
-  src_application["src.application"] -->|200| domain_domain["domain.domain"]
+  src_application["src.application"] -->|201| domain_domain["domain.domain"]
   src_interfaces["src.interfaces"] -->|113| src_application["src.application"]
-  src_application["src.application"] -->|93| src_infrastructure["src.infrastructure"]
+  src_application["src.application"] -->|96| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|49| domain_domain["domain.domain"]
   src_application_ledger["src.application.ledger"] -->|38| domain_domain_ledger["domain.domain.ledger"]
   src_application["src.application"] -->|32| domain_storage["domain.storage"]

--- a/docs/gateflow/sell-put-top1-w3/aggregate-review.md
+++ b/docs/gateflow/sell-put-top1-w3/aggregate-review.md
@@ -1,0 +1,23 @@
+# Gateflow Aggregate DeepReview — Sell Put Top1 W3
+
+- Gate: `aggregate review`
+- Work unit: `sell-put-top1-w3`
+- Reviewed range: `9a6a13c2..1c34b69d`
+- Review artifact: `docs/reviews/code-review-20260815-125230.md`
+- Status: pass; no unresolved finding; ready for Draft PR readiness gate
+
+## Result
+
+Kimi independently reviewed the fixed committed W3 range and found no substantive issue. It verified that committed bytes match the twice-reviewed current-change bytes, the accepted plan file set is complete, and no release, runtime, provider, scheduling, or future result-table scope entered the commit.
+
+## Verification
+
+- Focused W1-W3 suite: `110 passed`; Kimi's narrow review run: `13 passed`.
+- Adjacent regression suite: `104 passed`.
+- Ruff: pass.
+- BasedPyright error level: `0 errors, 0 warnings, 0 notes`.
+- Dependency graph: current, `production_modules=588`, `cycles=0`.
+- Final sandbox full suite: `4881 passed, 10 skipped`, with the sole denied loopback test separately passing outside the sandbox (`1 passed`).
+- Current-changes Kimi finding was fixed/reviewed to zero unresolved findings; aggregate committed-range review also has zero findings.
+
+No release, deployment, service/config change, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed by this gate.

--- a/docs/gateflow/sell-put-top1-w3/deepreview-fix.md
+++ b/docs/gateflow/sell-put-top1-w3/deepreview-fix.md
@@ -1,0 +1,20 @@
+# Gateflow Fix — Sell Put Top1 W3 Current-Changes DeepReview
+
+- Gate: `fix`
+- Work unit: `sell-put-top1-w3`
+- Review artifact: `docs/reviews/code-review-20260815-124143.md`
+- Status: finding addressed; pending Kimi re-review
+
+## Finding 1 — accepted in part, fixed; speculative claim-order change rejected
+
+Accepted issue: after a validation proposal invalidates authorization, the lifecycle already has enough current-state evidence to reject a stale hash before publishing the new content-addressed commitment. `start_validation()` now performs a read-side phase and exact-authorization preflight before any filesystem write. The store transaction remains the final authority and repeats every check to close races.
+
+Regression coverage now relocks a changed 20-date proposal, attempts start with the stale prior hash, and proves `authorization_required`, no new commitment file, and no `validation_started` business event.
+
+The suggested move of `_claim_event()` after all store checks is rejected: `_claim_event()` and the checks execute inside one `BEGIN IMMEDIATE` transaction, so every failed check rolls the event back before any reader can observe it. Claim-first is also required for a second caller idempotency key to replay the already-committed natural start fact after the state has advanced; moving it behind current-state guards would turn that legal replay into `invalid_transition`. No external event subscriber exists in W3, and adding one would require a separate contract change.
+
+## Verification
+
+- `tests/test_strategy_lab_top1_store.py` plus architecture guard: `13 passed`.
+- Ruff: pass.
+- BasedPyright error level: `0 errors, 0 warnings, 0 notes`.

--- a/docs/gateflow/sell-put-top1-w3/draft-pr-pass.md
+++ b/docs/gateflow/sell-put-top1-w3/draft-pr-pass.md
@@ -1,0 +1,43 @@
+# Gateflow Draft PR Pass — Sell Put Top1 W3
+
+## Gate
+
+- Work unit: `sell-put-top1-w3`
+- Gate: `draft-PR-pass`
+- Date: `2026-08-15`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/161`
+- Superseded PR: `#160` (automatically closed when `main` was force-pushed and its head ref was deleted)
+- Current base: `main@d905fb9b`
+- Accepted PR-review head: `10474af1`
+- PR review: `docs/reviews/pr-161-review-20260815-131215.md`
+- State at review: `OPEN`, `DRAFT`, `MERGEABLE`
+
+## Baseline recovery
+
+- The old base `baa3e363` and current base `d905fb9b` have the same tree `105af850a97cd2e4ed467e7d219a0d137faca7df`.
+- The old head `ce8e645f` and replayed head `10474af1` have the same tree `56c119f4063bc3d5eefa348b5e7099ee287cd38b`.
+- `git range-diff baa3e363..ce8e645f d905fb9b..10474af1` marks all four W3 commits as equal; the replacement PR has no code or documentation drift.
+
+## Entry criteria
+
+- [x] W3 lifecycle/store and terminal projection remain within the accepted module boundary.
+- [x] Initial, fix, aggregate, and PR-level Kimi DeepReviews have zero unresolved findings.
+- [x] Focused plus adjacent suites passed: `214 passed`.
+- [x] Ruff, BasedPyright error level, dependency graph, and `git diff --check` passed.
+- [x] Agent Plugin, Guardrails, CodeQL Actions, CodeQL Python, and CodeQL summary passed on `10474af1`.
+
+## Residual risks and owners
+
+- Normal experiment completion and outcomes remain W5/W6 ownership; W3 intentionally stops at `awaiting_outcomes`.
+- Multi-host writers remain outside W3; the current SQLite transaction contract covers the intended single-host runtime.
+- Production integration, runtime configuration, CLI/Agent surfaces, timers, and real experiment execution remain later work units.
+
+## Safety boundary
+
+No release, deployment, service/configuration change, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed.
+
+## Conclusion
+
+`draft-PR-pass`.
+
+Current gate / next entry point: commit this evidence, wait for final CI, then record W3 final closeout. Merge remains a separate authorization boundary.

--- a/docs/gateflow/sell-put-top1-w3/final-closeout.md
+++ b/docs/gateflow/sell-put-top1-w3/final-closeout.md
@@ -1,0 +1,45 @@
+# Gateflow Final Closeout — Sell Put Top1 W3
+
+## Gate
+
+- Work unit: `sell-put-top1-w3`
+- Gate: `final closeout`
+- Date: `2026-08-15`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/161`
+- Superseded PR: `#160`
+- Current base: `main@d905fb9b`
+- Accepted plan: `d684be70` (patch-equivalent to pre-rewrite `9a6a13c2`)
+- Accepted implementation: `907ef1ca` (patch-equivalent to pre-rewrite `1c34b69d`)
+- Accepted aggregate review: `648dabf2` (patch-equivalent to pre-rewrite `bc3a8421`)
+- Draft-PR readiness: `10474af1` (tree-equivalent to pre-rewrite `ce8e645f`)
+- Verified draft-PR-pass: `b36233d6`
+
+## What changed
+
+1. W3 adds the private SQLite v1 lifecycle store for the experimental Sell Put Top1 workflow.
+2. Research and hidden validation require separate exact-input authorizations; the store owns exactly 20 hidden dates and exposes only hidden-safe public status.
+3. Terminal and aborted receipts are projected deterministically with exact-byte crash recovery and idempotent publication.
+4. The product remains default-off and account-scoped; W3 adds no timer, CLI/Agent surface, provider call, strategy-result computation, or production tick integration.
+
+## What was verified
+
+- Focused plus adjacent suites: `214 passed`; prior aggregate full suite: `4881 passed, 10 skipped`, with the sole sandbox-denied loopback test separately passing outside the sandbox.
+- Ruff, BasedPyright error level, dependency graph (`588` modules, `0` cycles), and `git diff --check`: passed.
+- Initial, fix, aggregate, and PR-level Kimi DeepReviews: zero open finding.
+- The #160 to #161 replay was tree-identical and all four commits were patch-equivalent; the replacement PR has no implementation drift.
+- Agent Plugin, Guardrails, CodeQL Actions, CodeQL Python, and CodeQL summary passed on both the PR-review head and the draft-PR-pass head.
+
+## Remaining modules and risks
+
+- Corpus/outcome consumption, 40-day research, 20-day hidden validation result computation, decision tables, product integration, Agent tools, and the LLM hypothesis loop remain later work units.
+- W3 intentionally stops normal experiments at `awaiting_outcomes`; completion is owned by later result modules.
+- Multi-host writers remain outside the current single-host SQLite contract.
+
+## Safety and workspace status
+
+- No release, tag, deployment, remote upgrade, service/configuration mutation, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed.
+- Unrelated user changes in the root worktree were not touched.
+
+## Completion and merge authorization
+
+W3 is complete at `final closeout pass`, subject only to the final mechanical GitHub checks for this documentation commit. Merging PR #161 requires explicit W3 merge authorization; the earlier authorization for W2 does not carry forward. Release and deployment remain separate and unauthorized.

--- a/docs/gateflow/sell-put-top1-w3/goal-confirmation.md
+++ b/docs/gateflow/sell-put-top1-w3/goal-confirmation.md
@@ -1,0 +1,63 @@
+# Gateflow Goal Confirmation — Sell Put Top1 W3
+
+- Gate: `goal confirmation`
+- Work unit: `sell-put-top1-w3`
+- Branch: `feat/sell-put-top1-w3`
+- Base: `origin/main@baa3e363`
+- Product source: `docs/plans/sell-put-top1-optimization-loop-mvp-20260814.md`
+- Modular sources: `docs/plans/sell-put-top1-modular-technical-implementation-plan-20260814.md`, `docs/plans/sell-put-top1-modular-implementation-control-20260814.md`
+
+## Confirmed goal
+
+Implement the smallest production-grade SQLite lifecycle boundary that lets one Sell Put Top1 experiment survive process restarts and enforce human authorization, account opt-in, a single forward-validation collection slot, immutable hidden-window consumption, terminal-mode competition, and deterministic terminal-artifact recovery.
+
+W3 is state and write-authority infrastructure. It does not evaluate a hypothesis, select a research leader, read market data, capture corpus, calculate metrics, run a timer, expose CLI/Agent tools, or start a real experiment.
+
+## Success signal
+
+With only synthetic data and a temporary SQLite/artifact root, tests prove that:
+
+- account opt-in defaults off and maintainer availability always has final veto;
+- research and validation require separate exact-hash human confirmations;
+- a validation cannot start on an overlapping 20-trading-day commitment or while another collection slot is occupied;
+- the twentieth sealed decision partition atomically closes decision intake and releases the collection slot;
+- completed and aborted terminal requests cannot both win for one generation;
+- a crash after request commit, after file publication, or before final SQLite publication CAS recovers the same requested bytes and hashes;
+- terminal intent rejects all late experiment writes, while public status reveals no hidden intermediate result and receipt remains unavailable until conclusion.
+
+## Scope
+
+### Included
+
+- One compact, private SQLite schema and migration owned by `src/infrastructure/strategy_lab/experiment_store.py`.
+- Current feature/experiment/auth/progress state plus append-only audit/outbox events, generation rows, and consumed hidden commitments.
+- Application commands for prepare, separate authorization, research/validation start, leader lock, generation revision/seal, validation point/partition commit, abort/feature-disable termination, recovery, status, and receipt read.
+- Canonical generation-terminal and aborted-experiment receipt projection with content/file hashes.
+- Exact extraction of the existing deterministic JSON text renderer so requested bytes and published bytes share one owner.
+
+### Excluded
+
+- Corpus/recommendation-point copying, 40-day research execution, leader calculation, 20-day decision/outcome economics, outcome jobs, statistics, adoption, LLM, Prompt, CLI, Agent tools, timers, service profiles, release, deploy, runtime config, and real provider reads.
+- Generic feature-flag service, repository interface, event bus, workflow engine, task queue, ORM, registry, or multi-database transaction layer.
+- Corpus/validation/outcome result tables; later modules add only the tables they own.
+- Any production Candidate Engine, scheduler, notification, ledger, or broker behavior change.
+
+## Fixed boundaries
+
+- Scope remains first-release `market=HK`, lowercase account, `strategy_family=sell_put`.
+- SQLite is the single write authority. All writes use `BEGIN IMMEDIATE`; no WAL is introduced for this single-writer workload.
+- Events are immutable rows. Publication completion is a new event plus a CAS update, never an update to the requested event.
+- Specs and event payloads use compact canonical JSON in SQLite; no recommendation points, candidate rows, outcomes, or metric series are duplicated in W3.
+- A hidden commitment is inserted only when validation actually starts. It is never deleted, so an aborted validation still consumes the full committed window; a merely proposed/locked future window does not consume dates.
+- W3 models a validation point and a sealed trading-day partition separately. Multiple official points may belong to one partition; only partition seal advances the 20-day counter.
+- W3 can conclude the aborted path. Normal research/validation completion payloads remain later-module policy; W3 only provides the same generic terminal projection/CAS primitive for them.
+
+## Stop conditions
+
+Stop and return to design/PlanReview if implementation would require:
+
+- a new data authority beyond the single Strategy Lab SQLite store and immutable artifact files;
+- hidden intermediate metrics in public status/receipt;
+- a production tick dependency on the experiment store;
+- a Candidate Engine, scheduler, notification, production config, service, CLI, or Agent change;
+- market/provider reads or invented result policy inside the store.

--- a/docs/gateflow/sell-put-top1-w3/implementation.md
+++ b/docs/gateflow/sell-put-top1-w3/implementation.md
@@ -1,0 +1,37 @@
+# Gateflow Implementation — Sell Put Top1 W3
+
+- Gate: `implementation`
+- Work unit: `sell-put-top1-w3`
+- Accepted plan commit: `9a6a13c2`
+- Implementation base: `origin/main@baa3e363`
+- Branch: `feat/sell-put-top1-w3`
+- Status: S1/S2 implemented, verified, and Kimi re-review passed; ready for accepted implementation commit
+
+## Implemented scope
+
+- Added the private SQLite v1 experiment store for the account feature intent, current experiment/generation state, exact hidden-date ownership, and one append-only event/outbox table.
+- Added default-off effective-gate handling, separate research/validation authorization, research and validation transitions, exact 20-date validation ownership, point/partition append CAS, and day-20 `awaiting_outcomes` handoff.
+- Added deterministic generation terminal and aborted receipt requests plus write-once exact-byte publication, publication CAS, and crash recovery.
+- Added public status/receipt projections that do not expose hidden point facts or infer W5/W6 results.
+- Reused the existing canonical JSON/provenance/private-storage helpers. No ORM, worker, queue, provider read, production tick integration, runtime config change, or new dependency was added.
+
+## Local validation evidence
+
+- Focused W1-W3 suite: `110 passed`.
+- Adjacent snapshot/notification/projection regression suite: `104 passed`.
+- Ruff over all changed production/test files: pass.
+- BasedPyright error-level check for the three W3 production modules: `0 errors, 0 warnings, 0 notes`.
+- Dependency graph: current, `production_modules=588`, `cycles=0`.
+- Final full repository sandbox run with the temporary verified worktree `.venv` link: `4881 passed, 10 skipped`, with exactly one sandbox-denied loopback bind. The exact loopback test then passed outside the sandbox (`1 passed`). The temporary symlink was removed.
+- Localized state-machine fixes added durable binding for natural-fact alias idempotency keys, account-scoped recovery of pending projections during disable reconciliation, and a no-file-write stale-authorization preflight. Focused, adjacent, lint, type, graph, diff, concurrency, and stale-authorization checks passed.
+- `git diff --check`: pass.
+
+## Kimi review closure
+
+- Initial current-changes review: `docs/reviews/code-review-20260815-124143.md` — one medium finding.
+- Fix decision: `docs/gateflow/sell-put-top1-w3/deepreview-fix.md` — accepted the stale-authorization filesystem side effect and fixed it; rejected moving transactional natural-fact claim behind state guards because rollback prevents visibility and claim-first preserves cross-key replay after state advance.
+- Kimi re-review: `docs/reviews/code-review-20260815-124608.md` — zero unresolved findings; focused review suite `13 passed`.
+
+## Remaining gate boundary
+
+The current changes are ready for the accepted implementation commit. Aggregate committed-range Kimi review, Draft PR, CI, and PR-level Kimi review remain later gates. Release, deployment, runtime config/service changes, and real experiment execution remain outside this work unit.

--- a/docs/gateflow/sell-put-top1-w3/plan-fix.md
+++ b/docs/gateflow/sell-put-top1-w3/plan-fix.md
@@ -1,0 +1,41 @@
+# Gateflow Plan Fix — Sell Put Top1 W3
+
+- Gate: `plan review -> fix`
+- Work unit: `sell-put-top1-w3`
+- Plan: `docs/gateflow/sell-put-top1-w3/plan.md`
+- Review: `docs/reviews/plan-review-20260815-113103.md`
+- Artifact path: `docs/gateflow/sell-put-top1-w3/plan-fix.md`
+
+## Finding decisions
+
+### PR-W3-01 — accepted — fixed
+
+Hidden commitments now use an experiment-local content-addressed path. A file published before a failed start transaction has no SQLite authority, and a changed proposal uses a different path. The acceptance matrix covers publish-before-commit failure followed by a changed valid proposal.
+
+### PR-W3-02 — accepted — fixed
+
+Enable now requires exact maintainer availability and performs no SQLite write while unavailable. Disable remains unconditional and idempotently commits account opt-out before reconciling active experiments.
+
+### PR-W3-03 — accepted — fixed
+
+The existing commitment table now stores 20 lightweight date-occupancy rows with a unique `(market, account, strategy_family, trading_date)` constraint. The canonical payload/hash/ref remains stored once; no seventh table was added. Exact-date overlap replaces interval overlap.
+
+### PR-W3-04 — accepted — fixed
+
+W3 day 20 now always closes decision intake into `awaiting_outcomes`, requests the hidden generation terminal, and releases the slot. W6 owns the job-aware transition to `ready_to_conclude`, including the empty outcome seal. W3 no longer presents absence of a job table as evidence of no jobs.
+
+### PR-W3-05 — accepted — fixed
+
+The public `complete_experiment()` command was removed from W3. W3 concludes only deterministic aborted receipts and retains the generation terminal CAS/recovery primitive. W5/W6 add successful completion only with their exact result schema and authority.
+
+### PR-W3-06 — accepted — fixed
+
+Each mutation now has an explicit semantic subject key. Natural facts are unique on `(event_type, subject_key)`, while a caller idempotency key may only replay the same canonical payload inside its command scope. Tests cover different keys targeting one fact and one key targeting different bytes.
+
+### PR-W3-07 — accepted — fixed
+
+The spec rule now freezes only the research hash domain after research starts. After the research terminal is published, validation-only fields may be added or changed before validation starts while the exact research hash remains immutable; each change invalidates validation authorization.
+
+## Decision
+
+`fix complete`; next gate: `plan re-review`.

--- a/docs/gateflow/sell-put-top1-w3/plan.md
+++ b/docs/gateflow/sell-put-top1-w3/plan.md
@@ -1,0 +1,358 @@
+# Gateflow Plan — Sell Put Top1 W3
+
+- Gate: `plan`
+- Work unit: `sell-put-top1-w3`
+- Branch: `feat/sell-put-top1-w3`
+- Base: `origin/main@baa3e363`
+- Goal contract: `docs/gateflow/sell-put-top1-w3/goal-confirmation.md`
+- Artifact path: `docs/gateflow/sell-put-top1-w3/plan.md`
+- Current gate: draft pending PlanReview
+
+## 1. Goal and measurable completion
+
+W3 adds one production-grade persistence/write-authority seam for the Sell Put Top1 loop. It must preserve phase, authorization, hidden-window ownership, terminal intent, and projection recovery across process restarts without evaluating strategy results or reading providers.
+
+Completion means the synthetic acceptance matrix in §14 passes, the store remains the sole state authority, terminal bytes recover after every injected crash boundary, public reads reveal no hidden intermediate result, and Kimi finds no unresolved accepted issue in slice, aggregate, and PR reviews.
+
+## 2. Non-goals
+
+- No corpus, recommendation-point copying, research evaluator, leader calculation, hidden economics, outcome job/table, metrics, adoption, LLM, Prompt, CLI, Agent tool, timer, service profile, release, deploy, or real experiment.
+- No Candidate Engine, scheduler, notification, ledger, config, or broker changes.
+- No ORM, repository protocol, factory, workflow engine, event bus, queue, feature-flag platform, capability registry, or multi-store transaction coordinator.
+- No empty future tables for corpus, research results, validation rows, observations, or outcomes.
+- No duplicate raw point/candidate/result storage. W3 stores identities, refs, hashes, counters, and compact command facts only.
+
+## 3. Existing owners reused
+
+- `validate_experiment_spec()`, `build_research_spec_sha256()`, and `build_validation_spec_sha256()` remain the only ExperimentSpec/hash policy.
+- `strategy_lab_top1_available()` remains the exact maintainer gate parser; W3 imports it and does not create a second environment rule.
+- `attach_artifact_provenance()` and `artifact_content_sha256()` remain the content-hash contract for generation terminal payloads.
+- The JSON formatting already used by `shadow_replay.common.write_json()` becomes one public pure `render_json_text(payload) -> str`; `write_json()` delegates to it. No second renderer is added.
+- `private_storage` remains the sensitive SQLite path/permission owner.
+
+## 4. Files and dependency direction
+
+### Production
+
+- New `src/infrastructure/strategy_lab/__init__.py`.
+- New `src/infrastructure/strategy_lab/experiment_store.py`.
+- New `src/application/strategy_lab/top1/lifecycle.py`.
+- New `src/application/strategy_lab/top1/terminal_projection.py`.
+- Modify `src/application/shadow_replay/common.py` only to extract `render_json_text()` from the existing `write_json()` body.
+
+### Tests/docs
+
+- New `tests/test_strategy_lab_top1_store.py`.
+- Modify `tests/test_strategy_lab_top1_architecture.py` with exact import guards.
+- Regenerate `docs/DEPENDENCY_GRAPH.md` and `docs/dependency_graph.mmd` only for actual edges.
+- Add Gateflow and review artifacts.
+
+### Dependency rules
+
+```text
+experiment_store.py -> stdlib/sqlite3 + src.infrastructure.private_storage only
+terminal_projection.py -> stdlib + existing shadow_replay provenance/renderer
+lifecycle.py -> W1B contracts + M2 availability + store + terminal_projection
+production tick/M2 -> MUST NOT import lifecycle or store
+```
+
+The store never imports `domain/` or `src.application`; application policy never appears in SQL triggers.
+
+## 5. SQLite schema and migration
+
+Schema component is `sell_put_top1_experiment_store`, version `1`. The store exposes `schema_state()` without creating a file and `migrate(migrated_at_utc)` as an explicit write.
+
+Migration accepts:
+
+- a missing/empty database;
+- a synthetic version-0 database containing only the schema metadata table;
+- an already valid version-1 database idempotently.
+
+Any unknown version, missing v1 table/index, invalid foreign-key layout, or corrupt database fails closed as `schema_unsupported`; it is never silently rebuilt.
+
+Tables:
+
+### `strategy_lab_schema`
+
+`component` primary key, `schema_version`, `migrated_at_utc`.
+
+### `strategy_lab_features`
+
+One row per `(market, account)` with `user_opt_in` (`0|1`), last actor/time, and state version. Absence means false. This table never stores maintainer availability or environment values.
+
+### `strategy_lab_experiments`
+
+One row per experiment with only state/query/CAS fields:
+
+- identity: experiment/topic/market/account/strategy family;
+- one current canonical ExperimentSpec JSON plus research/validation spec hashes and compact initial provenance JSON;
+- `draft|research|validation|concluded`, nullable research/validation progress, blocked reason, completed validation partition count;
+- independent research/validation authorization status/hash/actor/time;
+- research leader/receipt binding and proposed hidden commitment binding;
+- experiment terminal intent/reason/scope/time/partition and final outcome status;
+- final receipt request/published event IDs plus ref/content/file hashes;
+- created/updated timestamps and `state_version`.
+
+Exact CHECK constraints enforce all enumerations. The only active-slot index is exactly:
+
+```sql
+UNIQUE(market, account, strategy_family)
+WHERE terminal_mode IS NULL
+  AND phase = 'validation'
+  AND validation_progress = 'collecting_decisions'
+```
+
+Research rows never match it.
+
+### `strategy_lab_generations`
+
+One row per `(experiment_id, generation_kind)` for `research|hidden|outcome` with:
+
+- `open|terminal`, monotonic revision, last revision ref/file hash, frozen-row content hash;
+- one immutable terminal-request event ID/mode/ref/content/file hash;
+- one terminal-published event ID and timestamps.
+
+No row is created for a not-yet-started generation. A generation receives at most one terminal request, so completed/aborted cannot coexist.
+
+### `strategy_lab_hidden_commitments`
+
+Exactly 20 immutable date-occupancy rows are inserted only in the transaction that starts validation. Each row stores experiment/scope, commitment hash, and one canonical trading date; the table has a unique constraint on `(market, account, strategy_family, trading_date)`. The canonical commitment JSON, ref, and content/file hashes remain stored once on the experiment and request event rather than repeated 20 times. Rows are never deleted or released.
+
+This means a proposed/locked window is not consumed, while any validation that actually starts consumes all 20 committed dates even if later aborted.
+
+### `strategy_lab_events`
+
+Append-only rows with deterministic event ID, experiment/generation scope, event type, semantic subject key, caller idempotency key, actor/time, and compact canonical payload JSON. Requested events are never updated. Publication creates a separate `terminal_projection_published` event and CAS-updates the owning row.
+
+Every mutation defines one natural subject before opening its transaction: validation point uses experiment plus point ID, partition uses experiment plus trading date, generation/experiment terminal uses its target, and singleton transitions use experiment plus transition name and bound hash/version. Natural facts are unique on `(event_type, subject_key)`. A caller idempotency key is unique inside its command scope and may only replay the same canonical request payload; the same key with different bytes conflicts. State CAS and these unique keys are both required, so different caller keys cannot duplicate the same fact.
+
+The event table is the minimal audit/outbox; there is no second outbox table. Terminal-request payloads are capped at 8 KiB. No event embeds ExperimentSpec, candidate rows, daily metrics, or source artifacts already stored by reference.
+
+All writes use one connection, `PRAGMA foreign_keys=ON`, `busy_timeout=5000`, and `BEGIN IMMEDIATE`. Default rollback journal is retained; W3 does not enable WAL.
+
+## 6. Canonical hidden commitment
+
+`build_hidden_window_commitment()` returns an exact `sell_put_top1_hidden_window_commitment.v1` object containing:
+
+- experiment ID, `HK`, lowercase account, `sell_put`;
+- exactly 20 strictly increasing canonical ISO trading dates, with start/end equal to the first/last;
+- market-calendar version;
+- fixed selector `official_scheduled_sell_put.v1` and capture schema `recommendation_point.v1`;
+- challenger variant ID, research spec hash, research terminal file hash, and behavior-binding hash.
+
+Its semantic identity is `canonical_sha256(payload)`. Its published pretty canonical bytes have a separate SHA-256. This object does not include `validation_spec_sha256`, avoiding a hash cycle; the validation hash binds the commitment hash through W1B's existing function.
+
+The artifact path is content-addressed beneath the caller-provided artifact root:
+
+```text
+strategy_lab/top1/experiments/<experiment_id>/hidden_window_commitments/<commitment_sha256>.json
+```
+
+It is write-once/adopt-exact. Publishing before the validation-start transaction is safe: a failed transaction leaves only an inert content-addressed file with no SQLite authority or date occupancy; a later changed proposal uses a different path. Public reads enumerate only SQLite-bound refs and never discover orphan files.
+
+## 7. Application commands and transitions
+
+All business write commands accept explicit `actor`, canonical UTC `occurred_at`, and `idempotency_key`. Commands that may advance an experiment also receive `artifact_root` and optional test `environ`; they evaluate the exact maintainer gate plus SQLite opt-in before any future module may read market/provider data.
+
+### Feature commands
+
+- `set_account_opt_in(store, market, account, enabled, actor, occurred_at, idempotency_key, artifact_root, environ)` stores only user intent.
+- Enabling requires the exact maintainer availability value `1`; when maintainer availability is off it returns `feature_disabled` without creating or changing the account feature row.
+- Disabling commits `user_opt_in=false` first, then idempotently terminates every active account experiment with `experimental_feature_disabled/user`; a crash can leave projection pending but never re-enable writes.
+- `reconcile_disabled_experiments(...)` handles maintainer-off with scope `maintainer` without changing user opt-in. It is idempotent and performs no market/provider read.
+- Every normal write calls the same effective-gate check. When false, it first reconciles active termination, then raises `feature_disabled`.
+
+### Draft and research
+
+- `prepare_experiment()` validates a research-ready W1B spec, exact experiment/account identity, initial source/config/policy hashes, and computes the research hash. A same-byte retry is idempotent.
+- While still draft, a changed valid spec replaces the single current spec and invalidates research plus validation authorization. Once research starts, the research-hash domain is immutable. After the completed research terminal is published, `lock_challenger()` may first add validation-only fields, and before validation starts may replace only those validation-only fields while the research hash remains exact; either change invalidates validation authorization.
+- `authorize_research()` records a human confirmation only for the current exact research hash.
+- `start_research()` requires effective feature, confirmed current hash, and the sealed historical dataset ref/hash already present in the spec. It atomically enters `research/building_dataset` and creates the research generation at revision 0 bound to that dataset. Research occupies no validation slot.
+- `record_generation_revision()` is a narrow lifecycle CAS used later by W5/W6: exact next revision, ref/file hash, and frozen-row hash only. It stores no result rows and rejects any terminal-requested generation.
+- `seal_generation()` requests one completed terminal for an open generation. It does not conclude the experiment or calculate a result.
+
+### Leader lock and validation
+
+- `lock_challenger()` requires a published completed research generation, a research receipt ref/hash, and a caller-supplied system leader equal to the requested non-baseline challenger. W3 checks membership and equality but does not calculate the leader.
+- It validates a validation-ready W1B spec whose research hash is unchanged, builds/validates the 20-date commitment, computes the validation hash, stores one current proposal, and sets validation authorization to unconfirmed/invalidated. Before validation starts, changing only a valid future commitment/spec repeats this step and invalidates any previous validation confirmation.
+- `authorize_validation()` confirms only the current exact validation hash.
+- `start_validation()` first write-once publishes/adopts the content-addressed canonical commitment. In one SQLite transaction it rechecks effective opt-in state, exact authorization/spec/hash, exact-date uniqueness for all 20 dates, and the partial unique slot; then it inserts the 20 consumed date rows, enters `validation/collecting_decisions`, and creates hidden generation revision 0 bound to the commitment artifact.
+
+### Validation writes and day-20 boundary
+
+- `commit_validation_point()` records only point ID, trading date, source ref/hash, and the resulting hidden-manifest next revision/ref/file/frozen-row hashes. Multiple points may share one committed trading date. Same identity/bytes is idempotent; same point with different facts conflicts.
+- `seal_validation_partition()` requires the next sequential commitment date, at least one committed official point for that date, and no later date already sealed. It increments only the completed-partition counter.
+- Partitions 1–19 retain `collecting_decisions` and the slot. Partition 20 atomically closes point/partition intake, requests the hidden generation's completed terminal, sets `validation_progress=awaiting_outcomes`, and releases the slot. W3 cannot infer an empty outcome set from the absence of W6's table and offers no normal completion path. W6 later extends this atomic command to close its job-registration set, request an empty/non-empty outcome terminal, and choose `awaiting_outcomes|ready_to_conclude` from actual job rows.
+- Any point, revision, or partition after terminal request/day 20 fails as `late_write`; legal appends do not change either authorization hash/status.
+
+## 8. Terminal payload and projection
+
+### Generation terminal
+
+`build_generation_terminal_request()` creates exact canonical bytes for `sell_put_top1_generation_terminal.v1` with generation kind/ID, terminal mode/reason/scope/time, last revision/ref/file hash, frozen-row hash, nullable compact aborted-partial summary, and existing `research_artifact_provenance.v1`.
+
+- Completed requires null reason/scope.
+- Aborted reason is exactly `human_abandoned|behavior_binding_drift|experimental_feature_disabled`; only feature-disabled allows `disabled_scope=user|maintainer`.
+- `terminal_sha256` is outside the terminal payload in SQLite/event rows, avoiding self-reference.
+
+### Aborted experiment receipt
+
+- `terminate_experiment()` builds W3's deterministic aborted `sell_put_top1_experiment_receipt.v1` with `outcome_status=insufficient_evidence`, no adoptable metrics, started-generation planned terminal refs/hashes, and not-started markers for absent generations.
+- W3 does not expose `complete_experiment()`. W5/W6 add normal completion only after their exact research/validation facts and receipt schema validation exist. The store keeps only the minimal terminal-request/CAS primitive they will reuse.
+- The aborted experiment terminal request is immutable. Same requested bytes are idempotent; a different mode or bytes conflict. W3's completed-vs-aborted competition is exercised at the generation terminal CAS.
+
+### Recovery
+
+The terminal transaction:
+
+1. commits experiment terminal intent when applicable;
+2. requests a terminal for every still-open generation that has no prior request, preserving already requested/published terminals;
+3. appends one final receipt request last.
+
+`recover_terminal_projection(store, artifact_root, publisher=None)` scans requested-but-unpublished targets in event order. The default publisher:
+
+- rejects unsafe/symlink paths;
+- writes requested UTF-8 bytes to a same-directory temporary file, file-fsyncs, atomically links/publishes or adopts exact existing bytes, and parent-fsyncs;
+- treats same parsed JSON with different bytes as conflict.
+
+After each successful file, a second SQLite transaction validates event/ref/content/file hashes, appends a published event, and CAS-updates its target. The experiment becomes `concluded` only when the receipt and every started generation are published. Crash/retry never re-renders bytes and never reads market/provider data.
+
+## 9. Termination semantics
+
+- `terminate_experiment()` is allowed even when feature gates are off and is the only normal write besides projection recovery allowed after disable.
+- Terminal reason/scope and `terminated_at_partition` are immutable. Validation abort records the current completed partition count and permanently retains the full hidden commitment; research/draft abort uses null partition.
+- Setting experiment terminal mode immediately blocks all new revisions, points, partitions, starts, and result requests, and releases an active validation slot even if artifact projection is pending.
+- A completed generation request that wins before abort remains completed; abort requests only generations still open without a request. If abort wins first, a late completed seal affects zero rows and returns `experiment_terminated`/`terminal_conflict` without storing the late result.
+- Feature disable terminates all active experiments with `experimental_feature_disabled`, the correct disabled scope, and caller actor. It never rewrites a previously terminal generation.
+
+## 10. Public read projections
+
+`read_public_status()` returns only:
+
+- effective gate sources/status;
+- experiment identity, phase/progress, authorization statuses and bound hashes;
+- completed partition count, blocked reason, terminal mode/reason/scope, projection state;
+- generation kind/state/revision/terminal mode/ref/hashes.
+
+It never returns point identities, variant interim ranks, daily deltas, observation/outcome facts, metrics, or an interim winner.
+
+`read_public_receipt()` returns `None` until phase is `concluded` and the receipt publication event is linked. It then parses the exact requested canonical bytes already verified by recovery. No filesystem or market read is performed by the store read.
+
+## 11. Error contract
+
+`Top1LifecycleError.reason_code` is limited to stable boundary failures:
+
+```text
+schema_unsupported
+feature_disabled
+experiment_invalid
+experiment_conflict
+invalid_transition
+authorization_required
+authorization_hash_mismatch
+hidden_window_overlap
+validation_slot_occupied
+generation_conflict
+late_write
+terminal_conflict
+projection_conflict
+receipt_unavailable
+```
+
+SQLite integrity errors are translated at the application boundary; raw SQL/schema text is not exposed in public status.
+
+## 12. Implementation slices
+
+### S1 — Store, gate, authorization, slot, and append CAS
+
+- Add schema/migration/store commands and lifecycle through point/partition commit.
+- Add exact import guards and migration/gate/authorization/slot/late-write tests.
+- No terminal file writer beyond commitment write-once publication.
+
+Completion: fresh/v0/v1 migration, default-off/effective gate, maintainer-off enable no-write, separate authorization, research no-slot, exact-date commitment ownership, second active validation, natural-fact/idempotency conflicts, and day19/day20 slot tests pass.
+
+### S2 — Terminal request, recovery, and public projection
+
+- Add generation/aborted-receipt terminal builders, generation completed/aborted CAS, disable/abandon reconciliation, safe publisher, recovery, status, and receipt.
+- Add all crash/concurrency/byte-conflict/non-leak tests.
+
+Completion: all §14 tests pass and S1 remains green.
+
+Each slice receives focused self-review. The complete W3 module then receives the user-required Kimi DeepReview, fixes/re-review, aggregate review, Draft PR, CI, PR-level Kimi review, and only separately authorized merge.
+
+## 13. Validation commands
+
+```text
+python -m pytest -q tests/test_strategy_lab_top1_store.py tests/test_strategy_lab_top1.py tests/test_strategy_lab_top1_w1b.py tests/test_recommendation_point.py tests/test_strategy_lab_top1_architecture.py
+python -m pytest -q tests/test_candidate_snapshot_manifest.py tests/test_opening_candidate_snapshot.py tests/test_daily_decision_brief_notification_flow.py tests/test_position_projection_migration.py
+ruff check src/infrastructure/strategy_lab src/application/strategy_lab/top1/lifecycle.py src/application/strategy_lab/top1/terminal_projection.py src/application/shadow_replay/common.py tests/test_strategy_lab_top1_store.py tests/test_strategy_lab_top1_architecture.py
+basedpyright --level error src/infrastructure/strategy_lab/experiment_store.py src/application/strategy_lab/top1/lifecycle.py src/application/strategy_lab/top1/terminal_projection.py
+python scripts/generate_dependency_graph.py --check
+python -m pytest -q
+git diff --check
+```
+
+Full-suite environmental failures are classified with exact evidence; they are not represented as broad passes without closure.
+
+## 14. Acceptance matrix
+
+### Migration and storage
+
+- Missing DB read is `not_initialized` without file creation; fresh/v0 migrate to v1; repeated v1 is identical; unknown/corrupt/partial v1 fails closed.
+- SQLite file and sidecars remain private; no WAL is enabled.
+- Exact schema constraints/indexes exist, including the required partial slot index; no future corpus/validation/outcome table exists.
+- Stored specs/events are compact canonical JSON; terminal request payload is below 8 KiB.
+
+### Gate and authorization
+
+- Missing/non-`1` maintainer env and absent account row are false; maintainer false overrides opt-in true.
+- Enabling while maintainer false changes no SQLite row; disabling remains idempotent even when maintainer false or the row is absent.
+- Research hash change in draft invalidates research/downstream validation; validation-only change after leader lock invalidates only validation.
+- Exact research/validation confirmation is required; stale/wrong hashes fail; legal hidden append does not invalidate either.
+
+### Slot and commitment
+
+- Multiple research experiments can start concurrently without occupying a slot.
+- Validation start rejects same account active collector, any exact historical trading-date overlap, wrong 20-date order/count, stale authorization, or same-path byte conflict.
+- A pair of commitments whose start/end envelopes intersect but whose exact dates do not may coexist; one shared exact date always conflicts.
+- A commitment file published before a failed start transaction has no SQLite authority and cannot block a changed content-addressed proposal.
+- Day 19 retains slot and rejects second collector; day 20 request/close transaction rejects late point/partition and permits a non-overlapping new collector while the old experiment remains `awaiting_outcomes`.
+- Aborting validation keeps all 20 commitment date rows and releases only the active collection slot.
+
+### Idempotency, terminal competition, and recovery
+
+- Same prepare/auth/start/point/partition/terminal command is idempotent; same identity with different bytes conflicts; double writers create one event/point/request. Different caller keys cannot duplicate one natural point/partition/terminal fact, and reuse of one caller key with different bytes conflicts.
+- Completed request first then abort preserves completed generation bytes; abort first rejects late completed seal; one generation never has two terminal requests.
+- Injected crash after terminal DB commit, after each file publish, and before/after publication CAS recovers the exact requested bytes/ref/content/file hashes without duplicate requested/published events.
+- Existing exact file adopts; same JSON content with a byte difference conflicts and leaves DB pending.
+- Feature disable before/during research, after research completion but before validation, during validation, and while projection pending blocks new writes immediately and converges to one aborted receipt with correct scope/reason.
+
+### Read isolation
+
+- Validation status throughout days 1–20 contains no point IDs, ranks, arm metrics, daily deltas, outcome facts, or leader conclusion.
+- In W3, receipt is unavailable before conclusion and exact after aborted projection CAS; normal completed receipt remains absent until W5/W6 add and validate it.
+- Terminal/recovery paths make zero market/provider/recommendation-point reads.
+
+## 15. Risks and deferred ownership
+
+- W4 owns corpus rows and long-term ranking projections.
+- W5 owns research result computation, leader policy, research receipt payload, and any research-only normal conclusion command.
+- W6 owns validation rows, outcome jobs, day-20 job-aware progress choice, metrics, and the normal final completion command/receipt validation.
+- W7 owns CLI/service/profile/timer surfaces and installed effective-gate evidence.
+- W8 owns LLM/Prompt/advisory provenance.
+- W3 deliberately uses one SQLite writer and synchronous artifact recovery calls; add a worker/queue only if measured runtime contention or recovery latency requires it.
+
+## 16. No-overdesign check
+
+The design adds exactly five current-state tables, one append-only event table as the outbox, two application modules, and no new dependency. It stores only facts required for restart, authorization, slot, and terminal recovery. Later data tables and successful-result policy remain absent.
+
+## 17. Gate sequence
+
+1. PlanReview this draft against the goal and current code.
+2. Fix every accepted plan finding and re-review until pass.
+3. Commit the accepted plan.
+4. Implement S1, verify, then S2 and verify.
+5. Run Kimi Current Changes DeepReview; fix/re-review to zero unresolved accepted findings.
+6. Commit accepted implementation and run Kimi aggregate committed-range review.
+7. Open Draft PR, wait required CI, run Kimi PR review, record closeout.
+8. Ready/merge only under explicit user authorization; never release or deploy implicitly.

--- a/docs/gateflow/sell-put-top1-w3/ready-to-open-draft-pr.md
+++ b/docs/gateflow/sell-put-top1-w3/ready-to-open-draft-pr.md
@@ -1,0 +1,33 @@
+# Gateflow Readiness — Sell Put Top1 W3 Draft PR
+
+- Gate: `ready-to-open-draft-PR`
+- Work unit: `sell-put-top1-w3`
+- Branch: `feat/sell-put-top1-w3`
+- Base: `origin/main@baa3e363`
+- Accepted plan: `9a6a13c2`
+- Accepted implementation: `1c34b69d`
+- Accepted aggregate review: `bc3a8421`
+- Status: ready to publish branch and open Draft PR
+
+## Scope check
+
+- `origin/main...HEAD` contains only the accepted W3 plan, private experiment lifecycle/store, exact terminal projection/recovery, focused tests, generated dependency graph, and Gateflow/review evidence.
+- W3 adds no strategy result computation, corpus/outcome/decision table, provider read, timer/CLI/Agent integration, production tick dependency, account runtime config, service change, or real experiment execution.
+- `origin/main` was refreshed immediately before this gate and remains `baa3e363`, equal to the branch merge base.
+- The worktree is clean and `git diff --check origin/main...HEAD` passes.
+
+## Validation
+
+- Focused W1-W3 suite: `110 passed`; adjacent regression suite: `104 passed`.
+- Ruff: pass; BasedPyright error level: `0 errors, 0 warnings, 0 notes`.
+- Dependency graph: current, `588` production modules, `0` cycles.
+- Initial, fix, and aggregate Kimi DeepReviews: pass, zero unresolved findings.
+- Final sandbox full suite: `4881 passed, 10 skipped`; its sole sandbox-denied loopback test passed separately outside the sandbox (`1 passed`).
+
+## Authority boundary
+
+Publishing the branch and opening a Draft PR are source-review actions only. This gate does not authorize merge, release, deployment, service/configuration changes, runtime writes, real experiments, notifications, market-data reads, ledger writes, or broker actions.
+
+## Next transition
+
+Commit this readiness artifact, push the accepted branch, open a Draft PR, wait for required CI, and run PR-level Kimi DeepReview before requesting merge authorization.

--- a/docs/reviews/code-review-20260815-124143.md
+++ b/docs/reviews/code-review-20260815-124143.md
@@ -1,0 +1,38 @@
+# Code Review
+
+## Scope
+
+- Mode: current changes
+- Work unit: `sell-put-top1-w3`（状态存储与终态恢复模块）
+- Base: `HEAD=9a6a13c2`（accepted plan commit）
+- Output file: `docs/reviews/code-review-20260815-124143.md`
+- Included scope: `src/infrastructure/strategy_lab/experiment_store.py`、`src/application/strategy_lab/top1/lifecycle.py`、`src/application/strategy_lab/top1/terminal_projection.py`、`src/application/shadow_replay/common.py`、`tests/test_strategy_lab_top1_store.py`、`tests/test_strategy_lab_top1_architecture.py`、`docs/DEPENDENCY_GRAPH.md`、`docs/dependency_graph.mmd`
+- Contract 对照：`docs/gateflow/sell-put-top1-w3/goal-confirmation.md`、`plan.md`、`plan-fix.md`、`implementation.md`
+- 验证：`tests/test_strategy_lab_top1_store.py` + `tests/test_strategy_lab_top1_architecture.py` 本地运行 `13 passed`；另用临时脚本实证两处疑点（store 层 stale-auth 拒绝、中间路径组件 symlink 拒绝）
+- Excluded scope: 全量 suite（按任务要求未运行）；W5/W6/W7 后续模块
+
+## Findings
+
+### 1-未修复-中-授权变更后过期确认会先发布承诺文件并在事件日志留下孤儿 `validation_started` 事实
+
+- **入口/函数**: `lifecycle.start_validation()` -> `publish_exact_text()` -> `store.start_validation()`
+- **文件(行号)**: `src/application/strategy_lab/top1/lifecycle.py:752-797`；`src/infrastructure/strategy_lab/experiment_store.py:743-772`
+- **输入场景**: 实验在 `challenger_locked` 且已确认 validation hash A；随后 `lock_challenger()` 以**变更后的** 20 日期（新 validation hash B）重新提案，`validation_authorization_status` 回到 `unconfirmed`；调用方持过期 hash A 调用 `start_validation()`。
+- **实际分支**: lifecycle 先做 4 项 hash/ref 一致性校验（`proposed_commitment_*`，均与当前提案 B 匹配、全部通过），再执行 `publish_exact_text()` 把 B 的承诺字节写入 content-addressed 文件，最后才进入 `store.start_validation()`。store 的 `_claim_event()` 在 `authorization_required` 校验**之前**就插入 `validation_started` 事件（subject 为 `experiment:exp:validation:<stale-hash-A>`）；授权检查失败抛错后整个事务回滚（`event INSERT` 回滚、`generations`/`experiments` 更新未发生），但 **B 的承诺文件已持久化在磁盘上**。
+- **预期行为**: 授权过期/不匹配时应尽早失败（在文件发布与事件声明之前），失败路径不留下任何带 stale hash 语义的 `validation_started` 意图记录；实现文档自述的 orphan 语义是“a failed transaction leaves only an inert content-addressed file”，即仅允许承诺文件残留。
+- **实际行为**: 承诺文件残留属于设计内（inert），不受影响的是 SQLite 权威；这里的问题仅剩事件声明在授权校验之前插入。若将来有人把 claim 与校验拆分（例如 claim 前置提交、或事件表被外部按 `validation_started` 订阅消费），stale-hash 事件会被误读为一次真实启动意图。当前实现中事务回滚使该事件不可见，因此风险为“顺序脆弱性”而非现行正确性漏洞。
+- **直接证据**: `experiment_store.py:743-772` 中 `self._claim_event(... event_type="validation_started", subject_key=f"experiment:{experiment_id}:validation:{authorized_hash}" ...)` 位于 `if current["validation_authorization_status"] != "confirmed" or current["validation_authorized_hash"] != authorized_hash ... raise authorization_required` 之前；`lifecycle.py:774-788` 先 `publish_exact_text()` 后 `_call(store.start_validation, ...)`。实证脚本（`/tmp/w3_check2.py`）输出：`CHECK3 rejected: authorization_required`、`commitment file exists after failed start: True`、事件序列中因回滚未见 `validation_started`（但 `challenger_locked` 重复出现，说明 relock 正常）。
+- **影响**: 当前无现行数据错误；一旦 claim/校验顺序被后续修改或事件被异步消费，stale hash 启动意图会泄漏为持久事实；同时“授权未确认时不应产生任何写入”的直觉语义被弱化，增加 W6 接入时的误用面。
+- **建议改法和验证点**: 将授权/状态前置校验移到 `_claim_event` 之前（`start_research`/`start_validation` 的 `authorization_required`、`invalid_transition`、`proposed_commitment_sha256` 校验同理），或至少把 `validation_started` 的 claim 移到所有前置校验之后；lifecycle 侧将 `publish_exact_text()` 移到 store 授权校验通过之后（例如 store 先做一次只读预检或在同一事务内先校验再发布——若保持文件发布在事务外，则可在 lifecycle 先用一次只读 `store.experiment`+authz 复核再发布）。新增测试：relock 变更后用 stale hash 调 `start_validation`，断言 `store.events()` 中不存在 `validation_started` 事件，且若保留“发布后置”设计则断言承诺文件不存在。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- `start_research` 与 `terminate`/`seal_validation_partition` 等其余写路径同样采用“先 `_claim_event` 后前置校验”的顺序（如 `start_research` 的 claim 在 `invalid_transition`/`authorization_required` 之前）。同一事务回滚使当前无泄漏，但上述 finding 的顺序修正若只做 `start_validation` 一处，模式不一致会留下同类脆弱性；建议统一修正或统一论证保留。
+- `lock_challenger()` 对 `spec_json` 的更新无“未实际变更”保护：同一提案重复调用会重复追加 `challenger_locked` 自然事实事件（不同 subject、无冲突），事件表随之增长。当前规模下无害，属刻意幂等语义而非缺陷。
+- 本会话未运行全量 suite；`ready_to_conclude` 等 W6 语义未被 W3 触发，符合 plan 的 deferral。

--- a/docs/reviews/code-review-20260815-124608.md
+++ b/docs/reviews/code-review-20260815-124608.md
@@ -1,0 +1,41 @@
+# Code Review
+
+## Scope
+
+- Mode: Kimi re-review of `docs/reviews/code-review-20260815-124143.md` Finding 1
+- Work unit: `sell-put-top1-w3`
+- Fix artifact: `docs/gateflow/sell-put-top1-w3/deepreview-fix.md`
+- Included scope: `src/application/strategy_lab/top1/lifecycle.py`（`start_validation` 预检）、`tests/test_strategy_lab_top1_store.py`（新增 stale-auth 回归）、`src/infrastructure/strategy_lab/experiment_store.py`（claim 顺序拒绝理由复核）
+- 验证：`tests/test_strategy_lab_top1_store.py` + `tests/test_strategy_lab_top1_architecture.py` 本地运行 `13 passed`
+
+## Findings
+
+无未解决实质性 finding。Finding 1 的处置裁决如下：
+
+### Finding 1 — 已修复（接受部分），剩余部分拒绝理由成立
+
+**接受部分已真正消除 stale authorization 的文件副作用。**
+
+`lifecycle.start_validation()` 现在在 `publish_exact_text()` 之前执行两项读侧预检：
+
+- phase/progress 预检（`experiment["terminal_mode"] is not None or not (phase == "research" and research_progress == "challenger_locked")` → `invalid_transition`）；
+- 精确授权预检（`validation_authorization_status != "confirmed"` 或 `validation_authorized_hash != validation_spec_sha256` 或 `validation_spec_sha256 != validation_spec_sha256` → `authorization_required`）。
+
+`tests/test_strategy_lab_top1_store.py:603-637` 的新回归覆盖完整场景：`experiment-overlap` 经变更式 relock 得到新 20 日期提案后，持旧 hash 调 `start_validation`，断言 `authorization_required`、`replacement_ref` 承诺文件不存在、且事件日志中没有任何 `authorized_hash == 旧 hash` 的 `validation_started` 业务事件。这关闭了 Finding 1 中“承诺文件残留 + stale-hash 事件意图”的文件副作用面；store 事务内的重复校验继续作为并发竞争的最终权威。
+
+**对“事务内 `_claim_event` 顺序”建议的拒绝理由成立。**
+
+两点均经得起复核：
+
+1. **BEGIN IMMEDIATE 回滚可见性**：`_claim_event` 与所有前置校验在同一 `BEGIN IMMEDIATE` 事务内执行；校验失败触发 rollback，`validation_started` 事件在提交前不可见。W3 无任何外部事件订阅者，`strategy_lab_events` 仅为内部审计/幂等依据，因此“事件先插入后回滚”不会泄漏为持久事实。事件表对外不可读（无公开 API 按 `event_type` 枚举业务事件供下游消费）。
+2. **状态推进后自然事实 alias replay**：`start_validation` 成功后 `phase` 从 `research/challenger_locked` 推进到 `validation/collecting_decisions`。若把 claim 移到状态校验之后，第二个持**不同 caller idempotency key** 的调用方重放同一自然启动事实时，会先撞上 `invalid_transition`（phase 已不再是 `challenger_locked`），而无法走到自然事实命中与 alias 绑定；claim-first 让该合法 replay 先命中自然事实、绑定 alias、返回当前状态。这与 `test_separate_authorization_day20_and_hidden_status` 中 `commit_validation_point` 双写并发（两个不同 caller key 同一 `point-1` 自然事实只产生一条事件）依赖的是同一机制。将 claim 移到校验之后会把这个合法 replay 变成 `invalid_transition`，破坏幂等语义。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 读侧预检与 store 事务校验之间存在 TOCTOU 窗口：预检通过后、事务开始前授权可能被并发 relock 吊销。此时文件已发布但 store 事务会 `authorization_required` 回滚，留下 inert content-addressed orphan 文件（与 PR-W3-01 的设计一致，无 SQLite 权威）。该窗口是“发布在事务外”架构的固有取舍，已在 plan 中明确接受。
+- `lock_challenger` 同字节重复调用仍追加 `challenger_locked` 自然事实事件（不同 subject），事件表随重试增长；当前规模无害。
+- 本 re-review 未运行全量 suite。

--- a/docs/reviews/code-review-20260815-125230.md
+++ b/docs/reviews/code-review-20260815-125230.md
@@ -1,0 +1,40 @@
+# Code Review
+
+## Scope
+
+- Mode: aggregate committed range
+- Range: `9a6a13c2..1c34b69d`（单提交 `1c34b69d feat(strategy-lab): add Top1 experiment lifecycle store`）
+- 工作树状态：空（`git status --short` 无输出）
+- 对照契约：`docs/gateflow/sell-put-top1-w3/goal-confirmation.md`、`plan.md`、`plan-fix.md`、`implementation.md`、`deepreview-fix.md`
+- 审查方式：committed bytes 与两轮 current-changes review 时通读的工作树文件逐字节 diff（`experiment_store.py`/`lifecycle.py`/`terminal_projection.py`/`test_strategy_lab_top1_store.py` 全部 `COMMITTED_MATCHES_REVIEWED`），并核对提交清单完整性
+- 测试证据：复用 re-review 时 `tests/test_strategy_lab_top1_store.py` + `tests/test_strategy_lab_top1_architecture.py` `13 passed`；未跑全量 suite
+
+## 提交完整性核对
+
+提交包含且仅包含 accepted plan §4 声明的文件集：
+
+- 生产：`src/infrastructure/strategy_lab/__init__.py`、`experiment_store.py`、`src/application/strategy_lab/top1/lifecycle.py`、`terminal_projection.py`，外加 plan 明确允许的 `src/application/shadow_replay/common.py` 的 `render_json_text()` 提取（9 行，纯函数抽取，`write_json` 委托，无行为变化）。
+- 测试/文档：`tests/test_strategy_lab_top1_store.py`（741 行，含 stale-auth 回归）、`tests/test_strategy_lab_top1_architecture.py`（精确 import guard + production tick 不依赖 store 的守卫）、`docs/DEPENDENCY_GRAPH.md`/`docs/dependency_graph.mmd`（仅边计数变化：`src.application → domain.domain` 200→201、`src.application → src.infrastructure` 93→96，无循环）。
+- Gateflow 闭环 artifacts：`implementation.md`、两份 current-changes review（`124143` 与 `124608`）、`deepreview-fix.md` 均已入库。
+
+无遗漏、无误带：无 `VERSION`/`CHANGELOG`/release/CI/生产 tick/config/service 文件；无 ORM/queue/event-bus/worker；无 corpus/validation/outcome 结果表。
+
+## Findings
+
+无。聚合范围内的关键路径在 committed bytes 上与两轮 current-changes review 通过的版本逐字节一致：
+
+- **SQLite schema/migration/事务**：单连接 `BEGIN IMMEDIATE`、无 WAL、`foreign_keys=ON`、缺/空/v0/v1/未知版本均 fail-closed；partial unique slot 索引与 20-date 精确占用唯一索引均在 `_validate_v1` 强制清单内。
+- **幂等与自然事实**：`_claim_event` 的 caller-scope 幂等键 + `(event_type, subject_key)` 自然事实唯一 + alias 绑定三层均保留；Finding 1 拒绝理由依赖的“状态推进后 alias replay”机制未被改动。
+- **20 日占用与 day20 原子边界**：20 行 date-occupancy 仅在 start_validation 事务内插入、从不删除；day20 在同一事务内关闭 intake、请求 hidden terminal、释放 slot。
+- **终态竞争与 crash recovery**：completed/aborted 单 terminal request CAS、`mark_projection_published` 二次事务、`_maybe_conclude` 仅当全部 started generation 已发布才 `concluded`；`publish_exact_text` 的 link/adopt-exact/byte-conflict/symlink 拒绝路径完整。
+- **Finding 1 修复**：`start_validation` 的读侧 phase+精确授权预检位于任何文件发布之前，stale-auth 回归测试在 committed 测试文件中（`tests/test_strategy_lab_top1_store.py` relock→stale start→`authorization_required`→无承诺文件→无 stale `validation_started` 事件）。
+- **hidden read isolation 与 W3 边界**：`read_public_status` 不输出 point/rank/delta/outcome；receipt 仅 concluded 后可读；无 W5/W6/W7 结果计算或 `complete_experiment` 公开命令。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 与前两份 review 一致：lifecycle 读侧预检与 store 事务间存在 TOCTOU 窗口，失败路径仅留下设计内的 inert content-addressed orphan 文件（无 SQLite 权威）；`lock_challenger` 同字节重复调用追加自然事实事件（规模无害）。
+- 聚合审查未重新执行测试，证据复用自 `1c34b69d` 提交前的聚焦运行；committed bytes 与当时工作树逐字节一致，故该证据对 committed range 有效。全量 suite 留待 CI 门禁。

--- a/docs/reviews/plan-review-20260815-113103.md
+++ b/docs/reviews/plan-review-20260815-113103.md
@@ -1,0 +1,115 @@
+# Plan Review — Sell Put Top1 W3
+
+- Reviewed target: `docs/gateflow/sell-put-top1-w3/plan.md`
+- Goal contract: `docs/gateflow/sell-put-top1-w3/goal-confirmation.md`
+- Reviewed base: `origin/main@baa3e363`
+- Scope: SQLite ownership, feature gate, authorization, exact hidden-date consumption, collection-slot release, terminal competition/recovery, public isolation, and W3/W5/W6 ownership
+- Artifact path: `docs/reviews/plan-review-20260815-113103.md`
+
+## Assumptions tested
+
+- Publishing the hidden commitment before the validation-start transaction cannot permanently block a later valid proposal.
+- A maintainer-disabled installation may safely persist a new account opt-in.
+- Inclusive start/end ranges are equivalent to exact-date overlap for every valid commitment.
+- W3 can determine the day-20 post-decision state without an outcome-job authority.
+- W3 can safely accept a caller-constructed successful final receipt before W5/W6 define its policy contract.
+- Deterministic event IDs alone fully specify command idempotency and natural-fact uniqueness.
+
+## Findings
+
+### PR-W3-01-未修复-高-固定 commitment 路径在事务前发布，会把未消费提案变成不可恢复的实验阻塞
+
+- **位置**: §6 固定 `hidden_window_commitment.json` 路径、§7 `start_validation()` 先发布文件再开始 SQLite 事务、§14 commitment/file conflict 验收。
+- **问题类型**: 崩溃恢复 / 状态机漏洞。
+- **反例/失败场景**: 提案 A 的 commitment 文件成功发布，但 validation-start 事务因 slot 竞争、日期重叠或进程崩溃而未提交。该窗口按合同尚未消费，用户随后合法改为提案 B；B 使用同一固定路径，但 bytes 不同，因此永久冲突。
+- **影响**: 一个未成功启动的提案会锁死整个 experiment ID；只能人工删文件或更换 experiment，违反 write-once、自动恢复和“仅实际 start 才消费窗口”的合同。
+- **建议改法和验证点**: 继续采用最小的写前发布，但把 ref 改为 experiment 下按 commitment SHA-256 分址的 write-once 路径。相同提案采用现有 bytes，不同提案使用不同路径；失败事务留下的小文件没有 SQLite 权威，也不占日期。增加“文件已发布、DB 未提交、随后更换 proposal”回归，证明 B 可启动且 A 不出现在 status/receipt/占用表。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 高。
+
+### PR-W3-02-未修复-高-maintainer 关闭时仍写入 opt-in，会产生维护方重新开放即自动生效的潜伏授权
+
+- **位置**: §7 Feature commands 的“Enabling is allowed while maintainer availability is off”。
+- **问题类型**: 产品授权合同偏移。
+- **反例/失败场景**: maintainer gate 为 false 时用户执行 enable，W3 保存 `user_opt_in=true`；之后维护方只恢复全局 availability，账户无需再次操作便自动成为 effective enabled。
+- **直接证据**: 产品合同 §15.1 明确规定 `feature enable` 只在 maintainer availability=true 时写入；maintainer 关闭返回 unavailable 且不写。`feature disable` 才是始终可调用的例外。
+- **影响**: 全局下线窗口中形成潜伏的账户授权，恢复功能时扩大实际启用范围。
+- **建议改法和验证点**: enable 在 maintainer 非 `1` 时返回 `feature_disabled` 且不创建/修改 feature row；disable 继续无条件、幂等地先落 `user_opt_in=false` 再封存 active experiments。增加“maintainer off enable leaves no row”测试。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 高。
+
+### PR-W3-03-未修复-中-用 start/end 区间代替 exact trading-date 占用，会把非重叠 commitment 错误永久封死
+
+- **位置**: §5 `strategy_lab_hidden_commitments` 单行 start/end、`BEGIN IMMEDIATE` 下 inclusive interval predicate；§14 historical inclusive overlap。
+- **问题类型**: 数据模型与产品合同不一致。
+- **反例/失败场景**: W3 只校验 20 个严格递增日期，不掌握交易日历连续性。一个稀疏或日历版本不同的 commitment 可与另一个 exact-date 集合没有共同日期，但其 start/end 区间交叠；区间判定会把后者永久拒绝。
+- **直接证据**: 产品合同 §6.3 要求同一事务逐个检查 `(market, account, strategy_family, trading_date)`；不是检查包络区间。
+- **影响**: 合法全新窗口被保守误杀，且 commitment 不可释放，误杀是永久的。
+- **建议改法和验证点**: 不增加新表；让现有 commitment 表按 20 个日期各存一条轻量占用行，并以 `(market, account, strategy_family, trading_date)` 唯一约束保证精确重叠。canonical payload/hash/ref 只在 experiment/event 中保存一次。增加“包络相交但 exact dates 不相交可通过”和“任一 exact date 相同即拒绝”测试；连续性仍由后续 calendar readiness 负责。
+- **修复风险（低/中/高）**: 中。
+- **严重程度（低/中/高/严重）**: 中。
+
+### PR-W3-04-未修复-高-W3 在 day 20 宣称 `ready_to_conclude`，越过了 W6 的 outcome-job 注册权威
+
+- **位置**: §7 day-20 boundary 的 `ready_to_conclude for W3's zero-outcome-job schema`；§14 day 20 old experiment ready/awaiting terminal work。
+- **问题类型**: 模块所有权 / 过早终态。
+- **反例/失败场景**: W3 的“没有 job 表”只能表示 W3 无法观察 job，不等于一次正式 validation 没有应注册的 outcome。若该状态配合 §8 的 `complete_experiment()`，实验可在决策窗口结束时提前成功完结，绕过到期结果。
+- **直接证据**: 产品合同 §3.2/§6.3 要求第 20 日在 job 注册集封闭的同一事务内，根据真实非终态 jobs 选择 `awaiting_outcomes|ready_to_conclude`；outcome jobs 和空队列 seal 均由 W6 拥有。
+- **影响**: W3 暴露一个看似合法但证据不完整的正常完成路径，W6 必须反向修正已发布状态语义。
+- **建议改法和验证点**: W3 day 20 固定进入 `awaiting_outcomes`、封闭 hidden generation 并释放 slot；W3 不提供正常完成。W6 增加 job 表后，在其原子 day-20 命令中按真实 job 集选择状态，并负责空 outcome seal。W3 验收只证明 slot 释放和 late-write 拒绝。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 高。
+
+### PR-W3-05-未修复-中-`complete_experiment()` 让 W3 接受尚无策略 schema 权威的成功回执
+
+- **位置**: §8 Experiment receipt、§9 completed/aborted 竞争、§11 error contract。
+- **问题类型**: 范围越界 / 信任边界缺失。
+- **反例/失败场景**: 调用者传入一份 envelope/hash 看似一致、但指标或结论语义错误的 `completed` receipt。W3 只验证“allowed outcome status”和 bindings，无法验证 W5/W6 尚未实现的 research/validation 事实，仍可把 experiment 置为 concluded。
+- **直接证据**: W3 goal contract 明确只允许 W3 完结 aborted path；正常 research/validation completion payload 属于 later-module policy。M3 的公开命令示例也只有 generation seal 与 terminate，没有 `complete_experiment()`。
+- **影响**: 正常结论的唯一权威被提前下放给任意调用者，也扩大 W3 实现和测试范围。
+- **建议改法和验证点**: 从 W3 删除公开 `complete_experiment()`；保留 store 内最小 terminal-request/CAS 原语和 generation completed-vs-aborted 竞争。W5/W6 各自在拥有精确 receipt schema/事实后新增正常完成命令。W3 `read_public_receipt()` 只需覆盖已封闭 aborted receipt。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 中。
+
+### PR-W3-06-未修复-中-event schema 没有给出自然事实唯一键，验收中的双 writer 幂等无法由计划推出
+
+- **位置**: §5 `strategy_lab_events`、§7 validation point/partition、§14 double writers。
+- **问题类型**: 并发合同缺失。
+- **反例/失败场景**: 两个 writer 为同一 `point_id` 使用不同 caller idempotency key。若 event ID 包含 idempotency key，两条 event 都可插入并各自推进 generation revision；若 event ID 不包含它，则同一 key 携带不同 payload 的冲突语义又未定义。
+- **影响**: 同一事实可能重复计数，或实现者需要在写代码时临时发明唯一键，计划不是 code-generation-ready。
+- **建议改法和验证点**: 计划为每种 mutation 固定 semantic subject key，并规定单例/自然事实 event 的唯一 `(event_type, subject_key)`；caller idempotency key 只允许同 command scope 重放同 canonical payload，payload 不同必须冲突。point subject 使用 experiment+point ID，partition 使用 experiment+trading date，terminal 使用 generation/experiment target。增加“同自然事实不同 idempotency key”和“同 idempotency key不同 bytes”并发测试。
+- **修复风险（低/中/高）**: 中。
+- **严重程度（低/中/高/严重）**: 中。
+
+### PR-W3-07-未修复-中-spec replacement 规则自相矛盾，`lock_challenger()` 按当前文字永远非法
+
+- **位置**: §7 Draft and research 的“Once research starts, spec replacement is forbidden”与 Leader lock 的 validation-ready spec replacement。
+- **问题类型**: 状态转换歧义。
+- **反例/失败场景**: research 已启动并封闭后，`lock_challenger()` 必须把 research-ready spec 扩充/替换为 validation-ready spec；但前一条规则禁止 research 开始后的任何 replacement。
+- **影响**: 实现者只能任选一条解释，导致合法 leader lock 被拒绝，或研究字段在封闭后仍可被修改。
+- **建议改法和验证点**: 明确 research start 后仅 research-hash 域不可变；research terminal 发布后允许首次增加 validation-only 字段，validation start 前也只允许 research hash 不变的 validation-only replacement，并使旧 validation authorization 失效。增加 research 字段变化拒绝、validation-only变化允许的成对测试。
+- **修复风险（低/中/高）**: 低。
+- **严重程度（低/中/高/严重）**: 中。
+
+## Open questions
+
+None.
+
+## Residual risks and tracking destination
+
+- Trading-calendar continuity and readiness remain W6/W7; W3 only enforces exact submitted-date uniqueness.
+- Research leader calculation and successful receipt validation remain W5/W6; W3 only binds their immutable refs/hashes once those modules exist.
+- Feature-disable cleanup is deliberately convergent after the opt-out commit; every later write/recovery path must reconcile unfinished active rows before doing any provider work.
+
+## Special lens verdicts
+
+- Goal-bound minimal design: fail until the premature successful-completion path and latent opt-in are removed.
+- Architecture boundary: fail until day-20 outcome authority remains with W6.
+- Best practice: fail until commitment pre-publication is crash-safe and exact-date ownership is represented exactly.
+- Optimal solution: pass after the proposed fixes; all use the existing store/event/artifact seams and add no service or abstraction.
+- Overengineering: fail only on W3's speculative successful receipt path; removing it restores the smallest useful boundary.
+- Overcoupling: pass; one SQLite store remains the correct atomic owner.
+
+## Conclusion
+
+`fail` until PR-W3-01 through PR-W3-07 are fixed and re-reviewed.

--- a/docs/reviews/plan-review-20260815-113648.md
+++ b/docs/reviews/plan-review-20260815-113648.md
@@ -1,0 +1,75 @@
+# Plan Re-review — Sell Put Top1 W3
+
+- Reviewed target: `docs/gateflow/sell-put-top1-w3/plan.md`
+- Prior review: `docs/reviews/plan-review-20260815-113103.md`
+- Fix artifact: `docs/gateflow/sell-put-top1-w3/plan-fix.md`
+- Reviewed base: `origin/main@baa3e363`
+- Review scope: all prior findings plus goal, architecture, concurrency, crash recovery, hidden isolation, module ownership, overengineering, and validation lenses
+- Artifact path: `docs/reviews/plan-review-20260815-113648.md`
+
+## Findings
+
+未发现新的实质性问题。
+
+## Prior finding status
+
+### PR-W3-01 — 已修复
+
+Commitment artifacts are content-addressed. A pre-transaction file has no SQLite authority, cannot occupy dates, is invisible to public projections, and cannot block a changed proposal.
+
+### PR-W3-02 — 已修复
+
+Maintainer-off enable is now a no-write failure. Disable remains the unconditional, fail-safe path and reconciles active experiments after account opt-out commits.
+
+### PR-W3-03 — 已修复
+
+The existing commitment table stores 20 exact date-occupancy rows with the required natural unique constraint. Exact overlap is enforced without adding another table or a calendar dependency.
+
+### PR-W3-04 — 已修复
+
+W3 closes day 20 into `awaiting_outcomes` and releases only the collection slot. W6 retains sole authority to inspect its job set and transition to `ready_to_conclude`.
+
+### PR-W3-05 — 已修复
+
+W3 no longer accepts successful experiment receipts. It owns deterministic aborted conclusion and the generation terminal CAS; W5/W6 own successful policy and validation.
+
+### PR-W3-06 — 已修复
+
+Natural-fact uniqueness and caller-idempotency replay are separate, explicit constraints. The plan now covers duplicate facts under different keys and changed bytes under one key.
+
+### PR-W3-07 — 已修复
+
+Research-hash fields become immutable at research start, while validation-only enrichment/replacement is allowed only after the completed research terminal and before validation start, with validation authorization invalidation.
+
+## Assumptions re-tested
+
+- A failed validation start consumes no date and cannot poison a later proposal: supported by content-addressed publication plus transactional date rows.
+- Feature enable cannot become a latent authorization while globally unavailable: supported by the no-write rule.
+- Day-20 slot release does not imply outcome completion: supported by mandatory `awaiting_outcomes` in W3.
+- W3 can be useful without inventing successful result policy: supported; aborted recovery and generation competition are independently testable.
+- Double writers cannot duplicate points, partitions, or terminal intents: specified through semantic subjects, unique constraints, and state CAS.
+- Later modules can add corpus/outcome facts without a second authority or cross-store transaction: supported by the single SQLite store and deferred migrations.
+
+## Open questions
+
+None.
+
+## Residual risks
+
+- Calendar continuity and provider/readiness truth remain W6/W7 and cannot be inferred by W3's synthetic date validator.
+- Research leader calculation and successful receipts remain W5/W6; W3 binds only their later immutable refs/hashes.
+- A failed validation-start transaction may leave one small inert content-addressed commitment file. This is accepted instead of adding a cleanup queue; add retention only if measured accumulation becomes material.
+- Feature-disable reconciliation is convergent rather than one large multi-experiment transaction. The opt-out commit is the immediate safety boundary; retries finish deterministic terminal projections.
+
+## Special lens verdicts
+
+- Goal-bound minimal design: pass.
+- Architecture boundary: pass; W3 owns persistence/CAS, W5/W6 own result policy, W7 owns runtime orchestration.
+- Best practice: pass; crash boundaries, exact date ownership, private SQLite, and non-leaking reads are explicit.
+- Optimal solution: pass; one store, one event/outbox table, stdlib SQLite, and existing artifact/private-storage helpers are reused.
+- Overengineering: pass; successful receipt policy, future result tables, worker/queue, ORM, and service surfaces remain absent.
+- Overcoupling: pass; production tick/Candidate Engine do not depend on the experimental ledger.
+
+## Conclusion
+
+`pass` — all prior findings are `已修复`; the plan is code-generation-ready.

--- a/docs/reviews/pr-161-review-20260815-131215.md
+++ b/docs/reviews/pr-161-review-20260815-131215.md
@@ -1,0 +1,54 @@
+# Code Review
+
+## Scope
+
+- Mode: PR
+- Branch or PR: #161 `feat: add Sell Put Top1 experiment lifecycle store` (`feat/sell-put-top1-w3`), author liuxie066, state OPEN
+- Base: `origin/main@d905fb9b16c4b1fe6f1dc8a2311d8fe8fcaab385`
+- Head: `10474af1ec9e6126bb5f62487b6c652d254fb354`
+- Output file: `docs/reviews/pr-161-review-20260815-131215.md`
+- Review worktree: `/private/tmp/options-monitor-sell-put-top1-w3-20260815` (clean, `## feat/sell-put-top1-w3...origin/feat/sell-put-top1-w3`)
+- Included scope: full PR diff base...head (21 files, 5137 insertions / 21 deletions), Gateflow plan/implementation/review docs, all implementation/test files, CI checks, and the #160 -> #161 replay equivalence claims
+- Excluded scope: files outside the PR diff (only touched via reused contracts read for context)
+- Parallel review coverage: 无；the PR was reviewed as one end-to-end range by the main reviewer
+
+## PR #160 -> #161 replay equivalence verification
+
+The user-supplied equivalence facts were re-verified live in this review:
+
+- `git rev-parse baa3e363^{tree}` == `git rev-parse d905fb9b^{tree}` == `105af850a97cd2e4ed467e7d219a0d137faca7df`
+- `git rev-parse ce8e645f^{tree}` == `git rev-parse 10474af1^{tree}` == `56c119f4063bc3d5eefa348b5e7099ee287cd38b`
+- `git range-diff baa3e363..ce8e645f d905fb9b..10474af1` reports all four commits as `=` (plan, implementation, aggregate review, readiness)
+- `git diff --stat d905fb9b...10474af1` matches the old range's file list and counts exactly (21 files)
+- PR metadata confirms `baseRefOid=d905fb9b...`, `headRefOid=10474af1...`, matching the local branch head; no push drift detected (`HEAD == origin/feat/sell-put-top1-w3`)
+
+Conclusion: the replay is byte-identical at the tree level; the #160 review evidence carries over, and this review re-examined the actual new-range diff rather than relying on that equivalence.
+
+## Findings
+
+未发现实质性问题。
+
+## Open Questions
+
+- 无。
+
+## Residual Risk
+
+- 全仓测试套件未在本次 PR 级 review 中重新运行（本 PR review 运行了 focused 214 项 + 邻接回归全量组合，全部通过；4881 项全仓结果来自 aggregate review 记录，PR CI 未含全仓 pytest job）。W3 模块不接入生产 tick/provider 路径，残留风险低。
+- W3 故意不实现 normal completion（`complete_experiment` 留给 W5/W6）；day-20 后实验停留在 `awaiting_outcomes`，这是计划内的 deferred ownership，不是缺陷。
+- 多主机/多进程并发写不在 W3 防护范围内（单 SQLite 写者 + `BEGIN IMMEDIATE` + busy_timeout 已覆盖单主机竞争）；若未来多主机写需单独设计。
+- sandbox 内 `gh` 初始网络失败，已通过授权的外部网络调用获取 PR 元数据与 CI；`git fetch` 在 worktree 内写 FETCH_HEAD 被 sandbox 拒绝，但 `origin/feat/sell-put-top1-w3` 已存在且与 HEAD 一致，不影响 push drift 结论。
+
+## Evidence notes
+
+主要审查路径与结论要点（均来自直接代码走读，非推测）：
+
+- SQLite 事务与幂等：所有写经 `_write()`（`BEGIN IMMEDIATE` + rollback on error），`_claim_event()` 同时强制 `(event_type, subject_key)` 自然事实唯一与 `(command_scope, idempotency_key)` 调用幂等，重放字节不同即 `idempotency_conflict`；alias event 机制保证不同 caller key 不会重复同一自然事实。测试覆盖了并发双写同点（ThreadPoolExecutor）与跨 key 冲突。
+- 崩溃恢复：terminal request 先入 SQLite，再由 `recover_terminal_projection()` 按事件顺序 publish 并 `mark_projection_published()` CAS；注入 "publish 后崩溃" 的测试证明重放不产生重复 request/published event 且字节逐字恢复。`publish_exact_text` 走同目录 tmp 文件 + fsync + `os.link` 原子发布 + 父目录 fsync，拒绝 symlink 与字节冲突。
+- 隐藏验证隔离：`read_public_status()` 只返回 phase/progress/authorization/hash 级别字段，不含 point ID、rank、daily delta、outcome；20 个 commitment date 行在验证开始的同一事务插入且永不删除，abort 保留全部日期占用。日期唯一性由 `strategy_lab_hidden_date_unique` 强制，active slot 由 partial unique index 强制。
+- 账户/槽位隔离：slot index 与 date unique 均按 `(market, account, strategy_family)` 作用域；`_identity()` 强制 `market='HK'` 且 account 小写。
+- 默认关闭与授权边界：maintainer env 非 `"1"` 或账户行缺失即 effective=false；enable 在 maintainer off 时不写任何行；disable 先落 `user_opt_in=0` 再 reconcile 终止；`_require_effective` 在所有正常写入口前执行，并先 reconcile 再 fail-closed。
+- 模块边界：architecture import guard 测试证明 store 只依赖 stdlib/sqlite3/private_storage，production tick 模块不 import lifecycle/store，domain 未被反向依赖；`docs/DEPENDENCY_GRAPH.md` 重新生成且 check 通过（588 production modules, 0 cycles）。
+- 过度设计检查：5 张当前态表 + 1 张 append-only event 表，无 ORM/queue/未来空表；错误码收敛到 plan §11 的封闭集合（store 侧的 `experiment_not_found`/`natural_fact_conflict`/`constraint_conflict` 等内部码在 `_raise_store` 统一映射到公开契约，未泄漏 SQL 文本）。
+- `shadow_replay/common.py` 的改动是纯提取：`render_json_text()` 从既有 `write_json()` 函数体原样拆出，字节行为不变（既有排序/ensure_ascii/allow_nan 参数一致）。
+- 等价性: 与 #160 被审查过的树逐字节相同（见上节），range-diff 四提交均为 `=`。

--- a/src/application/shadow_replay/common.py
+++ b/src/application/shadow_replay/common.py
@@ -210,8 +210,11 @@ def read_csv_rows(path: Path) -> list[dict[str, Any]]:
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    _atomic_write_text(
-        path,
+    _atomic_write_text(path, render_json_text(payload))
+
+
+def render_json_text(payload: dict[str, Any]) -> str:
+    return (
         json.dumps(
             payload,
             ensure_ascii=False,
@@ -219,7 +222,7 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
             sort_keys=True,
             allow_nan=False,
         )
-        + "\n",
+        + "\n"
     )
 
 

--- a/src/application/strategy_lab/top1/lifecycle.py
+++ b/src/application/strategy_lab/top1/lifecycle.py
@@ -1,0 +1,1186 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, NoReturn, Sequence, cast
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from src.application.recommendation_point import strategy_lab_top1_available
+from src.application.shadow_replay.common import artifact_content_sha256, render_json_text
+from src.application.strategy_lab.top1.contracts import (
+    Top1CoreContractError,
+    build_research_spec_sha256,
+    build_validation_spec_sha256,
+    validate_experiment_spec,
+)
+from src.application.strategy_lab.top1.terminal_projection import (
+    Publisher,
+    build_aborted_receipt_request,
+    build_generation_terminal_request,
+    publish_exact_text,
+    recover_terminal_projection,
+)
+from src.infrastructure.strategy_lab.experiment_store import (
+    ExperimentStore,
+    ExperimentStoreError,
+    compact_json,
+)
+
+
+HIDDEN_WINDOW_COMMITMENT_SCHEMA = "sell_put_top1_hidden_window_commitment.v1"
+PUBLIC_STATUS_SCHEMA = "sell_put_top1_experiment_status.v1"
+
+_HASH = re.compile(r"[0-9a-f]{64}\Z")
+_PATH_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+
+
+class Top1LifecycleError(ValueError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise Top1LifecycleError(reason_code, message)
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("experiment_invalid", f"{label} must be non-empty canonical text")
+    return value
+
+
+def _segment(value: object, label: str) -> str:
+    text = _text(value, label)
+    if _PATH_SEGMENT.fullmatch(text) is None:
+        _fail("experiment_invalid", f"{label} must be a safe path segment")
+    return text
+
+
+def _hash(value: object, label: str) -> str:
+    text = _text(value, label)
+    if _HASH.fullmatch(text) is None:
+        _fail("experiment_invalid", f"{label} must be a lowercase SHA-256")
+    return text
+
+
+def _ref(value: object, label: str) -> str:
+    text = _text(value, label)
+    if (
+        text.startswith("/")
+        or "\\" in text
+        or any(part in {"", ".", ".."} for part in text.split("/"))
+    ):
+        _fail("experiment_invalid", f"{label} must be a safe relative POSIX path")
+    return text
+
+
+def _timestamp(value: object, label: str = "occurred_at_utc") -> str:
+    text = _text(value, label)
+    if not text.endswith("Z") or "T" not in text:
+        _fail("experiment_invalid", f"{label} must be an ISO-8601 UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(f"{text[:-1]}+00:00")
+    except ValueError:
+        _fail("experiment_invalid", f"{label} must be an ISO-8601 UTC timestamp")
+    if parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        _fail("experiment_invalid", f"{label} must be UTC")
+    return text
+
+
+def _trading_dates(values: Sequence[object]) -> list[str]:
+    if isinstance(values, (str, bytes)) or len(values) != 20:
+        _fail("experiment_invalid", "hidden commitment must contain exactly 20 dates")
+    parsed: list[date] = []
+    texts: list[str] = []
+    for index, value in enumerate(values):
+        text = _text(value, f"trading_dates[{index}]")
+        try:
+            item = date.fromisoformat(text)
+        except ValueError:
+            _fail("experiment_invalid", "trading dates must be canonical ISO dates")
+        if item.isoformat() != text:
+            _fail("experiment_invalid", "trading dates must be canonical ISO dates")
+        parsed.append(item)
+        texts.append(text)
+    if any(left >= right for left, right in zip(parsed, parsed[1:])):
+        _fail("experiment_invalid", "trading dates must be strictly increasing")
+    return texts
+
+
+def _identity(market: object, account: object) -> tuple[str, str]:
+    if market != "HK":
+        _fail("experiment_invalid", "market must equal HK")
+    account_text = _text(account, "account")
+    if account_text != account_text.lower():
+        _fail("experiment_invalid", "account must be lowercase")
+    return "HK", account_text
+
+
+def _command_fields(
+    actor: object, occurred_at_utc: object, idempotency_key: object
+) -> tuple[str, str, str]:
+    return (
+        _text(actor, "actor"),
+        _timestamp(occurred_at_utc),
+        _segment(idempotency_key, "idempotency_key"),
+    )
+
+
+def _derived_key(*parts: str) -> str:
+    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+
+
+def _raise_store(exc: ExperimentStoreError) -> NoReturn:
+    mapping = {
+        "schema_unsupported": "schema_unsupported",
+        "invalid_transition": "invalid_transition",
+        "authorization_required": "authorization_required",
+        "authorization_hash_mismatch": "authorization_hash_mismatch",
+        "hidden_window_overlap": "hidden_window_overlap",
+        "validation_slot_occupied": "validation_slot_occupied",
+        "generation_conflict": "generation_conflict",
+        "generation_not_found": "generation_conflict",
+        "late_write": "late_write",
+        "terminal_conflict": "terminal_conflict",
+        "projection_conflict": "projection_conflict",
+        "stale_snapshot": "generation_conflict",
+    }
+    reason = mapping.get(exc.reason_code, "experiment_conflict")
+    raise Top1LifecycleError(reason, str(exc)) from exc
+
+
+def _call(function: Any, /, *args: Any, **kwargs: Any) -> Any:
+    try:
+        return function(*args, **kwargs)
+    except ExperimentStoreError as exc:
+        _raise_store(exc)
+
+
+def _recover_projection(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str | None = None,
+    publisher: Publisher | None = None,
+) -> None:
+    try:
+        recover_terminal_projection(
+            store,
+            artifact_root,
+            experiment_id=experiment_id,
+            publisher=publisher,
+        )
+    except ExperimentStoreError as exc:
+        _raise_store(exc)
+    except (OSError, ValueError) as exc:
+        _fail("projection_conflict", str(exc))
+
+
+def effective_feature_status(
+    store: ExperimentStore,
+    *,
+    market: str,
+    account: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    market, account = _identity(market, account)
+    try:
+        feature = store.feature(market, account)
+    except ExperimentStoreError as exc:
+        _raise_store(exc)
+    maintainer_available = strategy_lab_top1_available(environ)
+    user_opt_in = bool(feature and feature["user_opt_in"])
+    return {
+        "maintainer_available": maintainer_available,
+        "user_opt_in": user_opt_in,
+        "effective": maintainer_available and user_opt_in,
+    }
+
+
+def _require_effective(
+    store: ExperimentStore,
+    *,
+    market: str,
+    account: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None,
+) -> None:
+    status = effective_feature_status(
+        store, market=market, account=account, environ=environ
+    )
+    if status["effective"]:
+        return
+    scope = "maintainer" if not status["maintainer_available"] else "user"
+    reconcile_disabled_experiments(
+        store,
+        market=market,
+        account=account,
+        disabled_scope=scope,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=_derived_key(idempotency_key, "gate-disable"),
+        artifact_root=artifact_root,
+    )
+    _fail("feature_disabled", "Strategy Lab Top1 is disabled")
+
+
+def set_account_opt_in(
+    store: ExperimentStore,
+    *,
+    market: str,
+    account: str,
+    enabled: bool,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    market, account = _identity(market, account)
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    if type(enabled) is not bool:
+        _fail("experiment_invalid", "enabled must be boolean")
+    if enabled and not strategy_lab_top1_available(environ):
+        _fail("feature_disabled", "maintainer availability is off")
+    _call(
+        store.set_feature,
+        market=market,
+        account=account,
+        enabled=enabled,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+    if not enabled:
+        reconcile_disabled_experiments(
+            store,
+            market=market,
+            account=account,
+            disabled_scope="user",
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=_derived_key(idempotency_key, "user-disable"),
+            artifact_root=artifact_root,
+        )
+    return effective_feature_status(
+        store, market=market, account=account, environ=environ
+    )
+
+
+def prepare_experiment(
+    store: ExperimentStore,
+    spec: object,
+    *,
+    provenance: Mapping[str, object],
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    try:
+        validated = validate_experiment_spec(spec)
+    except Top1CoreContractError as exc:
+        _fail("experiment_invalid", str(exc))
+    if "validation_evaluation" in validated:
+        _fail("experiment_invalid", "prepare requires a research-only ExperimentSpec")
+    experiment_id = _segment(validated["experiment_id"], "experiment_id")
+    topic_id = _text(validated["topic_id"], "topic_id")
+    market, account = _identity(validated["market"], validated["account"])
+    _require_effective(
+        store,
+        market=market,
+        account=account,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    if not isinstance(provenance, Mapping) or not provenance:
+        _fail("experiment_invalid", "provenance must be a non-empty mapping")
+    try:
+        provenance_json = compact_json(dict(provenance))
+    except (TypeError, ValueError) as exc:
+        _fail("experiment_invalid", f"provenance is not canonical JSON: {exc}")
+    return _call(
+        store.prepare_experiment,
+        experiment_id=experiment_id,
+        topic_id=topic_id,
+        market=market,
+        account=account,
+        spec_json=compact_json(validated),
+        research_spec_sha256=build_research_spec_sha256(validated),
+        provenance_json=provenance_json,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def authorize_research(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    research_spec_sha256: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    return _authorize(
+        store,
+        experiment_id=experiment_id,
+        stage="research",
+        authorized_hash=research_spec_sha256,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+
+
+def authorize_validation(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    validation_spec_sha256: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    return _authorize(
+        store,
+        experiment_id=experiment_id,
+        stage="validation",
+        authorized_hash=validation_spec_sha256,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+
+
+def _authorize(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    stage: str,
+    authorized_hash: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    authorized_hash = _hash(authorized_hash, f"{stage}_spec_sha256")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    return _call(
+        store.authorize,
+        experiment_id=experiment_id,
+        stage=stage,
+        authorized_hash=authorized_hash,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def start_research(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    research_spec_sha256: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    research_spec_sha256 = _hash(research_spec_sha256, "research_spec_sha256")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    spec = json.loads(str(experiment["spec_json"]))
+    source = spec["research_source"]
+    return _call(
+        store.start_research,
+        experiment_id=experiment_id,
+        authorized_hash=research_spec_sha256,
+        dataset_ref=_ref(source["dataset_ref"], "research_source.dataset_ref"),
+        dataset_file_sha256=_hash(
+            source["dataset_sha256"], "research_source.dataset_sha256"
+        ),
+        frozen_row_sha256=_hash(
+            source["dataset_sha256"], "research_source.dataset_sha256"
+        ),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def record_generation_revision(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    generation_kind: str,
+    revision: int,
+    revision_ref: str,
+    revision_file_sha256: str,
+    frozen_row_sha256: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    if generation_kind not in {"research", "hidden", "outcome"}:
+        _fail("experiment_invalid", "generation_kind is unsupported")
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision <= 0:
+        _fail("experiment_invalid", "revision must be a positive integer")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    return _call(
+        store.record_generation_revision,
+        experiment_id=experiment_id,
+        generation_kind=generation_kind,
+        revision=revision,
+        revision_ref=_ref(revision_ref, "revision_ref"),
+        revision_file_sha256=_hash(
+            revision_file_sha256, "revision_file_sha256"
+        ),
+        frozen_row_sha256=_hash(frozen_row_sha256, "frozen_row_sha256"),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def seal_generation(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    generation_kind: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    if generation_kind != "research":
+        _fail(
+            "experiment_invalid",
+            "W3 seal_generation only accepts research; hidden seals at day 20",
+        )
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    generation = next(
+        (
+            item
+            for item in _call(store.generations, experiment_id)
+            if item["generation_kind"] == generation_kind
+        ),
+        None,
+    )
+    if generation is None:
+        _fail("generation_conflict", "generation does not exist")
+    request = build_generation_terminal_request(
+        generation,
+        terminal_mode="completed",
+        reason=None,
+        disabled_scope=None,
+        occurred_at_utc=occurred_at_utc,
+    )
+    return _call(
+        store.request_generation_terminal,
+        experiment_id=experiment_id,
+        generation_kind=generation_kind,
+        request=request,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def build_hidden_window_commitment(
+    *,
+    experiment_id: str,
+    account: str,
+    trading_dates: Sequence[object],
+    market_calendar_version: str,
+    challenger_variant_id: str,
+    research_spec_sha256: str,
+    research_terminal_file_sha256: str,
+    behavior_binding_sha256: str,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    _, account = _identity("HK", account)
+    dates = _trading_dates(trading_dates)
+    payload: dict[str, object] = {
+        "schema_version": HIDDEN_WINDOW_COMMITMENT_SCHEMA,
+        "experiment_id": experiment_id,
+        "market": "HK",
+        "account": account,
+        "strategy_family": "sell_put",
+        "trading_dates": dates,
+        "start_trading_date": dates[0],
+        "end_trading_date": dates[-1],
+        "market_calendar_version": _text(
+            market_calendar_version, "market_calendar_version"
+        ),
+        "point_selector": "official_scheduled_sell_put.v1",
+        "capture_schema": "recommendation_point.v1",
+        "challenger_variant_id": _text(
+            challenger_variant_id, "challenger_variant_id"
+        ),
+        "research_spec_sha256": _hash(
+            research_spec_sha256, "research_spec_sha256"
+        ),
+        "research_terminal_file_sha256": _hash(
+            research_terminal_file_sha256, "research_terminal_file_sha256"
+        ),
+        "behavior_binding_sha256": _hash(
+            behavior_binding_sha256, "behavior_binding_sha256"
+        ),
+    }
+    return payload
+
+
+def lock_challenger(
+    store: ExperimentStore,
+    validation_spec: object,
+    *,
+    system_leader: str,
+    challenger_variant_id: str,
+    research_receipt_ref: str,
+    research_receipt_file_sha256: str,
+    trading_dates: Sequence[object],
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    system_leader = _text(system_leader, "system_leader")
+    challenger_variant_id = _text(challenger_variant_id, "challenger_variant_id")
+    if system_leader != challenger_variant_id or challenger_variant_id == "baseline":
+        _fail("experiment_invalid", "challenger must equal the non-baseline system leader")
+    try:
+        spec = validate_experiment_spec(validation_spec)
+    except Top1CoreContractError as exc:
+        _fail("experiment_invalid", str(exc))
+    if "validation_evaluation" not in spec:
+        _fail("experiment_invalid", "validation-ready ExperimentSpec is required")
+    experiment_id = _segment(spec["experiment_id"], "experiment_id")
+    market, account = _identity(spec["market"], spec["account"])
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=market,
+        account=account,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    research_hash = build_research_spec_sha256(spec)
+    if research_hash != experiment["research_spec_sha256"]:
+        _fail("experiment_conflict", "research hash changed after start")
+    research_generation = next(
+        (
+            item
+            for item in _call(store.generations, experiment_id)
+            if item["generation_kind"] == "research"
+        ),
+        None,
+    )
+    if research_generation is None or research_generation["terminal_file_sha256"] is None:
+        _fail("invalid_transition", "published research terminal is required")
+    economics = cast(Mapping[str, object], spec["economics_contracts"])
+    baseline = cast(Mapping[str, object], spec["baseline"])
+    commitment = build_hidden_window_commitment(
+        experiment_id=experiment_id,
+        account=account,
+        trading_dates=trading_dates,
+        market_calendar_version=str(economics["market_calendar_version"]),
+        challenger_variant_id=challenger_variant_id,
+        research_spec_sha256=research_hash,
+        research_terminal_file_sha256=str(
+            research_generation["terminal_file_sha256"]
+        ),
+        behavior_binding_sha256=str(baseline["behavior_binding_sha256"]),
+    )
+    commitment_sha256 = canonical_sha256(commitment)
+    commitment_text = render_json_text(commitment)
+    commitment_file_sha256 = hashlib.sha256(
+        commitment_text.encode("utf-8")
+    ).hexdigest()
+    commitment_ref = (
+        f"strategy_lab/top1/experiments/{experiment_id}/hidden_window_commitments/"
+        f"{commitment_sha256}.json"
+    )
+    validation_hash = build_validation_spec_sha256(
+        spec,
+        research_terminal_sha256=str(research_generation["terminal_file_sha256"]),
+        challenger_variant_id=challenger_variant_id,
+        hidden_window_commitment_sha256=commitment_sha256,
+    )
+    variants = {
+        str(cast(Mapping[str, object], item)["variant_id"])
+        for item in cast(list[object], spec["variants"])
+    }
+    if challenger_variant_id not in variants:
+        _fail("experiment_invalid", "system leader is not an ExperimentSpec variant")
+    return _call(
+        store.lock_challenger,
+        experiment_id=experiment_id,
+        spec_json=compact_json(spec),
+        research_spec_sha256=research_hash,
+        validation_spec_sha256=validation_hash,
+        research_leader=challenger_variant_id,
+        research_receipt_ref=_ref(research_receipt_ref, "research_receipt_ref"),
+        research_receipt_file_sha256=_hash(
+            research_receipt_file_sha256, "research_receipt_file_sha256"
+        ),
+        commitment_json=compact_json(commitment),
+        commitment_sha256=commitment_sha256,
+        commitment_ref=commitment_ref,
+        commitment_content_sha256=artifact_content_sha256(commitment),
+        commitment_file_sha256=commitment_file_sha256,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def start_validation(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    validation_spec_sha256: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    validation_spec_sha256 = _hash(
+        validation_spec_sha256, "validation_spec_sha256"
+    )
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    if experiment["terminal_mode"] is not None or not (
+        experiment["phase"] == "research"
+        and experiment["research_progress"] == "challenger_locked"
+    ):
+        _fail("invalid_transition", "validation cannot start")
+    if (
+        experiment["validation_authorization_status"] != "confirmed"
+        or experiment["validation_authorized_hash"] != validation_spec_sha256
+        or experiment["validation_spec_sha256"] != validation_spec_sha256
+    ):
+        _fail(
+            "authorization_required",
+            "current validation hash is not confirmed",
+        )
+    commitment = json.loads(str(experiment["proposed_commitment_json"]))
+    text = render_json_text(commitment)
+    if canonical_sha256(commitment) != experiment["proposed_commitment_sha256"]:
+        _fail("experiment_conflict", "commitment semantic hash changed")
+    if artifact_content_sha256(commitment) != experiment[
+        "proposed_commitment_content_sha256"
+    ]:
+        _fail("experiment_conflict", "commitment content hash changed")
+    expected_ref = (
+        f"strategy_lab/top1/experiments/{experiment_id}/hidden_window_commitments/"
+        f"{experiment['proposed_commitment_sha256']}.json"
+    )
+    if experiment["proposed_commitment_ref"] != expected_ref:
+        _fail("experiment_conflict", "commitment ref is not content-addressed")
+    if hashlib.sha256(text.encode("utf-8")).hexdigest() != experiment[
+        "proposed_commitment_file_sha256"
+    ]:
+        _fail("experiment_conflict", "commitment file hash changed")
+    try:
+        publish_exact_text(
+            artifact_root,
+            str(experiment["proposed_commitment_ref"]),
+            text.encode("utf-8"),
+        )
+    except (OSError, ValueError) as exc:
+        _fail("experiment_conflict", f"commitment publication failed: {exc}")
+    return _call(
+        store.start_validation,
+        experiment_id=experiment_id,
+        authorized_hash=validation_spec_sha256,
+        commitment_sha256=str(experiment["proposed_commitment_sha256"]),
+        commitment_dates=_trading_dates(commitment["trading_dates"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def commit_validation_point(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    point_id: str,
+    trading_date: str,
+    source_ref: str,
+    source_file_sha256: str,
+    revision: int,
+    manifest_ref: str,
+    manifest_file_sha256: str,
+    frozen_row_sha256: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    point_id = _segment(point_id, "point_id")
+    date_text = _text(trading_date, "trading_date")
+    try:
+        if date.fromisoformat(date_text).isoformat() != date_text:
+            raise ValueError
+    except ValueError:
+        _fail("experiment_invalid", "trading_date must be a canonical ISO date")
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision <= 0:
+        _fail("experiment_invalid", "revision must be a positive integer")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    return _call(
+        store.commit_validation_point,
+        experiment_id=experiment_id,
+        point_id=point_id,
+        trading_date=date_text,
+        source_ref=_ref(source_ref, "source_ref"),
+        source_file_sha256=_hash(source_file_sha256, "source_file_sha256"),
+        revision=revision,
+        manifest_ref=_ref(manifest_ref, "manifest_ref"),
+        manifest_file_sha256=_hash(
+            manifest_file_sha256, "manifest_file_sha256"
+        ),
+        frozen_row_sha256=_hash(frozen_row_sha256, "frozen_row_sha256"),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def seal_validation_partition(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    trading_date: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    trading_date = _text(trading_date, "trading_date")
+    try:
+        if date.fromisoformat(trading_date).isoformat() != trading_date:
+            raise ValueError
+    except ValueError:
+        _fail("experiment_invalid", "trading_date must be a canonical ISO date")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    terminal_request: Mapping[str, object] | None = None
+    if int(experiment["completed_validation_partitions"]) == 19:
+        hidden = next(
+            item
+            for item in _call(store.generations, experiment_id)
+            if item["generation_kind"] == "hidden"
+        )
+        terminal_request = build_generation_terminal_request(
+            hidden,
+            terminal_mode="completed",
+            reason=None,
+            disabled_scope=None,
+            occurred_at_utc=occurred_at_utc,
+        )
+    return _call(
+        store.seal_validation_partition,
+        experiment_id=experiment_id,
+        trading_date=trading_date,
+        terminal_request=terminal_request,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+    )
+
+
+def terminate_experiment(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    reason: str,
+    disabled_scope: str | None,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    publisher: Publisher | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    if reason not in {
+        "human_abandoned",
+        "behavior_binding_drift",
+        "experimental_feature_disabled",
+    }:
+        _fail("experiment_invalid", "termination reason is unsupported")
+    if reason == "experimental_feature_disabled":
+        if disabled_scope not in {"user", "maintainer"}:
+            _fail("experiment_invalid", "feature disable requires disabled_scope")
+    elif disabled_scope is not None:
+        _fail("experiment_invalid", "disabled_scope is only valid for feature disable")
+
+    for _ in range(3):
+        experiment = _call(store.experiment, experiment_id)
+        if experiment["terminal_mode"] is not None:
+            if (
+                experiment["terminal_reason"] != reason
+                or experiment["disabled_scope"] != disabled_scope
+                or experiment["terminal_at_utc"] != occurred_at_utc
+            ):
+                _fail("terminal_conflict", "experiment terminal intent already differs")
+            _recover_projection(
+                store, artifact_root, experiment_id=experiment_id, publisher=publisher
+            )
+            return _call(store.experiment, experiment_id)
+        generations = _call(store.generations, experiment_id)
+        generation_requests = [
+            build_generation_terminal_request(
+                generation,
+                terminal_mode="aborted",
+                reason=reason,
+                disabled_scope=disabled_scope,
+                occurred_at_utc=occurred_at_utc,
+                partial_summary={
+                    "revision": generation["revision"],
+                    "completed_validation_partitions": experiment[
+                        "completed_validation_partitions"
+                    ],
+                },
+            )
+            for generation in generations
+            if generation["terminal_request_event_id"] is None
+        ]
+        partition = (
+            int(experiment["completed_validation_partitions"])
+            if experiment["phase"] == "validation"
+            else None
+        )
+        receipt_request = build_aborted_receipt_request(
+            experiment,
+            generations,
+            generation_requests,
+            reason=reason,
+            disabled_scope=disabled_scope,
+            occurred_at_utc=occurred_at_utc,
+            terminated_at_partition=partition,
+        )
+        try:
+            _call(
+                store.terminate,
+                experiment_id=experiment_id,
+                expected_state_version=int(experiment["state_version"]),
+                reason=reason,
+                disabled_scope=disabled_scope,
+                terminated_at_partition=partition,
+                generation_requests=generation_requests,
+                receipt_request=receipt_request,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=idempotency_key,
+            )
+            break
+        except Top1LifecycleError as exc:
+            if exc.reason_code != "generation_conflict":
+                raise
+    else:
+        _fail("terminal_conflict", "experiment changed during termination")
+    _recover_projection(
+        store, artifact_root, experiment_id=experiment_id, publisher=publisher
+    )
+    return _call(store.experiment, experiment_id)
+
+
+def reconcile_disabled_experiments(
+    store: ExperimentStore,
+    *,
+    market: str,
+    account: str,
+    disabled_scope: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+) -> list[str]:
+    market, account = _identity(market, account)
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    if disabled_scope not in {"user", "maintainer"}:
+        _fail("experiment_invalid", "disabled_scope is unsupported")
+    pending_ids = {
+        str(event["experiment_id"])
+        for event in _call(store.pending_projections)
+        if event["experiment_id"] is not None
+    }
+    for experiment_id in sorted(pending_ids):
+        experiment = _call(store.experiment, experiment_id)
+        if experiment["market"] == market and experiment["account"] == account:
+            _recover_projection(store, artifact_root, experiment_id=experiment_id)
+    experiment_ids: list[str] = []
+    for experiment in _call(store.active_experiments, market, account):
+        experiment_id = str(experiment["experiment_id"])
+        terminate_experiment(
+            store,
+            experiment_id=experiment_id,
+            reason="experimental_feature_disabled",
+            disabled_scope=disabled_scope,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=_derived_key(
+                idempotency_key, experiment_id, "feature-disable"
+            ),
+            artifact_root=artifact_root,
+        )
+        experiment_ids.append(experiment_id)
+    return experiment_ids
+
+
+def read_public_status(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    experiment = _call(store.experiment, experiment_id)
+    feature = effective_feature_status(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        environ=environ,
+    )
+    generations = _call(store.generations, experiment_id)
+    return {
+        "schema_version": PUBLIC_STATUS_SCHEMA,
+        "feature": feature,
+        "experiment": {
+            "experiment_id": experiment_id,
+            "topic_id": experiment["topic_id"],
+            "market": experiment["market"],
+            "account": experiment["account"],
+            "strategy_family": experiment["strategy_family"],
+            "phase": experiment["phase"],
+            "research_progress": experiment["research_progress"],
+            "validation_progress": experiment["validation_progress"],
+            "completed_validation_partitions": experiment[
+                "completed_validation_partitions"
+            ],
+            "blocked_reason": experiment["blocked_reason"],
+            "research_authorization_status": experiment[
+                "research_authorization_status"
+            ],
+            "research_authorized_hash": experiment["research_authorized_hash"],
+            "validation_authorization_status": experiment[
+                "validation_authorization_status"
+            ],
+            "validation_authorized_hash": experiment[
+                "validation_authorized_hash"
+            ],
+            "research_spec_sha256": experiment["research_spec_sha256"],
+            "validation_spec_sha256": experiment["validation_spec_sha256"],
+            "hidden_window_commitment_sha256": experiment[
+                "proposed_commitment_sha256"
+            ],
+            "terminal_mode": experiment["terminal_mode"],
+            "terminal_reason": experiment["terminal_reason"],
+            "disabled_scope": experiment["disabled_scope"],
+            "projection_state": (
+                "published"
+                if experiment["phase"] == "concluded"
+                else "pending"
+                if experiment["terminal_mode"] is not None
+                else "not_requested"
+            ),
+        },
+        "generations": [
+            {
+                "generation_kind": item["generation_kind"],
+                "state": item["state"],
+                "revision": item["revision"],
+                "terminal_mode": item["terminal_mode"],
+                "terminal_ref": item["terminal_ref"],
+                "terminal_content_sha256": item["terminal_content_sha256"],
+                "terminal_file_sha256": item["terminal_file_sha256"],
+                "projection_state": (
+                    "published"
+                    if item["terminal_published_event_id"] is not None
+                    else "pending"
+                    if item["terminal_request_event_id"] is not None
+                    else "not_requested"
+                ),
+            }
+            for item in generations
+        ],
+    }
+
+
+def read_public_receipt(
+    store: ExperimentStore, *, experiment_id: str
+) -> dict[str, object] | None:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    text = _call(store.receipt_text, experiment_id)
+    if text is None:
+        return None
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        _fail("projection_conflict", "receipt payload is not an object")
+    return payload
+
+
+__all__ = [
+    "HIDDEN_WINDOW_COMMITMENT_SCHEMA",
+    "PUBLIC_STATUS_SCHEMA",
+    "Top1LifecycleError",
+    "authorize_research",
+    "authorize_validation",
+    "build_hidden_window_commitment",
+    "commit_validation_point",
+    "effective_feature_status",
+    "lock_challenger",
+    "prepare_experiment",
+    "read_public_receipt",
+    "read_public_status",
+    "reconcile_disabled_experiments",
+    "record_generation_revision",
+    "seal_generation",
+    "seal_validation_partition",
+    "set_account_opt_in",
+    "start_research",
+    "start_validation",
+    "terminate_experiment",
+]

--- a/src/application/strategy_lab/top1/terminal_projection.py
+++ b/src/application/strategy_lab/top1/terminal_projection.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from src.application.shadow_replay.common import (
+    artifact_content_sha256,
+    attach_artifact_provenance,
+    render_json_text,
+)
+from src.infrastructure.private_storage import (
+    PRIVATE_FILE_MODE,
+    ensure_private_directory,
+    open_private_text,
+    private_path,
+)
+from src.infrastructure.strategy_lab.experiment_store import ExperimentStore
+
+
+GENERATION_TERMINAL_SCHEMA = "sell_put_top1_generation_terminal.v1"
+EXPERIMENT_RECEIPT_SCHEMA = "sell_put_top1_experiment_receipt.v1"
+
+Publisher = Callable[[str | Path, str, bytes], Path]
+
+
+def _file_sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _projection_request(ref: str, payload: dict[str, Any]) -> dict[str, object]:
+    text = render_json_text(payload)
+    request: dict[str, object] = {
+        "ref": ref,
+        "content_sha256": artifact_content_sha256(payload),
+        "file_sha256": _file_sha256(text),
+        "text": text,
+    }
+    if len(json.dumps(request, separators=(",", ":")).encode("utf-8")) > 8192:
+        raise ValueError("terminal projection request exceeds 8 KiB")
+    return request
+
+
+def build_generation_terminal_request(
+    generation: Mapping[str, object],
+    *,
+    terminal_mode: str,
+    reason: str | None,
+    disabled_scope: str | None,
+    occurred_at_utc: str,
+    partial_summary: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    if terminal_mode not in {"completed", "aborted"}:
+        raise ValueError("terminal_mode must be completed or aborted")
+    if terminal_mode == "completed" and (reason is not None or disabled_scope is not None):
+        raise ValueError("completed terminal cannot have reason or disabled_scope")
+    if terminal_mode == "aborted" and reason not in {
+        "human_abandoned",
+        "behavior_binding_drift",
+        "experimental_feature_disabled",
+    }:
+        raise ValueError("aborted terminal reason is unsupported")
+    if reason == "experimental_feature_disabled":
+        if disabled_scope not in {"user", "maintainer"}:
+            raise ValueError("feature-disabled terminal requires disabled_scope")
+    elif disabled_scope is not None:
+        raise ValueError("disabled_scope is only valid for feature disable")
+
+    experiment_id = str(generation["experiment_id"])
+    generation_kind = str(generation["generation_kind"])
+    revision_value = generation["revision"]
+    if isinstance(revision_value, bool) or not isinstance(revision_value, int):
+        raise ValueError("generation revision must be an integer")
+    revision = revision_value
+    payload: dict[str, Any] = {
+        "schema_version": GENERATION_TERMINAL_SCHEMA,
+        "experiment_id": experiment_id,
+        "generation": {
+            "generation_id": f"{experiment_id}:{generation_kind}",
+            "generation_kind": generation_kind,
+            "revision": revision,
+            "last_revision_ref": generation["last_revision_ref"],
+            "last_revision_file_sha256": generation[
+                "last_revision_file_sha256"
+            ],
+            "frozen_row_content_sha256": generation[
+                "frozen_row_content_sha256"
+            ],
+        },
+        "terminal": {
+            "mode": terminal_mode,
+            "reason": reason,
+            "disabled_scope": disabled_scope,
+            "occurred_at_utc": occurred_at_utc,
+            "partial_summary": dict(partial_summary or {}) if terminal_mode == "aborted" else None,
+        },
+    }
+    attach_artifact_provenance(
+        payload,
+        artifact_kind="sell_put_top1_generation_terminal",
+        source_generation={
+            "generation_id": f"{experiment_id}:{generation_kind}",
+            "revision": revision,
+        },
+    )
+    ref = (
+        f"strategy_lab/top1/experiments/{experiment_id}/generations/"
+        f"{generation_kind}.terminal.json"
+    )
+    return {
+        "experiment_id": experiment_id,
+        "generation_kind": generation_kind,
+        "revision": revision,
+        "last_revision_ref": generation["last_revision_ref"],
+        "last_revision_file_sha256": generation["last_revision_file_sha256"],
+        "frozen_row_content_sha256": generation["frozen_row_content_sha256"],
+        "terminal_mode": terminal_mode,
+        "reason": reason,
+        "disabled_scope": disabled_scope,
+        **_projection_request(ref, payload),
+    }
+
+
+def build_aborted_receipt_request(
+    experiment: Mapping[str, object],
+    generations: Sequence[Mapping[str, object]],
+    generation_requests: Sequence[Mapping[str, object]],
+    *,
+    reason: str,
+    disabled_scope: str | None,
+    occurred_at_utc: str,
+    terminated_at_partition: int | None,
+) -> dict[str, object]:
+    request_by_kind = {
+        str(item["generation_kind"]): item for item in generation_requests
+    }
+    row_by_kind = {str(item["generation_kind"]): item for item in generations}
+    generation_views: dict[str, object] = {}
+    for kind in ("research", "hidden", "outcome"):
+        row = row_by_kind.get(kind)
+        request = request_by_kind.get(kind)
+        if row is None:
+            generation_views[kind] = {
+                "state": "not_started",
+                "terminal_mode": None,
+                "ref": None,
+                "content_sha256": None,
+                "file_sha256": None,
+            }
+            continue
+        if request is not None:
+            generation_views[kind] = {
+                "state": "terminal",
+                "terminal_mode": request["terminal_mode"],
+                "ref": request["ref"],
+                "content_sha256": request["content_sha256"],
+                "file_sha256": request["file_sha256"],
+            }
+            continue
+        generation_views[kind] = {
+            "state": "terminal",
+            "terminal_mode": row["terminal_mode"],
+            "ref": row["terminal_ref"],
+            "content_sha256": row["terminal_content_sha256"],
+            "file_sha256": row["terminal_file_sha256"],
+        }
+
+    experiment_id = str(experiment["experiment_id"])
+    payload: dict[str, Any] = {
+        "schema_version": EXPERIMENT_RECEIPT_SCHEMA,
+        "experiment_id": experiment_id,
+        "topic_id": experiment["topic_id"],
+        "market": experiment["market"],
+        "account": experiment["account"],
+        "strategy_family": experiment["strategy_family"],
+        "terminal": {
+            "mode": "aborted",
+            "reason": reason,
+            "disabled_scope": disabled_scope,
+            "occurred_at_utc": occurred_at_utc,
+            "terminated_at_partition": terminated_at_partition,
+        },
+        "bindings": {
+            "research_spec_sha256": experiment["research_spec_sha256"],
+            "validation_spec_sha256": experiment["validation_spec_sha256"],
+            "hidden_window_commitment_sha256": experiment[
+                "proposed_commitment_sha256"
+            ],
+        },
+        "generations": generation_views,
+        "outcome_status": "insufficient_evidence",
+        "metrics": None,
+    }
+    attach_artifact_provenance(
+        payload,
+        artifact_kind="sell_put_top1_experiment_receipt",
+        source_generation={"generation_id": f"experiment:{experiment_id}:terminal"},
+    )
+    ref = f"strategy_lab/top1/experiments/{experiment_id}/experiment_receipt.json"
+    return {"experiment_id": experiment_id, **_projection_request(ref, payload)}
+
+
+def publish_exact_text(
+    artifact_root: str | Path,
+    relative_ref: str,
+    content: bytes,
+) -> Path:
+    parts = relative_ref.split("/")
+    if (
+        not relative_ref
+        or relative_ref.startswith("/")
+        or "\\" in relative_ref
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ValueError("artifact ref must be a safe relative POSIX path")
+    root = ensure_private_directory(private_path(artifact_root))
+    parent = root
+    for part in parts[:-1]:
+        parent = ensure_private_directory(parent / part)
+    target = parent / parts[-1]
+    if target.is_symlink():
+        raise ValueError("artifact target must not be a symlink")
+    if target.exists():
+        with open_private_text(target) as handle:
+            existing = handle.read().encode("utf-8")
+        if existing != content:
+            raise ValueError("artifact bytes conflict")
+        return target
+
+    descriptor, temp_name = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=parent
+    )
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(descriptor, PRIVATE_FILE_MODE)
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temp_path, target)
+        except FileExistsError:
+            with open_private_text(target) as handle:
+                existing = handle.read().encode("utf-8")
+            if existing != content:
+                raise ValueError("artifact bytes conflict")
+        target_stat = os.lstat(target)
+        if not stat.S_ISREG(target_stat.st_mode):
+            raise ValueError("artifact target is not a regular file")
+        os.chmod(target, PRIVATE_FILE_MODE)
+        directory_fd = os.open(parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        return target
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temp_path.unlink(missing_ok=True)
+
+
+def recover_terminal_projection(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str | None = None,
+    publisher: Publisher | None = None,
+) -> dict[str, int]:
+    publish = publisher or publish_exact_text
+    recovered = 0
+    for event in store.pending_projections(experiment_id=experiment_id):
+        request = json.loads(str(event["payload_json"]))
+        text = request.get("text")
+        if not isinstance(text, str):
+            raise ValueError("projection request text is missing")
+        if _file_sha256(text) != request.get("file_sha256"):
+            raise ValueError("projection file hash mismatch")
+        payload = json.loads(text)
+        if not isinstance(payload, dict):
+            raise ValueError("projection payload must be an object")
+        if artifact_content_sha256(payload) != request.get("content_sha256"):
+            raise ValueError("projection content hash mismatch")
+        published_path = publish(
+            artifact_root, str(request["ref"]), text.encode("utf-8")
+        )
+        expected_path = private_path(artifact_root).joinpath(
+            *str(request["ref"]).split("/")
+        )
+        if private_path(published_path) != expected_path:
+            raise ValueError("publisher returned an unexpected artifact path")
+        with open_private_text(published_path) as handle:
+            if handle.read() != text:
+                raise ValueError("published artifact bytes changed")
+        store.mark_projection_published(
+            request_event_id=str(event["event_id"]),
+            actor="terminal-projection-recovery",
+            occurred_at_utc=str(event["occurred_at_utc"]),
+        )
+        recovered += 1
+    return {
+        "recovered": recovered,
+        "pending": len(store.pending_projections(experiment_id=experiment_id)),
+    }
+
+
+__all__ = [
+    "EXPERIMENT_RECEIPT_SCHEMA",
+    "GENERATION_TERMINAL_SCHEMA",
+    "build_aborted_receipt_request",
+    "build_generation_terminal_request",
+    "publish_exact_text",
+    "recover_terminal_projection",
+]

--- a/src/infrastructure/strategy_lab/__init__.py
+++ b/src/infrastructure/strategy_lab/__init__.py
@@ -1,0 +1,1 @@
+"""Private persistence for experimental Strategy Lab features."""

--- a/src/infrastructure/strategy_lab/experiment_store.py
+++ b/src/infrastructure/strategy_lab/experiment_store.py
@@ -1,0 +1,1917 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Sequence
+from urllib.parse import quote
+
+from src.infrastructure.private_storage import (
+    connect_private_sqlite,
+    private_path,
+    secure_sqlite_artifacts,
+)
+
+
+SCHEMA_COMPONENT = "sell_put_top1_experiment_store"
+SCHEMA_VERSION = 1
+
+_REQUIRED_TABLES = {
+    "strategy_lab_schema",
+    "strategy_lab_features",
+    "strategy_lab_experiments",
+    "strategy_lab_generations",
+    "strategy_lab_hidden_commitments",
+    "strategy_lab_events",
+}
+_REQUIRED_INDEXES = {
+    "strategy_lab_one_active_validation",
+    "strategy_lab_hidden_date_unique",
+    "strategy_lab_event_subject_unique",
+    "strategy_lab_event_idempotency_unique",
+}
+_EXPECTED_FOREIGN_KEYS = {
+    "strategy_lab_experiments": {
+        ("receipt_request_event_id", "strategy_lab_events", "event_id"),
+        ("receipt_published_event_id", "strategy_lab_events", "event_id"),
+    },
+    "strategy_lab_generations": {
+        ("experiment_id", "strategy_lab_experiments", "experiment_id"),
+        ("terminal_request_event_id", "strategy_lab_events", "event_id"),
+        ("terminal_published_event_id", "strategy_lab_events", "event_id"),
+    },
+    "strategy_lab_hidden_commitments": {
+        ("experiment_id", "strategy_lab_experiments", "experiment_id"),
+    },
+    "strategy_lab_events": set(),
+}
+
+
+class ExperimentStoreError(RuntimeError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def compact_json(payload: object) -> str:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _row(row: sqlite3.Row | None) -> dict[str, Any] | None:
+    return None if row is None else dict(row)
+
+
+class ExperimentStore:
+    """Single SQLite write authority for the experimental Top1 lifecycle."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = private_path(path)
+
+    def schema_state(self) -> dict[str, object]:
+        if not self.path.exists():
+            return {"status": "not_initialized", "schema_version": None}
+        if self.path.is_symlink() or not self.path.is_file():
+            return {"status": "schema_unsupported", "schema_version": None}
+        if self.path.stat().st_size == 0:
+            return {"status": "empty", "schema_version": None}
+        try:
+            connection = self._readonly_connection()
+            try:
+                tables = self._tables(connection)
+                if not tables:
+                    return {"status": "empty", "schema_version": None}
+                if "strategy_lab_schema" not in tables:
+                    return {"status": "schema_unsupported", "schema_version": None}
+                metadata = connection.execute(
+                    "SELECT schema_version FROM strategy_lab_schema WHERE component = ?",
+                    (SCHEMA_COMPONENT,),
+                ).fetchone()
+                if metadata is None:
+                    return {"status": "schema_unsupported", "schema_version": None}
+                version = int(metadata[0])
+                if version == 0 and tables == {"strategy_lab_schema"}:
+                    return {"status": "migration_required", "schema_version": 0}
+                if version != SCHEMA_VERSION:
+                    return {"status": "schema_unsupported", "schema_version": version}
+                self._validate_v1(connection, deep=True)
+                return {"status": "ready", "schema_version": version}
+            finally:
+                connection.close()
+        except (OSError, sqlite3.DatabaseError, ValueError, ExperimentStoreError):
+            return {"status": "schema_unsupported", "schema_version": None}
+
+    def migrate(self, *, migrated_at_utc: str) -> dict[str, object]:
+        connection = connect_private_sqlite(self.path, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        try:
+            self._configure(connection)
+            connection.execute("BEGIN IMMEDIATE")
+            tables = self._tables(connection)
+            if not tables:
+                self._create_v1(connection)
+                connection.execute(
+                    "INSERT INTO strategy_lab_schema(component, schema_version, migrated_at_utc) "
+                    "VALUES (?, ?, ?)",
+                    (SCHEMA_COMPONENT, SCHEMA_VERSION, migrated_at_utc),
+                )
+            elif tables == {"strategy_lab_schema"}:
+                metadata = connection.execute(
+                    "SELECT schema_version FROM strategy_lab_schema WHERE component = ?",
+                    (SCHEMA_COMPONENT,),
+                ).fetchone()
+                if metadata is None or int(metadata[0]) != 0:
+                    raise ExperimentStoreError(
+                        "schema_unsupported", "version-0 metadata is invalid"
+                    )
+                connection.execute("DROP TABLE strategy_lab_schema")
+                self._create_v1(connection)
+                connection.execute(
+                    "INSERT INTO strategy_lab_schema(component, schema_version, migrated_at_utc) "
+                    "VALUES (?, ?, ?)",
+                    (SCHEMA_COMPONENT, SCHEMA_VERSION, migrated_at_utc),
+                )
+            else:
+                metadata = (
+                    connection.execute(
+                        "SELECT schema_version FROM strategy_lab_schema WHERE component = ?",
+                        (SCHEMA_COMPONENT,),
+                    ).fetchone()
+                    if "strategy_lab_schema" in tables
+                    else None
+                )
+                if metadata is None or int(metadata[0]) != SCHEMA_VERSION:
+                    raise ExperimentStoreError(
+                        "schema_unsupported", "existing schema cannot be migrated"
+                    )
+            connection.commit()
+            self._validate_v1(connection, deep=True)
+        except (sqlite3.DatabaseError, ValueError) as exc:
+            connection.rollback()
+            raise ExperimentStoreError("schema_unsupported", "SQLite schema is invalid") from exc
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+            secure_sqlite_artifacts(self.path)
+        return {"status": "ready", "schema_version": SCHEMA_VERSION}
+
+    def feature(self, market: str, account: str) -> dict[str, Any] | None:
+        with self._read() as connection:
+            return _row(
+                connection.execute(
+                    "SELECT * FROM strategy_lab_features WHERE market = ? AND account = ?",
+                    (market, account),
+                ).fetchone()
+            )
+
+    def set_feature(
+        self,
+        *,
+        market: str,
+        account: str,
+        enabled: bool,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {"market": market, "account": account, "user_opt_in": enabled}
+        with self._write() as connection:
+            existing_command = self._command_event(
+                connection, f"feature:{market}:{account}", idempotency_key
+            )
+            if existing_command is not None:
+                self._assert_event_replay(
+                    existing_command, request, actor, occurred_at_utc
+                )
+                return dict(
+                    connection.execute(
+                        "SELECT * FROM strategy_lab_features WHERE market = ? AND account = ?",
+                        (market, account),
+                    ).fetchone()
+                    or {}
+                )
+            current = connection.execute(
+                "SELECT * FROM strategy_lab_features WHERE market = ? AND account = ?",
+                (market, account),
+            ).fetchone()
+            version = int(current["state_version"]) if current is not None else 0
+            changed = current is None or bool(current["user_opt_in"]) != enabled
+            next_version = version + int(changed)
+            subject = f"feature:{market}:{account}:state:{next_version}:value:{int(enabled)}"
+            _, inserted = self._claim_event(
+                connection,
+                event_type="feature_intent_set",
+                subject_key=subject,
+                command_scope=f"feature:{market}:{account}",
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+            )
+            if inserted and changed:
+                connection.execute(
+                    """
+                    INSERT INTO strategy_lab_features(
+                        market, account, user_opt_in, last_actor, last_occurred_at_utc,
+                        state_version
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(market, account) DO UPDATE SET
+                        user_opt_in = excluded.user_opt_in,
+                        last_actor = excluded.last_actor,
+                        last_occurred_at_utc = excluded.last_occurred_at_utc,
+                        state_version = excluded.state_version
+                    """,
+                    (
+                        market,
+                        account,
+                        int(enabled),
+                        actor,
+                        occurred_at_utc,
+                        next_version,
+                    ),
+                )
+            return dict(
+                connection.execute(
+                    "SELECT * FROM strategy_lab_features WHERE market = ? AND account = ?",
+                    (market, account),
+                ).fetchone()
+                or {}
+            )
+
+    def prepare_experiment(
+        self,
+        *,
+        experiment_id: str,
+        topic_id: str,
+        market: str,
+        account: str,
+        spec_json: str,
+        research_spec_sha256: str,
+        provenance_json: str,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "spec_sha256": _sha256_text(spec_json),
+            "research_spec_sha256": research_spec_sha256,
+            "provenance_sha256": _sha256_text(provenance_json),
+        }
+        scope = f"experiment:{experiment_id}:prepare"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            current = connection.execute(
+                "SELECT * FROM strategy_lab_experiments WHERE experiment_id = ?",
+                (experiment_id,),
+            ).fetchone()
+            if current is not None and (
+                current["phase"] != "draft" or current["terminal_mode"] is not None
+            ):
+                raise ExperimentStoreError(
+                    "invalid_transition", "experiment is no longer editable"
+                )
+            if current is not None and (
+                current["market"] != market
+                or current["account"] != account
+                or current["topic_id"] != topic_id
+            ):
+                raise ExperimentStoreError(
+                    "experiment_conflict", "experiment identity changed"
+                )
+            subject = f"experiment:{experiment_id}:prepare:{request['spec_sha256']}"
+            _, inserted = self._claim_event(
+                connection,
+                event_type="experiment_prepared",
+                subject_key=subject,
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+            )
+            if inserted:
+                if current is None:
+                    connection.execute(
+                        """
+                        INSERT INTO strategy_lab_experiments(
+                            experiment_id, topic_id, market, account, strategy_family,
+                            spec_json, research_spec_sha256, source_provenance_json,
+                            phase, research_authorization_status,
+                            validation_authorization_status,
+                            completed_validation_partitions, created_at_utc,
+                            updated_at_utc, state_version
+                        ) VALUES (?, ?, ?, ?, 'sell_put', ?, ?, ?, 'draft',
+                                  'unconfirmed', 'unconfirmed', 0, ?, ?, 1)
+                        """,
+                        (
+                            experiment_id,
+                            topic_id,
+                            market,
+                            account,
+                            spec_json,
+                            research_spec_sha256,
+                            provenance_json,
+                            occurred_at_utc,
+                            occurred_at_utc,
+                        ),
+                    )
+                elif (
+                    current["spec_json"] != spec_json
+                    or current["source_provenance_json"] != provenance_json
+                ):
+                    connection.execute(
+                        """
+                        UPDATE strategy_lab_experiments SET
+                            spec_json = ?, research_spec_sha256 = ?,
+                            source_provenance_json = ?,
+                            validation_spec_sha256 = NULL,
+                            research_authorization_status = 'unconfirmed',
+                            research_authorized_hash = NULL,
+                            research_authorized_actor = NULL,
+                            research_authorized_at_utc = NULL,
+                            validation_authorization_status = 'unconfirmed',
+                            validation_authorized_hash = NULL,
+                            validation_authorized_actor = NULL,
+                            validation_authorized_at_utc = NULL,
+                            updated_at_utc = ?, state_version = state_version + 1
+                        WHERE experiment_id = ?
+                        """,
+                        (
+                            spec_json,
+                            research_spec_sha256,
+                            provenance_json,
+                            occurred_at_utc,
+                            experiment_id,
+                        ),
+                    )
+            return self._required_experiment(connection, experiment_id)
+
+    def authorize(
+        self,
+        *,
+        experiment_id: str,
+        stage: str,
+        authorized_hash: str,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        if stage not in {"research", "validation"}:
+            raise ValueError("stage must be research or validation")
+        request = {"experiment_id": experiment_id, "authorized_hash": authorized_hash}
+        scope = f"experiment:{experiment_id}:authorize:{stage}"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            current = self._required_experiment(connection, experiment_id)
+            expected = current[f"{stage}_spec_sha256"]
+            if expected is None or expected != authorized_hash:
+                raise ExperimentStoreError(
+                    "authorization_hash_mismatch", "authorization hash is stale"
+                )
+            if current["terminal_mode"] is not None:
+                raise ExperimentStoreError("invalid_transition", "experiment is terminal")
+            if stage == "research" and current["phase"] != "draft":
+                raise ExperimentStoreError(
+                    "invalid_transition", "research authorization is closed"
+                )
+            if stage == "validation" and not (
+                current["phase"] == "research"
+                and current["research_progress"] == "challenger_locked"
+            ):
+                raise ExperimentStoreError(
+                    "invalid_transition", "challenger is not locked"
+                )
+            if (
+                current[f"{stage}_authorization_status"] == "confirmed"
+                and current[f"{stage}_authorized_hash"] == authorized_hash
+            ):
+                return current
+            subject = (
+                f"experiment:{experiment_id}:authorize:{stage}:"
+                f"version:{current['state_version']}:hash:{authorized_hash}"
+            )
+            _, inserted = self._claim_event(
+                connection,
+                event_type=f"{stage}_authorized",
+                subject_key=subject,
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+            )
+            if inserted:
+                connection.execute(
+                    f"""
+                    UPDATE strategy_lab_experiments SET
+                        {stage}_authorization_status = 'confirmed',
+                        {stage}_authorized_hash = ?,
+                        {stage}_authorized_actor = ?,
+                        {stage}_authorized_at_utc = ?,
+                        updated_at_utc = ?, state_version = state_version + 1
+                    WHERE experiment_id = ?
+                    """,
+                    (
+                        authorized_hash,
+                        actor,
+                        occurred_at_utc,
+                        occurred_at_utc,
+                        experiment_id,
+                    ),
+                )
+            return self._required_experiment(connection, experiment_id)
+
+    def start_research(
+        self,
+        *,
+        experiment_id: str,
+        authorized_hash: str,
+        dataset_ref: str,
+        dataset_file_sha256: str,
+        frozen_row_sha256: str,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "authorized_hash": authorized_hash,
+            "dataset_ref": dataset_ref,
+            "dataset_file_sha256": dataset_file_sha256,
+            "frozen_row_sha256": frozen_row_sha256,
+        }
+        scope = f"experiment:{experiment_id}:start-research"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            current = self._required_experiment(connection, experiment_id)
+            _, inserted = self._claim_event(
+                connection,
+                event_type="research_started",
+                subject_key=f"experiment:{experiment_id}:research",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="research",
+            )
+            if not inserted:
+                return current
+            if current["terminal_mode"] is not None or current["phase"] != "draft":
+                raise ExperimentStoreError(
+                    "invalid_transition", "research cannot start from current state"
+                )
+            if (
+                current["research_authorization_status"] != "confirmed"
+                or current["research_authorized_hash"] != authorized_hash
+                or current["research_spec_sha256"] != authorized_hash
+            ):
+                raise ExperimentStoreError(
+                    "authorization_required", "current research hash is not confirmed"
+                )
+            connection.execute(
+                """
+                INSERT INTO strategy_lab_generations(
+                    experiment_id, generation_kind, state, revision,
+                    last_revision_ref, last_revision_file_sha256,
+                    frozen_row_content_sha256, created_at_utc, updated_at_utc
+                ) VALUES (?, 'research', 'open', 0, ?, ?, ?, ?, ?)
+                """,
+                (
+                    experiment_id,
+                    dataset_ref,
+                    dataset_file_sha256,
+                    frozen_row_sha256,
+                    occurred_at_utc,
+                    occurred_at_utc,
+                ),
+            )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    phase = 'research', research_progress = 'building_dataset',
+                    updated_at_utc = ?, state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (occurred_at_utc, experiment_id),
+            )
+            return self._required_experiment(connection, experiment_id)
+
+    def record_generation_revision(
+        self,
+        *,
+        experiment_id: str,
+        generation_kind: str,
+        revision: int,
+        revision_ref: str,
+        revision_file_sha256: str,
+        frozen_row_sha256: str,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "generation_kind": generation_kind,
+            "revision": revision,
+            "revision_ref": revision_ref,
+            "revision_file_sha256": revision_file_sha256,
+            "frozen_row_sha256": frozen_row_sha256,
+        }
+        scope = f"generation:{experiment_id}:{generation_kind}:revision"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_generation(connection, experiment_id, generation_kind)
+            experiment = self._required_experiment(connection, experiment_id)
+            generation = self._required_generation(
+                connection, experiment_id, generation_kind
+            )
+            _, inserted = self._claim_event(
+                connection,
+                event_type="generation_revision_recorded",
+                subject_key=f"generation:{experiment_id}:{generation_kind}:revision:{revision}",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind=generation_kind,
+            )
+            if not inserted:
+                return generation
+            if experiment["terminal_mode"] is not None:
+                raise ExperimentStoreError("late_write", "experiment is terminal")
+            if generation["terminal_request_event_id"] is not None:
+                raise ExperimentStoreError("late_write", "generation is terminal")
+            if revision != int(generation["revision"]) + 1:
+                raise ExperimentStoreError(
+                    "generation_conflict", "generation revision is not next"
+                )
+            connection.execute(
+                """
+                UPDATE strategy_lab_generations SET
+                    revision = ?, last_revision_ref = ?,
+                    last_revision_file_sha256 = ?, frozen_row_content_sha256 = ?,
+                    updated_at_utc = ?
+                WHERE experiment_id = ? AND generation_kind = ?
+                """,
+                (
+                    revision,
+                    revision_ref,
+                    revision_file_sha256,
+                    frozen_row_sha256,
+                    occurred_at_utc,
+                    experiment_id,
+                    generation_kind,
+                ),
+            )
+            return self._required_generation(connection, experiment_id, generation_kind)
+
+    def lock_challenger(
+        self,
+        *,
+        experiment_id: str,
+        spec_json: str,
+        research_spec_sha256: str,
+        validation_spec_sha256: str,
+        research_leader: str,
+        research_receipt_ref: str,
+        research_receipt_file_sha256: str,
+        commitment_json: str,
+        commitment_sha256: str,
+        commitment_ref: str,
+        commitment_content_sha256: str,
+        commitment_file_sha256: str,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "spec_sha256": _sha256_text(spec_json),
+            "research_spec_sha256": research_spec_sha256,
+            "validation_spec_sha256": validation_spec_sha256,
+            "research_leader": research_leader,
+            "research_receipt_ref": research_receipt_ref,
+            "research_receipt_file_sha256": research_receipt_file_sha256,
+            "commitment_sha256": commitment_sha256,
+            "commitment_ref": commitment_ref,
+            "commitment_content_sha256": commitment_content_sha256,
+            "commitment_file_sha256": commitment_file_sha256,
+        }
+        scope = f"experiment:{experiment_id}:lock-challenger"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            current = self._required_experiment(connection, experiment_id)
+            research = self._required_generation(connection, experiment_id, "research")
+            if current["terminal_mode"] is not None or current["phase"] != "research":
+                raise ExperimentStoreError(
+                    "invalid_transition", "challenger cannot be locked"
+                )
+            if current["research_spec_sha256"] != research_spec_sha256:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "research hash changed"
+                )
+            if not (
+                research["terminal_mode"] == "completed"
+                and research["terminal_published_event_id"] is not None
+            ):
+                raise ExperimentStoreError(
+                    "invalid_transition", "research terminal is not published"
+                )
+            if current["research_leader"] not in {None, research_leader}:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "research leader is already immutable"
+                )
+            if current["research_receipt_ref"] not in {None, research_receipt_ref}:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "research receipt ref changed"
+                )
+            if current["research_receipt_file_sha256"] not in {
+                None,
+                research_receipt_file_sha256,
+            }:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "research receipt hash changed"
+                )
+            subject = (
+                f"experiment:{experiment_id}:challenger:{research_leader}:"
+                f"validation:{validation_spec_sha256}"
+            )
+            _, inserted = self._claim_event(
+                connection,
+                event_type="challenger_locked",
+                subject_key=subject,
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+            )
+            if inserted:
+                connection.execute(
+                    """
+                    UPDATE strategy_lab_experiments SET
+                        spec_json = ?, validation_spec_sha256 = ?,
+                        research_leader = ?, research_receipt_ref = ?,
+                        research_receipt_file_sha256 = ?,
+                        proposed_commitment_json = ?, proposed_commitment_sha256 = ?,
+                        proposed_commitment_ref = ?,
+                        proposed_commitment_content_sha256 = ?,
+                        proposed_commitment_file_sha256 = ?,
+                        research_progress = 'challenger_locked',
+                        validation_authorization_status = 'unconfirmed',
+                        validation_authorized_hash = NULL,
+                        validation_authorized_actor = NULL,
+                        validation_authorized_at_utc = NULL,
+                        updated_at_utc = ?, state_version = state_version + 1
+                    WHERE experiment_id = ?
+                    """,
+                    (
+                        spec_json,
+                        validation_spec_sha256,
+                        research_leader,
+                        research_receipt_ref,
+                        research_receipt_file_sha256,
+                        commitment_json,
+                        commitment_sha256,
+                        commitment_ref,
+                        commitment_content_sha256,
+                        commitment_file_sha256,
+                        occurred_at_utc,
+                        experiment_id,
+                    ),
+                )
+            return self._required_experiment(connection, experiment_id)
+
+    def start_validation(
+        self,
+        *,
+        experiment_id: str,
+        authorized_hash: str,
+        commitment_sha256: str,
+        commitment_dates: Sequence[str],
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "authorized_hash": authorized_hash,
+            "commitment_sha256": commitment_sha256,
+            "trading_dates": list(commitment_dates),
+        }
+        scope = f"experiment:{experiment_id}:start-validation"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            current = self._required_experiment(connection, experiment_id)
+            _, inserted = self._claim_event(
+                connection,
+                event_type="validation_started",
+                subject_key=f"experiment:{experiment_id}:validation:{authorized_hash}",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="hidden",
+            )
+            if not inserted:
+                return current
+            if current["terminal_mode"] is not None or not (
+                current["phase"] == "research"
+                and current["research_progress"] == "challenger_locked"
+            ):
+                raise ExperimentStoreError(
+                    "invalid_transition", "validation cannot start"
+                )
+            if (
+                current["validation_authorization_status"] != "confirmed"
+                or current["validation_authorized_hash"] != authorized_hash
+                or current["validation_spec_sha256"] != authorized_hash
+            ):
+                raise ExperimentStoreError(
+                    "authorization_required", "current validation hash is not confirmed"
+                )
+            if current["proposed_commitment_sha256"] != commitment_sha256:
+                raise ExperimentStoreError(
+                    "authorization_hash_mismatch", "commitment changed after authorization"
+                )
+            occupied = connection.execute(
+                """
+                SELECT trading_date FROM strategy_lab_hidden_commitments
+                WHERE market = ? AND account = ? AND strategy_family = 'sell_put'
+                  AND trading_date IN ({}) LIMIT 1
+                """.format(",".join("?" for _ in commitment_dates)),
+                (current["market"], current["account"], *commitment_dates),
+            ).fetchone()
+            if occupied is not None:
+                raise ExperimentStoreError(
+                    "hidden_window_overlap", "hidden trading date is already consumed"
+                )
+            active = connection.execute(
+                """
+                SELECT experiment_id FROM strategy_lab_experiments
+                WHERE market = ? AND account = ? AND strategy_family = 'sell_put'
+                  AND terminal_mode IS NULL AND phase = 'validation'
+                  AND validation_progress = 'collecting_decisions'
+                LIMIT 1
+                """,
+                (current["market"], current["account"]),
+            ).fetchone()
+            if active is not None:
+                raise ExperimentStoreError(
+                    "validation_slot_occupied", "validation collection slot is occupied"
+                )
+            connection.executemany(
+                """
+                INSERT INTO strategy_lab_hidden_commitments(
+                    experiment_id, market, account, strategy_family,
+                    commitment_sha256, trading_date
+                ) VALUES (?, ?, ?, 'sell_put', ?, ?)
+                """,
+                [
+                    (
+                        experiment_id,
+                        current["market"],
+                        current["account"],
+                        commitment_sha256,
+                        trading_date,
+                    )
+                    for trading_date in commitment_dates
+                ],
+            )
+            connection.execute(
+                """
+                INSERT INTO strategy_lab_generations(
+                    experiment_id, generation_kind, state, revision,
+                    last_revision_ref, last_revision_file_sha256,
+                    frozen_row_content_sha256, created_at_utc, updated_at_utc
+                ) VALUES (?, 'hidden', 'open', 0, ?, ?, ?, ?, ?)
+                """,
+                (
+                    experiment_id,
+                    current["proposed_commitment_ref"],
+                    current["proposed_commitment_file_sha256"],
+                    current["proposed_commitment_content_sha256"],
+                    occurred_at_utc,
+                    occurred_at_utc,
+                ),
+            )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    phase = 'validation', validation_progress = 'collecting_decisions',
+                    completed_validation_partitions = 0,
+                    updated_at_utc = ?, state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (occurred_at_utc, experiment_id),
+            )
+            return self._required_experiment(connection, experiment_id)
+
+    def commit_validation_point(
+        self,
+        *,
+        experiment_id: str,
+        point_id: str,
+        trading_date: str,
+        source_ref: str,
+        source_file_sha256: str,
+        revision: int,
+        manifest_ref: str,
+        manifest_file_sha256: str,
+        frozen_row_sha256: str,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "point_id": point_id,
+            "trading_date": trading_date,
+            "source_ref": source_ref,
+            "source_file_sha256": source_file_sha256,
+            "revision": revision,
+            "manifest_ref": manifest_ref,
+            "manifest_file_sha256": manifest_file_sha256,
+            "frozen_row_sha256": frozen_row_sha256,
+        }
+        scope = f"experiment:{experiment_id}:validation-point"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_generation(connection, experiment_id, "hidden")
+            experiment = self._required_experiment(connection, experiment_id)
+            generation = self._required_generation(connection, experiment_id, "hidden")
+            _, inserted = self._claim_event(
+                connection,
+                event_type="validation_point_committed",
+                subject_key=f"experiment:{experiment_id}:point:{point_id}",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="hidden",
+            )
+            if not inserted:
+                return generation
+            if experiment["terminal_mode"] is not None or not (
+                experiment["phase"] == "validation"
+                and experiment["validation_progress"] == "collecting_decisions"
+                and generation["terminal_request_event_id"] is None
+            ):
+                raise ExperimentStoreError("late_write", "validation intake is closed")
+            committed_date = connection.execute(
+                """
+                SELECT 1 FROM strategy_lab_hidden_commitments
+                WHERE experiment_id = ? AND trading_date = ?
+                """,
+                (experiment_id, trading_date),
+            ).fetchone()
+            if committed_date is None:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "point date is outside commitment"
+                )
+            next_date = connection.execute(
+                """
+                SELECT trading_date FROM strategy_lab_hidden_commitments
+                WHERE experiment_id = ? ORDER BY trading_date LIMIT 1 OFFSET ?
+                """,
+                (experiment_id, int(experiment["completed_validation_partitions"])),
+            ).fetchone()
+            if next_date is None or str(next_date[0]) != trading_date:
+                raise ExperimentStoreError(
+                    "late_write", "point date partition is not open"
+                )
+            if revision != int(generation["revision"]) + 1:
+                raise ExperimentStoreError(
+                    "generation_conflict", "hidden revision is not next"
+                )
+            connection.execute(
+                """
+                UPDATE strategy_lab_generations SET
+                    revision = ?, last_revision_ref = ?,
+                    last_revision_file_sha256 = ?, frozen_row_content_sha256 = ?,
+                    updated_at_utc = ?
+                WHERE experiment_id = ? AND generation_kind = 'hidden'
+                """,
+                (
+                    revision,
+                    manifest_ref,
+                    manifest_file_sha256,
+                    frozen_row_sha256,
+                    occurred_at_utc,
+                    experiment_id,
+                ),
+            )
+            return self._required_generation(connection, experiment_id, "hidden")
+
+    def seal_validation_partition(
+        self,
+        *,
+        experiment_id: str,
+        trading_date: str,
+        terminal_request: Mapping[str, object] | None,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "trading_date": trading_date,
+            "terminal_request_sha256": (
+                _sha256_text(compact_json(terminal_request))
+                if terminal_request is not None
+                else None
+            ),
+        }
+        scope = f"experiment:{experiment_id}:validation-partition"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            experiment = self._required_experiment(connection, experiment_id)
+            generation = self._required_generation(connection, experiment_id, "hidden")
+            _, inserted = self._claim_event(
+                connection,
+                event_type="validation_partition_sealed",
+                subject_key=f"experiment:{experiment_id}:partition:{trading_date}",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="hidden",
+            )
+            if not inserted:
+                return experiment
+            if experiment["terminal_mode"] is not None or not (
+                experiment["phase"] == "validation"
+                and experiment["validation_progress"] == "collecting_decisions"
+                and generation["terminal_request_event_id"] is None
+            ):
+                raise ExperimentStoreError("late_write", "validation intake is closed")
+            dates = [
+                str(row[0])
+                for row in connection.execute(
+                    """
+                    SELECT trading_date FROM strategy_lab_hidden_commitments
+                    WHERE experiment_id = ? ORDER BY trading_date
+                    """,
+                    (experiment_id,),
+                ).fetchall()
+            ]
+            completed = int(experiment["completed_validation_partitions"])
+            if completed >= len(dates) or dates[completed] != trading_date:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "partition is not the next commitment date"
+                )
+            point_rows = connection.execute(
+                """
+                SELECT payload_json FROM strategy_lab_events
+                WHERE experiment_id = ? AND event_type = 'validation_point_committed'
+                """,
+                (experiment_id,),
+            ).fetchall()
+            if not any(
+                json.loads(str(row[0])).get("trading_date") == trading_date
+                for row in point_rows
+            ):
+                raise ExperimentStoreError(
+                    "experiment_conflict", "partition has no committed point"
+                )
+            is_final = completed + 1 == 20
+            if is_final != (terminal_request is not None):
+                raise ExperimentStoreError(
+                    "experiment_conflict", "terminal request is required only on day 20"
+                )
+            if terminal_request is not None:
+                self._request_generation_terminal(
+                    connection,
+                    experiment_id=experiment_id,
+                    generation_kind="hidden",
+                    request=terminal_request,
+                    actor=actor,
+                    occurred_at_utc=occurred_at_utc,
+                    idempotency_key=f"{idempotency_key}:hidden-terminal",
+                )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    completed_validation_partitions = ?,
+                    validation_progress = CASE WHEN ? THEN 'awaiting_outcomes'
+                                               ELSE validation_progress END,
+                    updated_at_utc = ?, state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (completed + 1, int(is_final), occurred_at_utc, experiment_id),
+            )
+            return self._required_experiment(connection, experiment_id)
+
+    def request_generation_terminal(
+        self,
+        *,
+        experiment_id: str,
+        generation_kind: str,
+        request: Mapping[str, object],
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        with self._write() as connection:
+            self._request_generation_terminal(
+                connection,
+                experiment_id=experiment_id,
+                generation_kind=generation_kind,
+                request=request,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=idempotency_key,
+            )
+            return self._required_generation(connection, experiment_id, generation_kind)
+
+    def terminate(
+        self,
+        *,
+        experiment_id: str,
+        expected_state_version: int,
+        reason: str,
+        disabled_scope: str | None,
+        terminated_at_partition: int | None,
+        generation_requests: Sequence[Mapping[str, object]],
+        receipt_request: Mapping[str, object],
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request_payload = {
+            "experiment_id": experiment_id,
+            "reason": reason,
+            "disabled_scope": disabled_scope,
+            "terminated_at_partition": terminated_at_partition,
+            "generation_request_sha256": [
+                _sha256_text(compact_json(item)) for item in generation_requests
+            ],
+            "receipt_request_sha256": _sha256_text(compact_json(receipt_request)),
+        }
+        scope = f"experiment:{experiment_id}:terminate"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(
+                    replay, request_payload, actor, occurred_at_utc
+                )
+                return self._required_experiment(connection, experiment_id)
+            experiment = self._required_experiment(connection, experiment_id)
+            if int(experiment["state_version"]) != expected_state_version:
+                raise ExperimentStoreError("stale_snapshot", "experiment changed")
+            if experiment["terminal_mode"] is not None:
+                raise ExperimentStoreError(
+                    "terminal_conflict", "experiment already has terminal intent"
+                )
+            self._claim_event(
+                connection,
+                event_type="experiment_termination_committed",
+                subject_key=f"experiment:{experiment_id}:terminal",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request_payload,
+                experiment_id=experiment_id,
+            )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    terminal_mode = 'aborted', terminal_reason = ?,
+                    disabled_scope = ?, terminal_at_utc = ?,
+                    terminated_at_partition = ?,
+                    final_outcome_status = 'insufficient_evidence',
+                    updated_at_utc = ?, state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (
+                    reason,
+                    disabled_scope,
+                    occurred_at_utc,
+                    terminated_at_partition,
+                    occurred_at_utc,
+                    experiment_id,
+                ),
+            )
+            for item in generation_requests:
+                self._request_generation_terminal(
+                    connection,
+                    experiment_id=experiment_id,
+                    generation_kind=str(item["generation_kind"]),
+                    request=item,
+                    actor=actor,
+                    occurred_at_utc=occurred_at_utc,
+                    idempotency_key=f"{idempotency_key}:{item['generation_kind']}-terminal",
+                    allow_experiment_terminal=True,
+                )
+            self._request_receipt(
+                connection,
+                experiment_id=experiment_id,
+                request=receipt_request,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=f"{idempotency_key}:receipt",
+            )
+            return self._required_experiment(connection, experiment_id)
+
+    def active_experiments(self, market: str, account: str) -> list[dict[str, Any]]:
+        with self._read() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_experiments
+                    WHERE market = ? AND account = ? AND terminal_mode IS NULL
+                      AND phase != 'concluded'
+                    ORDER BY created_at_utc, experiment_id
+                    """,
+                    (market, account),
+                ).fetchall()
+            ]
+
+    def experiment(self, experiment_id: str) -> dict[str, Any]:
+        with self._read() as connection:
+            return self._required_experiment(connection, experiment_id)
+
+    def generations(self, experiment_id: str) -> list[dict[str, Any]]:
+        with self._read() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_generations
+                    WHERE experiment_id = ? ORDER BY generation_kind
+                    """,
+                    (experiment_id,),
+                ).fetchall()
+            ]
+
+    def commitment_dates(self, experiment_id: str) -> list[str]:
+        with self._read() as connection:
+            return [
+                str(row[0])
+                for row in connection.execute(
+                    """
+                    SELECT trading_date FROM strategy_lab_hidden_commitments
+                    WHERE experiment_id = ? ORDER BY trading_date
+                    """,
+                    (experiment_id,),
+                ).fetchall()
+            ]
+
+    def pending_projections(
+        self, *, experiment_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        experiment_filter = "" if experiment_id is None else "AND e.experiment_id = ?"
+        parameters: tuple[object, ...] = () if experiment_id is None else (experiment_id,)
+        with self._read() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT e.* FROM strategy_lab_events e
+                LEFT JOIN strategy_lab_generations g
+                  ON e.event_id = g.terminal_request_event_id
+                LEFT JOIN strategy_lab_experiments x
+                  ON e.event_id = x.receipt_request_event_id
+                WHERE e.event_type IN (
+                    'generation_terminal_requested', 'experiment_receipt_requested'
+                ) AND (
+                    (g.terminal_request_event_id IS NOT NULL
+                     AND g.terminal_published_event_id IS NULL)
+                    OR
+                    (x.receipt_request_event_id IS NOT NULL
+                     AND x.receipt_published_event_id IS NULL)
+                )
+                {experiment_filter}
+                ORDER BY e.rowid
+                """,
+                parameters,
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+    def mark_projection_published(
+        self,
+        *,
+        request_event_id: str,
+        actor: str,
+        occurred_at_utc: str,
+    ) -> None:
+        with self._write() as connection:
+            request_event = connection.execute(
+                "SELECT * FROM strategy_lab_events WHERE event_id = ?",
+                (request_event_id,),
+            ).fetchone()
+            if request_event is None or request_event["event_type"] not in {
+                "generation_terminal_requested",
+                "experiment_receipt_requested",
+            }:
+                raise ExperimentStoreError(
+                    "projection_conflict", "projection request is missing"
+                )
+            request = json.loads(str(request_event["payload_json"]))
+            subject = f"projection:{request_event_id}:published"
+            published_event_id, _ = self._claim_event(
+                connection,
+                event_type="terminal_projection_published",
+                subject_key=subject,
+                command_scope=f"projection:{request_event_id}",
+                idempotency_key=request_event_id,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload={
+                    "request_event_id": request_event_id,
+                    "ref": request["ref"],
+                    "content_sha256": request["content_sha256"],
+                    "file_sha256": request["file_sha256"],
+                },
+                experiment_id=request_event["experiment_id"],
+                generation_kind=request_event["generation_kind"],
+            )
+            if request_event["event_type"] == "generation_terminal_requested":
+                generation = self._required_generation(
+                    connection,
+                    str(request_event["experiment_id"]),
+                    str(request_event["generation_kind"]),
+                )
+                if generation["terminal_request_event_id"] != request_event_id:
+                    raise ExperimentStoreError(
+                        "projection_conflict", "generation request binding changed"
+                    )
+                if generation["terminal_published_event_id"] is None:
+                    connection.execute(
+                        """
+                        UPDATE strategy_lab_generations SET
+                            terminal_published_event_id = ?, terminal_published_at_utc = ?,
+                            updated_at_utc = ?
+                        WHERE experiment_id = ? AND generation_kind = ?
+                        """,
+                        (
+                            published_event_id,
+                            occurred_at_utc,
+                            occurred_at_utc,
+                            request_event["experiment_id"],
+                            request_event["generation_kind"],
+                        ),
+                    )
+                    if (
+                        request_event["generation_kind"] == "research"
+                        and generation["terminal_mode"] == "completed"
+                    ):
+                        connection.execute(
+                            """
+                            UPDATE strategy_lab_experiments SET
+                                research_progress = 'ready_to_compare',
+                                updated_at_utc = ?, state_version = state_version + 1
+                            WHERE experiment_id = ? AND terminal_mode IS NULL
+                            """,
+                            (occurred_at_utc, request_event["experiment_id"]),
+                        )
+            else:
+                experiment = self._required_experiment(
+                    connection, str(request_event["experiment_id"])
+                )
+                if experiment["receipt_request_event_id"] != request_event_id:
+                    raise ExperimentStoreError(
+                        "projection_conflict", "receipt request binding changed"
+                    )
+                if experiment["receipt_published_event_id"] is None:
+                    connection.execute(
+                        """
+                        UPDATE strategy_lab_experiments SET
+                            receipt_published_event_id = ?,
+                            receipt_published_at_utc = ?, updated_at_utc = ?,
+                            state_version = state_version + 1
+                        WHERE experiment_id = ?
+                        """,
+                        (
+                            published_event_id,
+                            occurred_at_utc,
+                            occurred_at_utc,
+                            request_event["experiment_id"],
+                        ),
+                    )
+            self._maybe_conclude(connection, str(request_event["experiment_id"]), occurred_at_utc)
+
+    def receipt_text(self, experiment_id: str) -> str | None:
+        with self._read() as connection:
+            experiment = self._required_experiment(connection, experiment_id)
+            if not (
+                experiment["phase"] == "concluded"
+                and experiment["receipt_published_event_id"] is not None
+                and experiment["receipt_request_event_id"] is not None
+            ):
+                return None
+            event = connection.execute(
+                "SELECT payload_json FROM strategy_lab_events WHERE event_id = ?",
+                (experiment["receipt_request_event_id"],),
+            ).fetchone()
+            if event is None:
+                raise ExperimentStoreError(
+                    "projection_conflict", "receipt event is missing"
+                )
+            return str(json.loads(str(event[0]))["text"])
+
+    def events(self, experiment_id: str) -> list[dict[str, Any]]:
+        with self._read() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    "SELECT * FROM strategy_lab_events WHERE experiment_id = ? ORDER BY rowid",
+                    (experiment_id,),
+                ).fetchall()
+            ]
+
+    def _request_generation_terminal(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        experiment_id: str,
+        generation_kind: str,
+        request: Mapping[str, object],
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+        allow_experiment_terminal: bool = False,
+    ) -> str:
+        experiment = self._required_experiment(connection, experiment_id)
+        generation = self._required_generation(connection, experiment_id, generation_kind)
+        if experiment["terminal_mode"] is not None and not allow_experiment_terminal:
+            raise ExperimentStoreError("terminal_conflict", "experiment is terminal")
+        existing_request_id = generation["terminal_request_event_id"]
+        if existing_request_id is not None:
+            event = connection.execute(
+                "SELECT * FROM strategy_lab_events WHERE event_id = ?",
+                (existing_request_id,),
+            ).fetchone()
+            if event is None or str(event["payload_json"]) != compact_json(request):
+                raise ExperimentStoreError(
+                    "terminal_conflict", "generation terminal already requested"
+                )
+            return str(existing_request_id)
+        request_revision = request["revision"]
+        if isinstance(request_revision, bool) or not isinstance(request_revision, int):
+            raise ExperimentStoreError("stale_snapshot", "generation revision is invalid")
+        if request_revision != int(generation["revision"]):
+            raise ExperimentStoreError("stale_snapshot", "generation revision changed")
+        if request["last_revision_ref"] != generation["last_revision_ref"]:
+            raise ExperimentStoreError("stale_snapshot", "generation ref changed")
+        if request["last_revision_file_sha256"] != generation["last_revision_file_sha256"]:
+            raise ExperimentStoreError("stale_snapshot", "generation file hash changed")
+        if request["frozen_row_content_sha256"] != generation["frozen_row_content_sha256"]:
+            raise ExperimentStoreError("stale_snapshot", "generation content hash changed")
+        event_id, _ = self._claim_event(
+            connection,
+            event_type="generation_terminal_requested",
+            subject_key=f"generation:{experiment_id}:{generation_kind}:terminal",
+            command_scope=f"generation:{experiment_id}:{generation_kind}:terminal",
+            idempotency_key=idempotency_key,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            payload=request,
+            experiment_id=experiment_id,
+            generation_kind=generation_kind,
+        )
+        connection.execute(
+            """
+            UPDATE strategy_lab_generations SET
+                state = 'terminal', terminal_request_event_id = ?,
+                terminal_mode = ?, terminal_ref = ?,
+                terminal_content_sha256 = ?, terminal_file_sha256 = ?,
+                terminal_requested_at_utc = ?, updated_at_utc = ?
+            WHERE experiment_id = ? AND generation_kind = ?
+              AND terminal_request_event_id IS NULL
+            """,
+            (
+                event_id,
+                request["terminal_mode"],
+                request["ref"],
+                request["content_sha256"],
+                request["file_sha256"],
+                occurred_at_utc,
+                occurred_at_utc,
+                experiment_id,
+                generation_kind,
+            ),
+        )
+        return event_id
+
+    def _request_receipt(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        experiment_id: str,
+        request: Mapping[str, object],
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> str:
+        experiment = self._required_experiment(connection, experiment_id)
+        if experiment["receipt_request_event_id"] is not None:
+            event = connection.execute(
+                "SELECT payload_json FROM strategy_lab_events WHERE event_id = ?",
+                (experiment["receipt_request_event_id"],),
+            ).fetchone()
+            if event is None or str(event[0]) != compact_json(request):
+                raise ExperimentStoreError(
+                    "terminal_conflict", "receipt already requested"
+                )
+            return str(experiment["receipt_request_event_id"])
+        event_id, _ = self._claim_event(
+            connection,
+            event_type="experiment_receipt_requested",
+            subject_key=f"experiment:{experiment_id}:receipt",
+            command_scope=f"experiment:{experiment_id}:receipt",
+            idempotency_key=idempotency_key,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            payload=request,
+            experiment_id=experiment_id,
+        )
+        connection.execute(
+            """
+            UPDATE strategy_lab_experiments SET
+                receipt_request_event_id = ?, receipt_ref = ?,
+                receipt_content_sha256 = ?, receipt_file_sha256 = ?,
+                updated_at_utc = ?, state_version = state_version + 1
+            WHERE experiment_id = ? AND receipt_request_event_id IS NULL
+            """,
+            (
+                event_id,
+                request["ref"],
+                request["content_sha256"],
+                request["file_sha256"],
+                occurred_at_utc,
+                experiment_id,
+            ),
+        )
+        return event_id
+
+    def _maybe_conclude(
+        self, connection: sqlite3.Connection, experiment_id: str, occurred_at_utc: str
+    ) -> None:
+        experiment = self._required_experiment(connection, experiment_id)
+        if experiment["terminal_mode"] is None or experiment["receipt_published_event_id"] is None:
+            return
+        pending = connection.execute(
+            """
+            SELECT 1 FROM strategy_lab_generations
+            WHERE experiment_id = ? AND terminal_published_event_id IS NULL
+            LIMIT 1
+            """,
+            (experiment_id,),
+        ).fetchone()
+        if pending is None and experiment["phase"] != "concluded":
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    phase = 'concluded', updated_at_utc = ?, state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (occurred_at_utc, experiment_id),
+            )
+
+    def _claim_event(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        event_type: str,
+        subject_key: str,
+        command_scope: str,
+        idempotency_key: str,
+        actor: str,
+        occurred_at_utc: str,
+        payload: object,
+        experiment_id: str | None = None,
+        generation_kind: str | None = None,
+    ) -> tuple[str, bool]:
+        payload_json = compact_json(payload)
+        replay = self._command_event(connection, command_scope, idempotency_key)
+        if replay is not None:
+            self._assert_event_replay(replay, payload, actor, occurred_at_utc)
+            if replay["event_type"] != event_type or replay["subject_key"] != subject_key:
+                raise ExperimentStoreError(
+                    "idempotency_conflict", "idempotency key changed command subject"
+                )
+            return str(replay["event_id"]), False
+        natural = connection.execute(
+            """
+            SELECT * FROM strategy_lab_events
+            WHERE event_type = ? AND subject_key = ?
+            """,
+            (event_type, subject_key),
+        ).fetchone()
+        if natural is not None:
+            if str(natural["payload_json"]) != payload_json:
+                raise ExperimentStoreError(
+                    "natural_fact_conflict", "natural fact has different bytes"
+                )
+            target_event_id = str(natural["event_id"])
+            alias_key_sha256 = _sha256_text(
+                f"{command_scope}\0{idempotency_key}"
+            )
+            alias_subject = (
+                f"event:{target_event_id}:command:{alias_key_sha256}"
+            )
+            alias_event_id = _sha256_text(
+                f"command_idempotency_bound\0{alias_subject}"
+            )
+            connection.execute(
+                """
+                INSERT INTO strategy_lab_events(
+                    event_id, experiment_id, generation_kind, event_type, subject_key,
+                    command_scope, idempotency_key, actor, occurred_at_utc,
+                    payload_json, payload_sha256
+                ) VALUES (?, ?, ?, 'command_idempotency_bound', ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    alias_event_id,
+                    natural["experiment_id"],
+                    natural["generation_kind"],
+                    alias_subject,
+                    command_scope,
+                    idempotency_key,
+                    actor,
+                    occurred_at_utc,
+                    payload_json,
+                    _sha256_text(payload_json),
+                ),
+            )
+            return target_event_id, False
+        event_id = _sha256_text(f"{event_type}\0{subject_key}")
+        connection.execute(
+            """
+            INSERT INTO strategy_lab_events(
+                event_id, experiment_id, generation_kind, event_type, subject_key,
+                command_scope, idempotency_key, actor, occurred_at_utc,
+                payload_json, payload_sha256
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                experiment_id,
+                generation_kind,
+                event_type,
+                subject_key,
+                command_scope,
+                idempotency_key,
+                actor,
+                occurred_at_utc,
+                payload_json,
+                _sha256_text(payload_json),
+            ),
+        )
+        return event_id, True
+
+    @staticmethod
+    def _assert_event_replay(
+        event: sqlite3.Row,
+        payload: object,
+        actor: str,
+        occurred_at_utc: str,
+    ) -> None:
+        if (
+            str(event["payload_json"]) != compact_json(payload)
+            or event["actor"] != actor
+            or event["occurred_at_utc"] != occurred_at_utc
+        ):
+            raise ExperimentStoreError(
+                "idempotency_conflict", "idempotency key changed request bytes"
+            )
+
+    @staticmethod
+    def _command_event(
+        connection: sqlite3.Connection, command_scope: str, idempotency_key: str
+    ) -> sqlite3.Row | None:
+        return connection.execute(
+            """
+            SELECT * FROM strategy_lab_events
+            WHERE command_scope = ? AND idempotency_key = ?
+            """,
+            (command_scope, idempotency_key),
+        ).fetchone()
+
+    @staticmethod
+    def _required_experiment(
+        connection: sqlite3.Connection, experiment_id: str
+    ) -> dict[str, Any]:
+        row = connection.execute(
+            "SELECT * FROM strategy_lab_experiments WHERE experiment_id = ?",
+            (experiment_id,),
+        ).fetchone()
+        if row is None:
+            raise ExperimentStoreError("experiment_not_found", "experiment does not exist")
+        return dict(row)
+
+    @staticmethod
+    def _required_generation(
+        connection: sqlite3.Connection, experiment_id: str, generation_kind: str
+    ) -> dict[str, Any]:
+        row = connection.execute(
+            """
+            SELECT * FROM strategy_lab_generations
+            WHERE experiment_id = ? AND generation_kind = ?
+            """,
+            (experiment_id, generation_kind),
+        ).fetchone()
+        if row is None:
+            raise ExperimentStoreError("generation_not_found", "generation does not exist")
+        return dict(row)
+
+    @contextmanager
+    def _read(self) -> Iterator[sqlite3.Connection]:
+        connection = self._open_existing()
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    @contextmanager
+    def _write(self) -> Iterator[sqlite3.Connection]:
+        connection = self._open_existing()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            yield connection
+            connection.commit()
+        except sqlite3.IntegrityError as exc:
+            connection.rollback()
+            raise ExperimentStoreError("constraint_conflict", "SQLite constraint failed") from exc
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+            secure_sqlite_artifacts(self.path)
+
+    def _open_existing(self) -> sqlite3.Connection:
+        if not self.path.exists():
+            raise ExperimentStoreError("schema_unsupported", "store is not initialized")
+        connection = connect_private_sqlite(self.path, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        self._configure(connection)
+        self._validate_v1(connection)
+        return connection
+
+    def _readonly_connection(self) -> sqlite3.Connection:
+        uri = f"file:{quote(str(self.path), safe='/')}?mode=ro"
+        connection = sqlite3.connect(uri, uri=True)
+        connection.row_factory = sqlite3.Row
+        self._configure(connection)
+        return connection
+
+    @staticmethod
+    def _configure(connection: sqlite3.Connection) -> None:
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=5000")
+
+    @staticmethod
+    def _tables(connection: sqlite3.Connection) -> set[str]:
+        return {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            ).fetchall()
+        }
+
+    @staticmethod
+    def _indexes(connection: sqlite3.Connection) -> set[str]:
+        return {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%'"
+            ).fetchall()
+        }
+
+    def _validate_v1(
+        self, connection: sqlite3.Connection, *, deep: bool = False
+    ) -> None:
+        tables = self._tables(connection)
+        if not _REQUIRED_TABLES.issubset(tables):
+            raise ExperimentStoreError("schema_unsupported", "required table is missing")
+        metadata = connection.execute(
+            "SELECT schema_version FROM strategy_lab_schema WHERE component = ?",
+            (SCHEMA_COMPONENT,),
+        ).fetchone()
+        if metadata is None or int(metadata[0]) != SCHEMA_VERSION:
+            raise ExperimentStoreError("schema_unsupported", "schema version is unsupported")
+        if not _REQUIRED_INDEXES.issubset(self._indexes(connection)):
+            raise ExperimentStoreError("schema_unsupported", "required index is missing")
+        for table, expected in _EXPECTED_FOREIGN_KEYS.items():
+            observed = {
+                (str(row[3]), str(row[2]), str(row[4]))
+                for row in connection.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+            }
+            if observed != expected:
+                raise ExperimentStoreError(
+                    "schema_unsupported", f"foreign key layout is invalid for {table}"
+                )
+        if deep:
+            if str(connection.execute("PRAGMA integrity_check").fetchone()[0]) != "ok":
+                raise ExperimentStoreError("schema_unsupported", "integrity check failed")
+            if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+                raise ExperimentStoreError("schema_unsupported", "foreign key check failed")
+
+    @staticmethod
+    def _create_v1(connection: sqlite3.Connection) -> None:
+        schema_sql = """
+            CREATE TABLE strategy_lab_schema(
+                component TEXT PRIMARY KEY,
+                schema_version INTEGER NOT NULL,
+                migrated_at_utc TEXT NOT NULL
+            );
+            """
+        ddl = schema_sql + """
+            CREATE TABLE strategy_lab_features(
+                market TEXT NOT NULL,
+                account TEXT NOT NULL,
+                user_opt_in INTEGER NOT NULL CHECK(user_opt_in IN (0, 1)),
+                last_actor TEXT NOT NULL,
+                last_occurred_at_utc TEXT NOT NULL,
+                state_version INTEGER NOT NULL CHECK(state_version >= 1),
+                PRIMARY KEY(market, account)
+            );
+
+            CREATE TABLE strategy_lab_experiments(
+                experiment_id TEXT PRIMARY KEY,
+                topic_id TEXT NOT NULL,
+                market TEXT NOT NULL CHECK(market = 'HK'),
+                account TEXT NOT NULL,
+                strategy_family TEXT NOT NULL CHECK(strategy_family = 'sell_put'),
+                spec_json TEXT NOT NULL,
+                research_spec_sha256 TEXT NOT NULL,
+                validation_spec_sha256 TEXT,
+                source_provenance_json TEXT NOT NULL,
+                phase TEXT NOT NULL CHECK(phase IN ('draft','research','validation','concluded')),
+                research_progress TEXT CHECK(research_progress IS NULL OR research_progress IN (
+                    'building_dataset','ready_to_compare','challenger_locked'
+                )),
+                validation_progress TEXT CHECK(validation_progress IS NULL OR validation_progress IN (
+                    'collecting_decisions','awaiting_outcomes','ready_to_conclude'
+                )),
+                blocked_reason TEXT,
+                completed_validation_partitions INTEGER NOT NULL DEFAULT 0
+                    CHECK(completed_validation_partitions BETWEEN 0 AND 20),
+                research_authorization_status TEXT NOT NULL
+                    CHECK(research_authorization_status IN ('unconfirmed','confirmed')),
+                research_authorized_hash TEXT,
+                research_authorized_actor TEXT,
+                research_authorized_at_utc TEXT,
+                validation_authorization_status TEXT NOT NULL
+                    CHECK(validation_authorization_status IN ('unconfirmed','confirmed')),
+                validation_authorized_hash TEXT,
+                validation_authorized_actor TEXT,
+                validation_authorized_at_utc TEXT,
+                research_leader TEXT,
+                research_receipt_ref TEXT,
+                research_receipt_file_sha256 TEXT,
+                proposed_commitment_json TEXT,
+                proposed_commitment_sha256 TEXT,
+                proposed_commitment_ref TEXT,
+                proposed_commitment_content_sha256 TEXT,
+                proposed_commitment_file_sha256 TEXT,
+                terminal_mode TEXT CHECK(terminal_mode IS NULL OR terminal_mode = 'aborted'),
+                terminal_reason TEXT,
+                disabled_scope TEXT CHECK(disabled_scope IS NULL OR disabled_scope IN ('user','maintainer')),
+                terminal_at_utc TEXT,
+                terminated_at_partition INTEGER CHECK(
+                    terminated_at_partition IS NULL OR terminated_at_partition BETWEEN 0 AND 20
+                ),
+                final_outcome_status TEXT CHECK(
+                    final_outcome_status IS NULL OR final_outcome_status = 'insufficient_evidence'
+                ),
+                receipt_request_event_id TEXT,
+                receipt_published_event_id TEXT,
+                receipt_ref TEXT,
+                receipt_content_sha256 TEXT,
+                receipt_file_sha256 TEXT,
+                receipt_published_at_utc TEXT,
+                created_at_utc TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL,
+                state_version INTEGER NOT NULL CHECK(state_version >= 1),
+                FOREIGN KEY(receipt_request_event_id) REFERENCES strategy_lab_events(event_id),
+                FOREIGN KEY(receipt_published_event_id) REFERENCES strategy_lab_events(event_id)
+            );
+
+            CREATE TABLE strategy_lab_generations(
+                experiment_id TEXT NOT NULL,
+                generation_kind TEXT NOT NULL CHECK(generation_kind IN ('research','hidden','outcome')),
+                state TEXT NOT NULL CHECK(state IN ('open','terminal')),
+                revision INTEGER NOT NULL CHECK(revision >= 0),
+                last_revision_ref TEXT NOT NULL,
+                last_revision_file_sha256 TEXT NOT NULL,
+                frozen_row_content_sha256 TEXT NOT NULL,
+                terminal_request_event_id TEXT,
+                terminal_published_event_id TEXT,
+                terminal_mode TEXT CHECK(terminal_mode IS NULL OR terminal_mode IN ('completed','aborted')),
+                terminal_ref TEXT,
+                terminal_content_sha256 TEXT,
+                terminal_file_sha256 TEXT,
+                terminal_requested_at_utc TEXT,
+                terminal_published_at_utc TEXT,
+                created_at_utc TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL,
+                PRIMARY KEY(experiment_id, generation_kind),
+                FOREIGN KEY(experiment_id) REFERENCES strategy_lab_experiments(experiment_id),
+                FOREIGN KEY(terminal_request_event_id) REFERENCES strategy_lab_events(event_id),
+                FOREIGN KEY(terminal_published_event_id) REFERENCES strategy_lab_events(event_id)
+            );
+
+            CREATE TABLE strategy_lab_hidden_commitments(
+                experiment_id TEXT NOT NULL,
+                market TEXT NOT NULL,
+                account TEXT NOT NULL,
+                strategy_family TEXT NOT NULL,
+                commitment_sha256 TEXT NOT NULL,
+                trading_date TEXT NOT NULL,
+                PRIMARY KEY(experiment_id, trading_date),
+                FOREIGN KEY(experiment_id) REFERENCES strategy_lab_experiments(experiment_id)
+            );
+
+            CREATE TABLE strategy_lab_events(
+                event_id TEXT PRIMARY KEY,
+                experiment_id TEXT,
+                generation_kind TEXT,
+                event_type TEXT NOT NULL,
+                subject_key TEXT NOT NULL,
+                command_scope TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL,
+                actor TEXT NOT NULL,
+                occurred_at_utc TEXT NOT NULL,
+                payload_json TEXT NOT NULL CHECK(length(payload_json) <= 8192),
+                payload_sha256 TEXT NOT NULL
+            );
+
+            CREATE UNIQUE INDEX strategy_lab_one_active_validation
+            ON strategy_lab_experiments(market, account, strategy_family)
+            WHERE terminal_mode IS NULL
+              AND phase = 'validation'
+              AND validation_progress = 'collecting_decisions';
+
+            CREATE UNIQUE INDEX strategy_lab_hidden_date_unique
+            ON strategy_lab_hidden_commitments(market, account, strategy_family, trading_date);
+
+            CREATE UNIQUE INDEX strategy_lab_event_subject_unique
+            ON strategy_lab_events(event_type, subject_key);
+
+            CREATE UNIQUE INDEX strategy_lab_event_idempotency_unique
+            ON strategy_lab_events(command_scope, idempotency_key);
+            """
+        for statement in ddl.split(";"):
+            if statement.strip():
+                connection.execute(statement)
+
+
+__all__ = [
+    "ExperimentStore",
+    "ExperimentStoreError",
+    "SCHEMA_COMPONENT",
+    "SCHEMA_VERSION",
+    "compact_json",
+]

--- a/tests/test_strategy_lab_top1_architecture.py
+++ b/tests/test_strategy_lab_top1_architecture.py
@@ -11,6 +11,19 @@ ECONOMICS_MODULE = ROOT / "src/application/strategy_lab/top1/economics.py"
 STATISTICS_MODULE = ROOT / "src/application/strategy_lab/top1/statistics.py"
 RECOMMENDATION_POINT_MODULE = ROOT / "src/application/recommendation_point.py"
 CANDIDATE_ENGINE = ROOT / "domain/domain/engine/candidate_engine.py"
+EXPERIMENT_STORE_MODULE = (
+    ROOT / "src/infrastructure/strategy_lab/experiment_store.py"
+)
+LIFECYCLE_MODULE = ROOT / "src/application/strategy_lab/top1/lifecycle.py"
+TERMINAL_PROJECTION_MODULE = (
+    ROOT / "src/application/strategy_lab/top1/terminal_projection.py"
+)
+PRODUCTION_TICK_MODULES = (
+    ROOT / "src/application/multi_account_tick.py",
+    ROOT / "src/application/tick_account_execution.py",
+    ROOT / "src/application/tick_notification_flow.py",
+    RECOMMENDATION_POINT_MODULE,
+)
 
 
 def _imports(path: Path) -> set[str]:
@@ -97,3 +110,55 @@ def test_recommendation_point_imports_only_producer_evidence_owners() -> None:
         "src.application.strategy_lab.top1.ranking",
         "src.application.tick_run_workspace",
     }
+
+
+def test_top1_store_imports_only_stdlib_and_private_storage() -> None:
+    assert _imports(EXPERIMENT_STORE_MODULE) <= {
+        "__future__",
+        "contextlib",
+        "hashlib",
+        "json",
+        "pathlib",
+        "sqlite3",
+        "typing",
+        "urllib.parse",
+        "src.infrastructure.private_storage",
+    }
+
+
+def test_top1_lifecycle_and_terminal_projection_keep_dependency_direction() -> None:
+    assert _imports(LIFECYCLE_MODULE) <= {
+        "__future__",
+        "datetime",
+        "hashlib",
+        "json",
+        "pathlib",
+        "re",
+        "typing",
+        "domain.domain.decision_state_fingerprint",
+        "src.application.recommendation_point",
+        "src.application.shadow_replay.common",
+        "src.application.strategy_lab.top1.contracts",
+        "src.application.strategy_lab.top1.terminal_projection",
+        "src.infrastructure.strategy_lab.experiment_store",
+    }
+    assert _imports(TERMINAL_PROJECTION_MODULE) <= {
+        "__future__",
+        "hashlib",
+        "json",
+        "os",
+        "pathlib",
+        "stat",
+        "tempfile",
+        "typing",
+        "src.application.shadow_replay.common",
+        "src.infrastructure.private_storage",
+        "src.infrastructure.strategy_lab.experiment_store",
+    }
+
+
+def test_production_tick_does_not_depend_on_top1_experiment_store() -> None:
+    for path in PRODUCTION_TICK_MODULES:
+        imports = _imports(path)
+        assert "src.application.strategy_lab.top1.lifecycle" not in imports
+        assert "src.infrastructure.strategy_lab.experiment_store" not in imports

--- a/tests/test_strategy_lab_top1_store.py
+++ b/tests/test_strategy_lab_top1_store.py
@@ -1,0 +1,741 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from domain.domain.engine import (
+    SELL_PUT_RANKING_CONTRACT_VERSION,
+    SELL_PUT_RANKING_PROFILES,
+)
+from domain.domain.fee_calc import FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
+from src.application.opening_candidate_snapshot import OPENING_CANDIDATE_SNAPSHOT_SCHEMA
+from src.application.strategy_lab.top1.contracts import (
+    ACCEPTED_SET_CONTRACT_VERSION,
+    EXPERIMENT_SPEC_SCHEMA_VERSION,
+    EXPIRY_OUTCOME_CONTRACT_VERSION,
+    RESEARCH_METRIC_CONTRACT_VERSION,
+    RESEARCH_SELECTION_CONTRACT_VERSION,
+    VALIDATION_FILL_CONTRACT_VERSION,
+    VALIDATION_METRIC_CONTRACT_VERSION,
+    build_behavior_binding,
+    build_research_spec_sha256,
+)
+from src.application.strategy_lab.top1.lifecycle import (
+    Top1LifecycleError,
+    authorize_research,
+    authorize_validation,
+    commit_validation_point,
+    effective_feature_status,
+    lock_challenger,
+    prepare_experiment,
+    read_public_receipt,
+    read_public_status,
+    seal_generation,
+    seal_validation_partition,
+    set_account_opt_in,
+    start_research,
+    start_validation,
+    terminate_experiment,
+)
+from src.application.strategy_lab.top1.ranking import RANKING_PROJECTION_SCHEMA_VERSION
+from src.application.strategy_lab.top1.terminal_projection import (
+    publish_exact_text,
+    recover_terminal_projection,
+)
+from src.infrastructure.strategy_lab.experiment_store import (
+    ExperimentStore,
+    ExperimentStoreError,
+)
+
+
+AVAILABLE = {"OM_STRATEGY_LAB_TOP1_AVAILABLE": "1"}
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+SHA_C = "c" * 64
+NOW = "2026-08-15T03:00:00Z"
+
+
+def _behavior_versions(calendar: str = "hk-calendar.v1") -> dict[str, str]:
+    return {
+        "baseline_version": "sell-put-baseline.v1",
+        "opening_snapshot_schema_version": OPENING_CANDIDATE_SNAPSHOT_SCHEMA,
+        "accepted_set_contract_version": ACCEPTED_SET_CONTRACT_VERSION,
+        "ranking_projection_schema_version": RANKING_PROJECTION_SCHEMA_VERSION,
+        "sell_put_ranking_contract_version": SELL_PUT_RANKING_CONTRACT_VERSION,
+        "research_selection_contract_version": RESEARCH_SELECTION_CONTRACT_VERSION,
+        "research_metric_contract_version": RESEARCH_METRIC_CONTRACT_VERSION,
+        "validation_fill_contract_version": VALIDATION_FILL_CONTRACT_VERSION,
+        "validation_metric_contract_version": VALIDATION_METRIC_CONTRACT_VERSION,
+        "fee_schedule_version": FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION,
+        "market_calendar_version": calendar,
+        "expiry_outcome_contract_version": EXPIRY_OUTCOME_CONTRACT_VERSION,
+    }
+
+
+def _spec(experiment_id: str, *, validation: bool = False) -> dict[str, Any]:
+    profiles = tuple(SELL_PUT_RANKING_PROFILES)
+    spec: dict[str, Any] = {
+        "schema_version": EXPERIMENT_SPEC_SCHEMA_VERSION,
+        "topic_id": f"topic-{experiment_id}",
+        "experiment_id": experiment_id,
+        "market": "HK",
+        "account": "lx",
+        "hypothesis": {
+            "hypothesis_type": "sell_put_ranking",
+            "statement": "Prefer lower cross-symbol concentration earlier.",
+            "mechanism": "Move the existing concentration fact ahead of return.",
+            "independent_variable": "cross_symbol_concentration_priority",
+            "expected_direction": "higher_top1_efficiency_without_higher_concentration",
+        },
+        "baseline": {
+            "version": "sell-put-baseline.v1",
+            "opening_snapshot_schema": OPENING_CANDIDATE_SNAPSHOT_SCHEMA,
+            "accepted_set_contract_version": ACCEPTED_SET_CONTRACT_VERSION,
+            "ranking_projection_schema_version": RANKING_PROJECTION_SCHEMA_VERSION,
+            "sell_put_ranking_contract_version": SELL_PUT_RANKING_CONTRACT_VERSION,
+            "behavior_binding_sha256": build_behavior_binding(_behavior_versions()),
+        },
+        "research_source": {
+            "mode": "sealed_historical_dataset",
+            "dataset_ref": f"strategy_lab/top1/{experiment_id}/research.json",
+            "dataset_sha256": SHA_A,
+            "research_cutoff_at": "2026-08-14T16:00:00Z",
+            "start_trading_date": "2026-06-19",
+            "end_trading_date": "2026-08-14",
+        },
+        "research_evaluation": {
+            "contract_version": RESEARCH_SELECTION_CONTRACT_VERSION,
+            "metric_contract_version": RESEARCH_METRIC_CONTRACT_VERSION,
+            "fill_assumption": "t0_sell_limit",
+            "required_days": 40,
+            "window_mode": "fixed_consecutive_trading_days",
+            "visibility": "visible_after_research_seal",
+        },
+        "variants": [
+            {"variant_id": "baseline", "patch": {}},
+            *[
+                {
+                    "variant_id": f"level-{index}",
+                    "patch": {"ranking_profile": profile},
+                }
+                for index, profile in enumerate(profiles, start=1)
+            ],
+        ],
+        "frozen_safety": {
+            "mode": "inherit_each_point_producer_accepted_set",
+            "variant_may_change_acceptance": False,
+        },
+        "economics_contracts": {
+            "fee_schedule_version": FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION,
+            "market_calendar_version": "hk-calendar.v1",
+        },
+        "expiry_outcome": {
+            "contract_version": EXPIRY_OUTCOME_CONTRACT_VERSION,
+            "spot_source": "opend_history_kline",
+            "ktype": "K_DAY",
+            "autype": "NONE",
+            "price_field": "close",
+            "due_boundary": "expiration_observation_start_ms",
+            "pending_elapsed_hours": 72,
+        },
+    }
+    if validation:
+        spec.update(
+            {
+                "validation_evaluation": {
+                    "required_days": 20,
+                    "window_mode": "fixed_future_consecutive_trading_days",
+                    "visibility": "hidden_until_final_seal",
+                },
+                "fill_observation": {
+                    "applies_to": "validation_only",
+                    "contract_version": VALIDATION_FILL_CONTRACT_VERSION,
+                },
+                "timer_binding": {
+                    "revision": "top1-advance.v1",
+                    "producer_catchup_grace_seconds": 30,
+                    "producer_run_timeout_upper_bound_seconds": 120,
+                    "advance_cadence_seconds": 60,
+                    "fill_observation_duration_upper_bound_seconds": 120,
+                    "terms_capture_duration_upper_bound_seconds": 120,
+                },
+                "validation_metrics": {
+                    "contract_version": VALIDATION_METRIC_CONTRACT_VERSION,
+                    "confidence_level": 0.95,
+                    "worst_fraction": 0.20,
+                },
+            }
+        )
+    return spec
+
+
+def _dates(start: date, *, step: int = 1) -> list[str]:
+    return [(start + timedelta(days=index * step)).isoformat() for index in range(20)]
+
+
+def _store(tmp_path: Path) -> ExperimentStore:
+    store = ExperimentStore(tmp_path / "strategy-lab.sqlite3")
+    store.migrate(migrated_at_utc=NOW)
+    return store
+
+
+def _enable(
+    store: ExperimentStore, root: Path, *, idempotency_key: str = "enable"
+) -> None:
+    set_account_opt_in(
+        store,
+        market="HK",
+        account="lx",
+        enabled=True,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key=idempotency_key,
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+
+
+def _ready_research(store: ExperimentStore, root: Path, experiment_id: str) -> None:
+    spec = _spec(experiment_id)
+    prepared = prepare_experiment(
+        store,
+        spec,
+        provenance={"source_commit_sha": "commit-1", "config_sha256": SHA_B},
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key=f"prepare-{experiment_id}",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    authorize_research(
+        store,
+        experiment_id=experiment_id,
+        research_spec_sha256=str(prepared["research_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key=f"authorize-research-{experiment_id}",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    start_research(
+        store,
+        experiment_id=experiment_id,
+        research_spec_sha256=str(prepared["research_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key=f"start-research-{experiment_id}",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    seal_generation(
+        store,
+        experiment_id=experiment_id,
+        generation_kind="research",
+        actor="runner",
+        occurred_at_utc=NOW,
+        idempotency_key=f"seal-research-{experiment_id}",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    recover_terminal_projection(store, root)
+
+
+def _ready_validation(
+    store: ExperimentStore,
+    root: Path,
+    experiment_id: str,
+    trading_dates: list[str],
+) -> dict[str, Any]:
+    _ready_research(store, root, experiment_id)
+    research = store.generations(experiment_id)[0]
+    locked = lock_challenger(
+        store,
+        _spec(experiment_id, validation=True),
+        system_leader="level-1",
+        challenger_variant_id="level-1",
+        research_receipt_ref=f"strategy_lab/top1/{experiment_id}/research-receipt.json",
+        research_receipt_file_sha256=str(research["terminal_file_sha256"]),
+        trading_dates=trading_dates,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key=f"lock-{experiment_id}",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    authorize_validation(
+        store,
+        experiment_id=experiment_id,
+        validation_spec_sha256=str(locked["validation_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key=f"authorize-validation-{experiment_id}",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    return store.experiment(experiment_id)
+
+
+def test_schema_migration_is_explicit_private_and_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "lab.sqlite3"
+    store = ExperimentStore(path)
+    assert store.schema_state() == {"status": "not_initialized", "schema_version": None}
+    assert not path.exists()
+    assert store.migrate(migrated_at_utc=NOW) == {"status": "ready", "schema_version": 1}
+    assert store.migrate(migrated_at_utc=NOW) == {"status": "ready", "schema_version": 1}
+    assert stat_mode(path) == 0o600
+    assert not Path(f"{path}-wal").exists()
+    with sqlite3.connect(path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+        assert tables == {
+            "strategy_lab_schema",
+            "strategy_lab_features",
+            "strategy_lab_experiments",
+            "strategy_lab_generations",
+            "strategy_lab_hidden_commitments",
+            "strategy_lab_events",
+        }
+
+    v0_path = tmp_path / "v0.sqlite3"
+    with sqlite3.connect(v0_path) as connection:
+        connection.execute(
+            "CREATE TABLE strategy_lab_schema(component TEXT PRIMARY KEY, schema_version INTEGER, migrated_at_utc TEXT)"
+        )
+        connection.execute(
+            "INSERT INTO strategy_lab_schema VALUES (?, 0, ?)",
+            ("sell_put_top1_experiment_store", NOW),
+        )
+    assert ExperimentStore(v0_path).migrate(migrated_at_utc=NOW)["schema_version"] == 1
+
+    partial = tmp_path / "partial.sqlite3"
+    with sqlite3.connect(partial) as connection:
+        connection.execute("CREATE TABLE unexpected(value TEXT)")
+    with pytest.raises(ExperimentStoreError) as exc_info:
+        ExperimentStore(partial).migrate(migrated_at_utc=NOW)
+    assert exc_info.value.reason_code == "schema_unsupported"
+
+    missing_index = tmp_path / "missing-index.sqlite3"
+    missing_store = ExperimentStore(missing_index)
+    missing_store.migrate(migrated_at_utc=NOW)
+    with sqlite3.connect(missing_index) as connection:
+        connection.execute("DROP INDEX strategy_lab_one_active_validation")
+    assert missing_store.schema_state()["status"] == "schema_unsupported"
+
+
+def stat_mode(path: Path) -> int:
+    return os.stat(path).st_mode & 0o777
+
+
+def test_default_off_and_maintainer_off_enable_is_no_write(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    root = tmp_path / "artifacts"
+    assert effective_feature_status(
+        store, market="HK", account="lx", environ=AVAILABLE
+    )["effective"] is False
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        set_account_opt_in(
+            store,
+            market="HK",
+            account="lx",
+            enabled=True,
+            actor="human",
+            occurred_at_utc=NOW,
+            idempotency_key="enable-off",
+            artifact_root=root,
+            environ={},
+        )
+    assert exc_info.value.reason_code == "feature_disabled"
+    assert store.feature("HK", "lx") is None
+
+
+def test_exact_publisher_adopts_bytes_and_rejects_conflict_or_symlink(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "artifacts"
+    target = publish_exact_text(root, "safe/result.json", b"{}\n")
+    assert publish_exact_text(root, "safe/result.json", b"{}\n") == target
+    assert stat_mode(target) == 0o600
+    with pytest.raises(ValueError, match="bytes conflict"):
+        publish_exact_text(root, "safe/result.json", b"{ }\n")
+    link = root / "unsafe"
+    link.symlink_to(tmp_path)
+    with pytest.raises(OSError, match="symlink"):
+        publish_exact_text(root, "unsafe/result.json", b"{}\n")
+
+
+def test_separate_authorization_day20_and_hidden_status(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    root = tmp_path / "artifacts"
+    _enable(store, root)
+    dates = _dates(date(2026, 9, 1))
+    ready = _ready_validation(store, root, "experiment-a", dates)
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        start_validation(
+            store,
+            experiment_id="experiment-a",
+            validation_spec_sha256=SHA_C,
+            actor="human",
+            occurred_at_utc=NOW,
+            idempotency_key="start-validation-wrong",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+    assert exc_info.value.reason_code == "authorization_required"
+
+    start_validation(
+        store,
+        experiment_id="experiment-a",
+        validation_spec_sha256=str(ready["validation_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="start-validation-a",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    for index, trading_date in enumerate(dates, start=1):
+        kwargs = dict(
+            experiment_id="experiment-a",
+            point_id=f"point-{index}",
+            trading_date=trading_date,
+            source_ref=f"points/{index}.json",
+            source_file_sha256=SHA_A,
+            revision=index,
+            manifest_ref=f"hidden/{index}.json",
+            manifest_file_sha256=SHA_B,
+            frozen_row_sha256=SHA_C,
+            actor="runner",
+            occurred_at_utc=NOW,
+            idempotency_key=f"point-{index}",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+        if index == 1:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [
+                    executor.submit(commit_validation_point, store, **kwargs),
+                    executor.submit(
+                        commit_validation_point,
+                        store,
+                        **{**kwargs, "idempotency_key": "point-1-alias"},
+                    ),
+                ]
+                for future in futures:
+                    future.result()
+            assert len(
+                [
+                    event
+                    for event in store.events("experiment-a")
+                    if event["event_type"] == "validation_point_committed"
+                ]
+            ) == 1
+            with pytest.raises(Top1LifecycleError) as conflict_info:
+                commit_validation_point(
+                    store,
+                    **{
+                        **kwargs,
+                        "point_id": "different-point",
+                        "source_file_sha256": SHA_C,
+                        "idempotency_key": "point-1-alias",
+                    },
+                )
+            assert conflict_info.value.reason_code == "experiment_conflict"
+        else:
+            commit_validation_point(store, **kwargs)
+        seal_validation_partition(
+            store,
+            experiment_id="experiment-a",
+            trading_date=trading_date,
+            actor="runner",
+            occurred_at_utc=NOW,
+            idempotency_key=f"partition-{index}",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+        if index == 1:
+            with pytest.raises(Top1LifecycleError) as late_info:
+                commit_validation_point(
+                    store,
+                    experiment_id="experiment-a",
+                    point_id="late-day-one",
+                    trading_date=trading_date,
+                    source_ref="points/late-day-one.json",
+                    source_file_sha256=SHA_A,
+                    revision=2,
+                    manifest_ref="hidden/late-day-one.json",
+                    manifest_file_sha256=SHA_B,
+                    frozen_row_sha256=SHA_C,
+                    actor="runner",
+                    occurred_at_utc=NOW,
+                    idempotency_key="late-day-one",
+                    artifact_root=root,
+                    environ=AVAILABLE,
+                )
+            assert late_info.value.reason_code == "late_write"
+        state = store.experiment("experiment-a")
+        if index == 19:
+            assert state["validation_progress"] == "collecting_decisions"
+    state = store.experiment("experiment-a")
+    assert state["completed_validation_partitions"] == 20
+    assert state["validation_progress"] == "awaiting_outcomes"
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        commit_validation_point(
+            store,
+            experiment_id="experiment-a",
+            point_id="late-point",
+            trading_date=dates[-1],
+            source_ref="points/late.json",
+            source_file_sha256=SHA_A,
+            revision=21,
+            manifest_ref="hidden/late.json",
+            manifest_file_sha256=SHA_B,
+            frozen_row_sha256=SHA_C,
+            actor="runner",
+            occurred_at_utc=NOW,
+            idempotency_key="late-point",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+    assert exc_info.value.reason_code == "late_write"
+    public = json.dumps(read_public_status(store, experiment_id="experiment-a"))
+    assert "point-1" not in public
+    assert "daily_delta" not in public
+    assert read_public_receipt(store, experiment_id="experiment-a") is None
+
+
+def test_exact_date_overlap_and_content_addressed_orphan(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    root = tmp_path / "artifacts"
+    _enable(store, root)
+    odd_dates = _dates(date(2026, 9, 1), step=2)
+    even_dates = _dates(date(2026, 9, 2), step=2)
+    first = _ready_validation(store, root, "experiment-odd", odd_dates)
+    start_validation(
+        store,
+        experiment_id="experiment-odd",
+        validation_spec_sha256=str(first["validation_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="start-odd",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    second = _ready_validation(store, root, "experiment-even", even_dates)
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        start_validation(
+            store,
+            experiment_id="experiment-even",
+            validation_spec_sha256=str(second["validation_spec_sha256"]),
+            actor="human",
+            occurred_at_utc=NOW,
+            idempotency_key="start-even",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+    assert exc_info.value.reason_code == "validation_slot_occupied"
+    even_ref = str(store.experiment("experiment-even")["proposed_commitment_ref"])
+    assert (root / even_ref).is_file()
+    terminate_experiment(
+        store,
+        experiment_id="experiment-odd",
+        reason="human_abandoned",
+        disabled_scope=None,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="abort-odd",
+        artifact_root=root,
+    )
+    start_validation(
+        store,
+        experiment_id="experiment-even",
+        validation_spec_sha256=str(second["validation_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="start-even",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    terminate_experiment(
+        store,
+        experiment_id="experiment-even",
+        reason="human_abandoned",
+        disabled_scope=None,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="abort-even",
+        artifact_root=root,
+    )
+
+    overlap = [odd_dates[0], *_dates(date(2027, 1, 1))[:19]]
+    overlap = sorted(overlap)
+    third = _ready_validation(store, root, "experiment-overlap", overlap)
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        start_validation(
+            store,
+            experiment_id="experiment-overlap",
+            validation_spec_sha256=str(third["validation_spec_sha256"]),
+            actor="human",
+            occurred_at_utc=NOW,
+            idempotency_key="start-overlap",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+    assert exc_info.value.reason_code == "hidden_window_overlap"
+    orphan_ref = str(store.experiment("experiment-overlap")["proposed_commitment_ref"])
+    assert (root / orphan_ref).is_file()
+
+    replacement_dates = _dates(date(2027, 3, 1))
+    research = next(
+        row
+        for row in store.generations("experiment-overlap")
+        if row["generation_kind"] == "research"
+    )
+    relocked = lock_challenger(
+        store,
+        _spec("experiment-overlap", validation=True),
+        system_leader="level-1",
+        challenger_variant_id="level-1",
+        research_receipt_ref="strategy_lab/top1/experiment-overlap/research-receipt.json",
+        research_receipt_file_sha256=str(research["terminal_file_sha256"]),
+        trading_dates=replacement_dates,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="relock-overlap",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    replacement_ref = str(relocked["proposed_commitment_ref"])
+    assert not (root / replacement_ref).exists()
+    with pytest.raises(Top1LifecycleError) as stale_info:
+        start_validation(
+            store,
+            experiment_id="experiment-overlap",
+            validation_spec_sha256=str(third["validation_spec_sha256"]),
+            actor="human",
+            occurred_at_utc=NOW,
+            idempotency_key="start-stale-overlap",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+    assert stale_info.value.reason_code == "authorization_required"
+    assert not (root / replacement_ref).exists()
+    assert not any(
+        event["event_type"] == "validation_started"
+        and json.loads(str(event["payload_json"]))["authorized_hash"]
+        == third["validation_spec_sha256"]
+        for event in store.events("experiment-overlap")
+    )
+    authorize_validation(
+        store,
+        experiment_id="experiment-overlap",
+        validation_spec_sha256=str(relocked["validation_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="reauthorize-overlap",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    start_validation(
+        store,
+        experiment_id="experiment-overlap",
+        validation_spec_sha256=str(relocked["validation_spec_sha256"]),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="start-replacement",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    assert store.commitment_dates("experiment-overlap") == replacement_dates
+    assert str(store.experiment("experiment-overlap")["proposed_commitment_ref"]) != orphan_ref
+
+
+def test_terminal_competition_crash_recovery_and_disable(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    root = tmp_path / "artifacts"
+    _enable(store, root)
+    _ready_research(store, root, "experiment-terminal")
+    research_before = store.generations("experiment-terminal")[0]
+
+    crashed = False
+
+    def publish_then_crash(
+        artifact_root: str | Path, relative_ref: str, content: bytes
+    ) -> Path:
+        nonlocal crashed
+        path = publish_exact_text(artifact_root, relative_ref, content)
+        if not crashed:
+            crashed = True
+            raise RuntimeError("crash after publish before CAS")
+        return path
+
+    with pytest.raises(RuntimeError):
+        terminate_experiment(
+            store,
+            experiment_id="experiment-terminal",
+            reason="human_abandoned",
+            disabled_scope=None,
+            actor="human",
+            occurred_at_utc=NOW,
+            idempotency_key="abort-terminal",
+            artifact_root=root,
+            publisher=publish_then_crash,
+        )
+    assert store.experiment("experiment-terminal")["terminal_mode"] == "aborted"
+    assert read_public_receipt(store, experiment_id="experiment-terminal") is None
+    set_account_opt_in(
+        store,
+        market="HK",
+        account="lx",
+        enabled=False,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="disable-after-crash",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    receipt = read_public_receipt(store, experiment_id="experiment-terminal")
+    assert receipt is not None
+    assert receipt["terminal"]["mode"] == "aborted"
+    research_after = store.generations("experiment-terminal")[0]
+    assert research_after["terminal_mode"] == "completed"
+    assert research_after["terminal_file_sha256"] == research_before["terminal_file_sha256"]
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        seal_generation(
+            store,
+            experiment_id="experiment-terminal",
+            generation_kind="research",
+            actor="runner",
+            occurred_at_utc=NOW,
+            idempotency_key="late-seal",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+    assert exc_info.value.reason_code in {"feature_disabled", "terminal_conflict"}
+
+    _enable(store, root, idempotency_key="reenable")
+    _ready_research(store, root, "experiment-disable")
+    set_account_opt_in(
+        store,
+        market="HK",
+        account="lx",
+        enabled=False,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="disable",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    disabled = read_public_receipt(store, experiment_id="experiment-disable")
+    assert disabled is not None
+    assert disabled["terminal"]["reason"] == "experimental_feature_disabled"
+    assert disabled["terminal"]["disabled_scope"] == "user"


### PR DESCRIPTION
Replaces #160, which GitHub automatically closed after main was force-pushed and the head ref was deleted. The four W3 commits were replayed onto current main; git range-diff reports every patch as equal, and the old/new final trees are identical.

## Summary

- add the private SQLite v1 lifecycle store for the experimental Sell Put Top1 workflow
- add separate research/validation authorization, exact 20-date ownership, day-20 handoff, and hidden-safe public status
- add deterministic terminal/aborted receipt projection with exact-byte crash recovery
- keep result computation, outcome collection, timer, CLI, Agent, provider, and production integration out of W3

## Validation

- focused W1-W3: 110 passed
- adjacent regression: 104 passed
- full repository: 4881 passed, 10 skipped in sandbox; the sole sandbox-denied loopback test passed separately outside the sandbox
- Ruff: pass
- BasedPyright error level: 0 errors
- dependency graph: current, 588 production modules, 0 cycles
- Kimi current-change, fix, and aggregate reviews: zero unresolved findings

## Safety boundary

This PR does not release, deploy, change production config/services, run a real experiment, read market/provider data, send notifications, or write ledger/broker state.