### PR TITLE
feat: add Sell Put Top1 W5 pure research evaluator

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 938 (`src`: 505, `domain`: 75, `scripts`: 9, `tests`: 349)
-- Internal import edges: 6076 total, 2540 production/script edges excluding tests
+- Python files scanned: 940 (`src`: 506, `domain`: 75, `scripts`: 9, `tests`: 350)
+- Internal import edges: 6100 total, 2548 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,7 +31,7 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|390| domain
+  application -->|392| domain
   application -->|4| domain_services
   application -->|137| infrastructure
   application -->|41| storage
@@ -45,10 +45,10 @@ flowchart LR
   scripts -->|13| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2638| application
-  tests -->|432| domain
+  tests -->|2649| application
+  tests -->|435| domain
   tests -->|2| domain_services
-  tests -->|169| infrastructure
+  tests -->|170| infrastructure
   tests -->|221| interfaces
   tests -->|15| scripts
   tests -->|18| storage
@@ -58,7 +58,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 390 |
+| application | domain | 392 |
 | interfaces | application | 140 |
 | application | infrastructure | 137 |
 | application | storage | 41 |
@@ -77,10 +77,10 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2638 |
-| tests | domain | 432 |
+| tests | application | 2649 |
+| tests | domain | 435 |
 | tests | interfaces | 221 |
-| tests | infrastructure | 169 |
+| tests | infrastructure | 170 |
 | tests | storage | 18 |
 | tests | scripts | 15 |
 | tests | domain_services | 2 |
@@ -91,7 +91,7 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 
 | from | to | imports |
 |---|---|---|
-| src.application | domain.domain | 202 |
+| src.application | domain.domain | 204 |
 | src.interfaces | src.application | 113 |
 | src.application | src.infrastructure | 98 |
 | src.application.ledger | domain.domain | 49 |
@@ -185,9 +185,9 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | domain.domain.ledger.position_fields | 43 |
 | domain.domain.option_position_identity | 40 |
 | src.application.account_config | 38 |
-| src.application.shadow_replay.common | 28 |
+| src.application.shadow_replay.common | 29 |
 | domain.domain.engine | 25 |
-| domain.domain.decision_state_fingerprint | 24 |
+| domain.domain.decision_state_fingerprint | 25 |
 | src.application.settings | 23 |
 | domain.domain.trade_contract_identity | 23 |
 | src.application.agent_tools.runtime_helpers | 22 |

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  src_application["src.application"] -->|202| domain_domain["domain.domain"]
+  src_application["src.application"] -->|204| domain_domain["domain.domain"]
   src_interfaces["src.interfaces"] -->|113| src_application["src.application"]
   src_application["src.application"] -->|98| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|49| domain_domain["domain.domain"]

--- a/docs/gateflow/sell-put-top1-w5-evaluator/aggregate-review.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/aggregate-review.md
@@ -1,0 +1,23 @@
+# Gateflow Aggregate DeepReview — Sell Put Top1 W5 Evaluator
+
+- Gate: `aggregate review`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Reviewed range: `origin/main@6b16fb3d..cf54f979`
+- Review artifact: `docs/reviews/aggregate-review-20260815-082545.md`
+- Reviewer: Kimi K3, high reasoning
+- Status: pass; no unresolved finding; ready for Draft PR readiness gate
+
+## Result
+
+Kimi independently reviewed the accepted plan and evaluator slice. Eight candidate issues were checked against the source and rejected with evidence. No blocker, high, medium, or low finding remains; no over-design or goal drift was found.
+
+## Verification
+
+- W5 plus adjacent W1B/W4/M3/architecture suites: `55 passed`.
+- Ruff: pass.
+- Dependency graph: current, `production_modules=590`, `cycles=0`.
+- `git diff --check`: pass.
+- BasedPyright was unavailable in the existing environment; no dependency was added.
+- Slice and aggregate Kimi reviews have zero unresolved findings.
+
+No release, deployment, service/configuration change, provider call, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed by this gate.

--- a/docs/gateflow/sell-put-top1-w5-evaluator/draft-pr-pass.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/draft-pr-pass.md
@@ -1,0 +1,37 @@
+# Gateflow Draft PR Pass — Sell Put Top1 W5 Evaluator
+
+## Gate
+
+- Work unit: `sell-put-top1-w5-evaluator`
+- Gate: `draft-PR-pass`
+- Date: `2026-08-15`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/163`
+- Current base: `main@6b16fb3d`
+- Accepted PR-review head: `2a5b10f2`
+- PR review: `docs/reviews/pr-163-review-20260815-163730.md`
+- State at review: `OPEN`, `DRAFT`, `MERGEABLE`
+
+## Entry criteria
+
+- [x] The PR remains limited to the pure W5 evaluator and does not claim the runner or a real strategy conclusion.
+- [x] Slice, aggregate, and PR-level Kimi DeepReviews have zero unresolved findings.
+- [x] W5 plus adjacent suites passed: `55 passed`.
+- [x] Ruff, architecture guard, dependency graph, and `git diff --check` passed.
+- [x] Analyze actions/python, CodeQL, agent-plugin, and guardrails passed on `2a5b10f2`.
+- [x] PR base/head matched the reviewed range with no drift.
+
+## Residual risks and owners
+
+- Provider acquisition, close-reason alignment, sealed receipt publication, and runner behavior remain in a later W5 slice.
+- The real 40-day research conclusion is a separately authorized pilot; W6 owns independent 20-day hidden validation.
+- BasedPyright remains a project toolchain gap.
+
+## Safety boundary
+
+No release, deployment, service/configuration change, provider call, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed.
+
+## Conclusion
+
+`draft-PR-pass`.
+
+Current gate / next entry point: commit this evidence, wait for final CI, then record evaluator-slice closeout. Merge remains a separate authorization boundary.

--- a/docs/gateflow/sell-put-top1-w5-evaluator/final-closeout.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/final-closeout.md
@@ -1,0 +1,44 @@
+# Gateflow Final Closeout — Sell Put Top1 W5 Evaluator
+
+## Gate
+
+- Work unit: `sell-put-top1-w5-evaluator`
+- Gate: `final closeout`
+- Date: `2026-08-15`
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/163`
+- Current base: `main@6b16fb3d`
+- Accepted plan: `82e29ac6`
+- Accepted evaluator slice: `cf54f979`
+- Accepted aggregate review: `97baafcb`
+- Draft-PR readiness: `2a5b10f2`
+- Verified draft-PR-pass: `be776632`
+
+## What changed
+
+1. A pure `evaluate_research()` boundary validates one exact W4 40-day materialization and its hash-bound ranking projections.
+2. Every authorized arm is re-ranked over the same accepted universe, with W1A ranking and W1B economics/statistics remaining the policy owners.
+3. Missing currency, exact close, fee, economics, or statistical evidence fails the complete evaluation closed; deterministic passing-arm ordering selects at most one research leader.
+4. W4 source-deletion and M3 leader/authorization seams are proven without adding runtime I/O or claiming that the evaluation is sealed.
+
+## What was verified
+
+- W5 plus adjacent W1B/W4/M3/architecture suites: `55 passed`.
+- Ruff, architecture guard, dependency graph (`590` production modules, `0` cycles), and `git diff --check`: passed.
+- Slice, aggregate, and PR-level Kimi DeepReviews: zero open finding and no over-design/goal drift.
+- Analyze actions/python, CodeQL, agent-plugin, and guardrails passed on the implementation/readiness head and the draft-PR-pass head.
+- BasedPyright was unavailable in the existing environment; no dependency was installed.
+
+## Remaining work and risks
+
+- This closes only the pure evaluator slice, not the original W5 runtime work.
+- A later W5 slice owns provider acquisition, close-reason alignment, runner orchestration, sealed receipt publication, and M3 terminal binding.
+- A separately authorized real 40-day pilot owns any strategy conclusion; W6 owns the independent 20-day hidden validation.
+
+## Safety and workspace status
+
+- No release, tag, deployment, remote upgrade, service/configuration mutation, provider call, runtime write, real experiment, notification, market-data read, ledger write, or broker action was performed.
+- Unrelated user changes in the root worktree were not touched.
+
+## Completion and merge authorization
+
+The W5 pure evaluator slice is complete at `final closeout pass`, subject only to the final mechanical GitHub checks for this documentation commit. Merging PR #163 requires explicit authorization. Release, deployment, and the remaining W5 runtime slice remain separate and unauthorized.

--- a/docs/gateflow/sell-put-top1-w5-evaluator/goal-confirmation.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/goal-confirmation.md
@@ -1,0 +1,64 @@
+# Gateflow Goal Confirmation — Sell Put Top1 W5 Evaluator Slice
+
+- Gate: `goal confirmation`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Confirmed by user: 2026-08-15
+- Branch: `feat/sell-put-top1-w5`
+- Base: `origin/main@6b16fb3d189e68ba9957de3a60cfa59cc89a0294`
+- Artifact path: `docs/gateflow/sell-put-top1-w5-evaluator/goal-confirmation.md`
+- Decision: accepted
+
+## Goal and motivation
+
+Implement the smallest pure W5 research evaluator that can consume one already frozen W4 40-day dataset in memory, rerank the baseline and every authorized ranking variant through the existing Candidate Engine seam, reuse the existing expiry economics and paired-day statistics, and deterministically produce one of:
+
+- a unique `research_leader`;
+- `no_research_winner`;
+- `insufficient_evidence`.
+
+This slice exists so the core parameter-selection logic can be proved with synthetic sealed facts while the real `HK/lx` provider/readiness path remains unavailable.
+
+## Success signals
+
+- One hand-checkable synthetic 40-trading-day case proves T0 `sell_limit` counterfactual semantics, exact-expiration close use, terminal fee use, multiple points per day, daily aggregation, statistics, and unique leader selection.
+- Baseline and all ExperimentSpec variants reuse `rerank_recommendation_point()`, `calculate_expiry_efficiency()`, and `summarize_paired_daily_deltas()`; no ranking or formula is copied.
+- Leader selection is exactly mean descending, one-sided lower bound descending, worst-tail mean descending, then `variant_id` ascending.
+- No-winner, deterministic tie-break, missing exact close, incomplete fee evidence, empty/same-Top1 evidence, and concentration non-increase failure are deterministic.
+- A real W4 `sealed_historical_dataset.v1` shape and its referenced projections can be materialized into the pure evaluator without a new provider or storage abstraction.
+- The returned leader can enter the existing M3 `lock_challenger()` boundary only as the exact system leader; validation remains `unconfirmed` until a separate human authorization.
+
+The existing W1B statistics suite remains the owner of the generic `hard_risk_violation` and `risk_evidence_missing` branches. A valid W4 projection contains only the producer-accepted universe, so this evaluator supplies `hard_risk_status=passed` rather than inventing a second risk receipt.
+
+## Scope boundary
+
+This work unit adds only the pure evaluator and executable synthetic seams. It does not implement the original W5 provider runner and must not be described as completing W5 as a whole.
+
+Explicitly deferred:
+
+- `run_research()` orchestration;
+- filesystem loading/publication and SQLite research revision/terminal writes;
+- Futu/OpenD history K-line or quota calls;
+- a real fee-plan, calendar, close, quota, or capacity receipt;
+- a real 40-day research run;
+- live fill observation, outcome jobs, 20-day hidden validation, timer/service/CLI/Agent/LLM integration;
+- release, deployment, production config, notification, or market/broker write.
+
+## Direct code evidence
+
+- W4 already freezes `sealed_historical_dataset.v1` as a reference-only 40-day manifest in `corpus.py`; it intentionally does not load provider outcomes.
+- W1A already validates and reranks a projection with Candidate Engine in `ranking.py`.
+- W1B already owns canonical expiry economics in `economics.py` and paired daily statistics in `statistics.py`.
+- M3 already enforces immutable research/validation hashes, exact system-leader locking, separate human validation authorization, and terminal publication in `lifecycle.py` plus `ExperimentStore`.
+- `docs/performance/sell-put-top1-capability-preflight-20260814.md` remains `W0R runtime_no_go`; there is no local OpenD listener on port 11111 in this worktree preflight.
+
+## Parsimony decision
+
+Add one production module and one focused test module. Do not add a provider interface, loader class, repository, schema migration, workflow state, generic receipt framework, public CLI, or a second statistics/ranking implementation. The future runner will perform artifact I/O and sealing when runtime readiness is green.
+
+## Blocking open questions
+
+None. The user explicitly confirmed this narrowed evaluator-only boundary.
+
+## Next gate
+
+`plan`

--- a/docs/gateflow/sell-put-top1-w5-evaluator/implementation-s1.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/implementation-s1.md
@@ -1,0 +1,62 @@
+# Gateflow Implementation — Sell Put Top1 W5 Evaluator S1
+
+- Gate: `implementation`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Slice: `S1 — pure evaluator and seams`
+- Artifact path: `docs/gateflow/sell-put-top1-w5-evaluator/implementation-s1.md`
+- Status: `implementation and slice code review complete`
+
+## Scope and outcome
+
+Implemented the approved evaluator-only slice. `evaluate_research()` now consumes an exact materialized W4 dataset envelope, exact-expiration close receipts, and the existing HK fee contract; re-ranks every authorized arm over the same frozen accepted set; delegates economics and paired statistics to W1B; and returns one compact, unsealed deterministic evaluation.
+
+The implementation adds no runner, provider, storage schema, scheduler, CLI, Agent tool, lifecycle transition, production configuration, notification, release, or deployment path.
+
+## Changed files
+
+- `src/application/strategy_lab/top1/research.py`
+  - exact envelope, W4 manifest, projection, receipt, and fee validation;
+  - same-universe baseline/challenger evaluation;
+  - fail-closed close/currency/economics handling;
+  - fixed 40-day statistics policy and deterministic leader selection;
+  - compact unsealed output.
+- `tests/test_strategy_lab_top1_research.py`
+  - 40-day and multi-point calculation, evidence failures, deterministic selection, tamper rejection, real W4 materialization, source deletion, and M3 authorization seam.
+- `tests/test_strategy_lab_top1_architecture.py`
+  - pure-owner allowlist and production tick exclusion.
+- `docs/DEPENDENCY_GRAPH.md`, `docs/dependency_graph.mmd`
+  - regenerated import graph; zero production cycles.
+
+## Implementation decisions
+
+- Reused W1A ranking, W1B economics/statistics, W4 schema identity, and M3 lifecycle without adding parallel policy owners.
+- A differing Top1 with any non-HKD candidate, missing/conflicting/unavailable close, or unavailable assignment fee blocks the whole evaluation before statistics.
+- Same or both-empty Top1 does not require close or fee-plan facts.
+- Current real profiles can yield at most one passing changed arm under the mandatory concentration non-increase gate. The future-safe multi-pass ordering is therefore tested with synthetic W1B pass summaries; real statistics behavior remains covered by W1B and the end-to-end unique-leader test.
+- The evaluation is deliberately unsealed. Publication and revision ownership remain outside this slice.
+
+## Validation
+
+- `pytest` focused W5: `14 passed`.
+- W5 + W1B + W4 + M3/store + architecture: `55 passed`.
+- Ruff on changed Python files: passed.
+- Dependency graph check: passed; `production_modules=590`, `cycles=0`.
+- `git diff --check`: passed.
+- `basedpyright`: attempted but unavailable in the existing project environment (`No module named basedpyright`). No dependency was installed for this slice.
+- Kimi code review and evidence-led re-review: passed with no unresolved blocker/high/medium/low finding; review artifact: `docs/reviews/code-review-20260815-161754.md`.
+
+## Documentation decision
+
+No product/operator documentation changed because this slice exposes no public command or runtime capability. Gateflow artifacts and the generated dependency graph are the only documentation updates.
+
+## Residual risks and uncovered areas
+
+- Real close/quota/calendar/fee-plan acquisition and sealed receipt publication: assigned to the remaining W5 runner work after W0R is green.
+- Provider retry/dedupe/capacity behavior: assigned to the remaining W5 runner and W7 readiness work.
+- Real 40-day strategy conclusion: assigned to a separately authorized pilot; synthetic evidence is not a strategy conclusion.
+- Static type analysis: assigned to project toolchain/CI because `basedpyright` is not installed locally; focused runtime and lint checks passed.
+- No release, deployment, provider request, live experiment, or production write occurred.
+
+## Completion signal
+
+The approved S1 behavior is implemented, locally verified, and slice-reviewed. The next Gateflow entry point is the accepted-slice commit followed by aggregate review.

--- a/docs/gateflow/sell-put-top1-w5-evaluator/plan-fix.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/plan-fix.md
@@ -1,0 +1,43 @@
+# Gateflow Plan Fix — Sell Put Top1 W5 Evaluator Slice
+
+- Gate: `plan review -> fix`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Review artifact: `docs/reviews/plan-review-20260815-154327.md`
+- Artifact path: `docs/gateflow/sell-put-top1-w5-evaluator/plan-fix.md`
+- Status: fix complete; re-review passed
+
+## Finding decisions and fixes
+
+### PR-W5-01 — accepted — 已修复
+
+The plan now requires every baseline/challenger candidate that actually enters HK expiry economics to use `currency=HKD`. A compared non-HKD candidate produces `insufficient_evidence / ranking_projection_incomplete / candidate_currency_mismatch`, never reaches W1B economics, and cannot produce a leader. No currency-conversion behavior was added. A dedicated regression is required.
+
+### PR-W5-02 — accepted — 已修复
+
+The plan now defines:
+
+- the exact `variant_result`, daily-delta, and `missing_receipts` key sets;
+- overall `effective_days` as null before statistics and otherwise the minimum across authorized variants;
+- stable first-seen reason aggregation in authorized variant order;
+- lexically sorted pre-statistics reasons/missing tuples;
+- normal insufficient behavior for a duplicate required close and no effect from structurally valid unused duplicates;
+- the exact `ResearchEvaluationError.reason_code` set;
+- required deterministic-output assertions.
+
+## Validation
+
+- The confirmed pure-evaluator boundary is unchanged.
+- No provider, storage, loader, runner, state, or currency-conversion scope was added.
+- `git diff --check` remains required before accepted-plan commit.
+
+## Residual risks
+
+- Raw artifact byte verification: assigned to the remaining W5 runner.
+- Real provider/fee/calendar/quota evidence: assigned to W0R remediation and the remaining W5/W7 work.
+- Real evaluation publication into M3 terminal history: assigned to the remaining W5 runner.
+
+All residual risks are classified; none blocks plan re-review.
+
+## Next gate
+
+`accepted plan commit -> implementation S1`

--- a/docs/gateflow/sell-put-top1-w5-evaluator/plan.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/plan.md
@@ -1,0 +1,230 @@
+# Gateflow Plan — Sell Put Top1 W5 Evaluator Slice
+
+- Gate: `plan`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Branch: `feat/sell-put-top1-w5`
+- Base: `origin/main@6b16fb3d189e68ba9957de3a60cfa59cc89a0294`
+- Goal contract: `docs/gateflow/sell-put-top1-w5-evaluator/goal-confirmation.md`
+- Design sources:
+  - `docs/plans/sell-put-top1-optimization-loop-mvp-20260814.md`
+  - `docs/plans/sell-put-top1-modular-technical-implementation-plan-20260814.md`
+  - `docs/plans/sell-put-top1-modular-implementation-control-20260814.md`
+- Artifact path: `docs/gateflow/sell-put-top1-w5-evaluator/plan.md`
+- Current gate: accepted plan; implementation S1 pending
+
+## 1. Goal, motivation, and completion signal
+
+Implement `evaluate_research(dataset, close_receipts, fee_contract)` as a deterministic, side-effect-free application function. It evaluates one authorized research ExperimentSpec against exactly one materialized W4 40-day manifest, compares every non-baseline arm against the baseline on the same accepted candidate universe, and returns an unsealed research-evaluation payload.
+
+Completion requires the assertions in §10, no unresolved accepted review finding, no dependency reversal, and a Kimi aggregate DeepReview pass. Synthetic success proves evaluator correctness only; it does not prove runtime readiness, strategy improvement, a real research receipt, or completion of the full W5 runner.
+
+## 2. Non-goals and fixed boundary
+
+- No `run_research()`, provider call, quota query, retry, dedupe scheduler, filesystem reader/writer, SQLite change, generation revision, terminal projection, or sealed receipt.
+- No W4 artifact schema change or public loader. The future runner will read exact bytes, then pass the decoded W4 manifest and projections into this pure boundary.
+- No W6 validation logic, live fill observation, outcome job, timer/service, CLI/Agent tool, Prompt/LLM, production config, release, deploy, notification, ledger, or broker action.
+- No new ranking, economics, statistics, risk, fee, provider, or repository abstraction.
+- No configurable research confidence, tail fraction, or day count: v1 remains fixed at 0.95, 0.20, and 40 by the versioned research-selection contract.
+
+## 3. Existing owners and dependency direction
+
+Reuse:
+
+- `contracts.validate_experiment_spec()` and `build_research_spec_sha256()` for the authorized research contract;
+- `corpus.SEALED_HISTORICAL_DATASET_SCHEMA` for the W4 manifest identity only;
+- `ranking.validate_ranking_projection()` and `rerank_recommendation_point()` for all arm choices;
+- `economics.calculate_expiry_efficiency()` for T0 assumed-fill expiry economics;
+- `statistics.summarize_paired_daily_deltas()` for point pairing, day aggregation, t lower bound, tail gate, and concentration gate.
+
+Dependency rule:
+
+```text
+research -> contracts + corpus schema constant + ranking + economics + statistics
+research -> MUST NOT import lifecycle, store, terminal projection, provider, validation, service, CLI, or LLM
+producer/Candidate Engine -> MUST NOT import research
+```
+
+The evaluator sets `hard_risk_status=passed` only after consuming a valid W4 accepted-only projection. It does not infer or store a parallel risk model. Generic hard-risk failure behavior remains covered by the existing statistics owner.
+
+## 4. Affected files
+
+Production:
+
+- New `src/application/strategy_lab/top1/research.py`.
+
+Tests/docs:
+
+- New `tests/test_strategy_lab_top1_research.py`.
+- Modify `tests/test_strategy_lab_top1_architecture.py` with the W5 import boundary.
+- Regenerate `docs/DEPENDENCY_GRAPH.md` and `docs/dependency_graph.mmd` only if the repository generator reports a real graph change.
+- Add Gateflow and review artifacts under `docs/gateflow/sell-put-top1-w5-evaluator/` and `docs/reviews/`.
+
+## 5. Pure input contracts
+
+### 5.1 Materialized dataset argument
+
+`dataset` is an exact-key in-memory envelope, not a new stored artifact:
+
+```text
+schema_version = sell_put_top1_research_evaluation_input.v1
+experiment_spec
+dataset_ref
+sealed_dataset
+ranking_projections = [{projection_ref, projection}, ...]
+```
+
+Rules:
+
+- `experiment_spec` must be a valid research-only v1 spec.
+- `dataset_ref` and the canonical file SHA-256 of `sealed_dataset` must match `research_source.dataset_ref/dataset_sha256`.
+- The manifest must be exact `sealed_historical_dataset.v1`, have a valid semantic content hash, match spec market/account/cutoff/calendar/40-day start/end, and contain exactly 40 ordered unique dates.
+- `ranking_projections` must contain exactly one entry for every referenced point and no extra/duplicate ref.
+- Every projection must pass W1A validation; ref, semantic content hash, canonical file hash, point ID, market, and account must match the W4 manifest.
+- Any baseline/challenger candidate that actually needs an economic comparison must use `currency=HKD`. A different currency produces normal `insufficient_evidence / ranking_projection_incomplete / candidate_currency_mismatch`; W5 does not convert currencies or mix a non-HKD cash basis with the HKD terminal-fee calculator.
+- Structural/type/schema misuse raises a stable `ResearchEvaluationError`; artifact/ref/hash disagreement also raises fail closed with the evidence reason code. It never produces a partial winner from a corrupted materialization.
+
+This envelope exists only because a pure function cannot read W4 references or discover an ExperimentSpec. No loader interface or stored envelope is added.
+
+### 5.2 Exact-expiration close receipts
+
+`close_receipts` is a list of exact-key facts:
+
+```text
+schema_version = sell_put_top1_research_close_receipt.v1
+market, account, stock_owner, expiration
+spot_source = opend_history_kline
+ktype = K_DAY
+autype = NONE
+price_field = close
+status = available | unavailable
+underlier_close
+reason_detail
+```
+
+An available receipt requires one finite positive close and null reason. An unavailable receipt requires null close and one allowed outcome subreason. A missing required key becomes `research_expiry_close_missing`; duplicate facts for a required `(stock_owner, expiration)` produce normal `insufficient_evidence / required_outcome_missing / expiry_close_receipt_conflict`. No adjacent-date, realtime, adjusted, mid, last, or inferred-price fallback exists. Structurally valid receipts not selected by any differing arm, including duplicate unused keys, are ignored and cannot affect the result.
+
+### 5.3 Fee contract
+
+`fee_contract` has exact keys `market`, `account`, `fee_schedule_version`, and `account_fee_plan`. Identity and schedule must match the ExperimentSpec/current W1B contract. The account plan is passed unchanged to W1B; it is never defaulted. Missing/incomplete valid facts become `required_outcome_missing / expiry_fee_unavailable` only when a differing Top1 actually requires economics.
+
+## 6. Evaluation flow and invariants
+
+1. Validate the input envelope, ExperimentSpec, W4 manifest, all refs/hashes, and every W1A projection before computing any arm.
+2. For each point, call baseline profile `current_tie_break`, then every non-baseline variant's authorized `ranking_profile` on the same projection.
+3. Same Top1 produces `point_delta=0` without requiring close or fee facts. Both-empty produces no evidence. A one-sided candidate is a contract failure.
+4. For each differing Top1, locate both frozen candidate rows, require `currency=HKD`, and collect the unique `(stock_owner, expiration)` close requirements.
+5. Before statistics, fail the entire research evaluation to `insufficient_evidence` if any compared candidate currency is not HKD or any required close is absent/unavailable/conflicting. This prevents cross-currency economics and selection from a partially evaluable set of levels.
+6. Call W1B economics for each required baseline/challenger using `holding_start_date=trading_date`, frozen `net_premium`, `net_cash_basis`, `strike`, `multiplier`, the exact close, and unchanged account fee plan. Any not-evaluable result makes the entire research evaluation insufficient with its reason/detail.
+7. For each variant, call W1B statistics with fixed policy `{required_days:40, confidence_level:0.95, worst_fraction:0.20, require_concentration_non_increase:true}`.
+8. If any variant is `insufficient_evidence`, overall selection is `insufficient_evidence` and no leader is emitted. Otherwise collect variants with decision `pass`; none means `no_research_winner`.
+9. Sort passing variants by negative mean, negative lower bound, negative worst-tail mean, then `variant_id` ascending; emit only the first as `research_leader`.
+
+No intermediate value is rounded. Input ordering of close receipts cannot change output. Variant output order follows the authorized spec.
+
+## 7. Output contract and storage decision
+
+Return exact schema `sell_put_top1_research_evaluation.v1` with:
+
+```text
+schema_version, experiment_id, research_spec_sha256,
+dataset_ref, dataset_sha256, dataset_content_sha256,
+required_days, effective_days,
+research_fill_assumption, research_is_counterfactual,
+contract_terms_revalidated,
+selection, leader_variant_id, reason_codes, reason_details,
+variant_results, missing_receipts
+```
+
+Each `variant_result` contains only variant/profile identity, the existing statistics decision/reasons and aggregate scalars, `top1_change_count`, and the 40 compact daily deltas/effective-point counts. It omits duplicated candidate rows, point-level economics, raw provider payloads, and statistics `point_results`. The W4 projections and future close/fee artifacts remain the audit facts. This keeps the later research receipt compact without losing recomputability.
+
+Each `variant_result` has these exact keys:
+
+```text
+variant_id, ranking_profile, decision, reason_codes,
+required_days, effective_days,
+mean_daily_delta, sample_std, standard_error, t_critical,
+one_sided_lower_bound, worst_k, worst_tail_mean,
+serial_correlation_unadjusted, top1_change_count, daily_deltas
+```
+
+Each daily item keeps the existing statistics exact keys `trading_date`, `effective_point_count`, and `daily_delta`.
+
+`missing_receipts` items have exact keys `stock_owner`, `expiration`, `reason_code`, and `reason_detail`, sorted by that tuple. Structurally valid unused receipt facts never appear. Top-level `effective_days` is `null` when evaluation stops before statistics; otherwise it is the minimum `effective_days` across all authorized variants. Top-level reason codes and reason details are first-seen de-duplicated in authorized variant order; pre-statistics reason/missing sets use lexical tuple order. These rules, authorized variant order, and sorted missing receipts make input receipt ordering irrelevant.
+
+Selection fields are exact: `research_leader` copies the selected variant's three passing reason codes and has no reason details; `no_research_winner` uses only `reason_codes=["no_research_winner"]`; `insufficient_evidence` aggregates only the blocking evidence reasons/details and always has `leader_variant_id=null`.
+
+The payload is explicitly unsealed. A later, separately reviewed `run_research()` will own reading exact bytes, provider receipts, revision publication, and M3 terminal sealing.
+
+## 8. M4 and M3 seams
+
+- M4 seam test freezes a real W4 manifest, materializes its referenced projections, and proves the evaluator accepts the exact W4 refs/hashes after source-run deletion. The test performs local fixture I/O only; production evaluator remains pure.
+- M3 seam test uses a synthetic completed research generation and the evaluator's exact `leader_variant_id` as `system_leader`/challenger. It proves a different challenger is rejected and the accepted lock remains `validation_authorization_status=unconfirmed`; no validation starts without separate human authorization.
+
+The M3 seam does not claim the evaluation payload itself has been sealed. It supplies synthetic receipt ref/hash solely to exercise the already implemented M3 boundary.
+
+## 9. Error and conclusion rules
+
+- Malformed public input, schema drift, unsafe identity, ref/hash mismatch, incomplete projection materialization, or baseline parity failure raises `ResearchEvaluationError` with a stable reason code and no result. Its reason-code set is exactly `research_input_invalid | experiment_spec_invalid | research_corpus_conflict | ranking_projection_incomplete | baseline_rank_parity_mismatch`; W1A errors retain the latter two codes and other malformed shapes use `research_input_invalid`.
+- Missing/unavailable exact close, incomplete canonical fee evidence, no-evidence days, statistics backend failure, or an evaluable statistical gate produces a normal deterministic evaluation result.
+- A compared non-HKD candidate is a normal insufficient result with `ranking_projection_incomplete / candidate_currency_mismatch`; it never reaches W1B economics.
+- A duplicate required close is a normal insufficient result with `required_outcome_missing / expiry_close_receipt_conflict`; unused duplicate keys do not affect the result.
+- Any evidence-insufficient variant blocks leader selection for the whole research window.
+- A keep-baseline variant does not block another fully evaluable passing variant.
+- `research_leader` is model-selection evidence only, never `candidate_for_adoption` and never a production configuration change.
+
+## 10. Implementation slice S1 — pure evaluator and seams
+
+Objective: implement and verify the complete narrowed work unit in one reviewable slice.
+
+Allowed production file:
+
+- `src/application/strategy_lab/top1/research.py`.
+
+Allowed supporting changes:
+
+- `tests/test_strategy_lab_top1_research.py`;
+- W5 architecture assertion and dependency graph output;
+- this work unit's Gateflow/review artifacts.
+
+Required tests:
+
+- exact 40-day, two-points-on-one-day hand calculation including terminal fee and daily mean;
+- all authorized levels rerank the same projection and one unique leader is selected;
+- multiple passing variants use every deterministic tie-break key, including lexical variant ID last;
+- zero/same Top1 produces `no_research_winner` without needing close/fee facts;
+- one missing/unavailable/duplicate exact close blocks the whole selection with no fallback;
+- incomplete fee facts and concentration increase fail closed through the existing owners;
+- a compared USD candidate in an otherwise valid HK projection is insufficient, never calls economics, and never emits a leader;
+- fewer than 40 effective days yields insufficient evidence;
+- W4 manifest/projection hash or baseline parity tampering is rejected;
+- close-receipt order does not change output;
+- reason aggregation, overall effective days, missing-receipt tuple ordering, and variant-result exact keys match §7;
+- W4 source deletion seam and M3 exact-leader/human-authorization seam pass;
+- evaluator has no filesystem, store, provider, validation, service, CLI, or LLM import.
+
+Validation commands:
+
+```bash
+./.venv/bin/python -m pytest -q tests/test_strategy_lab_top1_research.py tests/test_strategy_lab_top1_w1b.py tests/test_strategy_lab_top1_corpus.py tests/test_strategy_lab_top1_store.py tests/test_strategy_lab_top1_architecture.py -p no:cacheprovider
+./.venv/bin/python -m ruff check src/application/strategy_lab/top1/research.py tests/test_strategy_lab_top1_research.py tests/test_strategy_lab_top1_architecture.py
+./.venv/bin/python -m basedpyright src/application/strategy_lab/top1/research.py tests/test_strategy_lab_top1_research.py
+./.venv/bin/python scripts/generate_dependency_graph.py --check
+git diff --check
+```
+
+Completion signal: all required assertions pass, Kimi code/aggregate/PR reviews have no unresolved accepted finding, and the draft PR truthfully states that the provider runner and real W5 remain deferred.
+
+Stop condition: any evidence that the evaluator requires a new provider/storage schema, changes Candidate Engine behavior, or cannot prove the M4/M3 seams without production I/O returns the work unit to goal confirmation rather than expanding scope.
+
+## 11. Documentation, risks, and completion report
+
+No product or operator documentation changes because there is no public command or runtime capability. Gateflow artifacts document the internal contract and the explicit partial-W5 boundary.
+
+Classified residual risks:
+
+- Real close/quota/calendar/fee-plan acquisition and exact artifact sealing: assigned to the remaining W5 runner work after W0R becomes green.
+- Provider retries, request dedupe, endpoint limits, and capacity: assigned to the remaining W5 runner/W7 readiness work.
+- Real 40-day strategy conclusion: assigned to an explicitly authorized pilot after release/install readiness.
+- Generic hard-risk failure generation: owned by W1B statistics; valid W4 accepted-only inputs make W5's status `passed` by construction.
+
+Completion report must state changed code, validation evidence, review finding status, draft PR URL, and the above deferred owners. It must not call the original W5 complete and must state that no release/deploy/provider/live experiment occurred.

--- a/docs/gateflow/sell-put-top1-w5-evaluator/ready-to-open-draft-pr.md
+++ b/docs/gateflow/sell-put-top1-w5-evaluator/ready-to-open-draft-pr.md
@@ -1,0 +1,33 @@
+# Gateflow Readiness — Sell Put Top1 W5 Evaluator Draft PR
+
+- Gate: `ready-to-open-draft-PR`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Branch: `feat/sell-put-top1-w5`
+- Base: `origin/main@6b16fb3d`
+- Accepted plan: `82e29ac6`
+- Accepted evaluator slice: `cf54f979`
+- Accepted aggregate review: `97baafcb`
+- Status: ready to publish branch and open Draft PR
+
+## Scope check
+
+- `origin/main...HEAD` contains only the accepted W5 evaluator plan, pure evaluator, W4/M3 seams, focused tests, generated dependency graph, and Gateflow/review evidence.
+- The slice adds no runner, provider call, receipt sealing/publication, storage schema, timer, CLI/Agent tool, LLM loop, production configuration/service change, real 40-day experiment, or 20-day hidden validation.
+- `origin/main` was refreshed immediately before this gate and remains `6b16fb3d`, equal to the branch merge base.
+- The worktree is clean and `git diff --check origin/main...HEAD` passes.
+
+## Validation
+
+- W5 plus adjacent W1B/W4/M3/architecture suites: `55 passed`.
+- Ruff: pass.
+- Dependency graph: current, `590` production modules, `0` cycles.
+- Slice and aggregate Kimi DeepReviews: pass, zero unresolved findings.
+- BasedPyright is not installed in the existing environment; no dependency was added.
+
+## Authority boundary
+
+Publishing the branch and opening a Draft PR are source-review actions only. This gate does not authorize merge, release, deployment, service/configuration changes, provider calls, runtime writes, real experiments, notifications, market-data reads, ledger writes, or broker actions.
+
+## Next transition
+
+Commit this readiness artifact, push the accepted branch, open a Draft PR, wait for required CI, and run PR-level Kimi DeepReview. The Draft PR must state that this completes only the pure evaluator slice, not the W5 runner or a real strategy conclusion.

--- a/docs/reviews/aggregate-review-20260815-082545.md
+++ b/docs/reviews/aggregate-review-20260815-082545.md
@@ -1,0 +1,82 @@
+# Aggregate Deep Review
+
+## Scope
+
+- Mode: aggregate review of branch commits, read-only
+- Branch: `feat/sell-put-top1-w5`
+- Range: `origin/main@6b16fb3d..HEAD` (`82e29ac6` accepted plan + `cf54f979` evaluator slice)
+- Output file: `docs/reviews/aggregate-review-20260815-082545.md`
+- Included scope: accepted W5 evaluator-only plan, `evaluate_research()` implementation, W4/M3 seam tests, W5 architecture assertions, regenerated dependency graph, and Gateflow artifacts
+- Excluded scope (accepted deferrals, not findings): provider runner, real close/quota/calendar acquisition, receipt sealing/publication, storage schema, real 40-day experiment, W6 validation, CLI/Agent tool, release, deploy
+- Review question: does the slice accurately implement the accepted plan, hold the trust boundary (determinism, fail-closed, statistics/economics contracts, W4/M3 seams), keep dependency direction, avoid over-design and goal drift, and avoid claims exceeding evidence
+
+## Findings
+
+No blocker, high, medium, or low finding.
+
+Every candidate below was investigated against source and rejected with evidence.
+
+### AR-01 — rejected-with-reason — output omits `point_results` but remains recomputable
+
+- Candidate: the variant result drops per-point economics and statistics `point_results`, which could break auditability of the daily deltas.
+- Evidence: `plan.md` §7 explicitly fixes the compact output contract (`variant_result` exact keys; "omits duplicated candidate rows, point-level economics, raw provider payloads, and statistics `point_results`"). Recomputability is preserved because the W4 projections and close/fee facts remain the audit facts, and each daily delta item keeps `trading_date`, `effective_point_count`, and `daily_delta`. `tests/test_strategy_lab_top1_research.py:80-123` locks the exact top-level and variant key sets, and `test_selects_unique_leader_and_aggregates_two_points_by_day` re-derives the two-point daily mean by hand.
+- Decision: rejected. The compaction is the accepted contract, not drift.
+
+### AR-02 — rejected-with-reason — hard-coding `required_days=40` and the fixed policy is the versioned contract
+
+- Candidate: `research.py` fixes `required_days: 40`, `confidence_level: 0.95`, `worst_fraction: 0.20` instead of reading them from the spec, which could silently diverge if the spec changes.
+- Evidence: `plan.md` §2 fixes these as non-configurable for v1; `contracts._validate_research_evaluation()` (`contracts.py:312-346`) hard-fails any spec whose `required_days` is not 40, and `validate_experiment_spec()` runs before any evaluation, so an out-of-contract spec can never reach the fixed policy. The architecture test also pins the research module's import allowlist.
+- Decision: rejected. The spec validator is the guard; duplicating the values in the evaluator is consistent with the fixed v1 contract, not a drift channel.
+
+### AR-03 — rejected-with-reason — `candidate_currency_mismatch` blocks the whole window before statistics
+
+- Candidate: one non-HKD compared candidate makes the entire research window `insufficient_evidence` instead of degrading only the affected variant, which could be seen as over-broad.
+- Evidence: this is the accepted fail-closed rule in `plan.md` §6 step 5 ("fail the entire research evaluation ... This prevents cross-currency economics and selection from a partially evaluable set of levels") and §9. The economics owner (`economics.calculate_expiry_efficiency`) is HKD-only via `calc_futu_hk_terminal_fee`, and `ranking.validate_ranking_projection()` requires uppercase currency but does not restrict to HKD, so the evaluator is the correct boundary to stop cross-currency comparisons. `test_currency_and_materialization_tampering_fail_closed` proves economics is never called for a USD candidate (monkeypatched to `pytest.fail`).
+- Decision: rejected. Whole-window fail-closed is the designed behavior; partial-window selection would be the defect.
+
+### AR-04 — rejected-with-reason — unchecked W4 manifest fields are bound by the content hash
+
+- Candidate: `_validate_dataset()` does not cross-check `cutoff_trading_date`, `window_facts_content_sha256`, `market_calendar_ref`, `market_calendar_sha256`, `trading_calendar_dates_sha256`, `maturity_evidence_ref`, or `maturity_evidence_sha256` against the spec, so a tampered manifest field could pass.
+- Evidence: `research.py:246-254` recomputes `canonical_sha256` over every manifest field except `content_sha256` and compares it to the supplied `content_sha256`, then recomputes the canonical file SHA-256 over the full manifest and compares it to the spec-pinned `research_source.dataset_sha256`. Any tampered field breaks the semantic hash and raises `research_corpus_conflict` fail-closed (covered by `test_currency_and_materialization_tampering_fail_closed`, which flips `cutoff_trading_date` and expects the error). The fields the evaluator actually consumes for evaluation semantics (`market`, `account`, `cutoff_at_utc`, `market_calendar_version`, 40 ordered dates, start/end) are additionally cross-checked against the spec. Refs (`market_calendar_ref`, `maturity_evidence_ref`) and evidence hashes are provider/runner-side facts whose verification the accepted plan assigns to the W4 freeze path and the future runner; the pure evaluator cannot read those files by design (plan §2, §5.1).
+- Decision: rejected. Hash binding plus consumed-field cross-checks cover the trust boundary; verifying unused evidence refs here would require filesystem I/O that the plan explicitly forbids in this slice.
+
+### AR-05 — rejected-with-reason — the M3 seam's synthetic receipt hash is not a false sealing claim
+
+- Candidate: the M3 seam test passes the research generation terminal hash as `research_receipt_file_sha256`, which could be read as claiming the evaluator payload was sealed and bound into the lifecycle.
+- Evidence: `plan.md` §8 fixes the seam scope ("The M3 seam does not claim the evaluation payload itself has been sealed. It supplies synthetic receipt ref/hash solely to exercise the already implemented M3 boundary."). The test asserts exactly two things: a challenger different from the evaluator's `leader_variant_id` is rejected, and the accepted lock remains `validation_authorization_status=unconfirmed` so `start_validation` raises `authorization_required`. The implementation artifact states the payload is unsealed and the completion signal forbids calling the original W5 complete. `lifecycle.lock_challenger()` only validates ref/hash shape (`lifecycle.py:715-717`); real receipt binding belongs to the deferred runner slice.
+- Decision: rejected. The seam tests the M3 gate, not sealing; no artifact claims sealing happened.
+
+### AR-06 — rejected-with-reason — `account_fee_plan=None` fails closed through the W1B owner
+
+- Candidate: a null fee plan could be defaulted into zero fees and permit leader selection.
+- Evidence: `economics.calculate_expiry_efficiency()` passes the plan unchanged to `calc_futu_hk_terminal_fee()`, which converts a non-dict plan to an empty fact set, keeps `complete=false`, and returns `hk_account_fee_plan_missing`; the economics layer then returns `not_evaluable / required_outcome_missing / expiry_fee_unavailable`, and the evaluator turns any not-evaluable result into whole-window `insufficient_evidence` with no leader. `test_incomplete_assignment_fee_and_short_window_fail_closed` exercises the exact `None` plan input and asserts `insufficient_evidence / required_outcome_missing / expiry_fee_unavailable`. The evaluator never defaults the plan (`research.py:441-443` returns `None` unchanged).
+- Decision: rejected. Fail-closed behavior is implemented and regression-locked; this was already dispositioned as CR-03 in the slice review and the aggregate review independently re-verified it against source.
+
+### AR-07 — rejected-with-reason — dependency direction and producer isolation hold
+
+- Candidate: the new module could leak into the Candidate Engine / tick path or import forbidden owners.
+- Evidence: `research.py` imports only `hashlib`, `math`, `re`, `collections.abc`, `datetime`, `typing`, `domain.domain.decision_state_fingerprint`, `domain.domain.fee_calc`, `src.application.shadow_replay.common`, and the four top1 owners (contracts, corpus schema constant, economics, ranking, statistics). `tests/test_strategy_lab_top1_architecture.py` asserts this exact allowlist and additionally asserts no production tick module imports `research`, `lifecycle`, `corpus`, or the experiment store. The regenerated graph reports `production_modules=590 cycles=0`, and `generate_dependency_graph.py --check` passes.
+- Decision: rejected. The direction matches `plan.md` §3.
+
+### AR-08 — rejected-with-reason — determinism and input-order independence are enforced, not just claimed
+
+- Candidate: receipt ordering or dict iteration could change output.
+- Evidence: required close keys are iterated in sorted order (`research.py:624`), missing receipts are sorted by the full tuple (`research.py:519-527`), pre-statistics reason sets are sorted and de-duplicated, variant output order follows the authorized spec order, and leader selection uses the fixed key `(mean desc, lcb desc, worst-tail desc, variant_id asc)`. `test_required_close_failures_block_every_variant_and_order_is_stable` asserts forward vs. reversed receipt input produce byte-identical results across three failure modes, and `test_passing_leader_uses_every_deterministic_tie_break` covers every tie-break key including lexical variant ID last.
+- Decision: rejected.
+
+## Open Questions
+
+- None for this slice.
+
+## Residual Risk
+
+- Accepted deferrals stand as documented in `plan.md` §11: real close/quota/calendar/fee-plan acquisition, receipt sealing, provider retry/dedupe, and the real 40-day conclusion belong to the deferred runner and pilot work. Nothing in this slice claims otherwise.
+- `basedpyright` is not installed in the project environment, so static type analysis was not run locally; runtime (55 focused tests), Ruff, dependency-graph check, and `git diff --check` all pass. This is a toolchain gap, not a code defect.
+- The future runner must use the close-receipt failure-reason vocabulary (`_CLOSE_FAILURE_DETAILS`) defined here; the seam is documented but not yet exercised by a producer, which is expected at this stage.
+
+## Verification run during this review
+
+- `pytest -q tests/test_strategy_lab_top1_research.py tests/test_strategy_lab_top1_w1b.py tests/test_strategy_lab_top1_corpus.py tests/test_strategy_lab_top1_store.py tests/test_strategy_lab_top1_architecture.py -p no:cacheprovider` — 55 passed.
+- `ruff check` on the three changed Python files — passed.
+- `scripts/generate_dependency_graph.py --check` — current, 590 production modules, 0 cycles.
+- `git diff --check origin/main..HEAD` — clean.

--- a/docs/reviews/code-review-20260815-161754.md
+++ b/docs/reviews/code-review-20260815-161754.md
@@ -1,0 +1,43 @@
+# Code Review
+
+## Scope
+
+- Mode: current W5 evaluator-only slice
+- Branch or PR: `feat/sell-put-top1-w5`
+- Base: `origin/main@6b16fb3d`
+- Output file: `docs/reviews/code-review-20260815-161754.md`
+- Included scope: pure research evaluator, W4 materialization seam, W1A/W1B reuse, M3 authorization seam, architecture checks, tests, and generated dependency graph
+- Excluded scope: runner, provider calls, sealed receipt publication, storage, CLI, production configuration, release, deployment, and a real 40-day experiment
+- Independent review coverage: Kimi high-reasoning code review and evidence-led re-review
+
+## Findings
+
+No unresolved blocker, high, medium, or low finding remains in the accepted slice.
+
+### CR-01 — rejected-with-reason — economics units are already contract-consistent
+
+- Candidate: opening premium and assignment economics were alleged to mix per-share and per-contract units.
+- Evidence: the accepted product contract defines `opening_net_premium` as Candidate Engine `net_premium/net_income`, already calculated as `sell_limit * multiplier - opening fee`; Candidate Engine implements that exact calculation. The assignment formula then applies `(S_H - K) * multiplier - assignment_fees` at the same contract scope.
+- Decision: rejected. This is the existing W1B contract and is covered by hand-calculation tests; changing it in W5 would introduce a unit error and cross an owner boundary.
+
+### CR-02 — rejected-with-reason — the M3 seam intentionally does not seal the evaluator payload
+
+- Candidate: the M3 seam does not prove that its synthetic receipt hash is the evaluator payload hash.
+- Evidence: the accepted W5 plan explicitly defines this result as unsealed and assigns byte reading, revision publication, and M3 terminal sealing to the later `run_research()` slice. The current seam only proves exact leader identity and separate human authorization.
+- Decision: rejected. Adding fake binding here would claim a runner/sealing capability that this slice does not implement.
+
+### CR-03 — rejected-with-reason — a missing account fee plan already fails closed
+
+- Candidate: `account_fee_plan=None` might default fees and permit selection.
+- Evidence: `calc_futu_hk_terminal_fee()` converts a non-mapping plan to an empty fact set, retains `complete=false`, and returns `hk_account_fee_plan_missing`; W1B maps that to `required_outcome_missing / expiry_fee_unavailable`. A W5 regression now exercises the exact `None` input and passes.
+- Decision: rejected. No production-code change was necessary.
+
+## Open Questions
+
+- None for this slice.
+
+## Residual Risk
+
+- The future runner must define its unavailable-close reason vocabulary against this evaluator contract; adding a shared abstraction now would be speculative.
+- Malformed fee-plan values fail closed through W1B as unavailable evidence rather than receiving finer input-diagnostic codes. That matches the accepted unchanged-pass-through contract and does not permit a leader.
+- Provider acquisition, sealed receipt publication, and a real 40-day conclusion remain deliberately outside this evaluator-only slice.

--- a/docs/reviews/plan-review-20260815-154327.md
+++ b/docs/reviews/plan-review-20260815-154327.md
@@ -1,0 +1,69 @@
+# Plan Review — Sell Put Top1 W5 Evaluator Slice
+
+## Reviewed target and scope
+
+- Target: `docs/gateflow/sell-put-top1-w5-evaluator/plan.md`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Base: `origin/main@6b16fb3d189e68ba9957de3a60cfa59cc89a0294`
+- Review mode: adversarial implementation-plan review
+- Included: pure evaluator input/output contracts, W4 materialization seam, W1A/W1B reuse, leader selection, M3 human-authorization seam, tests, and deferred runtime boundary
+- Excluded: provider runner, real OpenD/fee/calendar/quota facts, release/deploy, and real experiment execution
+- Artifact path: `docs/reviews/plan-review-20260815-154327.md`
+
+## Assumptions tested
+
+- A W1A-valid HK projection is automatically safe to pass to HK terminal-fee economics.
+- The proposed input envelope can preserve W4 identity without adding a stored schema or loader.
+- The output description is precise enough for an implementation agent to produce deterministic bytes and tests without inventing policy.
+- Treating every valid W4 accepted-only point as `hard_risk_status=passed` does not create a second risk authority.
+- A pure evaluator can prove the M4 and M3 seams without pretending to publish a real research receipt.
+
+## Review lenses
+
+- Architecture boundary: the proposed dependency direction is narrow and does not reverse Candidate Engine, W4, M3, or storage ownership.
+- Best practice: strict trust-boundary validation and deterministic output are required because the result chooses the only challenger a human may lock.
+- Optimal solution: one pure module reusing W1A/W1B is materially simpler than adding a runner/provider abstraction while W0R is red.
+- Overengineering: the in-memory envelope is justified by the mismatch between a reference-only W4 manifest and a pure evaluator; storing it or adding a loader interface now would not be justified.
+- Overcoupling: the synthetic M3 seam remains a test-only consumer and does not make research import lifecycle/store.
+
+## Findings
+
+### PR-W5-01-未修复-高-HK 费用公式缺少候选币种门，可能产生跨币种伪效率
+- **位置**: §5.1 materialized dataset validation、§6 step 6 economics flow、§10 required tests
+- **问题类型**: 契约缺失 / 架构边界 / 测试缺口
+- **当前写法**: plan 验证 projection 的 market/account/ref/hash 后，直接把选中候选的 premium、cash basis、strike 和 exact close 送入 HK terminal-fee economics。
+- **反例/失败场景**: 一个 `market=HK` 的 projection 含 `currency=USD` 候选。W1A 只要求 currency 为 uppercase text，不验证 HK 必须 HKD；该 projection 仍可通过。W5 随后把 USD premium/cash basis 与 HKD terminal fee 相减并计算 efficiency，输出看似合法的 leader。
+- **为什么有问题**: W1B calculator 固定返回 HKD terminal fee，而 W5 是第一次把候选货币事实与该 calculator 组合。这里不做同币种门会产生数值有效、业务无效且难以察觉的模型选择结论。
+- **直接证据**: `ranking.py::validate_ranking_projection()` 只检查 `candidate.currency == upper(currency)`；`economics.py::calculate_expiry_efficiency()` 要求 terminal fee currency 为 `HKD`，但输入 facts 不含 candidate currency，无法自己阻断跨币种组合；ExperimentSpec 首发固定 `market=HK`。
+- **影响**: 可能选出错误 research leader，并把错误结论送到 M3 人工锁定边界。
+- **建议改法和验证点**: plan 明确规定：任何需要 economics 的选中候选必须 `currency=HKD`，否则整体 `insufficient_evidence / ranking_projection_incomplete` 或稳定 fail-closed error；新增 HK projection 中 USD candidate 的回归测试，断言不会调用 economics、不会产生 leader。不要把币种转换加入 W5。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 高
+
+### PR-W5-02-未修复-中-输出与错误聚合仍欠规格，无法保证真正确定性
+- **位置**: §5.2 close receipts、§7 output contract、§9 error rules、§10 deterministic tests
+- **问题类型**: 契约缺失 / 不可直接实施 / 测试缺口
+- **当前写法**: plan 列出顶层和 variant result 的概念字段，但未定义 `effective_days` 的 overall 语义、variant result exact keys、reason aggregation/order、`missing_receipts` exact keys/order，以及 duplicate close 是异常还是正常 insufficient result。
+- **反例/失败场景**: 两个 variants 分别得到 `effective_days=39` 与 40，且缺失 receipt 输入顺序不同。两个合理实现可以分别选择 min/max/首个 effective days，以 encounter order 或 variant order 输出理由，并对 duplicate receipt 抛异常或返回 insufficient；它们都符合当前文字但生成不同 payload/hash。
+- **为什么有问题**: 该 payload 后续要封存并由 M3/LLM 消费。若当前 slice 没有唯一结构和排序，未来 runner 会被迫重新定义契约，测试也可能只锁住偶然实现。
+- **直接证据**: §7 只列顶层字段和“aggregate scalars”；§9 只区分 malformed 与 evidence outcome；§5.2 称 duplicate 为 conflict，§6 又把 conflicting close 归入 normal insufficient，但没有优先级和排序规则。
+- **影响**: 实施 Agent 需要现场设计，输出 hash 不稳定，后续 runner/M3 seam 返工，review 无法判断行为是否符合已确认策略。
+- **建议改法和验证点**: 在 plan 中列出 variant result 和 missing item exact keys；定义 overall `effective_days=min(variant effective_days)`（pre-statistics failure 为 null）；reason codes/details 按 authorized variant order first-seen 去重；missing receipts 按 `(stock_owner, expiration, reason_detail)` 排序；duplicate required receipt 正常返回 `insufficient_evidence / required_outcome_missing / expiry_close_receipt_conflict`，结构错误才抛 `ResearchEvaluationError`；列出 error reason code 集合并加输入重排等价测试。
+- **修复风险（低/中/高）**: 低
+- **严重程度（低/中/高/严重）**: 中
+
+## Open Questions
+
+None. Both findings can be resolved without changing the confirmed goal or adding a provider/storage boundary.
+
+## Residual risks
+
+- Exact raw-byte verification still belongs to the future runner because a decoded in-memory mapping cannot prove which bytes were read. Track in the remaining W5 runner work.
+- Real HK close/calendar/quota/fee-plan truth remains blocked by W0R. Track in capability remediation and the remaining W5/W7 work.
+- The M3 seam uses a synthetic terminal/receipt in tests and therefore proves contract compatibility, not real research publication. Track in the remaining W5 runner work.
+
+## Conclusion
+
+`fail`
+
+The architecture and narrowed scope are sound, but implementation should not start until the candidate-currency gate and deterministic output/error contract are added to the plan and re-reviewed.

--- a/docs/reviews/plan-review-20260815-154601.md
+++ b/docs/reviews/plan-review-20260815-154601.md
@@ -1,0 +1,57 @@
+# Plan Re-Review — Sell Put Top1 W5 Evaluator Slice
+
+## Reviewed target and scope
+
+- Target: `docs/gateflow/sell-put-top1-w5-evaluator/plan.md`
+- Prior review: `docs/reviews/plan-review-20260815-154327.md`
+- Fix artifact: `docs/gateflow/sell-put-top1-w5-evaluator/plan-fix.md`
+- Work unit: `sell-put-top1-w5-evaluator`
+- Base: `origin/main@6b16fb3d189e68ba9957de3a60cfa59cc89a0294`
+- Artifact path: `docs/reviews/plan-review-20260815-154601.md`
+
+## Assumptions re-tested
+
+- HK terminal-fee economics is reached only for compared HKD candidates.
+- Output shape, reason aggregation, missing-evidence order, and overall effective-days semantics no longer require implementation-time policy decisions.
+- Duplicate required close evidence fails closed without making unused receipts outcome-relevant.
+- The narrowed evaluator remains pure and does not smuggle in the deferred runner/provider/storage work.
+
+## Finding re-review
+
+### PR-W5-01 — 已修复
+
+The plan now rejects compared non-HKD candidate economics as normal insufficient evidence before W1B is called, requires a regression test, and explicitly forbids currency conversion. This closes the cross-currency false-efficiency path without broadening W5.
+
+### PR-W5-02 — 已修复
+
+The plan now fixes exact output key sets, daily/missing item shapes, overall effective-days semantics, reason aggregation/order, selection reason behavior, duplicate-required-close behavior, and the structural error-code set. Required tests make receipt input ordering and output determinism reviewable.
+
+## Architecture, best-practice, optimality, and complexity result
+
+- Dependency ownership remains correct: research composes W1A/W1B and imports no lifecycle/store/provider boundary.
+- Trust-boundary validation is proportionate to a model-selection result.
+- The in-memory envelope is the minimum viable bridge from W4's reference-only manifest to a pure evaluator.
+- No provider interface, public loader, schema migration, runner, alternate risk engine, or configurable policy was added.
+- The test-only M3 seam proves exact-leader and human-authorization behavior without representing synthetic bytes as a real receipt.
+
+## New findings
+
+None.
+
+## Open questions
+
+None.
+
+## Residual risks
+
+- Exact raw-byte artifact loading/publication: assigned to the remaining W5 runner.
+- Real HK fee/calendar/close/quota/provider capability: assigned to W0R remediation and the remaining W5/W7 work.
+- Real strategy evidence and pilot conclusion: assigned to a separately authorized release/install/pilot.
+
+All residual risks are classified outside this evaluator slice.
+
+## Conclusion
+
+`pass`
+
+The plan is code-generation-ready for the confirmed evaluator-only work unit.

--- a/docs/reviews/pr-163-review-20260815-163730.md
+++ b/docs/reviews/pr-163-review-20260815-163730.md
@@ -1,0 +1,35 @@
+# PR Review — Sell Put Top1 W5 Evaluator
+
+## Scope
+
+- Mode: final read-only PR-level DeepReview
+- Draft PR: `https://github.com/liuxie066/options-monitor/pull/163`
+- Reviewed range: `main@6b16fb3d...feat/sell-put-top1-w5@2a5b10f2`
+- State confirmed by parent: `OPEN`, `DRAFT`, `MERGEABLE`
+- Included scope: accepted plan, pure evaluator, W4/M3 seams, tests, dependency graph, and Gateflow/review evidence
+- Excluded scope: runner, provider, receipt sealing/publication, storage, timer, CLI/Agent/LLM integration, real 40-day experiment, hidden validation, release, and deployment
+- Reviewer: Kimi K3, high reasoning
+
+## Findings
+
+No blocker, high, medium, or low finding.
+
+The reviewer confirmed exact base/head identity with no drift; precise envelope, manifest, projection, reference, and hash validation; whole-evaluation fail-closed behavior; reuse of W1A/W1B owners; deterministic leader ordering; truthful W4/M3 seam claims; and the absence of plan-excluded runtime capabilities. It found no over-design or goal drift.
+
+## Verification
+
+- W5 plus adjacent W1B/W4/M3/architecture suites: `55 passed` in both parent and reviewer runs.
+- Ruff: pass.
+- Dependency graph: current, `production_modules=590`, `cycles=0`.
+- Initial PR checks on reviewed head: Analyze actions/python, CodeQL, agent-plugin, and guardrails passed.
+- `git diff --check`: pass.
+
+## Open Questions
+
+- None for this slice.
+
+## Residual Risk
+
+- The future runner must align its close-unavailable vocabulary with the evaluator contract.
+- BasedPyright is not installed in the existing environment; no dependency was added.
+- Provider acquisition, sealing, and any real strategy conclusion remain deferred and are not claimed by this PR.

--- a/src/application/strategy_lab/top1/research.py
+++ b/src/application/strategy_lab/top1/research.py
@@ -1,0 +1,838 @@
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from collections.abc import Mapping
+from datetime import date
+from typing import Any, NoReturn, cast
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.fee_calc import FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
+from src.application.shadow_replay.common import render_json_text
+from src.application.strategy_lab.top1.contracts import (
+    Top1CoreContractError,
+    build_research_spec_sha256,
+    validate_experiment_spec,
+)
+from src.application.strategy_lab.top1.corpus import (
+    RECOMMENDATION_POINT_SELECTOR,
+    SEALED_HISTORICAL_DATASET_SCHEMA,
+)
+from src.application.strategy_lab.top1.economics import calculate_expiry_efficiency
+from src.application.strategy_lab.top1.ranking import (
+    RANKING_PROJECTION_SCHEMA_VERSION,
+    Top1RankingError,
+    rerank_recommendation_point,
+    validate_ranking_projection,
+)
+from src.application.strategy_lab.top1.statistics import (
+    summarize_paired_daily_deltas,
+)
+
+
+RESEARCH_EVALUATION_INPUT_SCHEMA = "sell_put_top1_research_evaluation_input.v1"
+RESEARCH_CLOSE_RECEIPT_SCHEMA = "sell_put_top1_research_close_receipt.v1"
+RESEARCH_EVALUATION_SCHEMA = "sell_put_top1_research_evaluation.v1"
+
+_HASH_64 = re.compile(r"[0-9a-f]{64}\Z")
+_INPUT_KEYS = frozenset(
+    {
+        "schema_version",
+        "experiment_spec",
+        "dataset_ref",
+        "sealed_dataset",
+        "ranking_projections",
+    }
+)
+_DATASET_KEYS = frozenset(
+    {
+        "schema_version",
+        "market",
+        "account",
+        "cutoff_at_utc",
+        "cutoff_trading_date",
+        "required_days",
+        "window_facts_content_sha256",
+        "market_calendar_version",
+        "market_calendar_ref",
+        "market_calendar_sha256",
+        "trading_calendar_dates_sha256",
+        "latest_mature_trading_date",
+        "maturity_evidence_ref",
+        "maturity_evidence_sha256",
+        "recommendation_point_selector",
+        "ranking_projection_schema_version",
+        "selected_trading_dates",
+        "days",
+        "content_sha256",
+    }
+)
+_DAY_KEYS = frozenset(
+    {
+        "trading_date",
+        "expectation_ref",
+        "expectation_content_sha256",
+        "expectation_file_sha256",
+        "points",
+    }
+)
+_POINT_KEYS = frozenset(
+    {
+        "recommendation_point_id",
+        "projection_ref",
+        "projection_content_sha256",
+        "projection_file_sha256",
+    }
+)
+_MATERIALIZED_PROJECTION_KEYS = frozenset({"projection_ref", "projection"})
+_CLOSE_KEYS = frozenset(
+    {
+        "schema_version",
+        "market",
+        "account",
+        "stock_owner",
+        "expiration",
+        "spot_source",
+        "ktype",
+        "autype",
+        "price_field",
+        "status",
+        "underlier_close",
+        "reason_detail",
+    }
+)
+_CLOSE_FAILURE_DETAILS = frozenset(
+    {
+        "expiry_calendar_mismatch",
+        "expiry_close_missing_after_deadline",
+        "expiry_source_unavailable_after_deadline",
+        "expiry_close_receipt_conflict",
+        "expiry_outcome_conflict",
+    }
+)
+_FEE_KEYS = frozenset(
+    {"market", "account", "fee_schedule_version", "account_fee_plan"}
+)
+_FEE_PLAN_KEYS = frozenset({"commission_free", "platform_fee", "fee_plan_ref"})
+_STAT_FIELDS = (
+    "required_days",
+    "effective_days",
+    "mean_daily_delta",
+    "sample_std",
+    "standard_error",
+    "t_critical",
+    "one_sided_lower_bound",
+    "worst_k",
+    "worst_tail_mean",
+    "serial_correlation_unadjusted",
+)
+
+
+class ResearchEvaluationError(ValueError):
+    """Stable fail-closed error from the pure research boundary."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise ResearchEvaluationError(reason_code, message)
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        _fail("research_input_invalid", f"{label} must be a mapping")
+    raw = cast(Mapping[object, object], value)
+    if not all(isinstance(key, str) for key in raw):
+        _fail("research_input_invalid", f"{label} keys must be strings")
+    return cast(Mapping[str, object], raw)
+
+
+def _exact_keys(
+    value: Mapping[str, object],
+    expected: frozenset[str],
+    label: str,
+    *,
+    reason_code: str = "research_input_invalid",
+) -> None:
+    if set(value) != set(expected):
+        _fail(reason_code, f"{label} keys are incomplete or unexpected")
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("research_input_invalid", f"{label} must be non-empty canonical text")
+    return value
+
+
+def _hash(value: object, label: str, *, reason_code: str) -> str:
+    text = _text(value, label)
+    if _HASH_64.fullmatch(text) is None:
+        _fail(reason_code, f"{label} must be a lowercase SHA-256")
+    return text
+
+
+def _relative_ref(value: object, label: str) -> str:
+    text = _text(value, label)
+    parts = text.split("/")
+    if text.startswith("/") or "\\" in text or any(
+        part in {"", ".", ".."} for part in parts
+    ):
+        _fail("research_input_invalid", f"{label} must be a safe relative POSIX path")
+    return text
+
+
+def _iso_date(value: object, label: str) -> str:
+    text = _text(value, label)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as exc:
+        raise ResearchEvaluationError(
+            "research_input_invalid", f"{label} must be a canonical ISO date"
+        ) from exc
+    if parsed.isoformat() != text:
+        _fail("research_input_invalid", f"{label} must be a canonical ISO date")
+    return text
+
+
+def _canonical_file_sha256(payload: Mapping[str, object]) -> str:
+    text = render_json_text(dict(payload))
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _validate_dataset(
+    value: object,
+    *,
+    dataset_ref: str,
+    spec: Mapping[str, object],
+) -> tuple[dict[str, object], list[dict[str, str]]]:
+    item = _mapping(value, "sealed_dataset")
+    _exact_keys(
+        item,
+        _DATASET_KEYS,
+        "sealed_dataset",
+        reason_code="research_corpus_conflict",
+    )
+    if item["schema_version"] != SEALED_HISTORICAL_DATASET_SCHEMA:
+        _fail("research_corpus_conflict", "sealed dataset schema is unsupported")
+    if item["market"] != spec["market"] or item["account"] != spec["account"]:
+        _fail("research_corpus_conflict", "sealed dataset identity does not match spec")
+    if item["required_days"] != 40:
+        _fail("research_corpus_conflict", "sealed dataset must contain 40 days")
+    if item["recommendation_point_selector"] != RECOMMENDATION_POINT_SELECTOR:
+        _fail("research_corpus_conflict", "sealed dataset selector is unsupported")
+    if item["ranking_projection_schema_version"] != RANKING_PROJECTION_SCHEMA_VERSION:
+        _fail("research_corpus_conflict", "sealed dataset projection schema changed")
+
+    source = _mapping(spec["research_source"], "experiment_spec.research_source")
+    economics = _mapping(
+        spec["economics_contracts"], "experiment_spec.economics_contracts"
+    )
+    if dataset_ref != source["dataset_ref"]:
+        _fail("research_corpus_conflict", "dataset ref does not match spec")
+    if item["cutoff_at_utc"] != source["research_cutoff_at"]:
+        _fail("research_corpus_conflict", "dataset cutoff does not match spec")
+    if item["market_calendar_version"] != economics["market_calendar_version"]:
+        _fail("research_corpus_conflict", "dataset calendar does not match spec")
+
+    supplied_content_hash = _hash(
+        item["content_sha256"],
+        "sealed_dataset.content_sha256",
+        reason_code="research_corpus_conflict",
+    )
+    content_source = {
+        key: raw_value for key, raw_value in item.items() if key != "content_sha256"
+    }
+    if canonical_sha256(content_source) != supplied_content_hash:
+        _fail("research_corpus_conflict", "sealed dataset content hash mismatch")
+    if _canonical_file_sha256(item) != source["dataset_sha256"]:
+        _fail("research_corpus_conflict", "sealed dataset file hash mismatch")
+
+    raw_dates = item["selected_trading_dates"]
+    raw_days = item["days"]
+    if not isinstance(raw_dates, list) or not isinstance(raw_days, list):
+        _fail("research_corpus_conflict", "sealed dataset dates and days must be lists")
+    selected_dates = [
+        _iso_date(raw, f"sealed_dataset.selected_trading_dates[{index}]")
+        for index, raw in enumerate(cast(list[object], raw_dates))
+    ]
+    if (
+        len(selected_dates) != 40
+        or len(set(selected_dates)) != 40
+        or selected_dates != sorted(selected_dates)
+    ):
+        _fail("research_corpus_conflict", "sealed dataset dates are not exact and ordered")
+    if (
+        selected_dates[0] != source["start_trading_date"]
+        or selected_dates[-1] != source["end_trading_date"]
+        or item["latest_mature_trading_date"] != selected_dates[-1]
+    ):
+        _fail("research_corpus_conflict", "sealed dataset window does not match spec")
+    if len(raw_days) != 40:
+        _fail("research_corpus_conflict", "sealed dataset day count is incomplete")
+
+    point_rows: list[dict[str, str]] = []
+    point_ids: set[str] = set()
+    for day_index, raw_day in enumerate(cast(list[object], raw_days)):
+        day = _mapping(raw_day, f"sealed_dataset.days[{day_index}]")
+        _exact_keys(
+            day,
+            _DAY_KEYS,
+            f"sealed_dataset.days[{day_index}]",
+            reason_code="research_corpus_conflict",
+        )
+        trading_date = _iso_date(
+            day["trading_date"], f"sealed_dataset.days[{day_index}].trading_date"
+        )
+        if trading_date != selected_dates[day_index]:
+            _fail("research_corpus_conflict", "sealed dataset day order changed")
+        _ = _relative_ref(day["expectation_ref"], "sealed_dataset.expectation_ref")
+        _ = _hash(
+            day["expectation_content_sha256"],
+            "sealed_dataset.expectation_content_sha256",
+            reason_code="research_corpus_conflict",
+        )
+        _ = _hash(
+            day["expectation_file_sha256"],
+            "sealed_dataset.expectation_file_sha256",
+            reason_code="research_corpus_conflict",
+        )
+        raw_points = day["points"]
+        if not isinstance(raw_points, list) or not raw_points:
+            _fail("research_corpus_conflict", "sealed dataset day has no point denominator")
+        for point_index, raw_point in enumerate(cast(list[object], raw_points)):
+            point = _mapping(
+                raw_point,
+                f"sealed_dataset.days[{day_index}].points[{point_index}]",
+            )
+            _exact_keys(
+                point,
+                _POINT_KEYS,
+                "sealed dataset point",
+                reason_code="research_corpus_conflict",
+            )
+            point_id = _text(point["recommendation_point_id"], "recommendation_point_id")
+            if point_id in point_ids:
+                _fail("research_corpus_conflict", "recommendation point is duplicated")
+            point_ids.add(point_id)
+            point_rows.append(
+                {
+                    "trading_date": trading_date,
+                    "recommendation_point_id": point_id,
+                    "projection_ref": _relative_ref(
+                        point["projection_ref"], "projection_ref"
+                    ),
+                    "projection_content_sha256": _hash(
+                        point["projection_content_sha256"],
+                        "projection_content_sha256",
+                        reason_code="research_corpus_conflict",
+                    ),
+                    "projection_file_sha256": _hash(
+                        point["projection_file_sha256"],
+                        "projection_file_sha256",
+                        reason_code="research_corpus_conflict",
+                    ),
+                }
+            )
+    return dict(item), point_rows
+
+
+def _validate_projections(
+    value: object,
+    *,
+    point_rows: list[dict[str, str]],
+    market: str,
+    account: str,
+) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, list):
+        _fail("research_input_invalid", "ranking_projections must be a list")
+    supplied: dict[str, dict[str, Any]] = {}
+    for index, raw in enumerate(cast(list[object], value)):
+        item = _mapping(raw, f"ranking_projections[{index}]")
+        _exact_keys(item, _MATERIALIZED_PROJECTION_KEYS, f"ranking_projections[{index}]")
+        ref = _relative_ref(item["projection_ref"], "ranking_projection.projection_ref")
+        if ref in supplied:
+            _fail("research_corpus_conflict", "materialized projection ref is duplicated")
+        projection_mapping = _mapping(item["projection"], "ranking_projection.projection")
+        try:
+            projection = validate_ranking_projection(cast(Mapping[str, Any], projection_mapping))
+        except Top1RankingError as exc:
+            _fail(exc.reason_code, str(exc))
+        supplied[ref] = projection
+
+    expected_refs = {point["projection_ref"] for point in point_rows}
+    if set(supplied) != expected_refs:
+        _fail("research_corpus_conflict", "materialized projections do not match dataset")
+    for point in point_rows:
+        projection = supplied[point["projection_ref"]]
+        if (
+            projection["recommendation_point_id"] != point["recommendation_point_id"]
+            or projection["market"] != market
+            or projection["account"] != account
+            or projection["artifact_provenance"]["content_sha256"]
+            != point["projection_content_sha256"]
+            or _canonical_file_sha256(projection) != point["projection_file_sha256"]
+        ):
+            _fail("research_corpus_conflict", "materialized projection binding changed")
+    return supplied
+
+
+def _validate_close_receipts(
+    value: object, *, market: str, account: str
+) -> dict[tuple[str, str], list[dict[str, object]]]:
+    if not isinstance(value, list):
+        _fail("research_input_invalid", "close_receipts must be a list")
+    indexed: dict[tuple[str, str], list[dict[str, object]]] = {}
+    for index, raw in enumerate(cast(list[object], value)):
+        item = _mapping(raw, f"close_receipts[{index}]")
+        _exact_keys(item, _CLOSE_KEYS, f"close_receipts[{index}]")
+        if item["schema_version"] != RESEARCH_CLOSE_RECEIPT_SCHEMA:
+            _fail("research_input_invalid", "close receipt schema is unsupported")
+        if item["market"] != market or item["account"] != account:
+            _fail("research_input_invalid", "close receipt identity does not match")
+        if (
+            item["spot_source"] != "opend_history_kline"
+            or item["ktype"] != "K_DAY"
+            or item["autype"] != "NONE"
+            or item["price_field"] != "close"
+        ):
+            _fail("research_input_invalid", "close receipt source semantics changed")
+        stock_owner = _text(item["stock_owner"], "close_receipt.stock_owner")
+        expiration = _iso_date(item["expiration"], "close_receipt.expiration")
+        status = item["status"]
+        close = item["underlier_close"]
+        reason = item["reason_detail"]
+        if status == "available":
+            if (
+                isinstance(close, bool)
+                or not isinstance(close, (int, float))
+                or not math.isfinite(float(close))
+                or float(close) <= 0
+                or reason is not None
+            ):
+                _fail("research_input_invalid", "available close receipt is invalid")
+        elif status == "unavailable":
+            if close is not None or reason not in _CLOSE_FAILURE_DETAILS:
+                _fail("research_input_invalid", "unavailable close receipt is invalid")
+        else:
+            _fail("research_input_invalid", "close receipt status is unsupported")
+        indexed.setdefault((stock_owner, expiration), []).append(dict(item))
+    return indexed
+
+
+def _validate_fee_contract(
+    value: object, *, spec: Mapping[str, object]
+) -> Mapping[str, object] | None:
+    item = _mapping(value, "fee_contract")
+    _exact_keys(item, _FEE_KEYS, "fee_contract")
+    if item["market"] != spec["market"] or item["account"] != spec["account"]:
+        _fail("research_input_invalid", "fee contract identity does not match")
+    economics = _mapping(spec["economics_contracts"], "experiment_spec.economics_contracts")
+    if (
+        item["fee_schedule_version"] != FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
+        or item["fee_schedule_version"] != economics["fee_schedule_version"]
+    ):
+        _fail("research_input_invalid", "fee schedule version does not match")
+    raw_plan = item["account_fee_plan"]
+    if raw_plan is None:
+        return None
+    plan = _mapping(raw_plan, "fee_contract.account_fee_plan")
+    if not set(plan).issubset(_FEE_PLAN_KEYS):
+        _fail("research_input_invalid", "account fee plan contains unexpected keys")
+    return dict(plan)
+
+
+def _candidate(
+    projection: Mapping[str, Any], candidate_id: str | None
+) -> Mapping[str, object] | None:
+    if candidate_id is None:
+        return None
+    for raw in cast(list[object], projection["candidates"]):
+        candidate = cast(Mapping[str, object], raw)
+        if candidate["candidate_id"] == candidate_id:
+            return candidate
+    _fail("ranking_projection_incomplete", "selected candidate is absent from projection")
+
+
+def _base_result(
+    *,
+    spec: Mapping[str, object],
+    dataset_ref: str,
+    sealed_dataset: Mapping[str, object],
+    effective_days: int | None,
+    selection: str,
+    leader_variant_id: str | None,
+    reason_codes: list[str],
+    reason_details: list[str],
+    variant_results: list[dict[str, object]],
+    missing_receipts: list[dict[str, object]],
+) -> dict[str, object]:
+    source = _mapping(spec["research_source"], "experiment_spec.research_source")
+    return {
+        "schema_version": RESEARCH_EVALUATION_SCHEMA,
+        "experiment_id": spec["experiment_id"],
+        "research_spec_sha256": build_research_spec_sha256(spec),
+        "dataset_ref": dataset_ref,
+        "dataset_sha256": source["dataset_sha256"],
+        "dataset_content_sha256": sealed_dataset["content_sha256"],
+        "required_days": 40,
+        "effective_days": effective_days,
+        "research_fill_assumption": "t0_sell_limit",
+        "research_is_counterfactual": True,
+        "contract_terms_revalidated": False,
+        "selection": selection,
+        "leader_variant_id": leader_variant_id,
+        "reason_codes": reason_codes,
+        "reason_details": reason_details,
+        "variant_results": variant_results,
+        "missing_receipts": missing_receipts,
+    }
+
+
+def _insufficient_before_statistics(
+    *,
+    spec: Mapping[str, object],
+    dataset_ref: str,
+    sealed_dataset: Mapping[str, object],
+    reasons: list[tuple[str, str | None]],
+    missing_receipts: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    ordered = sorted(set(reasons), key=lambda item: (item[0], item[1] or ""))
+    return _base_result(
+        spec=spec,
+        dataset_ref=dataset_ref,
+        sealed_dataset=sealed_dataset,
+        effective_days=None,
+        selection="insufficient_evidence",
+        leader_variant_id=None,
+        reason_codes=_unique([reason for reason, _detail in ordered]),
+        reason_details=_unique(
+            [detail for _reason, detail in ordered if detail is not None]
+        ),
+        variant_results=[],
+        missing_receipts=sorted(
+            missing_receipts or [],
+            key=lambda item: (
+                str(item["stock_owner"]),
+                str(item["expiration"]),
+                str(item["reason_code"]),
+                str(item["reason_detail"]),
+            ),
+        ),
+    )
+
+
+def evaluate_research(
+    dataset: object,
+    close_receipts: object,
+    fee_contract: object,
+) -> dict[str, object]:
+    envelope = _mapping(dataset, "dataset")
+    _exact_keys(envelope, _INPUT_KEYS, "dataset")
+    if envelope["schema_version"] != RESEARCH_EVALUATION_INPUT_SCHEMA:
+        _fail("research_input_invalid", "research evaluation input schema is unsupported")
+    try:
+        spec = validate_experiment_spec(envelope["experiment_spec"])
+    except Top1CoreContractError as exc:
+        _fail("experiment_spec_invalid", str(exc))
+    if "validation_evaluation" in spec:
+        _fail("experiment_spec_invalid", "research evaluator requires a research-only spec")
+    dataset_ref = _relative_ref(envelope["dataset_ref"], "dataset.dataset_ref")
+    sealed_dataset, point_rows = _validate_dataset(
+        envelope["sealed_dataset"], dataset_ref=dataset_ref, spec=spec
+    )
+    projections = _validate_projections(
+        envelope["ranking_projections"],
+        point_rows=point_rows,
+        market=str(spec["market"]),
+        account=str(spec["account"]),
+    )
+    receipts = _validate_close_receipts(
+        close_receipts, market=str(spec["market"]), account=str(spec["account"])
+    )
+    fee_plan = _validate_fee_contract(fee_contract, spec=spec)
+
+    variants: list[tuple[str, str]] = []
+    for raw_variant in cast(list[object], spec["variants"])[1:]:
+        variant = cast(Mapping[str, object], raw_variant)
+        patch = cast(Mapping[str, object], variant["patch"])
+        variants.append((str(variant["variant_id"]), str(patch["ranking_profile"])))
+
+    selections: dict[str, list[dict[str, object]]] = {
+        variant_id: [] for variant_id, _profile in variants
+    }
+    required_close_keys: set[tuple[str, str]] = set()
+    currency_mismatch = False
+    for point in point_rows:
+        projection = projections[point["projection_ref"]]
+        try:
+            baseline_rank = rerank_recommendation_point(
+                projection, ranking_profile="current_tie_break"
+            )
+        except Top1RankingError as exc:
+            _fail(exc.reason_code, str(exc))
+        baseline_id = cast(str | None, baseline_rank["top1_candidate_id"])
+        baseline_candidate = _candidate(projection, baseline_id)
+        for variant_id, profile in variants:
+            try:
+                challenger_rank = rerank_recommendation_point(
+                    projection, ranking_profile=profile
+                )
+            except Top1RankingError as exc:
+                _fail(exc.reason_code, str(exc))
+            challenger_id = cast(str | None, challenger_rank["top1_candidate_id"])
+            challenger_candidate = _candidate(projection, challenger_id)
+            if (baseline_candidate is None) != (challenger_candidate is None):
+                _fail(
+                    "ranking_projection_incomplete",
+                    "same accepted universe produced a one-sided Top1",
+                )
+            differs = baseline_id != challenger_id
+            if differs:
+                assert baseline_candidate is not None and challenger_candidate is not None
+                for candidate in (baseline_candidate, challenger_candidate):
+                    if candidate["currency"] != "HKD":
+                        currency_mismatch = True
+                    required_close_keys.add(
+                        (str(candidate["stock_owner"]), str(candidate["expiration"]))
+                    )
+            selections[variant_id].append(
+                {
+                    "trading_date": point["trading_date"],
+                    "recommendation_point_id": point["recommendation_point_id"],
+                    "baseline_candidate_id": baseline_id,
+                    "challenger_candidate_id": challenger_id,
+                    "baseline_candidate": baseline_candidate,
+                    "challenger_candidate": challenger_candidate,
+                }
+            )
+    if currency_mismatch:
+        return _insufficient_before_statistics(
+            spec=spec,
+            dataset_ref=dataset_ref,
+            sealed_dataset=sealed_dataset,
+            reasons=[("ranking_projection_incomplete", "candidate_currency_mismatch")],
+        )
+
+    missing: list[dict[str, object]] = []
+    for stock_owner, expiration in sorted(required_close_keys):
+        matches = receipts.get((stock_owner, expiration), [])
+        if not matches:
+            missing.append(
+                {
+                    "stock_owner": stock_owner,
+                    "expiration": expiration,
+                    "reason_code": "research_expiry_close_missing",
+                    "reason_detail": "expiry_close_missing_after_deadline",
+                }
+            )
+        elif len(matches) > 1:
+            missing.append(
+                {
+                    "stock_owner": stock_owner,
+                    "expiration": expiration,
+                    "reason_code": "required_outcome_missing",
+                    "reason_detail": "expiry_close_receipt_conflict",
+                }
+            )
+        elif matches[0]["status"] == "unavailable":
+            missing.append(
+                {
+                    "stock_owner": stock_owner,
+                    "expiration": expiration,
+                    "reason_code": "required_outcome_missing",
+                    "reason_detail": matches[0]["reason_detail"],
+                }
+            )
+    if missing:
+        return _insufficient_before_statistics(
+            spec=spec,
+            dataset_ref=dataset_ref,
+            sealed_dataset=sealed_dataset,
+            reasons=[
+                (str(item["reason_code"]), str(item["reason_detail"]))
+                for item in missing
+            ],
+            missing_receipts=missing,
+        )
+
+    economic_failures: list[tuple[str, str | None]] = []
+    point_rows_by_variant: dict[str, list[dict[str, object]]] = {
+        variant_id: [] for variant_id, _profile in variants
+    }
+    for variant_id, _profile in variants:
+        for selection in selections[variant_id]:
+            baseline = cast(Mapping[str, object] | None, selection["baseline_candidate"])
+            challenger = cast(
+                Mapping[str, object] | None, selection["challenger_candidate"]
+            )
+            baseline_efficiency: float | None = None
+            challenger_efficiency: float | None = None
+            if selection["baseline_candidate_id"] != selection["challenger_candidate_id"]:
+                assert baseline is not None and challenger is not None
+                results: list[dict[str, object]] = []
+                for candidate in (baseline, challenger):
+                    key = (str(candidate["stock_owner"]), str(candidate["expiration"]))
+                    receipt = receipts[key][0]
+                    try:
+                        result = calculate_expiry_efficiency(
+                            {
+                                "stage": "research",
+                                "fill_status": "t0_assumed_fill",
+                                "holding_start_date": selection["trading_date"],
+                                "expiration": candidate["expiration"],
+                                "opening_net_premium": candidate["net_premium"],
+                                "net_cash_basis": candidate["net_cash_basis"],
+                                "strike": candidate["strike"],
+                                "multiplier": candidate["multiplier"],
+                                "underlier_close": receipt["underlier_close"],
+                                "account_fee_plan": fee_plan,
+                            }
+                        )
+                    except ValueError as exc:
+                        _fail("ranking_projection_incomplete", str(exc))
+                    results.append(result)
+                    if result["status"] != "evaluable":
+                        economic_failures.append(
+                            (
+                                str(result["reason_code"]),
+                                (
+                                    str(result["reason_detail"])
+                                    if result["reason_detail"] is not None
+                                    else None
+                                ),
+                            )
+                        )
+                baseline_efficiency = cast(float | None, results[0]["efficiency"])
+                challenger_efficiency = cast(float | None, results[1]["efficiency"])
+            point_rows_by_variant[variant_id].append(
+                {
+                    "recommendation_point_id": selection["recommendation_point_id"],
+                    "trading_date": selection["trading_date"],
+                    "baseline_candidate_id": selection["baseline_candidate_id"],
+                    "challenger_candidate_id": selection["challenger_candidate_id"],
+                    "baseline_efficiency": baseline_efficiency,
+                    "challenger_efficiency": challenger_efficiency,
+                    "hard_risk_status": "passed",
+                    "baseline_concentration": (
+                        baseline["symbol_concentration_after"]
+                        if baseline is not None
+                        else None
+                    ),
+                    "challenger_concentration": (
+                        challenger["symbol_concentration_after"]
+                        if challenger is not None
+                        else None
+                    ),
+                }
+            )
+    if economic_failures:
+        return _insufficient_before_statistics(
+            spec=spec,
+            dataset_ref=dataset_ref,
+            sealed_dataset=sealed_dataset,
+            reasons=economic_failures,
+        )
+
+    variant_results: list[dict[str, object]] = []
+    for variant_id, profile in variants:
+        summary = summarize_paired_daily_deltas(
+            point_rows_by_variant[variant_id],
+            {
+                "required_days": 40,
+                "confidence_level": 0.95,
+                "worst_fraction": 0.20,
+                "require_concentration_non_increase": True,
+            },
+        )
+        result: dict[str, object] = {
+            "variant_id": variant_id,
+            "ranking_profile": profile,
+            "decision": summary["decision"],
+            "reason_codes": list(cast(list[str], summary["reason_codes"])),
+            **{field: summary[field] for field in _STAT_FIELDS},
+            "top1_change_count": sum(
+                row["baseline_candidate_id"] != row["challenger_candidate_id"]
+                for row in point_rows_by_variant[variant_id]
+            ),
+            "daily_deltas": list(cast(list[dict[str, object]], summary["daily_deltas"])),
+        }
+        variant_results.append(result)
+
+    effective_days = min(int(result["effective_days"]) for result in variant_results)
+    insufficient = [
+        result
+        for result in variant_results
+        if result["decision"] == "insufficient_evidence"
+    ]
+    if insufficient:
+        return _base_result(
+            spec=spec,
+            dataset_ref=dataset_ref,
+            sealed_dataset=sealed_dataset,
+            effective_days=effective_days,
+            selection="insufficient_evidence",
+            leader_variant_id=None,
+            reason_codes=_unique(
+                [
+                    reason
+                    for result in insufficient
+                    for reason in cast(list[str], result["reason_codes"])
+                ]
+            ),
+            reason_details=[],
+            variant_results=variant_results,
+            missing_receipts=[],
+        )
+
+    passing = [result for result in variant_results if result["decision"] == "pass"]
+    if not passing:
+        return _base_result(
+            spec=spec,
+            dataset_ref=dataset_ref,
+            sealed_dataset=sealed_dataset,
+            effective_days=effective_days,
+            selection="no_research_winner",
+            leader_variant_id=None,
+            reason_codes=["no_research_winner"],
+            reason_details=[],
+            variant_results=variant_results,
+            missing_receipts=[],
+        )
+
+    def leader_key(result: Mapping[str, object]) -> tuple[float, float, float, str]:
+        return (
+            -float(cast(float, result["mean_daily_delta"])),
+            -float(cast(float, result["one_sided_lower_bound"])),
+            -float(cast(float, result["worst_tail_mean"])),
+            str(result["variant_id"]),
+        )
+
+    leader = min(passing, key=leader_key)
+    return _base_result(
+        spec=spec,
+        dataset_ref=dataset_ref,
+        sealed_dataset=sealed_dataset,
+        effective_days=effective_days,
+        selection="research_leader",
+        leader_variant_id=str(leader["variant_id"]),
+        reason_codes=list(cast(list[str], leader["reason_codes"])),
+        reason_details=[],
+        variant_results=variant_results,
+        missing_receipts=[],
+    )
+
+
+__all__ = [
+    "RESEARCH_CLOSE_RECEIPT_SCHEMA",
+    "RESEARCH_EVALUATION_INPUT_SCHEMA",
+    "RESEARCH_EVALUATION_SCHEMA",
+    "ResearchEvaluationError",
+    "evaluate_research",
+]

--- a/tests/test_strategy_lab_top1_architecture.py
+++ b/tests/test_strategy_lab_top1_architecture.py
@@ -9,6 +9,7 @@ RANKING_MODULE = ROOT / "src/application/strategy_lab/top1/ranking.py"
 CONTRACTS_MODULE = ROOT / "src/application/strategy_lab/top1/contracts.py"
 ECONOMICS_MODULE = ROOT / "src/application/strategy_lab/top1/economics.py"
 STATISTICS_MODULE = ROOT / "src/application/strategy_lab/top1/statistics.py"
+RESEARCH_MODULE = ROOT / "src/application/strategy_lab/top1/research.py"
 RECOMMENDATION_POINT_MODULE = ROOT / "src/application/recommendation_point.py"
 CANDIDATE_ENGINE = ROOT / "domain/domain/engine/candidate_engine.py"
 EXPERIMENT_STORE_MODULE = (
@@ -91,6 +92,23 @@ def test_top1_core_imports_only_approved_pure_owners() -> None:
         "datetime",
         "typing",
         "scipy.stats",
+    }
+    assert _imports(RESEARCH_MODULE) <= {
+        "__future__",
+        "hashlib",
+        "math",
+        "re",
+        "collections.abc",
+        "datetime",
+        "typing",
+        "domain.domain.decision_state_fingerprint",
+        "domain.domain.fee_calc",
+        "src.application.shadow_replay.common",
+        "src.application.strategy_lab.top1.contracts",
+        "src.application.strategy_lab.top1.corpus",
+        "src.application.strategy_lab.top1.economics",
+        "src.application.strategy_lab.top1.ranking",
+        "src.application.strategy_lab.top1.statistics",
     }
 
 
@@ -185,4 +203,5 @@ def test_production_tick_does_not_depend_on_top1_experiment_store() -> None:
         imports = _imports(path)
         assert "src.application.strategy_lab.top1.lifecycle" not in imports
         assert "src.application.strategy_lab.top1.corpus" not in imports
+        assert "src.application.strategy_lab.top1.research" not in imports
         assert "src.infrastructure.strategy_lab.experiment_store" not in imports

--- a/tests/test_strategy_lab_top1_research.py
+++ b/tests/test_strategy_lab_top1_research.py
@@ -1,0 +1,1054 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from copy import deepcopy
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.engine import SELL_PUT_RANKING_CONTRACT_VERSION
+from domain.domain.fee_calc import FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
+from src.application.opening_candidate_snapshot import (
+    OPENING_CANDIDATE_SNAPSHOT_FILE,
+    OPENING_CANDIDATE_SNAPSHOT_SCHEMA,
+    load_opening_candidate_snapshot,
+)
+from src.application.recommendation_point import (
+    RECOMMENDATION_POINT_FILE,
+    capture_scheduled_recommendation_point,
+)
+from src.application.shadow_replay.common import (
+    attach_artifact_provenance,
+    render_json_text,
+)
+from src.application.strategy_lab.top1 import research as research_module
+from src.application.strategy_lab.top1.contracts import (
+    ACCEPTED_SET_CONTRACT_VERSION,
+    EXPERIMENT_SPEC_SCHEMA_VERSION,
+    EXPIRY_OUTCOME_CONTRACT_VERSION,
+    RESEARCH_METRIC_CONTRACT_VERSION,
+    RESEARCH_SELECTION_CONTRACT_VERSION,
+    VALIDATION_FILL_CONTRACT_VERSION,
+    VALIDATION_METRIC_CONTRACT_VERSION,
+    build_behavior_binding,
+)
+from src.application.strategy_lab.top1.corpus import (
+    RESEARCH_WINDOW_FACTS_SCHEMA,
+    capture_recommendation_point,
+    freeze_research_dataset,
+    seal_day_expectation,
+)
+from src.application.strategy_lab.top1.lifecycle import (
+    Top1LifecycleError,
+    authorize_research,
+    lock_challenger,
+    prepare_experiment,
+    seal_generation,
+    set_account_opt_in,
+    start_research,
+    start_validation,
+)
+from src.application.strategy_lab.top1.ranking import (
+    RANKING_PROJECTION_ARTIFACT_KIND,
+    RANKING_PROJECTION_SCHEMA_VERSION,
+    build_ranking_projection,
+)
+from src.application.strategy_lab.top1.research import (
+    RESEARCH_CLOSE_RECEIPT_SCHEMA,
+    RESEARCH_EVALUATION_INPUT_SCHEMA,
+    RESEARCH_EVALUATION_SCHEMA,
+    ResearchEvaluationError,
+    evaluate_research,
+)
+from src.application.strategy_lab.top1.terminal_projection import (
+    recover_terminal_projection,
+)
+from src.infrastructure.strategy_lab.experiment_store import ExperimentStore
+from tests.candidate_evidence_helpers import seal_opening_candidate_fixture
+
+
+AVAILABLE = {"OM_STRATEGY_LAB_TOP1_AVAILABLE": "1"}
+CALENDAR = "hk-calendar.fixture.v1"
+CALENDAR_SHA = "a" * 64
+SOURCE_SHA = "c" * 40
+EXPIRATION = "2026-09-18"
+TOP_LEVEL_KEYS = {
+    "schema_version",
+    "experiment_id",
+    "research_spec_sha256",
+    "dataset_ref",
+    "dataset_sha256",
+    "dataset_content_sha256",
+    "required_days",
+    "effective_days",
+    "research_fill_assumption",
+    "research_is_counterfactual",
+    "contract_terms_revalidated",
+    "selection",
+    "leader_variant_id",
+    "reason_codes",
+    "reason_details",
+    "variant_results",
+    "missing_receipts",
+}
+VARIANT_KEYS = {
+    "variant_id",
+    "ranking_profile",
+    "decision",
+    "reason_codes",
+    "required_days",
+    "effective_days",
+    "mean_daily_delta",
+    "sample_std",
+    "standard_error",
+    "t_critical",
+    "one_sided_lower_bound",
+    "worst_k",
+    "worst_tail_mean",
+    "serial_correlation_unadjusted",
+    "top1_change_count",
+    "daily_deltas",
+}
+
+
+def _trading_days(start: str, count: int) -> list[str]:
+    current = date.fromisoformat(start)
+    days: list[str] = []
+    while len(days) < count:
+        if current.weekday() < 5:
+            days.append(current.isoformat())
+        current += timedelta(days=1)
+    return days
+
+
+def _candidate(
+    symbol: str,
+    *,
+    period_return: float,
+    concentration: float,
+    discount: float,
+    premium: float,
+    cash_basis: float,
+    currency: str = "HKD",
+) -> dict[str, Any]:
+    code = symbol.removesuffix(".HK")
+    return {
+        "symbol": symbol,
+        "contract_symbol": f"{code}260918P00400000",
+        "expiration": EXPIRATION,
+        "option_type": "put",
+        "stock_owner": f"HK.{code}",
+        "strike": 400.0,
+        "spot": 450.0,
+        "dte": 70,
+        "bid": premium / 100,
+        "ask": premium / 100,
+        "mid": premium / 100,
+        "sell_limit": premium / 100,
+        "multiplier": 100,
+        "currency": currency,
+        "open_interest": 500,
+        "volume": 50,
+        "spread_ratio": 0.10,
+        "period_net_return_on_cash_basis": period_return,
+        "annualized_net_return_on_cash_basis": period_return * 365 / 70,
+        "net_assignment_discount_pct": discount,
+        "symbol_concentration_after": concentration,
+        "net_income": premium,
+        "net_premium": premium,
+        "net_cash_basis": cash_basis,
+        "net_income_cny": premium,
+        "fee_schedule_version": "fixture.v1",
+        "fee_basis": "fixture",
+        "fee_schedule_url": "https://example.test/fees",
+    }
+
+
+def _candidates(*, boosted: bool = False) -> list[dict[str, Any]]:
+    return [
+        _candidate(
+            "0700.HK",
+            period_return=0.020,
+            concentration=0.30,
+            discount=0.10,
+            premium=1500.0,
+            cash_basis=38_500.0,
+        ),
+        _candidate(
+            "3690.HK",
+            period_return=0.019,
+            concentration=0.50,
+            discount=0.20,
+            premium=1800.0,
+            cash_basis=38_200.0,
+        ),
+        _candidate(
+            "9988.HK",
+            period_return=0.015,
+            concentration=0.10,
+            discount=0.05,
+            premium=3200.0 if boosted else 3000.0,
+            cash_basis=37_000.0,
+        ),
+    ]
+
+
+def _base_projection(
+    root: Path, *, run_id: str, candidates: list[dict[str, Any]]
+) -> dict[str, Any]:
+    seal_opening_candidate_fixture(
+        root,
+        run_id=run_id,
+        market="HK",
+        accepted_rows=candidates,
+    )
+    snapshot = load_opening_candidate_snapshot(
+        base=root,
+        run_id=run_id,
+        account="lx",
+        require_current_contract=True,
+    )
+    return build_ranking_projection(
+        snapshot,
+        point_binding={
+            "recommendation_point_id": canonical_sha256({"run_id": run_id}),
+            "market": "HK",
+            "account": "lx",
+            "run_id": run_id,
+            "opening_snapshot_ref": (
+                f"output_runs/{run_id}/accounts/lx/state/"
+                f"{OPENING_CANDIDATE_SNAPSHOT_FILE}"
+            ),
+            "opening_snapshot_sha256": snapshot["content_sha256"],
+            "decision_at_utc": "2026-06-08T02:00:00Z",
+            "source_commit_sha": SOURCE_SHA,
+        },
+    )
+
+
+def _rebind_projection(
+    template: dict[str, Any], *, trading_date: str, sequence: int
+) -> dict[str, Any]:
+    projection = deepcopy(template)
+    source = deepcopy(projection.pop("artifact_provenance")["source_generation"])
+    projection["recommendation_point_id"] = canonical_sha256(
+        {"trading_date": trading_date, "sequence": sequence}
+    )
+    projection["decision_at_utc"] = f"{trading_date}T02:{sequence:02d}:00Z"
+    return attach_artifact_provenance(
+        projection,
+        artifact_kind=RANKING_PROJECTION_ARTIFACT_KIND,
+        source_generation=source,
+    )
+
+
+def _file_sha256(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(render_json_text(payload).encode("utf-8")).hexdigest()
+
+
+def _spec(
+    manifest: dict[str, Any],
+    *,
+    variants: tuple[tuple[str, str], ...],
+    validation: bool = False,
+) -> dict[str, Any]:
+    behavior = {
+        "baseline_version": "sell-put-baseline.v1",
+        "opening_snapshot_schema_version": OPENING_CANDIDATE_SNAPSHOT_SCHEMA,
+        "accepted_set_contract_version": ACCEPTED_SET_CONTRACT_VERSION,
+        "ranking_projection_schema_version": RANKING_PROJECTION_SCHEMA_VERSION,
+        "sell_put_ranking_contract_version": SELL_PUT_RANKING_CONTRACT_VERSION,
+        "research_selection_contract_version": RESEARCH_SELECTION_CONTRACT_VERSION,
+        "research_metric_contract_version": RESEARCH_METRIC_CONTRACT_VERSION,
+        "validation_fill_contract_version": VALIDATION_FILL_CONTRACT_VERSION,
+        "validation_metric_contract_version": VALIDATION_METRIC_CONTRACT_VERSION,
+        "fee_schedule_version": FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION,
+        "market_calendar_version": manifest["market_calendar_version"],
+        "expiry_outcome_contract_version": EXPIRY_OUTCOME_CONTRACT_VERSION,
+    }
+    spec: dict[str, Any] = {
+        "schema_version": EXPERIMENT_SPEC_SCHEMA_VERSION,
+        "topic_id": "topic-concentration",
+        "experiment_id": "experiment-w5-evaluator",
+        "market": "HK",
+        "account": "lx",
+        "hypothesis": {
+            "hypothesis_type": "sell_put_ranking",
+            "statement": "Prefer lower concentration when it improves Top1 efficiency.",
+            "mechanism": "Reorder the same producer-accepted candidate universe.",
+            "independent_variable": "cross_symbol_concentration_priority",
+            "expected_direction": (
+                "higher_top1_efficiency_without_higher_concentration"
+            ),
+        },
+        "baseline": {
+            "version": "sell-put-baseline.v1",
+            "opening_snapshot_schema": OPENING_CANDIDATE_SNAPSHOT_SCHEMA,
+            "accepted_set_contract_version": ACCEPTED_SET_CONTRACT_VERSION,
+            "ranking_projection_schema_version": RANKING_PROJECTION_SCHEMA_VERSION,
+            "sell_put_ranking_contract_version": SELL_PUT_RANKING_CONTRACT_VERSION,
+            "behavior_binding_sha256": build_behavior_binding(behavior),
+        },
+        "research_source": {
+            "mode": "sealed_historical_dataset",
+            "dataset_ref": "strategy_lab/top1/research-w5.json",
+            "dataset_sha256": _file_sha256(manifest),
+            "research_cutoff_at": manifest["cutoff_at_utc"],
+            "start_trading_date": manifest["selected_trading_dates"][0],
+            "end_trading_date": manifest["selected_trading_dates"][-1],
+        },
+        "research_evaluation": {
+            "contract_version": RESEARCH_SELECTION_CONTRACT_VERSION,
+            "metric_contract_version": RESEARCH_METRIC_CONTRACT_VERSION,
+            "fill_assumption": "t0_sell_limit",
+            "required_days": 40,
+            "window_mode": "fixed_consecutive_trading_days",
+            "visibility": "visible_after_research_seal",
+        },
+        "variants": [
+            {"variant_id": "baseline", "patch": {}},
+            *[
+                {"variant_id": variant_id, "patch": {"ranking_profile": profile}}
+                for variant_id, profile in variants
+            ],
+        ],
+        "frozen_safety": {
+            "mode": "inherit_each_point_producer_accepted_set",
+            "variant_may_change_acceptance": False,
+        },
+        "economics_contracts": {
+            "fee_schedule_version": FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION,
+            "market_calendar_version": manifest["market_calendar_version"],
+        },
+        "expiry_outcome": {
+            "contract_version": EXPIRY_OUTCOME_CONTRACT_VERSION,
+            "spot_source": "opend_history_kline",
+            "ktype": "K_DAY",
+            "autype": "NONE",
+            "price_field": "close",
+            "due_boundary": "expiration_observation_start_ms",
+            "pending_elapsed_hours": 72,
+        },
+    }
+    if validation:
+        spec.update(
+            {
+                "validation_evaluation": {
+                    "required_days": 20,
+                    "window_mode": "fixed_future_consecutive_trading_days",
+                    "visibility": "hidden_until_final_seal",
+                },
+                "fill_observation": {
+                    "applies_to": "validation_only",
+                    "contract_version": VALIDATION_FILL_CONTRACT_VERSION,
+                },
+                "timer_binding": {
+                    "revision": "top1-advance.v1",
+                    "producer_catchup_grace_seconds": 30,
+                    "producer_run_timeout_upper_bound_seconds": 120,
+                    "advance_cadence_seconds": 60,
+                    "fill_observation_duration_upper_bound_seconds": 120,
+                    "terms_capture_duration_upper_bound_seconds": 120,
+                },
+                "validation_metrics": {
+                    "contract_version": VALIDATION_METRIC_CONTRACT_VERSION,
+                    "confidence_level": 0.95,
+                    "worst_fraction": 0.20,
+                },
+            }
+        )
+    return spec
+
+
+def _build_case(root: Path) -> dict[str, Any]:
+    days = _trading_days("2026-06-08", 40)
+    standard = _base_projection(root, run_id="run-standard", candidates=_candidates())
+    boosted = _base_projection(
+        root,
+        run_id="run-boosted",
+        candidates=_candidates(boosted=True),
+    )
+    materialized: list[dict[str, Any]] = []
+    dataset_days: list[dict[str, Any]] = []
+    for day_index, trading_date in enumerate(days):
+        projections = [_rebind_projection(standard, trading_date=trading_date, sequence=0)]
+        if day_index == 0:
+            projections.append(
+                _rebind_projection(boosted, trading_date=trading_date, sequence=1)
+            )
+        points: list[dict[str, Any]] = []
+        for projection in projections:
+            point_id = projection["recommendation_point_id"]
+            ref = f"strategy_lab/top1/projections/{point_id}.json"
+            points.append(
+                {
+                    "recommendation_point_id": point_id,
+                    "projection_ref": ref,
+                    "projection_content_sha256": projection["artifact_provenance"][
+                        "content_sha256"
+                    ],
+                    "projection_file_sha256": _file_sha256(projection),
+                }
+            )
+            materialized.append({"projection_ref": ref, "projection": projection})
+        dataset_days.append(
+            {
+                "trading_date": trading_date,
+                "expectation_ref": f"strategy_lab/top1/days/{trading_date}.json",
+                "expectation_content_sha256": canonical_sha256(
+                    {"trading_date": trading_date}
+                ),
+                "expectation_file_sha256": canonical_sha256(
+                    {"trading_date": trading_date, "file": True}
+                ),
+                "points": points,
+            }
+        )
+    manifest: dict[str, Any] = {
+        "schema_version": "sealed_historical_dataset.v1",
+        "market": "HK",
+        "account": "lx",
+        "cutoff_at_utc": "2026-10-01T08:00:00Z",
+        "cutoff_trading_date": "2026-10-01",
+        "required_days": 40,
+        "window_facts_content_sha256": canonical_sha256({"window": days}),
+        "market_calendar_version": CALENDAR,
+        "market_calendar_ref": "evidence/hk-calendar.fixture.json",
+        "market_calendar_sha256": CALENDAR_SHA,
+        "trading_calendar_dates_sha256": canonical_sha256(days),
+        "latest_mature_trading_date": days[-1],
+        "maturity_evidence_ref": "evidence/hk-maturity.fixture.json",
+        "maturity_evidence_sha256": "b" * 64,
+        "recommendation_point_selector": "official_scheduled_sell_put.v1",
+        "ranking_projection_schema_version": RANKING_PROJECTION_SCHEMA_VERSION,
+        "selected_trading_dates": days,
+        "days": dataset_days,
+    }
+    manifest["content_sha256"] = canonical_sha256(manifest)
+    spec = _spec(
+        manifest,
+        variants=(
+            ("without", "without_concentration"),
+            ("concentration", "concentration_first"),
+        ),
+    )
+    return {
+        "schema_version": RESEARCH_EVALUATION_INPUT_SCHEMA,
+        "experiment_spec": spec,
+        "dataset_ref": spec["research_source"]["dataset_ref"],
+        "sealed_dataset": manifest,
+        "ranking_projections": materialized,
+    }
+
+
+@pytest.fixture(scope="module")
+def research_case(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    return _build_case(tmp_path_factory.mktemp("w5-research"))
+
+
+def _fee_contract(*, complete: bool = True) -> dict[str, Any]:
+    return {
+        "market": "HK",
+        "account": "lx",
+        "fee_schedule_version": FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION,
+        "account_fee_plan": (
+            {
+                "commission_free": True,
+                "platform_fee": 0.0,
+                "fee_plan_ref": "fixture://lx/hk-fee-plan",
+            }
+            if complete
+            else {"commission_free": True}
+        ),
+    }
+
+
+def _receipt(
+    owner: str,
+    *,
+    close: float | None = 390.0,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": RESEARCH_CLOSE_RECEIPT_SCHEMA,
+        "market": "HK",
+        "account": "lx",
+        "stock_owner": owner,
+        "expiration": EXPIRATION,
+        "spot_source": "opend_history_kline",
+        "ktype": "K_DAY",
+        "autype": "NONE",
+        "price_field": "close",
+        "status": "available" if close is not None else "unavailable",
+        "underlier_close": close,
+        "reason_detail": reason,
+    }
+
+
+def _receipts() -> list[dict[str, Any]]:
+    return [_receipt(owner) for owner in ("HK.0700", "HK.3690", "HK.9988")]
+
+
+def _refresh_case(case: dict[str, Any]) -> None:
+    manifest = case["sealed_dataset"]
+    manifest["content_sha256"] = canonical_sha256(
+        {key: value for key, value in manifest.items() if key != "content_sha256"}
+    )
+    spec = case["experiment_spec"]
+    spec["research_source"]["dataset_sha256"] = _file_sha256(manifest)
+
+
+def _replace_point_projection(
+    case: dict[str, Any], *, day_index: int, projection: dict[str, Any]
+) -> None:
+    point = case["sealed_dataset"]["days"][day_index]["points"][0]
+    old_ref = point["projection_ref"]
+    projection = _rebind_projection(
+        projection,
+        trading_date=case["sealed_dataset"]["selected_trading_dates"][day_index],
+        sequence=0,
+    )
+    point.update(
+        {
+            "recommendation_point_id": projection["recommendation_point_id"],
+            "projection_content_sha256": projection["artifact_provenance"][
+                "content_sha256"
+            ],
+            "projection_file_sha256": _file_sha256(projection),
+        }
+    )
+    materialized = next(
+        item for item in case["ranking_projections"] if item["projection_ref"] == old_ref
+    )
+    materialized["projection"] = projection
+    _refresh_case(case)
+
+
+def _set_variants(
+    case: dict[str, Any], variants: tuple[tuple[str, str], ...]
+) -> None:
+    case["experiment_spec"]["variants"] = [
+        {"variant_id": "baseline", "patch": {}},
+        *[
+            {"variant_id": variant_id, "patch": {"ranking_profile": profile}}
+            for variant_id, profile in variants
+        ],
+    ]
+
+
+def test_selects_unique_leader_and_aggregates_two_points_by_day(
+    research_case: dict[str, Any],
+) -> None:
+    result = evaluate_research(research_case, _receipts(), _fee_contract())
+
+    assert set(result) == TOP_LEVEL_KEYS
+    assert result["schema_version"] == RESEARCH_EVALUATION_SCHEMA
+    assert result["selection"] == "research_leader"
+    assert result["leader_variant_id"] == "concentration"
+    assert result["effective_days"] == 40
+    assert result["research_fill_assumption"] == "t0_sell_limit"
+    assert result["research_is_counterfactual"] is True
+    assert result["contract_terms_revalidated"] is False
+    variants = {item["variant_id"]: item for item in result["variant_results"]}
+    assert all(set(item) == VARIANT_KEYS for item in variants.values())
+    assert variants["without"]["decision"] == "keep_baseline"
+    assert variants["without"]["reason_codes"] == [
+        "concentration_non_increase_failed"
+    ]
+    assert variants["concentration"]["decision"] == "pass"
+    assert variants["concentration"]["top1_change_count"] == 41
+
+    first_day = variants["concentration"]["daily_deltas"][0]
+    holding_days = (date.fromisoformat(EXPIRATION) - date(2026, 6, 8)).days
+    terminal_fee = 45.08
+    baseline_efficiency = (1500.0 - 1000.0 - terminal_fee) / 38_500.0 / holding_days * 365
+    challenger = (3000.0 - 1000.0 - terminal_fee) / 37_000.0 / holding_days * 365
+    boosted = (3200.0 - 1000.0 - terminal_fee) / 37_000.0 / holding_days * 365
+    assert first_day == {
+        "trading_date": "2026-06-08",
+        "effective_point_count": 2,
+        "daily_delta": pytest.approx(
+            ((challenger - baseline_efficiency) + (boosted - baseline_efficiency))
+            / 2
+        ),
+    }
+    assert result["reason_codes"] == [
+        "positive_one_sided_lcb",
+        "non_negative_worst_tail",
+        "hard_risk_passed",
+    ]
+
+
+def test_same_or_empty_top1_needs_no_close_or_fee_plan(
+    research_case: dict[str, Any],
+) -> None:
+    case = deepcopy(research_case)
+    _set_variants(case, (("same", "current_tie_break"),))
+
+    result = evaluate_research(case, [], _fee_contract(complete=False))
+
+    assert result["selection"] == "no_research_winner"
+    assert result["leader_variant_id"] is None
+    assert result["effective_days"] == 40
+    assert result["reason_codes"] == ["no_research_winner"]
+    assert result["variant_results"][0]["mean_daily_delta"] == 0.0
+
+
+@pytest.mark.parametrize("mode", ["missing", "unavailable", "duplicate"])
+def test_required_close_failures_block_every_variant_and_order_is_stable(
+    research_case: dict[str, Any], mode: str
+) -> None:
+    receipts = _receipts()
+    target = next(item for item in receipts if item["stock_owner"] == "HK.9988")
+    if mode == "missing":
+        receipts.remove(target)
+    elif mode == "unavailable":
+        target.update(
+            {
+                "status": "unavailable",
+                "underlier_close": None,
+                "reason_detail": "expiry_source_unavailable_after_deadline",
+            }
+        )
+    else:
+        receipts.append(deepcopy(target))
+    unused = _receipt("HK.00001")
+    receipts.extend((unused, deepcopy(unused)))
+
+    forward = evaluate_research(research_case, receipts, _fee_contract())
+    reverse = evaluate_research(research_case, list(reversed(receipts)), _fee_contract())
+
+    assert forward == reverse
+    assert forward["selection"] == "insufficient_evidence"
+    assert forward["leader_variant_id"] is None
+    assert forward["effective_days"] is None
+    assert forward["variant_results"] == []
+    assert [item["stock_owner"] for item in forward["missing_receipts"]] == [
+        "HK.9988"
+    ]
+    expected = {
+        "missing": (
+            "research_expiry_close_missing",
+            "expiry_close_missing_after_deadline",
+        ),
+        "unavailable": (
+            "required_outcome_missing",
+            "expiry_source_unavailable_after_deadline",
+        ),
+        "duplicate": (
+            "required_outcome_missing",
+            "expiry_close_receipt_conflict",
+        ),
+    }[mode]
+    assert forward["reason_codes"] == [expected[0]]
+    assert forward["reason_details"] == [expected[1]]
+
+
+def test_incomplete_assignment_fee_and_short_window_fail_closed(
+    research_case: dict[str, Any],
+) -> None:
+    fee_result = evaluate_research(research_case, _receipts(), _fee_contract(complete=False))
+    assert fee_result["selection"] == "insufficient_evidence"
+    assert fee_result["reason_codes"] == ["required_outcome_missing"]
+    assert fee_result["reason_details"] == ["expiry_fee_unavailable"]
+
+    missing_plan = _fee_contract()
+    missing_plan["account_fee_plan"] = None
+    missing_plan_result = evaluate_research(research_case, _receipts(), missing_plan)
+    assert missing_plan_result["selection"] == "insufficient_evidence"
+    assert missing_plan_result["reason_codes"] == ["required_outcome_missing"]
+    assert missing_plan_result["reason_details"] == ["expiry_fee_unavailable"]
+
+    short = deepcopy(research_case)
+    _set_variants(short, (("same", "current_tie_break"),))
+    empty = deepcopy(short["ranking_projections"][0]["projection"])
+    source = deepcopy(empty.pop("artifact_provenance")["source_generation"])
+    empty["producer_accepted_candidate_ids"] = []
+    empty["candidates"] = []
+    attach_artifact_provenance(
+        empty,
+        artifact_kind=RANKING_PROJECTION_ARTIFACT_KIND,
+        source_generation=source,
+    )
+    _replace_point_projection(
+        short,
+        day_index=1,
+        projection=empty,
+    )
+    short_result = evaluate_research(short, [], _fee_contract(complete=False))
+    assert short_result["selection"] == "insufficient_evidence"
+    assert short_result["effective_days"] == 39
+    assert short_result["reason_codes"] == ["effective_days_below_required"]
+
+
+def test_currency_and_materialization_tampering_fail_closed(
+    research_case: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    currency = deepcopy(research_case)
+    projection = currency["ranking_projections"][0]["projection"]
+    source = deepcopy(projection.pop("artifact_provenance")["source_generation"])
+    next(
+        row for row in projection["candidates"] if row["stock_owner"] == "HK.9988"
+    )["currency"] = "USD"
+    attach_artifact_provenance(
+        projection,
+        artifact_kind=RANKING_PROJECTION_ARTIFACT_KIND,
+        source_generation=source,
+    )
+    point = currency["sealed_dataset"]["days"][0]["points"][0]
+    point["projection_content_sha256"] = projection["artifact_provenance"][
+        "content_sha256"
+    ]
+    point["projection_file_sha256"] = _file_sha256(projection)
+    _refresh_case(currency)
+    monkeypatch.setattr(
+        research_module,
+        "calculate_expiry_efficiency",
+        lambda _facts: pytest.fail("cross-currency candidate reached economics"),
+    )
+    result = evaluate_research(currency, _receipts(), _fee_contract())
+    assert result["selection"] == "insufficient_evidence"
+    assert result["reason_codes"] == ["ranking_projection_incomplete"]
+    assert result["reason_details"] == ["candidate_currency_mismatch"]
+
+    corpus = deepcopy(research_case)
+    corpus["sealed_dataset"]["cutoff_trading_date"] = "2026-09-30"
+    with pytest.raises(ResearchEvaluationError) as exc_info:
+        evaluate_research(corpus, _receipts(), _fee_contract())
+    assert exc_info.value.reason_code == "research_corpus_conflict"
+
+
+def test_baseline_parity_tampering_is_rejected(
+    research_case: dict[str, Any],
+) -> None:
+    case = deepcopy(research_case)
+    projection = case["ranking_projections"][0]["projection"]
+    source = deepcopy(projection.pop("artifact_provenance")["source_generation"])
+    projection["candidates"][0], projection["candidates"][1] = (
+        projection["candidates"][1],
+        projection["candidates"][0],
+    )
+    for rank, row in enumerate(projection["candidates"], start=1):
+        row["producer_rank"] = rank
+    projection["producer_accepted_candidate_ids"] = [
+        row["candidate_id"] for row in projection["candidates"]
+    ]
+    attach_artifact_provenance(
+        projection,
+        artifact_kind=RANKING_PROJECTION_ARTIFACT_KIND,
+        source_generation=source,
+    )
+    point = case["sealed_dataset"]["days"][0]["points"][0]
+    point["projection_content_sha256"] = projection["artifact_provenance"][
+        "content_sha256"
+    ]
+    point["projection_file_sha256"] = _file_sha256(projection)
+    _refresh_case(case)
+
+    with pytest.raises(ResearchEvaluationError) as exc_info:
+        evaluate_research(case, _receipts(), _fee_contract())
+    assert exc_info.value.reason_code == "baseline_rank_parity_mismatch"
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "expected"),
+    [
+        ((2.0, 1.0, 1.0), (1.0, 9.0, 9.0), "zeta"),
+        ((2.0, 2.0, 1.0), (2.0, 1.0, 9.0), "zeta"),
+        ((2.0, 2.0, 2.0), (2.0, 2.0, 1.0), "zeta"),
+        ((2.0, 2.0, 2.0), (2.0, 2.0, 2.0), "alpha"),
+    ],
+)
+def test_passing_leader_uses_every_deterministic_tie_break(
+    research_case: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    first: tuple[float, float, float],
+    second: tuple[float, float, float],
+    expected: str,
+) -> None:
+    case = deepcopy(research_case)
+    _set_variants(
+        case,
+        (
+            ("zeta", "without_concentration"),
+            ("alpha", "concentration_first"),
+        ),
+    )
+    values = iter((first, second))
+
+    def fake_summary(_rows: object, _policy: object) -> dict[str, Any]:
+        mean, lower, tail = next(values)
+        return {
+            "decision": "pass",
+            "reason_codes": [
+                "positive_one_sided_lcb",
+                "non_negative_worst_tail",
+                "hard_risk_passed",
+            ],
+            "required_days": 40,
+            "effective_days": 40,
+            "point_results": [],
+            "daily_deltas": [],
+            "mean_daily_delta": mean,
+            "sample_std": 0.0,
+            "standard_error": 0.0,
+            "t_critical": 1.0,
+            "one_sided_lower_bound": lower,
+            "worst_k": 8,
+            "worst_tail_mean": tail,
+            "serial_correlation_unadjusted": True,
+        }
+
+    monkeypatch.setattr(research_module, "summarize_paired_daily_deltas", fake_summary)
+    result = evaluate_research(case, _receipts(), _fee_contract())
+    assert result["leader_variant_id"] == expected
+
+
+def _store(path: Path) -> ExperimentStore:
+    store = ExperimentStore(path)
+    store.migrate(migrated_at_utc="2026-08-15T03:00:00Z")
+    return store
+
+
+def _enable(store: ExperimentStore, root: Path, *, key: str) -> None:
+    set_account_opt_in(
+        store,
+        market="HK",
+        account="lx",
+        enabled=True,
+        actor="human",
+        occurred_at_utc="2026-08-15T03:00:00Z",
+        idempotency_key=key,
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+
+
+def test_evaluator_leader_crosses_existing_m3_human_authorization_gate(
+    tmp_path: Path, research_case: dict[str, Any]
+) -> None:
+    evaluation = evaluate_research(research_case, _receipts(), _fee_contract())
+    leader = evaluation["leader_variant_id"]
+    assert leader == "concentration"
+    store = _store(tmp_path / "lab.sqlite3")
+    _enable(store, tmp_path, key="enable-m3-seam")
+    spec = research_case["experiment_spec"]
+    prepared = prepare_experiment(
+        store,
+        spec,
+        provenance={"source_commit_sha": SOURCE_SHA},
+        actor="human",
+        occurred_at_utc="2026-08-15T03:01:00Z",
+        idempotency_key="prepare-m3-seam",
+        artifact_root=tmp_path,
+        environ=AVAILABLE,
+    )
+    authorize_research(
+        store,
+        experiment_id=spec["experiment_id"],
+        research_spec_sha256=prepared["research_spec_sha256"],
+        actor="human",
+        occurred_at_utc="2026-08-15T03:02:00Z",
+        idempotency_key="authorize-research-m3-seam",
+        artifact_root=tmp_path,
+        environ=AVAILABLE,
+    )
+    start_research(
+        store,
+        experiment_id=spec["experiment_id"],
+        research_spec_sha256=prepared["research_spec_sha256"],
+        actor="human",
+        occurred_at_utc="2026-08-15T03:03:00Z",
+        idempotency_key="start-research-m3-seam",
+        artifact_root=tmp_path,
+        environ=AVAILABLE,
+    )
+    seal_generation(
+        store,
+        experiment_id=spec["experiment_id"],
+        generation_kind="research",
+        actor="runner",
+        occurred_at_utc="2026-08-15T03:04:00Z",
+        idempotency_key="seal-research-m3-seam",
+        artifact_root=tmp_path,
+        environ=AVAILABLE,
+    )
+    recover_terminal_projection(store, tmp_path)
+    terminal_sha = store.generations(spec["experiment_id"])[0]["terminal_file_sha256"]
+    validation_spec = _spec(
+        research_case["sealed_dataset"],
+        variants=(
+            ("without", "without_concentration"),
+            ("concentration", "concentration_first"),
+        ),
+        validation=True,
+    )
+    hidden_days = _trading_days("2026-08-04", 20)
+    with pytest.raises(Top1LifecycleError, match="system leader"):
+        lock_challenger(
+            store,
+            validation_spec,
+            system_leader=str(leader),
+            challenger_variant_id="without",
+            research_receipt_ref="strategy_lab/top1/research-receipt.json",
+            research_receipt_file_sha256=str(terminal_sha),
+            trading_dates=hidden_days,
+            actor="human",
+            occurred_at_utc="2026-08-15T03:05:00Z",
+            idempotency_key="wrong-leader-m3-seam",
+            artifact_root=tmp_path,
+            environ=AVAILABLE,
+        )
+    locked = lock_challenger(
+        store,
+        validation_spec,
+        system_leader=str(leader),
+        challenger_variant_id=str(leader),
+        research_receipt_ref="strategy_lab/top1/research-receipt.json",
+        research_receipt_file_sha256=str(terminal_sha),
+        trading_dates=hidden_days,
+        actor="human",
+        occurred_at_utc="2026-08-15T03:06:00Z",
+        idempotency_key="lock-leader-m3-seam",
+        artifact_root=tmp_path,
+        environ=AVAILABLE,
+    )
+    assert locked["validation_authorization_status"] == "unconfirmed"
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        start_validation(
+            store,
+            experiment_id=spec["experiment_id"],
+            validation_spec_sha256=str(locked["validation_spec_sha256"]),
+            actor="runner",
+            occurred_at_utc="2026-08-15T03:07:00Z",
+            idempotency_key="start-without-human-authorization",
+            artifact_root=tmp_path,
+            environ=AVAILABLE,
+        )
+    assert exc_info.value.reason_code == "authorization_required"
+
+
+def _schedule() -> dict[str, Any]:
+    return {
+        "enabled": True,
+        "timezone": "Asia/Hong_Kong",
+        "run_window": {"start": "09:50", "end": "10:10"},
+        "run_points": {"start_plus_min": 10},
+    }
+
+
+def _scheduler(day: str) -> dict[str, Any]:
+    target = datetime.fromisoformat(f"{day}T10:00:00+08:00")
+    now_utc = target.astimezone(timezone.utc) + timedelta(seconds=30)
+    return {
+        "should_run_scan": True,
+        "scheduled_scan_target_market": target.isoformat(),
+        "now_utc": now_utc.isoformat().replace("+00:00", "Z"),
+    }
+
+
+def test_accepts_real_w4_manifest_after_source_run_deletion(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    artifact_root = tmp_path / "artifacts"
+    store = _store(tmp_path / "w4.sqlite3")
+    _enable(store, artifact_root, key="enable-w4-seam")
+    days = _trading_days("2026-06-08", 40)
+    for index, trading_date in enumerate(days):
+        seal_day_expectation(
+            store,
+            artifact_root,
+            market="HK",
+            account="lx",
+            schedule=_schedule(),
+            trading_date=trading_date,
+            market_calendar_version=CALENDAR,
+            market_calendar_sha256=CALENDAR_SHA,
+            sealed_at_utc=f"{trading_date}T01:00:00Z",
+            environ=AVAILABLE,
+        )
+        run_id = f"w4-seam-{index:02d}"
+        seal_opening_candidate_fixture(
+            source_root,
+            run_id=run_id,
+            market="HK",
+            accepted_rows=[],
+        )
+        publication, _point = capture_scheduled_recommendation_point(
+            source_root,
+            run_id,
+            "lx",
+            _scheduler(trading_date),
+            source_commit_sha=SOURCE_SHA,
+        )
+        assert publication == "published"
+        captured = capture_recommendation_point(
+            store,
+            source_root,
+            artifact_root,
+            point_ref=(
+                f"output_runs/{run_id}/accounts/lx/state/{RECOMMENDATION_POINT_FILE}"
+            ),
+            trading_date=trading_date,
+            captured_at_utc=f"{trading_date}T02:01:00Z",
+            environ=AVAILABLE,
+        )
+        assert captured["status"] == "published"
+    facts: dict[str, Any] = {
+        "schema_version": RESEARCH_WINDOW_FACTS_SCHEMA,
+        "market": "HK",
+        "account": "lx",
+        "cutoff_at_utc": f"{days[-1]}T08:00:00Z",
+        "cutoff_trading_date": days[-1],
+        "market_calendar_version": CALENDAR,
+        "market_calendar_ref": "evidence/hk-calendar.fixture.json",
+        "market_calendar_sha256": CALENDAR_SHA,
+        "trading_calendar_dates": days,
+        "trading_calendar_dates_sha256": canonical_sha256(days),
+        "latest_mature_trading_date": days[-1],
+        "maturity_evidence_ref": "evidence/hk-maturity.fixture.json",
+        "maturity_evidence_sha256": "b" * 64,
+        "recommendation_point_selector": "official_scheduled_sell_put.v1",
+    }
+    facts["content_sha256"] = canonical_sha256(facts)
+    frozen = freeze_research_dataset(
+        store,
+        artifact_root,
+        window_facts=facts,
+        environ=AVAILABLE,
+    )
+    assert frozen["status"] == "ready"
+    manifest = json.loads(
+        (artifact_root / str(frozen["dataset_ref"])).read_text(encoding="utf-8")
+    )
+    materialized = [
+        {
+            "projection_ref": point["projection_ref"],
+            "projection": json.loads(
+                (artifact_root / point["projection_ref"]).read_text(encoding="utf-8")
+            ),
+        }
+        for day in manifest["days"]
+        for point in day["points"]
+    ]
+    shutil.rmtree(source_root / "output_runs")
+    spec = _spec(manifest, variants=(("same", "current_tie_break"),))
+    spec["research_source"]["dataset_ref"] = frozen["dataset_ref"]
+    spec["research_source"]["dataset_sha256"] = frozen["dataset_sha256"]
+    envelope = {
+        "schema_version": RESEARCH_EVALUATION_INPUT_SCHEMA,
+        "experiment_spec": spec,
+        "dataset_ref": frozen["dataset_ref"],
+        "sealed_dataset": manifest,
+        "ranking_projections": materialized,
+    }
+
+    result = evaluate_research(envelope, [], _fee_contract(complete=False))
+
+    assert result["selection"] == "insufficient_evidence"
+    assert result["effective_days"] == 0
+    assert result["reason_codes"] == ["effective_days_below_required"]


### PR DESCRIPTION
## Summary

- add the deterministic, side-effect-free W5 research evaluator
- re-rank every authorized variant on the same frozen W4 projection universe and reuse W1B economics/statistics
- fail closed on missing close, currency, fee, materialization, or statistical evidence
- cover real W4 materialization and the existing M3 authorization seam

## Validation

- 55 focused and adjacent tests passed
- Ruff passed
- dependency graph current: 590 production modules, 0 cycles
- slice and aggregate Kimi DeepReviews: zero unresolved findings

## Boundary

This PR completes only the pure evaluator slice. It does not add the provider runner, receipt sealing/publication, storage, CLI/timer/Agent integration, a real 40-day experiment, 20-day hidden validation, release, or deployment.