### PR TITLE
feat(strategy-lab): add Sell Put Top1 W5 research runner

### DIFF
--- a/src/application/strategy_lab/top1/lifecycle.py
+++ b/src/application/strategy_lab/top1/lifecycle.py
@@ -620,10 +620,7 @@ def lock_challenger(
     store: ExperimentStore,
     validation_spec: object,
     *,
-    system_leader: str,
     challenger_variant_id: str,
-    research_receipt_ref: str,
-    research_receipt_file_sha256: str,
     trading_dates: Sequence[object],
     actor: str,
     occurred_at_utc: str,
@@ -631,13 +628,23 @@ def lock_challenger(
     artifact_root: str | Path,
     environ: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
+    # Local imports avoid corpus -> lifecycle -> research -> corpus initialization.
+    from src.application.strategy_lab.top1.research import (
+        ResearchEvaluationError,
+        validate_internal_research_revision,
+    )
+    from src.application.strategy_lab.top1.research_artifacts import (
+        ResearchArtifactError,
+        load_materialized_research_input,
+        load_recorded_research_revision,
+    )
+
     actor, occurred_at_utc, idempotency_key = _command_fields(
         actor, occurred_at_utc, idempotency_key
     )
-    system_leader = _text(system_leader, "system_leader")
     challenger_variant_id = _text(challenger_variant_id, "challenger_variant_id")
-    if system_leader != challenger_variant_id or challenger_variant_id == "baseline":
-        _fail("experiment_invalid", "challenger must equal the non-baseline system leader")
+    if challenger_variant_id == "baseline":
+        _fail("experiment_invalid", "challenger must be non-baseline")
     try:
         spec = validate_experiment_spec(validation_spec)
     except Top1CoreContractError as exc:
@@ -668,8 +675,46 @@ def lock_challenger(
         ),
         None,
     )
-    if research_generation is None or research_generation["terminal_file_sha256"] is None:
+    if (
+        research_generation is None
+        or int(research_generation["revision"]) != 1
+        or research_generation["terminal_file_sha256"] is None
+        or research_generation["terminal_published_event_id"] is None
+    ):
         _fail("invalid_transition", "published research terminal is required")
+    try:
+        research_spec = {
+            key: value
+            for key, value in spec.items()
+            if key
+            not in {
+                "validation_evaluation",
+                "fill_observation",
+                "timer_binding",
+                "validation_metrics",
+            }
+        }
+        dataset = load_materialized_research_input(
+            artifact_root, research_spec
+        )
+        revision = load_recorded_research_revision(
+            artifact_root, research_generation
+        )
+        validated_revision = validate_internal_research_revision(dataset, revision)
+    except (ResearchArtifactError, ResearchEvaluationError) as exc:
+        _fail("experiment_conflict", f"research revision is invalid: {exc}")
+    evaluation = cast(Mapping[str, object], validated_revision["evaluation"])
+    if evaluation["selection"] != "research_leader":
+        _fail("invalid_transition", "research did not select a challenger")
+    if evaluation["leader_variant_id"] != challenger_variant_id:
+        _fail("experiment_invalid", "challenger does not match the research leader")
+    research_receipt_ref = _ref(
+        research_generation["last_revision_ref"], "research_receipt_ref"
+    )
+    research_receipt_file_sha256 = _hash(
+        research_generation["last_revision_file_sha256"],
+        "research_receipt_file_sha256",
+    )
     economics = cast(Mapping[str, object], spec["economics_contracts"])
     baseline = cast(Mapping[str, object], spec["baseline"])
     commitment = build_hidden_window_commitment(
@@ -712,10 +757,8 @@ def lock_challenger(
         research_spec_sha256=research_hash,
         validation_spec_sha256=validation_hash,
         research_leader=challenger_variant_id,
-        research_receipt_ref=_ref(research_receipt_ref, "research_receipt_ref"),
-        research_receipt_file_sha256=_hash(
-            research_receipt_file_sha256, "research_receipt_file_sha256"
-        ),
+        research_receipt_ref=research_receipt_ref,
+        research_receipt_file_sha256=research_receipt_file_sha256,
         commitment_json=compact_json(commitment),
         commitment_sha256=commitment_sha256,
         commitment_ref=commitment_ref,

--- a/src/application/strategy_lab/top1/research.py
+++ b/src/application/strategy_lab/top1/research.py
@@ -528,11 +528,15 @@ def _insufficient_before_statistics(
     )
 
 
-def evaluate_research(
+def _validated_research_input(
     dataset: object,
-    close_receipts: object,
-    fee_contract: object,
-) -> dict[str, object]:
+) -> tuple[
+    dict[str, Any],
+    str,
+    dict[str, object],
+    list[dict[str, str]],
+    dict[str, dict[str, Any]],
+]:
     envelope = _mapping(dataset, "dataset")
     _exact_keys(envelope, _INPUT_KEYS, "dataset")
     if envelope["schema_version"] != RESEARCH_EVALUATION_INPUT_SCHEMA:
@@ -553,10 +557,20 @@ def evaluate_research(
         market=str(spec["market"]),
         account=str(spec["account"]),
     )
-    receipts = _validate_close_receipts(
-        close_receipts, market=str(spec["market"]), account=str(spec["account"])
-    )
-    fee_plan = _validate_fee_contract(fee_contract, spec=spec)
+    return spec, dataset_ref, sealed_dataset, point_rows, projections
+
+
+def _research_selections(
+    *,
+    spec: Mapping[str, object],
+    point_rows: list[dict[str, str]],
+    projections: Mapping[str, Mapping[str, Any]],
+) -> tuple[
+    list[tuple[str, str]],
+    dict[str, list[dict[str, object]]],
+    set[tuple[str, str]],
+    bool,
+]:
 
     variants: list[tuple[str, str]] = []
     for raw_variant in cast(list[object], spec["variants"])[1:]:
@@ -612,6 +626,46 @@ def evaluate_research(
                     "challenger_candidate": challenger_candidate,
                 }
             )
+    return variants, selections, required_close_keys, currency_mismatch
+
+
+def required_research_close_keys(
+    dataset: object,
+    fee_contract: object,
+) -> list[tuple[str, str]]:
+    spec, _dataset_ref, _sealed_dataset, point_rows, projections = (
+        _validated_research_input(dataset)
+    )
+    _ = _validate_fee_contract(fee_contract, spec=spec)
+    _variants, _selections, required_close_keys, currency_mismatch = (
+        _research_selections(
+            spec=spec,
+            point_rows=point_rows,
+            projections=projections,
+        )
+    )
+    return [] if currency_mismatch else sorted(required_close_keys)
+
+
+def evaluate_research(
+    dataset: object,
+    close_receipts: object,
+    fee_contract: object,
+) -> dict[str, object]:
+    spec, dataset_ref, sealed_dataset, point_rows, projections = (
+        _validated_research_input(dataset)
+    )
+    receipts = _validate_close_receipts(
+        close_receipts, market=str(spec["market"]), account=str(spec["account"])
+    )
+    fee_plan = _validate_fee_contract(fee_contract, spec=spec)
+    variants, selections, required_close_keys, currency_mismatch = (
+        _research_selections(
+            spec=spec,
+            point_rows=point_rows,
+            projections=projections,
+        )
+    )
     if currency_mismatch:
         return _insufficient_before_statistics(
             spec=spec,
@@ -835,4 +889,5 @@ __all__ = [
     "RESEARCH_EVALUATION_SCHEMA",
     "ResearchEvaluationError",
     "evaluate_research",
+    "required_research_close_keys",
 ]

--- a/src/application/strategy_lab/top1/research.py
+++ b/src/application/strategy_lab/top1/research.py
@@ -4,7 +4,7 @@ import hashlib
 import math
 import re
 from collections.abc import Mapping
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import Any, NoReturn, cast
 
 from domain.domain.decision_state_fingerprint import canonical_sha256
@@ -34,6 +34,10 @@ from src.application.strategy_lab.top1.statistics import (
 RESEARCH_EVALUATION_INPUT_SCHEMA = "sell_put_top1_research_evaluation_input.v1"
 RESEARCH_CLOSE_RECEIPT_SCHEMA = "sell_put_top1_research_close_receipt.v1"
 RESEARCH_EVALUATION_SCHEMA = "sell_put_top1_research_evaluation.v1"
+INTERNAL_RESEARCH_REVISION_SCHEMA = "sell_put_top1_research_revision.v1"
+INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA = (
+    "sell_put_top1_research_quota_decision.v1"
+)
 
 _HASH_64 = re.compile(r"[0-9a-f]{64}\Z")
 _INPUT_KEYS = frozenset(
@@ -115,6 +119,21 @@ _FEE_KEYS = frozenset(
     {"market", "account", "fee_schedule_version", "account_fee_plan"}
 )
 _FEE_PLAN_KEYS = frozenset({"commission_free", "platform_fee", "fee_plan_ref"})
+_REVISION_KEYS = frozenset(
+    {"schema_version", "evaluation", "fee_contract", "history_kline_evidence"}
+)
+_HISTORY_EVIDENCE_KEYS = frozenset(
+    {"observed_at_utc", "page_complete", "quota_decision", "close_receipts"}
+)
+_QUOTA_DECISION_KEYS = frozenset(
+    {
+        "schema_version",
+        "required_stock_owners",
+        "already_counted_stock_owners",
+        "new_stock_owners",
+        "remain_quota",
+    }
+)
 _STAT_FIELDS = (
     "required_days",
     "effective_days",
@@ -880,6 +899,197 @@ def evaluate_research(
         reason_details=[],
         variant_results=variant_results,
         missing_receipts=[],
+    )
+
+
+def _utc_timestamp(value: object, label: str) -> str:
+    text = _text(value, label)
+    if not text.endswith("Z") or "T" not in text:
+        _fail("research_revision_conflict", f"{label} must be an ISO-8601 UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(f"{text[:-1]}+00:00")
+    except ValueError as exc:
+        raise ResearchEvaluationError(
+            "research_revision_conflict",
+            f"{label} must be an ISO-8601 UTC timestamp",
+        ) from exc
+    if parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        _fail("research_revision_conflict", f"{label} must be UTC")
+    return text
+
+
+def _normalized_fee_contract(
+    value: object, *, spec: Mapping[str, object]
+) -> dict[str, object]:
+    item = _mapping(value, "research_revision.fee_contract")
+    plan = _validate_fee_contract(item, spec=spec)
+    return {
+        "market": spec["market"],
+        "account": spec["account"],
+        "fee_schedule_version": item["fee_schedule_version"],
+        "account_fee_plan": dict(plan) if plan is not None else None,
+    }
+
+
+def _sorted_owner_list(value: object, label: str) -> list[str]:
+    if not isinstance(value, list):
+        _fail("research_revision_conflict", f"{label} must be a list")
+    owners = [_text(item, label) for item in cast(list[object], value)]
+    if owners != sorted(set(owners)):
+        _fail("research_revision_conflict", f"{label} must be sorted and unique")
+    return owners
+
+
+def _validated_quota_decision(
+    value: object,
+    *,
+    required_owners: list[str],
+) -> dict[str, object]:
+    item = _mapping(value, "research_revision.quota_decision")
+    _exact_keys(
+        item,
+        _QUOTA_DECISION_KEYS,
+        "research_revision.quota_decision",
+        reason_code="research_revision_conflict",
+    )
+    if item["schema_version"] != INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA:
+        _fail("research_revision_conflict", "quota decision schema is unsupported")
+    required = _sorted_owner_list(
+        item["required_stock_owners"], "quota_decision.required_stock_owners"
+    )
+    counted = _sorted_owner_list(
+        item["already_counted_stock_owners"],
+        "quota_decision.already_counted_stock_owners",
+    )
+    new = _sorted_owner_list(
+        item["new_stock_owners"], "quota_decision.new_stock_owners"
+    )
+    remaining = item["remain_quota"]
+    if isinstance(remaining, bool) or not isinstance(remaining, int) or remaining < 0:
+        _fail("research_revision_conflict", "quota decision remaining value is invalid")
+    if (
+        required != required_owners
+        or set(counted) & set(new)
+        or sorted([*counted, *new]) != required
+        or len(new) > remaining
+    ):
+        _fail("research_revision_conflict", "quota decision does not cover requirements")
+    return {
+        "schema_version": INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
+        "required_stock_owners": required,
+        "already_counted_stock_owners": counted,
+        "new_stock_owners": new,
+        "remain_quota": remaining,
+    }
+
+
+def validate_internal_research_revision(
+    dataset: object,
+    value: object,
+) -> dict[str, object]:
+    spec, _dataset_ref, _sealed_dataset, _point_rows, _projections = (
+        _validated_research_input(dataset)
+    )
+    revision = _mapping(value, "research_revision")
+    _exact_keys(
+        revision,
+        _REVISION_KEYS,
+        "research_revision",
+        reason_code="research_revision_conflict",
+    )
+    if revision["schema_version"] != INTERNAL_RESEARCH_REVISION_SCHEMA:
+        _fail("research_revision_conflict", "research revision schema is unsupported")
+
+    fee_contract = _normalized_fee_contract(revision["fee_contract"], spec=spec)
+    requirements = required_research_close_keys(dataset, fee_contract)
+    required_owners = sorted({owner for owner, _expiration in requirements})
+    history = revision["history_kline_evidence"]
+    close_receipts: list[dict[str, object]] = []
+    normalized_history: dict[str, object] | None = None
+    if requirements:
+        history_item = _mapping(history, "research_revision.history_kline_evidence")
+        _exact_keys(
+            history_item,
+            _HISTORY_EVIDENCE_KEYS,
+            "research_revision.history_kline_evidence",
+            reason_code="research_revision_conflict",
+        )
+        if history_item["page_complete"] is not True:
+            _fail("research_revision_conflict", "history pages are incomplete")
+        observed_at_utc = _utc_timestamp(
+            history_item["observed_at_utc"], "history_kline_evidence.observed_at_utc"
+        )
+        quota_decision = _validated_quota_decision(
+            history_item["quota_decision"], required_owners=required_owners
+        )
+        raw_receipts = history_item["close_receipts"]
+        indexed = _validate_close_receipts(
+            raw_receipts,
+            market=str(spec["market"]),
+            account=str(spec["account"]),
+        )
+        if set(indexed) != set(requirements) or any(
+            len(indexed[key]) != 1 for key in requirements
+        ):
+            _fail("research_revision_conflict", "close receipts do not cover requirements")
+        close_receipts = [indexed[key][0] for key in requirements]
+        if raw_receipts != close_receipts:
+            _fail("research_revision_conflict", "close receipts are not canonical")
+        normalized_history = {
+            "observed_at_utc": observed_at_utc,
+            "page_complete": True,
+            "quota_decision": quota_decision,
+            "close_receipts": close_receipts,
+        }
+    elif history is not None:
+        _fail("research_revision_conflict", "history evidence is unexpected")
+
+    evaluation = dict(_mapping(revision["evaluation"], "research_revision.evaluation"))
+    expected_evaluation = evaluate_research(dataset, close_receipts, fee_contract)
+    if evaluation != expected_evaluation:
+        _fail("research_revision_conflict", "research evaluation does not match evidence")
+    normalized = {
+        "schema_version": INTERNAL_RESEARCH_REVISION_SCHEMA,
+        "evaluation": evaluation,
+        "fee_contract": fee_contract,
+        "history_kline_evidence": normalized_history,
+    }
+    if dict(revision) != normalized:
+        _fail("research_revision_conflict", "research revision is not canonical")
+    return normalized
+
+
+def build_internal_research_revision(
+    dataset: object,
+    *,
+    evaluation: object,
+    fee_contract: object,
+    close_receipts: list[dict[str, object]],
+    quota_decision: object,
+    observed_at_utc: str,
+) -> dict[str, object]:
+    spec, _dataset_ref, _sealed_dataset, _point_rows, _projections = (
+        _validated_research_input(dataset)
+    )
+    normalized_fee = _normalized_fee_contract(fee_contract, spec=spec)
+    history = (
+        {
+            "observed_at_utc": observed_at_utc,
+            "page_complete": True,
+            "quota_decision": quota_decision,
+            "close_receipts": close_receipts,
+        }
+        if close_receipts
+        else None
+    )
+    return validate_internal_research_revision(
+        dataset,
+        {
+            "schema_version": INTERNAL_RESEARCH_REVISION_SCHEMA,
+            "evaluation": evaluation,
+            "fee_contract": normalized_fee,
+            "history_kline_evidence": history,
+        },
     )
 
 

--- a/src/application/strategy_lab/top1/research_artifacts.py
+++ b/src/application/strategy_lab/top1/research_artifacts.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+from src.application.shadow_replay.common import render_json_text
+from src.application.strategy_lab.top1.research import (
+    RESEARCH_EVALUATION_INPUT_SCHEMA,
+)
+from src.infrastructure.private_storage import open_private_text, private_path
+
+
+_HASH_64 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class ResearchArtifactError(RuntimeError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise ResearchArtifactError(reason_code, message)
+
+
+def _safe_ref(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("research_artifact_invalid", f"{label} must be canonical text")
+    parts = value.split("/")
+    if value.startswith("/") or "\\" in value or any(
+        part in {"", ".", ".."} for part in parts
+    ):
+        _fail("research_artifact_invalid", f"{label} must be a safe relative ref")
+    return value
+
+
+def _hash(value: object, label: str) -> str:
+    if not isinstance(value, str) or _HASH_64.fullmatch(value) is None:
+        _fail("research_artifact_invalid", f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def _read_canonical_json(
+    artifact_root: str | Path,
+    *,
+    ref: object,
+    expected_file_sha256: object,
+    label: str,
+) -> dict[str, Any]:
+    relative_ref = _safe_ref(ref, f"{label}.ref")
+    expected_hash = _hash(expected_file_sha256, f"{label}.file_sha256")
+    path = private_path(artifact_root).joinpath(*relative_ref.split("/"))
+    try:
+        with open_private_text(path) as handle:
+            text = handle.read()
+        content = text.encode("utf-8")
+        payload = json.loads(text)
+        canonical_text = render_json_text(payload) if isinstance(payload, dict) else None
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise ResearchArtifactError(
+            "research_artifact_invalid", f"{label} artifact cannot be read"
+        ) from exc
+    if hashlib.sha256(content).hexdigest() != expected_hash:
+        _fail("research_artifact_invalid", f"{label} file hash changed")
+    if canonical_text != text:
+        _fail("research_artifact_invalid", f"{label} bytes are not canonical JSON")
+    return cast(dict[str, Any], payload)
+
+
+def load_materialized_research_input(
+    artifact_root: str | Path,
+    spec: Mapping[str, Any],
+) -> dict[str, object]:
+    source = spec.get("research_source")
+    if not isinstance(source, Mapping):
+        _fail("research_artifact_invalid", "research source is invalid")
+    sealed_dataset = _read_canonical_json(
+        artifact_root,
+        ref=source.get("dataset_ref"),
+        expected_file_sha256=source.get("dataset_sha256"),
+        label="sealed_dataset",
+    )
+    raw_days = sealed_dataset.get("days")
+    if not isinstance(raw_days, list):
+        _fail("research_artifact_invalid", "sealed dataset days must be a list")
+    projections: list[dict[str, object]] = []
+    for raw_day in raw_days:
+        if not isinstance(raw_day, Mapping) or not isinstance(
+            raw_day.get("points"), list
+        ):
+            _fail("research_artifact_invalid", "sealed dataset point index is invalid")
+        for raw_point in cast(list[object], raw_day["points"]):
+            if not isinstance(raw_point, Mapping):
+                _fail("research_artifact_invalid", "sealed dataset point is invalid")
+            ref = raw_point.get("projection_ref")
+            projections.append(
+                {
+                    "projection_ref": ref,
+                    "projection": _read_canonical_json(
+                        artifact_root,
+                        ref=ref,
+                        expected_file_sha256=raw_point.get(
+                            "projection_file_sha256"
+                        ),
+                        label="ranking_projection",
+                    ),
+                }
+            )
+    return {
+        "schema_version": RESEARCH_EVALUATION_INPUT_SCHEMA,
+        "experiment_spec": dict(spec),
+        "dataset_ref": source.get("dataset_ref"),
+        "sealed_dataset": sealed_dataset,
+        "ranking_projections": projections,
+    }
+
+
+def load_recorded_research_revision(
+    artifact_root: str | Path,
+    generation: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _read_canonical_json(
+        artifact_root,
+        ref=generation.get("last_revision_ref"),
+        expected_file_sha256=generation.get("last_revision_file_sha256"),
+        label="research_revision",
+    )
+
+
+__all__ = [
+    "ResearchArtifactError",
+    "load_materialized_research_input",
+    "load_recorded_research_revision",
+]

--- a/src/application/strategy_lab/top1/research_runner.py
+++ b/src/application/strategy_lab/top1/research_runner.py
@@ -24,19 +24,25 @@ from src.application.strategy_lab.top1.lifecycle import (
     start_research,
 )
 from src.application.strategy_lab.top1.research import (
+    INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
     RESEARCH_CLOSE_RECEIPT_SCHEMA,
-    RESEARCH_EVALUATION_INPUT_SCHEMA,
-    RESEARCH_EVALUATION_SCHEMA,
     ResearchEvaluationError,
+    build_internal_research_revision,
     evaluate_research,
     required_research_close_keys,
+    validate_internal_research_revision,
+)
+from src.application.strategy_lab.top1.research_artifacts import (
+    ResearchArtifactError,
+    load_materialized_research_input,
+    load_recorded_research_revision,
 )
 from src.application.strategy_lab.top1.terminal_projection import (
     publish_exact_text,
     recover_terminal_projection,
 )
 from src.infrastructure.futu_gateway import FutuGateway
-from src.infrastructure.private_storage import open_private_text, private_path
+from src.infrastructure.private_storage import private_path
 from src.infrastructure.strategy_lab.experiment_store import (
     ExperimentStore,
     ExperimentStoreError,
@@ -67,50 +73,12 @@ def _hash(value: object, label: str) -> str:
     return value
 
 
-def _safe_ref(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value or value != value.strip():
-        _fail("research_artifact_invalid", f"{label} must be canonical text")
-    parts = value.split("/")
-    if value.startswith("/") or "\\" in value or any(
-        part in {"", ".", ".."} for part in parts
-    ):
-        _fail("research_artifact_invalid", f"{label} must be a safe relative ref")
-    return value
-
-
 def _file_sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
 def _derived_key(idempotency_key: str, step: str) -> str:
     return hashlib.sha256(f"{idempotency_key}\0{step}".encode("utf-8")).hexdigest()
-
-
-def _read_canonical_json(
-    artifact_root: str | Path,
-    *,
-    ref: object,
-    expected_file_sha256: object,
-    label: str,
-) -> dict[str, Any]:
-    relative_ref = _safe_ref(ref, f"{label}.ref")
-    expected_hash = _hash(expected_file_sha256, f"{label}.file_sha256")
-    path = private_path(artifact_root).joinpath(*relative_ref.split("/"))
-    try:
-        with open_private_text(path) as handle:
-            text = handle.read()
-        content = text.encode("utf-8")
-        payload = json.loads(text)
-        canonical_text = render_json_text(payload) if isinstance(payload, dict) else None
-    except (OSError, UnicodeDecodeError, ValueError) as exc:
-        raise ResearchRunnerError(
-            "research_artifact_invalid", f"{label} artifact cannot be read"
-        ) from exc
-    if _file_sha256(content) != expected_hash:
-        _fail("research_artifact_invalid", f"{label} file hash changed")
-    if canonical_text != text:
-        _fail("research_artifact_invalid", f"{label} bytes are not canonical JSON")
-    return cast(dict[str, Any], payload)
 
 
 def _load_spec(
@@ -174,57 +142,13 @@ def _require_effective_feature(
         _fail("feature_disabled", "Strategy Lab Top1 is disabled")
 
 
-def _load_dataset(
+def _materialized_input(
     artifact_root: str | Path, spec: Mapping[str, Any]
-) -> dict[str, Any]:
-    source = cast(Mapping[str, object], spec["research_source"])
-    return _read_canonical_json(
-        artifact_root,
-        ref=source["dataset_ref"],
-        expected_file_sha256=source["dataset_sha256"],
-        label="sealed_dataset",
-    )
-
-
-def _materialize_input(
-    artifact_root: str | Path,
-    *,
-    spec: dict[str, Any],
-    sealed_dataset: dict[str, Any],
 ) -> dict[str, object]:
-    raw_days = sealed_dataset.get("days")
-    if not isinstance(raw_days, list):
-        _fail("research_artifact_invalid", "sealed dataset days must be a list")
-    projections: list[dict[str, object]] = []
-    for raw_day in raw_days:
-        if not isinstance(raw_day, Mapping) or not isinstance(
-            raw_day.get("points"), list
-        ):
-            _fail("research_artifact_invalid", "sealed dataset point index is invalid")
-        for raw_point in cast(list[object], raw_day["points"]):
-            if not isinstance(raw_point, Mapping):
-                _fail("research_artifact_invalid", "sealed dataset point is invalid")
-            ref = raw_point.get("projection_ref")
-            projections.append(
-                {
-                    "projection_ref": ref,
-                    "projection": _read_canonical_json(
-                        artifact_root,
-                        ref=ref,
-                        expected_file_sha256=raw_point.get(
-                            "projection_file_sha256"
-                        ),
-                        label="ranking_projection",
-                    ),
-                }
-            )
-    return {
-        "schema_version": RESEARCH_EVALUATION_INPUT_SCHEMA,
-        "experiment_spec": spec,
-        "dataset_ref": spec["research_source"]["dataset_ref"],
-        "sealed_dataset": sealed_dataset,
-        "ranking_projections": projections,
-    }
+    try:
+        return load_materialized_research_input(artifact_root, spec)
+    except ResearchArtifactError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
 
 
 def _validated_quota(value: object) -> tuple[int, set[str]]:
@@ -268,9 +192,9 @@ def _close_receipts(
     market: str,
     account: str,
     requirements: list[tuple[str, str]],
-) -> list[dict[str, object]]:
+) -> tuple[list[dict[str, object]], dict[str, object] | None]:
     if not requirements:
-        return []
+        return [], None
     try:
         raw_quota = gateway.get_history_kl_quota()
     except Exception as exc:
@@ -279,8 +203,16 @@ def _close_receipts(
         ) from exc
     remaining, existing_codes = _validated_quota(raw_quota)
     required_codes = {stock_owner for stock_owner, _expiration in requirements}
-    if len(required_codes - existing_codes) > remaining:
+    new_codes = required_codes - existing_codes
+    if len(new_codes) > remaining:
         _fail("research_history_quota_insufficient", "history quota is insufficient")
+    quota_decision: dict[str, object] = {
+        "schema_version": INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
+        "required_stock_owners": sorted(required_codes),
+        "already_counted_stock_owners": sorted(required_codes & existing_codes),
+        "new_stock_owners": sorted(new_codes),
+        "remain_quota": remaining,
+    }
 
     limit = resolve_opend_fetch_limits(dict(config or {})).history_kline
     receipts: list[dict[str, object]] = []
@@ -344,7 +276,7 @@ def _close_receipts(
                 "reason_detail": reason,
             }
         )
-    return receipts
+    return receipts, quota_decision
 
 
 def _evaluate(
@@ -367,13 +299,51 @@ def _requirements(
         raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
 
 
+def _revision(
+    dataset: dict[str, object],
+    *,
+    evaluation: dict[str, object],
+    fee_contract: object,
+    close_receipts: list[dict[str, object]],
+    quota_decision: object,
+    observed_at_utc: str,
+) -> dict[str, object]:
+    try:
+        return build_internal_research_revision(
+            dataset,
+            evaluation=evaluation,
+            fee_contract=fee_contract,
+            close_receipts=close_receipts,
+            quota_decision=quota_decision,
+            observed_at_utc=observed_at_utc,
+        )
+    except ResearchEvaluationError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+
+
+def _recorded_evaluation(
+    artifact_root: str | Path,
+    *,
+    generation: Mapping[str, Any],
+    dataset: dict[str, object],
+) -> dict[str, object]:
+    try:
+        revision = load_recorded_research_revision(artifact_root, generation)
+        validated = validate_internal_research_revision(dataset, revision)
+    except ResearchArtifactError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+    except ResearchEvaluationError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+    return cast(dict[str, object], validated["evaluation"])
+
+
 def _record_revision(
     store: ExperimentStore,
     artifact_root: str | Path,
     *,
     experiment_id: str,
     generation: Mapping[str, Any],
-    evaluation: dict[str, object],
+    revision: dict[str, object],
     actor: str,
     occurred_at_utc: str,
     idempotency_key: str,
@@ -383,7 +353,7 @@ def _record_revision(
         f"strategy_lab/top1/experiments/{experiment_id}/generations/"
         "research.revision.1.json"
     )
-    text = render_json_text(evaluation)
+    text = render_json_text(revision)
     content = text.encode("utf-8")
     try:
         publish_exact_text(artifact_root, ref, content)
@@ -407,35 +377,6 @@ def _record_revision(
         raise ResearchRunnerError(
             "research_revision_conflict", "research revision cannot be recorded"
         ) from exc
-
-
-def _read_recorded_evaluation(
-    artifact_root: str | Path,
-    *,
-    generation: Mapping[str, Any],
-    experiment_id: str,
-    research_spec_sha256: str,
-    spec: Mapping[str, Any],
-    sealed_dataset: Mapping[str, Any],
-) -> dict[str, object]:
-    evaluation = _read_canonical_json(
-        artifact_root,
-        ref=generation["last_revision_ref"],
-        expected_file_sha256=generation["last_revision_file_sha256"],
-        label="research_revision",
-    )
-    source = cast(Mapping[str, object], spec["research_source"])
-    expected = {
-        "schema_version": RESEARCH_EVALUATION_SCHEMA,
-        "experiment_id": experiment_id,
-        "research_spec_sha256": research_spec_sha256,
-        "dataset_ref": source["dataset_ref"],
-        "dataset_sha256": source["dataset_sha256"],
-        "dataset_content_sha256": sealed_dataset.get("content_sha256"),
-    }
-    if any(evaluation.get(key) != value for key, value in expected.items()):
-        _fail("research_revision_conflict", "research revision binding changed")
-    return cast(dict[str, object], evaluation)
 
 
 def _finish_terminal(
@@ -497,16 +438,13 @@ def run_research(
         experiment_id=experiment_id,
         research_spec_sha256=research_spec_sha256,
     )
-    sealed_dataset = _load_dataset(artifact_root, spec)
+    dataset = _materialized_input(artifact_root, spec)
     generation = _research_generation(store, experiment_id)
     if generation is not None and int(generation["revision"]) == 1:
-        evaluation = _read_recorded_evaluation(
+        evaluation = _recorded_evaluation(
             artifact_root,
             generation=generation,
-            experiment_id=experiment_id,
-            research_spec_sha256=research_spec_sha256,
-            spec=spec,
-            sealed_dataset=sealed_dataset,
+            dataset=dataset,
         )
         _require_effective_feature(store, experiment=experiment, environ=environ)
         _finish_terminal(
@@ -526,11 +464,6 @@ def run_research(
     ):
         _fail("research_generation_conflict", "research generation state is unsupported")
 
-    dataset = _materialize_input(
-        artifact_root,
-        spec=spec,
-        sealed_dataset=sealed_dataset,
-    )
     requirements = _requirements(dataset, fee_contract)
     if generation is None:
         try:
@@ -552,7 +485,7 @@ def run_research(
     else:
         _require_effective_feature(store, experiment=experiment, environ=environ)
 
-    receipts = _close_receipts(
+    receipts, quota_decision = _close_receipts(
         artifact_root=artifact_root,
         config=config,
         gateway=gateway,
@@ -561,12 +494,20 @@ def run_research(
         requirements=requirements,
     )
     evaluation = _evaluate(dataset, receipts, fee_contract)
+    revision = _revision(
+        dataset,
+        evaluation=evaluation,
+        fee_contract=fee_contract,
+        close_receipts=receipts,
+        quota_decision=quota_decision,
+        observed_at_utc=occurred_at_utc,
+    )
     _record_revision(
         store,
         artifact_root,
         experiment_id=experiment_id,
         generation=generation,
-        evaluation=evaluation,
+        revision=revision,
         actor=actor,
         occurred_at_utc=occurred_at_utc,
         idempotency_key=idempotency_key,

--- a/src/application/strategy_lab/top1/research_runner.py
+++ b/src/application/strategy_lab/top1/research_runner.py
@@ -1,0 +1,591 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+from src.application.opend_call_coordinator import rate_limited_opend_call
+from src.application.opend_fetch_config import resolve_opend_fetch_limits
+from src.application.shadow_replay.common import render_json_text
+from src.application.strategy_lab.top1.contracts import (
+    Top1CoreContractError,
+    build_research_spec_sha256,
+    validate_experiment_spec,
+)
+from src.application.strategy_lab.top1.lifecycle import (
+    Top1LifecycleError,
+    effective_feature_status,
+    record_generation_revision,
+    seal_generation,
+    start_research,
+)
+from src.application.strategy_lab.top1.research import (
+    RESEARCH_CLOSE_RECEIPT_SCHEMA,
+    RESEARCH_EVALUATION_INPUT_SCHEMA,
+    RESEARCH_EVALUATION_SCHEMA,
+    ResearchEvaluationError,
+    evaluate_research,
+    required_research_close_keys,
+)
+from src.application.strategy_lab.top1.terminal_projection import (
+    publish_exact_text,
+    recover_terminal_projection,
+)
+from src.infrastructure.futu_gateway import FutuGateway
+from src.infrastructure.private_storage import open_private_text, private_path
+from src.infrastructure.strategy_lab.experiment_store import (
+    ExperimentStore,
+    ExperimentStoreError,
+)
+
+
+_HASH_64 = re.compile(r"[0-9a-f]{64}\Z")
+_QUOTA_KEYS = frozenset({"used_quota", "remain_quota", "detail_list"})
+_QUOTA_DETAIL_KEYS = frozenset({"code", "request_time"})
+_CLOSE_KEYS = frozenset({"code", "expiration", "close"})
+
+
+class ResearchRunnerError(RuntimeError):
+    """Stable fail-closed error from the W5 orchestration boundary."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise ResearchRunnerError(reason_code, message)
+
+
+def _hash(value: object, label: str) -> str:
+    if not isinstance(value, str) or _HASH_64.fullmatch(value) is None:
+        _fail("research_runner_input_invalid", f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def _safe_ref(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("research_artifact_invalid", f"{label} must be canonical text")
+    parts = value.split("/")
+    if value.startswith("/") or "\\" in value or any(
+        part in {"", ".", ".."} for part in parts
+    ):
+        _fail("research_artifact_invalid", f"{label} must be a safe relative ref")
+    return value
+
+
+def _file_sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _derived_key(idempotency_key: str, step: str) -> str:
+    return hashlib.sha256(f"{idempotency_key}\0{step}".encode("utf-8")).hexdigest()
+
+
+def _read_canonical_json(
+    artifact_root: str | Path,
+    *,
+    ref: object,
+    expected_file_sha256: object,
+    label: str,
+) -> dict[str, Any]:
+    relative_ref = _safe_ref(ref, f"{label}.ref")
+    expected_hash = _hash(expected_file_sha256, f"{label}.file_sha256")
+    path = private_path(artifact_root).joinpath(*relative_ref.split("/"))
+    try:
+        with open_private_text(path) as handle:
+            text = handle.read()
+        content = text.encode("utf-8")
+        payload = json.loads(text)
+        canonical_text = render_json_text(payload) if isinstance(payload, dict) else None
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise ResearchRunnerError(
+            "research_artifact_invalid", f"{label} artifact cannot be read"
+        ) from exc
+    if _file_sha256(content) != expected_hash:
+        _fail("research_artifact_invalid", f"{label} file hash changed")
+    if canonical_text != text:
+        _fail("research_artifact_invalid", f"{label} bytes are not canonical JSON")
+    return cast(dict[str, Any], payload)
+
+
+def _load_spec(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    research_spec_sha256: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    expected_hash = _hash(research_spec_sha256, "research_spec_sha256")
+    try:
+        experiment = store.experiment(experiment_id)
+        raw_spec = json.loads(str(experiment["spec_json"]))
+        spec = validate_experiment_spec(raw_spec)
+    except ExperimentStoreError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+    except (json.JSONDecodeError, Top1CoreContractError) as exc:
+        raise ResearchRunnerError(
+            "experiment_spec_invalid", "stored experiment spec is invalid"
+        ) from exc
+    if (
+        spec["experiment_id"] != experiment_id
+        or experiment["research_spec_sha256"] != expected_hash
+        or build_research_spec_sha256(spec) != expected_hash
+    ):
+        _fail("experiment_spec_conflict", "research spec binding changed")
+    return experiment, spec
+
+
+def _research_generation(
+    store: ExperimentStore, experiment_id: str
+) -> dict[str, Any] | None:
+    try:
+        return next(
+            (
+                row
+                for row in store.generations(experiment_id)
+                if row["generation_kind"] == "research"
+            ),
+            None,
+        )
+    except ExperimentStoreError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+
+
+def _require_effective_feature(
+    store: ExperimentStore,
+    *,
+    experiment: Mapping[str, Any],
+    environ: Mapping[str, str] | None,
+) -> None:
+    try:
+        effective = effective_feature_status(
+            store,
+            market=str(experiment["market"]),
+            account=str(experiment["account"]),
+            environ=environ,
+        )["effective"]
+    except Top1LifecycleError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+    if not effective:
+        _fail("feature_disabled", "Strategy Lab Top1 is disabled")
+
+
+def _load_dataset(
+    artifact_root: str | Path, spec: Mapping[str, Any]
+) -> dict[str, Any]:
+    source = cast(Mapping[str, object], spec["research_source"])
+    return _read_canonical_json(
+        artifact_root,
+        ref=source["dataset_ref"],
+        expected_file_sha256=source["dataset_sha256"],
+        label="sealed_dataset",
+    )
+
+
+def _materialize_input(
+    artifact_root: str | Path,
+    *,
+    spec: dict[str, Any],
+    sealed_dataset: dict[str, Any],
+) -> dict[str, object]:
+    raw_days = sealed_dataset.get("days")
+    if not isinstance(raw_days, list):
+        _fail("research_artifact_invalid", "sealed dataset days must be a list")
+    projections: list[dict[str, object]] = []
+    for raw_day in raw_days:
+        if not isinstance(raw_day, Mapping) or not isinstance(
+            raw_day.get("points"), list
+        ):
+            _fail("research_artifact_invalid", "sealed dataset point index is invalid")
+        for raw_point in cast(list[object], raw_day["points"]):
+            if not isinstance(raw_point, Mapping):
+                _fail("research_artifact_invalid", "sealed dataset point is invalid")
+            ref = raw_point.get("projection_ref")
+            projections.append(
+                {
+                    "projection_ref": ref,
+                    "projection": _read_canonical_json(
+                        artifact_root,
+                        ref=ref,
+                        expected_file_sha256=raw_point.get(
+                            "projection_file_sha256"
+                        ),
+                        label="ranking_projection",
+                    ),
+                }
+            )
+    return {
+        "schema_version": RESEARCH_EVALUATION_INPUT_SCHEMA,
+        "experiment_spec": spec,
+        "dataset_ref": spec["research_source"]["dataset_ref"],
+        "sealed_dataset": sealed_dataset,
+        "ranking_projections": projections,
+    }
+
+
+def _validated_quota(value: object) -> tuple[int, set[str]]:
+    if not isinstance(value, Mapping) or set(value) != _QUOTA_KEYS:
+        _fail("research_history_quota_invalid", "history quota receipt is invalid")
+    used = value["used_quota"]
+    remaining = value["remain_quota"]
+    details = value["detail_list"]
+    if (
+        isinstance(used, bool)
+        or not isinstance(used, int)
+        or used < 0
+        or isinstance(remaining, bool)
+        or not isinstance(remaining, int)
+        or remaining < 0
+        or not isinstance(details, list)
+        or len(details) != used
+    ):
+        _fail("research_history_quota_invalid", "history quota receipt is invalid")
+    codes: set[str] = set()
+    for detail in cast(list[object], details):
+        if not isinstance(detail, Mapping) or set(detail) != _QUOTA_DETAIL_KEYS:
+            _fail("research_history_quota_invalid", "history quota detail is invalid")
+        code = detail["code"]
+        if (
+            not isinstance(code, str)
+            or not code
+            or code != code.strip().upper()
+            or code in codes
+        ):
+            _fail("research_history_quota_invalid", "history quota code is invalid")
+        codes.add(code)
+    return remaining, codes
+
+
+def _close_receipts(
+    *,
+    artifact_root: str | Path,
+    config: Mapping[str, Any] | None,
+    gateway: FutuGateway,
+    market: str,
+    account: str,
+    requirements: list[tuple[str, str]],
+) -> list[dict[str, object]]:
+    if not requirements:
+        return []
+    try:
+        raw_quota = gateway.get_history_kl_quota()
+    except Exception as exc:
+        raise ResearchRunnerError(
+            "research_history_quota_unavailable", "history quota cannot be read"
+        ) from exc
+    remaining, existing_codes = _validated_quota(raw_quota)
+    required_codes = {stock_owner for stock_owner, _expiration in requirements}
+    if len(required_codes - existing_codes) > remaining:
+        _fail("research_history_quota_insufficient", "history quota is insufficient")
+
+    limit = resolve_opend_fetch_limits(dict(config or {})).history_kline
+    receipts: list[dict[str, object]] = []
+    for stock_owner, expiration in requirements:
+        try:
+            result = rate_limited_opend_call(
+                base_dir=private_path(artifact_root),
+                endpoint="history_kline",
+                **limit.call_kwargs(),
+                call=lambda stock_owner=stock_owner, expiration=expiration: (
+                    gateway.get_exact_expiration_close(
+                        code=stock_owner,
+                        expiration=expiration,
+                    )
+                ),
+            )
+        except Exception as exc:
+            raise ResearchRunnerError(
+                "research_expiry_close_unavailable",
+                "exact-expiration close cannot be read",
+            ) from exc
+        if result is None:
+            close = None
+            status = "unavailable"
+            reason = "expiry_close_missing_after_deadline"
+        else:
+            if not isinstance(result, Mapping) or set(result) != _CLOSE_KEYS:
+                _fail(
+                    "research_expiry_close_invalid",
+                    "exact-expiration close receipt is invalid",
+                )
+            close = result["close"]
+            if (
+                result["code"] != stock_owner
+                or result["expiration"] != expiration
+                or isinstance(close, bool)
+                or not isinstance(close, (int, float))
+                or not math.isfinite(float(close))
+                or float(close) <= 0
+            ):
+                _fail(
+                    "research_expiry_close_invalid",
+                    "exact-expiration close receipt is invalid",
+                )
+            close = float(close)
+            status = "available"
+            reason = None
+        receipts.append(
+            {
+                "schema_version": RESEARCH_CLOSE_RECEIPT_SCHEMA,
+                "market": market,
+                "account": account,
+                "stock_owner": stock_owner,
+                "expiration": expiration,
+                "spot_source": "opend_history_kline",
+                "ktype": "K_DAY",
+                "autype": "NONE",
+                "price_field": "close",
+                "status": status,
+                "underlier_close": close,
+                "reason_detail": reason,
+            }
+        )
+    return receipts
+
+
+def _evaluate(
+    dataset: dict[str, object],
+    close_receipts: list[dict[str, object]],
+    fee_contract: object,
+) -> dict[str, object]:
+    try:
+        return evaluate_research(dataset, close_receipts, fee_contract)
+    except ResearchEvaluationError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+
+
+def _requirements(
+    dataset: dict[str, object], fee_contract: object
+) -> list[tuple[str, str]]:
+    try:
+        return required_research_close_keys(dataset, fee_contract)
+    except ResearchEvaluationError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+
+
+def _record_revision(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    generation: Mapping[str, Any],
+    evaluation: dict[str, object],
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None,
+) -> None:
+    ref = (
+        f"strategy_lab/top1/experiments/{experiment_id}/generations/"
+        "research.revision.1.json"
+    )
+    text = render_json_text(evaluation)
+    content = text.encode("utf-8")
+    try:
+        publish_exact_text(artifact_root, ref, content)
+        record_generation_revision(
+            store,
+            experiment_id=experiment_id,
+            generation_kind="research",
+            revision=1,
+            revision_ref=ref,
+            revision_file_sha256=_file_sha256(content),
+            frozen_row_sha256=str(generation["frozen_row_content_sha256"]),
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=_derived_key(idempotency_key, "revision"),
+            artifact_root=artifact_root,
+            environ=environ,
+        )
+    except Top1LifecycleError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+    except (OSError, ValueError) as exc:
+        raise ResearchRunnerError(
+            "research_revision_conflict", "research revision cannot be recorded"
+        ) from exc
+
+
+def _read_recorded_evaluation(
+    artifact_root: str | Path,
+    *,
+    generation: Mapping[str, Any],
+    experiment_id: str,
+    research_spec_sha256: str,
+    spec: Mapping[str, Any],
+    sealed_dataset: Mapping[str, Any],
+) -> dict[str, object]:
+    evaluation = _read_canonical_json(
+        artifact_root,
+        ref=generation["last_revision_ref"],
+        expected_file_sha256=generation["last_revision_file_sha256"],
+        label="research_revision",
+    )
+    source = cast(Mapping[str, object], spec["research_source"])
+    expected = {
+        "schema_version": RESEARCH_EVALUATION_SCHEMA,
+        "experiment_id": experiment_id,
+        "research_spec_sha256": research_spec_sha256,
+        "dataset_ref": source["dataset_ref"],
+        "dataset_sha256": source["dataset_sha256"],
+        "dataset_content_sha256": sealed_dataset.get("content_sha256"),
+    }
+    if any(evaluation.get(key) != value for key, value in expected.items()):
+        _fail("research_revision_conflict", "research revision binding changed")
+    return cast(dict[str, object], evaluation)
+
+
+def _finish_terminal(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    generation: Mapping[str, Any],
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None,
+) -> None:
+    if generation["terminal_mode"] not in {None, "completed"}:
+        _fail("research_generation_terminal", "research generation is not completable")
+    try:
+        if generation["terminal_request_event_id"] is None:
+            seal_generation(
+                store,
+                experiment_id=experiment_id,
+                generation_kind="research",
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=_derived_key(idempotency_key, "seal"),
+                artifact_root=artifact_root,
+                environ=environ,
+            )
+        recovered = recover_terminal_projection(
+            store,
+            artifact_root,
+            experiment_id=experiment_id,
+        )
+    except Top1LifecycleError as exc:
+        raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+    except (ExperimentStoreError, OSError, ValueError) as exc:
+        raise ResearchRunnerError(
+            "research_terminal_publish_failed", "research terminal cannot be published"
+        ) from exc
+    if recovered["pending"] != 0:
+        _fail("research_terminal_pending", "research terminal remains pending")
+
+
+def run_research(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    research_spec_sha256: str,
+    fee_contract: object,
+    gateway: FutuGateway,
+    config: Mapping[str, Any] | None,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment, spec = _load_spec(
+        store,
+        experiment_id=experiment_id,
+        research_spec_sha256=research_spec_sha256,
+    )
+    sealed_dataset = _load_dataset(artifact_root, spec)
+    generation = _research_generation(store, experiment_id)
+    if generation is not None and int(generation["revision"]) == 1:
+        evaluation = _read_recorded_evaluation(
+            artifact_root,
+            generation=generation,
+            experiment_id=experiment_id,
+            research_spec_sha256=research_spec_sha256,
+            spec=spec,
+            sealed_dataset=sealed_dataset,
+        )
+        _require_effective_feature(store, experiment=experiment, environ=environ)
+        _finish_terminal(
+            store,
+            artifact_root,
+            experiment_id=experiment_id,
+            generation=generation,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=idempotency_key,
+            environ=environ,
+        )
+        return evaluation
+    if generation is not None and (
+        int(generation["revision"]) != 0
+        or generation["terminal_request_event_id"] is not None
+    ):
+        _fail("research_generation_conflict", "research generation state is unsupported")
+
+    dataset = _materialize_input(
+        artifact_root,
+        spec=spec,
+        sealed_dataset=sealed_dataset,
+    )
+    requirements = _requirements(dataset, fee_contract)
+    if generation is None:
+        try:
+            start_research(
+                store,
+                experiment_id=experiment_id,
+                research_spec_sha256=research_spec_sha256,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=_derived_key(idempotency_key, "start"),
+                artifact_root=artifact_root,
+                environ=environ,
+            )
+        except Top1LifecycleError as exc:
+            raise ResearchRunnerError(exc.reason_code, str(exc)) from exc
+        generation = _research_generation(store, experiment_id)
+        if generation is None:
+            _fail("research_generation_conflict", "research generation was not created")
+    else:
+        _require_effective_feature(store, experiment=experiment, environ=environ)
+
+    receipts = _close_receipts(
+        artifact_root=artifact_root,
+        config=config,
+        gateway=gateway,
+        market=str(spec["market"]),
+        account=str(spec["account"]),
+        requirements=requirements,
+    )
+    evaluation = _evaluate(dataset, receipts, fee_contract)
+    _record_revision(
+        store,
+        artifact_root,
+        experiment_id=experiment_id,
+        generation=generation,
+        evaluation=evaluation,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        environ=environ,
+    )
+    generation = _research_generation(store, experiment_id)
+    if generation is None or int(generation["revision"]) != 1:
+        _fail("research_generation_conflict", "research revision was not recorded")
+    _finish_terminal(
+        store,
+        artifact_root,
+        experiment_id=experiment_id,
+        generation=generation,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        environ=environ,
+    )
+    return evaluation
+
+
+__all__ = ["ResearchRunnerError", "run_research"]

--- a/tests/test_strategy_lab_top1_architecture.py
+++ b/tests/test_strategy_lab_top1_architecture.py
@@ -13,6 +13,9 @@ RESEARCH_MODULE = ROOT / "src/application/strategy_lab/top1/research.py"
 RESEARCH_RUNNER_MODULE = (
     ROOT / "src/application/strategy_lab/top1/research_runner.py"
 )
+RESEARCH_ARTIFACTS_MODULE = (
+    ROOT / "src/application/strategy_lab/top1/research_artifacts.py"
+)
 RECOMMENDATION_POINT_MODULE = ROOT / "src/application/recommendation_point.py"
 CANDIDATE_ENGINE = ROOT / "domain/domain/engine/candidate_engine.py"
 EXPERIMENT_STORE_MODULE = (
@@ -161,6 +164,8 @@ def test_top1_lifecycle_and_terminal_projection_keep_dependency_direction() -> N
         "src.application.recommendation_point",
         "src.application.shadow_replay.common",
         "src.application.strategy_lab.top1.contracts",
+        "src.application.strategy_lab.top1.research",
+        "src.application.strategy_lab.top1.research_artifacts",
         "src.application.strategy_lab.top1.terminal_projection",
         "src.infrastructure.strategy_lab.experiment_store",
     }
@@ -215,10 +220,23 @@ def test_top1_lifecycle_and_terminal_projection_keep_dependency_direction() -> N
         "src.application.strategy_lab.top1.contracts",
         "src.application.strategy_lab.top1.lifecycle",
         "src.application.strategy_lab.top1.research",
+        "src.application.strategy_lab.top1.research_artifacts",
         "src.application.strategy_lab.top1.terminal_projection",
         "src.infrastructure.futu_gateway",
         "src.infrastructure.private_storage",
         "src.infrastructure.strategy_lab.experiment_store",
+    }
+    assert _imports(RESEARCH_ARTIFACTS_MODULE) <= {
+        "__future__",
+        "hashlib",
+        "json",
+        "re",
+        "collections.abc",
+        "pathlib",
+        "typing",
+        "src.application.shadow_replay.common",
+        "src.application.strategy_lab.top1.research",
+        "src.infrastructure.private_storage",
     }
 
 
@@ -228,4 +246,5 @@ def test_production_tick_does_not_depend_on_top1_experiment_store() -> None:
         assert "src.application.strategy_lab.top1.lifecycle" not in imports
         assert "src.application.strategy_lab.top1.corpus" not in imports
         assert "src.application.strategy_lab.top1.research" not in imports
+        assert "src.application.strategy_lab.top1.research_artifacts" not in imports
         assert "src.infrastructure.strategy_lab.experiment_store" not in imports

--- a/tests/test_strategy_lab_top1_architecture.py
+++ b/tests/test_strategy_lab_top1_architecture.py
@@ -10,6 +10,9 @@ CONTRACTS_MODULE = ROOT / "src/application/strategy_lab/top1/contracts.py"
 ECONOMICS_MODULE = ROOT / "src/application/strategy_lab/top1/economics.py"
 STATISTICS_MODULE = ROOT / "src/application/strategy_lab/top1/statistics.py"
 RESEARCH_MODULE = ROOT / "src/application/strategy_lab/top1/research.py"
+RESEARCH_RUNNER_MODULE = (
+    ROOT / "src/application/strategy_lab/top1/research_runner.py"
+)
 RECOMMENDATION_POINT_MODULE = ROOT / "src/application/recommendation_point.py"
 CANDIDATE_ENGINE = ROOT / "domain/domain/engine/candidate_engine.py"
 EXPERIMENT_STORE_MODULE = (
@@ -193,6 +196,27 @@ def test_top1_lifecycle_and_terminal_projection_keep_dependency_direction() -> N
         "src.application.strategy_lab.top1.lifecycle",
         "src.application.strategy_lab.top1.ranking",
         "src.application.strategy_lab.top1.terminal_projection",
+        "src.infrastructure.private_storage",
+        "src.infrastructure.strategy_lab.experiment_store",
+    }
+
+    assert _imports(RESEARCH_RUNNER_MODULE) <= {
+        "__future__",
+        "hashlib",
+        "json",
+        "math",
+        "re",
+        "collections.abc",
+        "pathlib",
+        "typing",
+        "src.application.opend_call_coordinator",
+        "src.application.opend_fetch_config",
+        "src.application.shadow_replay.common",
+        "src.application.strategy_lab.top1.contracts",
+        "src.application.strategy_lab.top1.lifecycle",
+        "src.application.strategy_lab.top1.research",
+        "src.application.strategy_lab.top1.terminal_projection",
+        "src.infrastructure.futu_gateway",
         "src.infrastructure.private_storage",
         "src.infrastructure.strategy_lab.experiment_store",
     }

--- a/tests/test_strategy_lab_top1_research.py
+++ b/tests/test_strategy_lab_top1_research.py
@@ -48,6 +48,7 @@ from src.application.strategy_lab.top1.lifecycle import (
     authorize_research,
     lock_challenger,
     prepare_experiment,
+    record_generation_revision,
     seal_generation,
     set_account_opt_in,
     start_research,
@@ -59,13 +60,16 @@ from src.application.strategy_lab.top1.ranking import (
     build_ranking_projection,
 )
 from src.application.strategy_lab.top1.research import (
+    INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
     RESEARCH_CLOSE_RECEIPT_SCHEMA,
     RESEARCH_EVALUATION_INPUT_SCHEMA,
     RESEARCH_EVALUATION_SCHEMA,
     ResearchEvaluationError,
+    build_internal_research_revision,
     evaluate_research,
 )
 from src.application.strategy_lab.top1.terminal_projection import (
+    publish_exact_text,
     recover_terminal_projection,
 )
 from src.infrastructure.strategy_lab.experiment_store import ExperimentStore
@@ -868,6 +872,52 @@ def test_evaluator_leader_crosses_existing_m3_human_authorization_gate(
         artifact_root=tmp_path,
         environ=AVAILABLE,
     )
+    publish_exact_text(
+        tmp_path,
+        research_case["dataset_ref"],
+        render_json_text(research_case["sealed_dataset"]).encode("utf-8"),
+    )
+    for item in research_case["ranking_projections"]:
+        publish_exact_text(
+            tmp_path,
+            item["projection_ref"],
+            render_json_text(item["projection"]).encode("utf-8"),
+        )
+    revision = build_internal_research_revision(
+        research_case,
+        evaluation=evaluation,
+        fee_contract=_fee_contract(),
+        close_receipts=_receipts(),
+        quota_decision={
+            "schema_version": INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
+            "required_stock_owners": ["HK.0700", "HK.3690", "HK.9988"],
+            "already_counted_stock_owners": ["HK.0700", "HK.3690", "HK.9988"],
+            "new_stock_owners": [],
+            "remain_quota": 0,
+        },
+        observed_at_utc="2026-08-15T03:03:00Z",
+    )
+    revision_ref = (
+        "strategy_lab/top1/experiments/experiment-w5-evaluator/generations/"
+        "research.revision.1.json"
+    )
+    revision_content = render_json_text(revision).encode("utf-8")
+    publish_exact_text(tmp_path, revision_ref, revision_content)
+    generation = store.generations(spec["experiment_id"])[0]
+    record_generation_revision(
+        store,
+        experiment_id=spec["experiment_id"],
+        generation_kind="research",
+        revision=1,
+        revision_ref=revision_ref,
+        revision_file_sha256=hashlib.sha256(revision_content).hexdigest(),
+        frozen_row_sha256=str(generation["frozen_row_content_sha256"]),
+        actor="runner",
+        occurred_at_utc="2026-08-15T03:03:30Z",
+        idempotency_key="record-research-m3-seam",
+        artifact_root=tmp_path,
+        environ=AVAILABLE,
+    )
     seal_generation(
         store,
         experiment_id=spec["experiment_id"],
@@ -879,7 +929,7 @@ def test_evaluator_leader_crosses_existing_m3_human_authorization_gate(
         environ=AVAILABLE,
     )
     recover_terminal_projection(store, tmp_path)
-    terminal_sha = store.generations(spec["experiment_id"])[0]["terminal_file_sha256"]
+    generation = store.generations(spec["experiment_id"])[0]
     validation_spec = _spec(
         research_case["sealed_dataset"],
         variants=(
@@ -889,14 +939,11 @@ def test_evaluator_leader_crosses_existing_m3_human_authorization_gate(
         validation=True,
     )
     hidden_days = _trading_days("2026-08-04", 20)
-    with pytest.raises(Top1LifecycleError, match="system leader"):
+    with pytest.raises(Top1LifecycleError) as wrong_leader:
         lock_challenger(
             store,
             validation_spec,
-            system_leader=str(leader),
             challenger_variant_id="without",
-            research_receipt_ref="strategy_lab/top1/research-receipt.json",
-            research_receipt_file_sha256=str(terminal_sha),
             trading_dates=hidden_days,
             actor="human",
             occurred_at_utc="2026-08-15T03:05:00Z",
@@ -904,13 +951,29 @@ def test_evaluator_leader_crosses_existing_m3_human_authorization_gate(
             artifact_root=tmp_path,
             environ=AVAILABLE,
         )
+    assert wrong_leader.value.reason_code == "experiment_invalid", str(
+        wrong_leader.value
+    )
+    revision_path = tmp_path.joinpath(*revision_ref.split("/"))
+    revision_path.write_bytes(b"{}\n")
+    with pytest.raises(Top1LifecycleError) as tampered_revision:
+        lock_challenger(
+            store,
+            validation_spec,
+            challenger_variant_id=str(leader),
+            trading_dates=hidden_days,
+            actor="human",
+            occurred_at_utc="2026-08-15T03:05:30Z",
+            idempotency_key="tampered-revision-m3-seam",
+            artifact_root=tmp_path,
+            environ=AVAILABLE,
+        )
+    assert tampered_revision.value.reason_code == "experiment_conflict"
+    revision_path.write_bytes(revision_content)
     locked = lock_challenger(
         store,
         validation_spec,
-        system_leader=str(leader),
         challenger_variant_id=str(leader),
-        research_receipt_ref="strategy_lab/top1/research-receipt.json",
-        research_receipt_file_sha256=str(terminal_sha),
         trading_dates=hidden_days,
         actor="human",
         occurred_at_utc="2026-08-15T03:06:00Z",
@@ -919,6 +982,23 @@ def test_evaluator_leader_crosses_existing_m3_human_authorization_gate(
         environ=AVAILABLE,
     )
     assert locked["validation_authorization_status"] == "unconfirmed"
+    assert locked["research_receipt_ref"] == generation["last_revision_ref"]
+    assert locked["research_receipt_file_sha256"] == generation[
+        "last_revision_file_sha256"
+    ]
+    relocked = lock_challenger(
+        store,
+        validation_spec,
+        challenger_variant_id=str(leader),
+        trading_dates=_trading_days("2026-09-01", 20),
+        actor="human",
+        occurred_at_utc="2026-08-15T03:06:30Z",
+        idempotency_key="relock-leader-m3-seam",
+        artifact_root=tmp_path,
+        environ=AVAILABLE,
+    )
+    assert relocked["research_receipt_ref"] == generation["last_revision_ref"]
+    locked = relocked
     with pytest.raises(Top1LifecycleError) as exc_info:
         start_validation(
             store,

--- a/tests/test_strategy_lab_top1_research_runner.py
+++ b/tests/test_strategy_lab_top1_research_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 from typing import Any
 
@@ -9,13 +10,20 @@ import pytest
 import src.application.strategy_lab.top1.research_runner as runner_module
 from src.application.shadow_replay.common import render_json_text
 from src.application.strategy_lab.top1.lifecycle import (
+    Top1LifecycleError,
     authorize_research,
+    lock_challenger,
     prepare_experiment,
     record_generation_revision,
     set_account_opt_in,
     start_research,
 )
-from src.application.strategy_lab.top1.research import evaluate_research
+from src.application.strategy_lab.top1.research import (
+    INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
+    INTERNAL_RESEARCH_REVISION_SCHEMA,
+    build_internal_research_revision,
+    evaluate_research,
+)
 from src.application.strategy_lab.top1.research_runner import (
     ResearchRunnerError,
     run_research,
@@ -29,6 +37,8 @@ from tests.test_strategy_lab_top1_research import (
     _fee_contract,
     _receipts,
     _set_variants,
+    _spec,
+    _trading_days,
 )
 
 
@@ -89,6 +99,24 @@ def _publish_case(root: Path, case: dict[str, Any]) -> None:
             item["projection_ref"],
             render_json_text(item["projection"]).encode("utf-8"),
         )
+
+
+def _revision(case: dict[str, Any]) -> dict[str, object]:
+    receipts = _receipts()
+    return build_internal_research_revision(
+        case,
+        evaluation=evaluate_research(case, receipts, _fee_contract()),
+        fee_contract=_fee_contract(),
+        close_receipts=receipts,
+        quota_decision={
+            "schema_version": INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
+            "required_stock_owners": ["HK.0700", "HK.3690", "HK.9988"],
+            "already_counted_stock_owners": ["HK.0700"],
+            "new_stock_owners": ["HK.3690", "HK.9988"],
+            "remain_quota": 2,
+        },
+        observed_at_utc=NOW,
+    )
 
 
 def _prepared(
@@ -188,6 +216,21 @@ def test_runner_deduplicates_closes_and_recovers_terminal_without_provider_repla
     generation = store.generations(case["experiment_spec"]["experiment_id"])[0]
     assert generation["revision"] == 1
     assert generation["terminal_published_event_id"] is None
+    revision_path = root.joinpath(*str(generation["last_revision_ref"]).split("/"))
+    revision = json.loads(revision_path.read_text(encoding="utf-8"))
+    assert revision["schema_version"] == INTERNAL_RESEARCH_REVISION_SCHEMA
+    assert revision["fee_contract"] == _fee_contract()
+    evidence = revision["history_kline_evidence"]
+    assert evidence["observed_at_utc"] == NOW
+    assert evidence["page_complete"] is True
+    assert evidence["quota_decision"] == {
+        "schema_version": INTERNAL_RESEARCH_QUOTA_DECISION_SCHEMA,
+        "required_stock_owners": ["HK.0700", "HK.3690", "HK.9988"],
+        "already_counted_stock_owners": ["HK.0700"],
+        "new_stock_owners": ["HK.3690", "HK.9988"],
+        "remain_quota": 2,
+    }
+    assert evidence["close_receipts"] == _receipts()
 
     monkeypatch.setattr(runner_module, "recover_terminal_projection", recover)
     result = _run(store, root, case, research_hash, gateway)
@@ -220,6 +263,40 @@ def test_runner_skips_provider_when_top1_does_not_change(
     assert result["selection"] == "no_research_winner"
     assert gateway.quota_calls == 0
     assert gateway.close_calls == []
+
+
+@pytest.mark.parametrize("mode", ["no_research_winner", "insufficient_evidence"])
+def test_m3_rejects_research_without_a_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    same_top1 = mode == "no_research_winner"
+    store, root, case, research_hash = _prepared(tmp_path, same_top1=same_top1)
+    gateway = FakeGateway(close_value=None)
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+
+    result = _run(store, root, case, research_hash, gateway)
+    assert result["selection"] == mode
+    variants = (
+        (("same", "current_tie_break"),)
+        if same_top1
+        else (
+            ("without", "without_concentration"),
+            ("concentration", "concentration_first"),
+        )
+    )
+    with pytest.raises(Top1LifecycleError) as exc_info:
+        lock_challenger(
+            store,
+            _spec(case["sealed_dataset"], variants=variants, validation=True),
+            challenger_variant_id="same" if same_top1 else "concentration",
+            trading_dates=_trading_days("2026-10-02", 20),
+            actor="human",
+            occurred_at_utc=NOW,
+            idempotency_key=f"lock-{mode}",
+            artifact_root=root,
+            environ=AVAILABLE,
+        )
+    assert exc_info.value.reason_code == "invalid_transition"
 
 
 @pytest.mark.parametrize("tampered_bytes", [b"\xff", b'{"value": 1e999}\n'])
@@ -351,7 +428,7 @@ def test_runner_checks_feature_gate_before_completed_revision_replay(
     assert generation["terminal_published_event_id"] == published_event_id
 
 
-def test_runner_rejects_hash_valid_foreign_revision_without_sealing(
+def test_runner_rejects_revision_when_evidence_and_evaluation_disagree(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, root, case, research_hash = _prepared(tmp_path)
@@ -367,13 +444,15 @@ def test_runner_rejects_hash_valid_foreign_revision_without_sealing(
         environ=AVAILABLE,
     )
     generation = store.generations(experiment_id)[0]
-    foreign = evaluate_research(case, _receipts(), _fee_contract())
-    foreign["experiment_id"] = "another-experiment"
+    revision = _revision(case)
+    revision["history_kline_evidence"]["close_receipts"][0][
+        "underlier_close"
+    ] = 1.0
     ref = (
         f"strategy_lab/top1/experiments/{experiment_id}/generations/"
         "research.revision.1.json"
     )
-    content = render_json_text(foreign).encode("utf-8")
+    content = render_json_text(revision).encode("utf-8")
     publish_exact_text(root, ref, content)
     record_generation_revision(
         store,
@@ -385,7 +464,7 @@ def test_runner_rejects_hash_valid_foreign_revision_without_sealing(
         frozen_row_sha256=str(generation["frozen_row_content_sha256"]),
         actor="runner",
         occurred_at_utc=NOW,
-        idempotency_key="foreign-revision",
+        idempotency_key="inconsistent-revision",
         artifact_root=root,
         environ=AVAILABLE,
     )

--- a/tests/test_strategy_lab_top1_research_runner.py
+++ b/tests/test_strategy_lab_top1_research_runner.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import src.application.strategy_lab.top1.research_runner as runner_module
+from src.application.shadow_replay.common import render_json_text
+from src.application.strategy_lab.top1.lifecycle import (
+    authorize_research,
+    prepare_experiment,
+    record_generation_revision,
+    set_account_opt_in,
+    start_research,
+)
+from src.application.strategy_lab.top1.research import evaluate_research
+from src.application.strategy_lab.top1.research_runner import (
+    ResearchRunnerError,
+    run_research,
+)
+from src.application.strategy_lab.top1.terminal_projection import publish_exact_text
+from src.infrastructure.strategy_lab.experiment_store import ExperimentStore
+from tests.test_strategy_lab_top1_research import (
+    AVAILABLE,
+    SOURCE_SHA,
+    _build_case,
+    _fee_contract,
+    _receipts,
+    _set_variants,
+)
+
+
+NOW = "2026-08-15T12:00:00Z"
+
+
+class FakeGateway:
+    def __init__(
+        self,
+        *,
+        remaining: int = 2,
+        existing_codes: tuple[str, ...] = ("HK.0700",),
+        close_value: float | None = 390.0,
+        close_error: bool = False,
+    ) -> None:
+        self.remaining = remaining
+        self.existing_codes = existing_codes
+        self.close_value = close_value
+        self.close_error = close_error
+        self.quota_calls = 0
+        self.close_calls: list[tuple[str, str]] = []
+
+    def get_history_kl_quota(self) -> dict[str, Any]:
+        self.quota_calls += 1
+        return {
+            "used_quota": len(self.existing_codes),
+            "remain_quota": self.remaining,
+            "detail_list": [
+                {"code": code, "request_time": "2026-08-15 09:00:00"}
+                for code in self.existing_codes
+            ],
+        }
+
+    def get_exact_expiration_close(
+        self, *, code: str, expiration: str
+    ) -> dict[str, object] | None:
+        self.close_calls.append((code, expiration))
+        if self.close_error:
+            raise RuntimeError("provider unavailable")
+        if self.close_value is None:
+            return None
+        return {"code": code, "expiration": expiration, "close": self.close_value}
+
+
+def _direct_limiter(*, call: Any, **_kwargs: Any) -> Any:
+    return call()
+
+
+def _publish_case(root: Path, case: dict[str, Any]) -> None:
+    publish_exact_text(
+        root,
+        case["dataset_ref"],
+        render_json_text(case["sealed_dataset"]).encode("utf-8"),
+    )
+    for item in case["ranking_projections"]:
+        publish_exact_text(
+            root,
+            item["projection_ref"],
+            render_json_text(item["projection"]).encode("utf-8"),
+        )
+
+
+def _prepared(
+    tmp_path: Path, *, same_top1: bool = False
+) -> tuple[ExperimentStore, Path, dict[str, Any], str]:
+    case = _build_case(tmp_path / "source")
+    if same_top1:
+        _set_variants(case, (("same", "current_tie_break"),))
+    root = tmp_path / "artifacts"
+    _publish_case(root, case)
+    store = ExperimentStore(tmp_path / "strategy-lab.sqlite3")
+    store.migrate(migrated_at_utc=NOW)
+    set_account_opt_in(
+        store,
+        market="HK",
+        account="lx",
+        enabled=True,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="enable",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    prepared = prepare_experiment(
+        store,
+        case["experiment_spec"],
+        provenance={"source_commit_sha": SOURCE_SHA},
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="prepare",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    research_hash = str(prepared["research_spec_sha256"])
+    authorize_research(
+        store,
+        experiment_id=case["experiment_spec"]["experiment_id"],
+        research_spec_sha256=research_hash,
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="authorize",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    return store, root, case, research_hash
+
+
+def _run(
+    store: ExperimentStore,
+    root: Path,
+    case: dict[str, Any],
+    research_hash: str,
+    gateway: FakeGateway,
+    *,
+    fee_contract: object | None = None,
+    environ: dict[str, str] = AVAILABLE,
+) -> dict[str, object]:
+    return run_research(
+        store,
+        root,
+        experiment_id=case["experiment_spec"]["experiment_id"],
+        research_spec_sha256=research_hash,
+        fee_contract=_fee_contract() if fee_contract is None else fee_contract,
+        gateway=gateway,  # type: ignore[arg-type]
+        config=None,
+        actor="runner",
+        occurred_at_utc=NOW,
+        idempotency_key="run",
+        environ=environ,
+    )
+
+
+def test_runner_deduplicates_closes_and_recovers_terminal_without_provider_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path)
+    gateway = FakeGateway()
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+    recover = runner_module.recover_terminal_projection
+    monkeypatch.setattr(
+        runner_module,
+        "recover_terminal_projection",
+        lambda *_args, **_kwargs: {"recovered": 0, "pending": 1},
+    )
+
+    with pytest.raises(ResearchRunnerError) as exc_info:
+        _run(store, root, case, research_hash, gateway)
+    assert exc_info.value.reason_code == "research_terminal_pending"
+    assert gateway.quota_calls == 1
+    assert gateway.close_calls == sorted(set(gateway.close_calls))
+    assert {code for code, _expiration in gateway.close_calls} == {
+        "HK.0700",
+        "HK.3690",
+        "HK.9988",
+    }
+    first_counts = (gateway.quota_calls, len(gateway.close_calls))
+    generation = store.generations(case["experiment_spec"]["experiment_id"])[0]
+    assert generation["revision"] == 1
+    assert generation["terminal_published_event_id"] is None
+
+    monkeypatch.setattr(runner_module, "recover_terminal_projection", recover)
+    result = _run(store, root, case, research_hash, gateway)
+
+    assert result["selection"] == "research_leader"
+    assert (gateway.quota_calls, len(gateway.close_calls)) == first_counts
+    generation = store.generations(case["experiment_spec"]["experiment_id"])[0]
+    assert generation["terminal_published_event_id"] is not None
+    assert store.experiment(case["experiment_spec"]["experiment_id"])[
+        "research_progress"
+    ] == "ready_to_compare"
+
+
+def test_runner_skips_provider_when_top1_does_not_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path, same_top1=True)
+    gateway = FakeGateway(remaining=0, existing_codes=())
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+
+    result = _run(
+        store,
+        root,
+        case,
+        research_hash,
+        gateway,
+        fee_contract=_fee_contract(complete=False),
+    )
+
+    assert result["selection"] == "no_research_winner"
+    assert gateway.quota_calls == 0
+    assert gateway.close_calls == []
+
+
+@pytest.mark.parametrize("tampered_bytes", [b"\xff", b'{"value": 1e999}\n'])
+def test_runner_rejects_tampered_artifact_before_state_or_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tampered_bytes: bytes
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path)
+    dataset_path = root.joinpath(*case["dataset_ref"].split("/"))
+    dataset_path.write_bytes(tampered_bytes)
+    gateway = FakeGateway()
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+
+    with pytest.raises(ResearchRunnerError) as exc_info:
+        _run(store, root, case, research_hash, gateway)
+
+    assert exc_info.value.reason_code == "research_artifact_invalid"
+    assert store.generations(case["experiment_spec"]["experiment_id"]) == []
+    assert gateway.quota_calls == 0
+    assert gateway.close_calls == []
+
+
+def test_runner_rejects_malformed_fee_before_state_or_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path)
+    fee_contract = _fee_contract()
+    fee_contract["account_fee_plan"]["unexpected"] = True
+    gateway = FakeGateway()
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+
+    with pytest.raises(ResearchRunnerError) as exc_info:
+        _run(
+            store,
+            root,
+            case,
+            research_hash,
+            gateway,
+            fee_contract=fee_contract,
+        )
+
+    assert exc_info.value.reason_code == "research_input_invalid"
+    assert store.generations(case["experiment_spec"]["experiment_id"]) == []
+    assert gateway.quota_calls == 0
+    assert gateway.close_calls == []
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_reason", "expected_revision"),
+    [
+        ("quota", "research_history_quota_insufficient", 0),
+        ("provider", "research_expiry_close_unavailable", 0),
+        ("missing", None, 1),
+    ],
+)
+def test_runner_fails_closed_for_quota_provider_and_missing_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    expected_reason: str | None,
+    expected_revision: int,
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path)
+    gateway = FakeGateway(
+        remaining=0 if mode == "quota" else 2,
+        close_error=mode == "provider",
+        close_value=None if mode == "missing" else 390.0,
+    )
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+
+    if expected_reason is not None:
+        with pytest.raises(ResearchRunnerError) as exc_info:
+            _run(store, root, case, research_hash, gateway)
+        assert exc_info.value.reason_code == expected_reason
+    else:
+        result = _run(store, root, case, research_hash, gateway)
+        assert result["selection"] == "insufficient_evidence"
+        assert result["reason_details"] == ["expiry_close_missing_after_deadline"]
+    generation = store.generations(case["experiment_spec"]["experiment_id"])[0]
+    assert generation["revision"] == expected_revision
+    if mode == "quota":
+        assert gateway.close_calls == []
+
+
+def test_runner_checks_feature_gate_before_provider_on_open_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path)
+    start_research(
+        store,
+        experiment_id=case["experiment_spec"]["experiment_id"],
+        research_spec_sha256=research_hash,
+        actor="runner",
+        occurred_at_utc=NOW,
+        idempotency_key="manual-start",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    gateway = FakeGateway()
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+
+    with pytest.raises(ResearchRunnerError) as exc_info:
+        _run(store, root, case, research_hash, gateway, environ={})
+
+    assert exc_info.value.reason_code == "feature_disabled"
+    assert gateway.quota_calls == 0
+    assert gateway.close_calls == []
+    assert store.generations(case["experiment_spec"]["experiment_id"])[0][
+        "revision"
+    ] == 0
+
+
+def test_runner_checks_feature_gate_before_completed_revision_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path)
+    gateway = FakeGateway()
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+    _run(store, root, case, research_hash, gateway)
+    first_counts = (gateway.quota_calls, len(gateway.close_calls))
+    generation = store.generations(case["experiment_spec"]["experiment_id"])[0]
+    published_event_id = generation["terminal_published_event_id"]
+
+    with pytest.raises(ResearchRunnerError) as exc_info:
+        _run(store, root, case, research_hash, gateway, environ={})
+
+    assert exc_info.value.reason_code == "feature_disabled"
+    assert (gateway.quota_calls, len(gateway.close_calls)) == first_counts
+    generation = store.generations(case["experiment_spec"]["experiment_id"])[0]
+    assert generation["terminal_published_event_id"] == published_event_id
+
+
+def test_runner_rejects_hash_valid_foreign_revision_without_sealing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, root, case, research_hash = _prepared(tmp_path)
+    experiment_id = case["experiment_spec"]["experiment_id"]
+    start_research(
+        store,
+        experiment_id=experiment_id,
+        research_spec_sha256=research_hash,
+        actor="runner",
+        occurred_at_utc=NOW,
+        idempotency_key="manual-start",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    generation = store.generations(experiment_id)[0]
+    foreign = evaluate_research(case, _receipts(), _fee_contract())
+    foreign["experiment_id"] = "another-experiment"
+    ref = (
+        f"strategy_lab/top1/experiments/{experiment_id}/generations/"
+        "research.revision.1.json"
+    )
+    content = render_json_text(foreign).encode("utf-8")
+    publish_exact_text(root, ref, content)
+    record_generation_revision(
+        store,
+        experiment_id=experiment_id,
+        generation_kind="research",
+        revision=1,
+        revision_ref=ref,
+        revision_file_sha256=hashlib.sha256(content).hexdigest(),
+        frozen_row_sha256=str(generation["frozen_row_content_sha256"]),
+        actor="runner",
+        occurred_at_utc=NOW,
+        idempotency_key="foreign-revision",
+        artifact_root=root,
+        environ=AVAILABLE,
+    )
+    gateway = FakeGateway()
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+
+    with pytest.raises(ResearchRunnerError) as exc_info:
+        _run(store, root, case, research_hash, gateway)
+
+    assert exc_info.value.reason_code == "research_revision_conflict"
+    assert gateway.quota_calls == 0
+    assert gateway.close_calls == []
+    generation = store.generations(experiment_id)[0]
+    assert generation["terminal_request_event_id"] is None

--- a/tests/test_strategy_lab_top1_store.py
+++ b/tests/test_strategy_lab_top1_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -10,12 +11,14 @@ from typing import Any
 
 import pytest
 
+from domain.domain.decision_state_fingerprint import canonical_sha256
 from domain.domain.engine import (
     SELL_PUT_RANKING_CONTRACT_VERSION,
     SELL_PUT_RANKING_PROFILES,
 )
 from domain.domain.fee_calc import FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
 from src.application.opening_candidate_snapshot import OPENING_CANDIDATE_SNAPSHOT_SCHEMA
+from src.application.shadow_replay.common import artifact_content_sha256, render_json_text
 from src.application.strategy_lab.top1.contracts import (
     ACCEPTED_SET_CONTRACT_VERSION,
     EXPERIMENT_SPEC_SCHEMA_VERSION,
@@ -26,14 +29,15 @@ from src.application.strategy_lab.top1.contracts import (
     VALIDATION_METRIC_CONTRACT_VERSION,
     build_behavior_binding,
     build_research_spec_sha256,
+    build_validation_spec_sha256,
 )
 from src.application.strategy_lab.top1.lifecycle import (
     Top1LifecycleError,
     authorize_research,
     authorize_validation,
+    build_hidden_window_commitment,
     commit_validation_point,
     effective_feature_status,
-    lock_challenger,
     prepare_experiment,
     read_public_receipt,
     read_public_status,
@@ -52,6 +56,7 @@ from src.application.strategy_lab.top1.terminal_projection import (
 from src.infrastructure.strategy_lab.experiment_store import (
     ExperimentStore,
     ExperimentStoreError,
+    compact_json,
 )
 
 
@@ -247,6 +252,66 @@ def _ready_research(store: ExperimentStore, root: Path, experiment_id: str) -> N
     recover_terminal_projection(store, root)
 
 
+def _lock_store_challenger(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    trading_dates: list[str],
+    idempotency_key: str,
+) -> dict[str, Any]:
+    spec = _spec(experiment_id, validation=True)
+    research = next(
+        item
+        for item in store.generations(experiment_id)
+        if item["generation_kind"] == "research"
+    )
+    research_hash = build_research_spec_sha256(spec)
+    terminal_hash = str(research["terminal_file_sha256"])
+    commitment = build_hidden_window_commitment(
+        experiment_id=experiment_id,
+        account="lx",
+        trading_dates=trading_dates,
+        market_calendar_version=str(
+            spec["economics_contracts"]["market_calendar_version"]
+        ),
+        challenger_variant_id="level-1",
+        research_spec_sha256=research_hash,
+        research_terminal_file_sha256=terminal_hash,
+        behavior_binding_sha256=str(spec["baseline"]["behavior_binding_sha256"]),
+    )
+    commitment_sha = canonical_sha256(commitment)
+    commitment_text = render_json_text(commitment)
+    return store.lock_challenger(
+        experiment_id=experiment_id,
+        spec_json=compact_json(spec),
+        research_spec_sha256=research_hash,
+        validation_spec_sha256=build_validation_spec_sha256(
+            spec,
+            research_terminal_sha256=terminal_hash,
+            challenger_variant_id="level-1",
+            hidden_window_commitment_sha256=commitment_sha,
+        ),
+        research_leader="level-1",
+        research_receipt_ref=(
+            f"strategy_lab/top1/{experiment_id}/research-receipt.json"
+        ),
+        research_receipt_file_sha256=terminal_hash,
+        commitment_json=compact_json(commitment),
+        commitment_sha256=commitment_sha,
+        commitment_ref=(
+            f"strategy_lab/top1/experiments/{experiment_id}/"
+            f"hidden_window_commitments/{commitment_sha}.json"
+        ),
+        commitment_content_sha256=artifact_content_sha256(commitment),
+        commitment_file_sha256=hashlib.sha256(
+            commitment_text.encode("utf-8")
+        ).hexdigest(),
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key=idempotency_key,
+    )
+
+
 def _ready_validation(
     store: ExperimentStore,
     root: Path,
@@ -254,20 +319,11 @@ def _ready_validation(
     trading_dates: list[str],
 ) -> dict[str, Any]:
     _ready_research(store, root, experiment_id)
-    research = store.generations(experiment_id)[0]
-    locked = lock_challenger(
+    locked = _lock_store_challenger(
         store,
-        _spec(experiment_id, validation=True),
-        system_leader="level-1",
-        challenger_variant_id="level-1",
-        research_receipt_ref=f"strategy_lab/top1/{experiment_id}/research-receipt.json",
-        research_receipt_file_sha256=str(research["terminal_file_sha256"]),
+        experiment_id=experiment_id,
         trading_dates=trading_dates,
-        actor="human",
-        occurred_at_utc=NOW,
         idempotency_key=f"lock-{experiment_id}",
-        artifact_root=root,
-        environ=AVAILABLE,
     )
     authorize_validation(
         store,
@@ -619,24 +675,11 @@ def test_exact_date_overlap_and_content_addressed_orphan(tmp_path: Path) -> None
     assert (root / orphan_ref).is_file()
 
     replacement_dates = _dates(date(2027, 3, 1))
-    research = next(
-        row
-        for row in store.generations("experiment-overlap")
-        if row["generation_kind"] == "research"
-    )
-    relocked = lock_challenger(
+    relocked = _lock_store_challenger(
         store,
-        _spec("experiment-overlap", validation=True),
-        system_leader="level-1",
-        challenger_variant_id="level-1",
-        research_receipt_ref="strategy_lab/top1/experiment-overlap/research-receipt.json",
-        research_receipt_file_sha256=str(research["terminal_file_sha256"]),
+        experiment_id="experiment-overlap",
         trading_dates=replacement_dates,
-        actor="human",
-        occurred_at_utc=NOW,
         idempotency_key="relock-overlap",
-        artifact_root=root,
-        environ=AVAILABLE,
     )
     replacement_ref = str(relocked["proposed_commitment_ref"])
     assert not (root / replacement_ref).exists()


### PR DESCRIPTION
## Summary

- compose the authorized W3 experiment and exact W4 sealed corpus into one W5 research run
- deduplicate quota-bound exact-expiration close reads and persist a compact, hash-bound research evidence envelope
- make replay provider-free and self-validate persisted close/fee evidence against the nested evaluation
- make M3 derive the actual winner and receipt binding from generation revision 1 instead of caller claims

## Validation

- 75 focused tests passed
- full repository Ruff passed
- git diff --check passed
- Kimi DeepReview aggregate findings fixed; re-review passed with no remaining finding

## Scope

No live OpenD call, W6 hidden validation, CLI/service/config change, notification, release, deploy, or production write.