### PR TITLE
feat(strategy-lab): add Top1 hidden validation core

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 942 (`src`: 508, `domain`: 75, `scripts`: 9, `tests`: 350)
-- Internal import edges: 6150 total, 2609 production/script edges excluding tests
+- Python files scanned: 946 (`src`: 511, `domain`: 75, `scripts`: 9, `tests`: 351)
+- Internal import edges: 6189 total, 2635 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,9 +31,9 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|391| domain
+  application -->|396| domain
   application -->|4| domain_services
-  application -->|141| infrastructure
+  application -->|145| infrastructure
   application -->|41| storage
   domain_services -->|5| domain
   domain_services -->|2| storage
@@ -45,10 +45,10 @@ flowchart LR
   scripts -->|13| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2631| application
+  tests -->|2638| application
   tests -->|436| domain
   tests -->|2| domain_services
-  tests -->|176| infrastructure
+  tests -->|178| infrastructure
   tests -->|221| interfaces
   tests -->|15| scripts
   tests -->|18| storage
@@ -58,8 +58,8 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 391 |
-| application | infrastructure | 141 |
+| application | domain | 396 |
+| application | infrastructure | 145 |
 | interfaces | application | 140 |
 | application | storage | 41 |
 | infrastructure | application | 13 |
@@ -77,10 +77,10 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2631 |
+| tests | application | 2638 |
 | tests | domain | 436 |
 | tests | interfaces | 221 |
-| tests | infrastructure | 176 |
+| tests | infrastructure | 178 |
 | tests | storage | 18 |
 | tests | scripts | 15 |
 | tests | domain_services | 2 |
@@ -91,9 +91,9 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 
 | from | to | imports |
 |---|---|---|
-| src.application | domain.domain | 204 |
+| src.application | domain.domain | 209 |
 | src.interfaces | src.application | 113 |
-| src.application | src.infrastructure | 102 |
+| src.application | src.infrastructure | 106 |
 | src.application.ledger | domain.domain | 49 |
 | src.application.ledger | domain.domain.ledger | 38 |
 | src.application | domain.storage | 32 |
@@ -186,9 +186,9 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | domain.domain.ledger.position_fields | 43 |
 | domain.domain.option_position_identity | 40 |
 | src.application.account_config | 38 |
-| src.application.shadow_replay.common | 31 |
+| src.application.shadow_replay.common | 32 |
+| domain.domain.decision_state_fingerprint | 28 |
 | domain.domain.engine | 25 |
-| domain.domain.decision_state_fingerprint | 25 |
 | src.application.settings | 23 |
 | domain.domain.trade_contract_identity | 23 |
 | src.application.agent_tools.runtime_helpers | 22 |

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,7 +1,7 @@
 flowchart LR
-  src_application["src.application"] -->|204| domain_domain["domain.domain"]
+  src_application["src.application"] -->|209| domain_domain["domain.domain"]
   src_interfaces["src.interfaces"] -->|113| src_application["src.application"]
-  src_application["src.application"] -->|102| src_infrastructure["src.infrastructure"]
+  src_application["src.application"] -->|106| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|49| domain_domain["domain.domain"]
   src_application_ledger["src.application.ledger"] -->|38| domain_domain_ledger["domain.domain.ledger"]
   src_application["src.application"] -->|32| domain_storage["domain.storage"]

--- a/src/application/strategy_lab/top1/corpus.py
+++ b/src/application/strategy_lab/top1/corpus.py
@@ -1065,6 +1065,111 @@ def _read_indexed_projection(
     return item, content
 
 
+def read_validation_day_source(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    market: str,
+    account: str,
+    trading_date: str,
+) -> dict[str, Any]:
+    """Read one indexed validation denominator without repairing producer data."""
+
+    market, account = _identity(market, account)
+    trading_date = _trading_date(trading_date)
+    row = _store_call(store.corpus_day, market, account, trading_date)
+    if row is None:
+        return {"status": "missing", "row": None, "expectation": None}
+    if row["conflict_status"] != "clean" or row["completeness_reason"] is not None:
+        return {
+            "status": "not_evaluable",
+            "reason_code": row["completeness_reason"] or "research_corpus_conflict",
+            "row": dict(row),
+            "expectation": None,
+        }
+    expectation, _content = _read_indexed_expectation(artifact_root, row)
+    if not expectation["expected_recommendation_point_ids"]:
+        return {
+            "status": "not_evaluable",
+            "reason_code": "corpus_day_expectation_empty",
+            "row": dict(row),
+            "expectation": expectation,
+        }
+    return {
+        "status": "available",
+        "reason_code": None,
+        "row": dict(row),
+        "expectation": expectation,
+    }
+
+
+def read_validation_point_source(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    market: str,
+    account: str,
+    trading_date: str,
+    recommendation_point_id: str,
+) -> dict[str, Any]:
+    """Read one point strictly bound to its canonical day expectation and index."""
+
+    day = read_validation_day_source(
+        store,
+        artifact_root,
+        market=market,
+        account=account,
+        trading_date=trading_date,
+    )
+    if day["status"] != "available":
+        return {**day, "point_row": None, "projection": None}
+    expectation = day["expectation"]
+    assert isinstance(expectation, dict)
+    expected_ids = expectation["expected_recommendation_point_ids"]
+    if recommendation_point_id not in expected_ids:
+        _fail(
+            "unexpected_recommendation_point",
+            "validation point is absent from the canonical expectation",
+        )
+    row = _store_call(
+        store.corpus_point, market, account, recommendation_point_id
+    )
+    if row is None:
+        return {
+            **day,
+            "status": "missing",
+            "reason_code": "corpus_point_missing",
+            "point_row": None,
+            "projection": None,
+        }
+    if row["trading_date"] != trading_date:
+        _fail("corpus_artifact_invalid", "point index trading date changed")
+    if row["conflict_status"] != "clean":
+        return {
+            **day,
+            "status": "not_evaluable",
+            "reason_code": "research_corpus_conflict",
+            "point_row": dict(row),
+            "projection": None,
+        }
+    if row["capture_status"] != "captured":
+        return {
+            **day,
+            "status": "not_evaluable",
+            "reason_code": row["reason_code"],
+            "point_row": dict(row),
+            "projection": None,
+        }
+    projection, _content = _read_indexed_projection(artifact_root, row)
+    return {
+        **day,
+        "status": "available",
+        "reason_code": None,
+        "point_row": dict(row),
+        "projection": projection,
+    }
+
+
 def read_corpus_status(
     store: ExperimentStore,
     *,
@@ -1373,5 +1478,7 @@ __all__ = [
     "capture_recommendation_point",
     "freeze_research_dataset",
     "read_corpus_status",
+    "read_validation_day_source",
+    "read_validation_point_source",
     "seal_day_expectation",
 ]

--- a/src/application/strategy_lab/top1/fill_observation.py
+++ b/src/application/strategy_lab/top1/fill_observation.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.option_lifecycle import expiration_observation_start_ms
+from src.application.strategy_lab.top1.corpus import (
+    CorpusError,
+    read_validation_day_source,
+)
+from src.application.strategy_lab.top1.lifecycle import (
+    _call,
+    _command_fields,
+    _require_effective,
+    _segment,
+)
+from src.application.strategy_lab.top1.validation import (
+    Top1ValidationError,
+    _context,
+    _generation,
+    _revision_request,
+    _terminal_if_final,
+    _utc,
+)
+from src.infrastructure.strategy_lab.experiment_store import (
+    ExperimentStore,
+    compact_json,
+)
+
+
+_HASH = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class FillObservationError(ValueError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise FillObservationError(reason_code, message)
+
+
+def _rows(value: object) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        if any(not isinstance(item, Mapping) for item in value):
+            _fail("fill_observation_invalid", "snapshot rows must be objects")
+        return [dict(cast(Mapping[str, Any], item)) for item in value]
+    to_dict = getattr(value, "to_dict", None)
+    if not callable(to_dict):
+        _fail("fill_observation_invalid", "snapshot result must be tabular")
+    try:
+        raw = to_dict(orient="records")
+    except (TypeError, ValueError) as exc:
+        raise FillObservationError(
+            "fill_observation_invalid", "snapshot result cannot be projected"
+        ) from exc
+    if not isinstance(raw, list) or any(not isinstance(item, Mapping) for item in raw):
+        _fail("fill_observation_invalid", "snapshot rows must be objects")
+    return [dict(cast(Mapping[str, Any], item)) for item in raw]
+
+
+def _price(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    result = float(value)
+    return result if math.isfinite(result) else None
+
+
+def _snapshot_by_code(
+    value: object, requested_codes: list[str]
+) -> tuple[dict[str, dict[str, Any]], str | None]:
+    rows = _rows(value)
+    requested = set(requested_codes)
+    by_code: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        code = str(row.get("code") or "").strip().upper()
+        if not code or code not in requested or code in by_code:
+            return {}, "snapshot_coverage_conflict"
+        by_code[code] = row
+    return by_code, None
+
+
+def _job(
+    *,
+    decision: Mapping[str, Any],
+    arm: str,
+    candidate: Mapping[str, Any],
+    market: str,
+    pending_hours: int,
+) -> dict[str, object]:
+    due_ms = expiration_observation_start_ms(str(candidate["expiration"]), market)
+    if due_ms is None:
+        _fail("outcome_contract_invalid", "expiration due boundary is unavailable")
+    due = datetime.fromtimestamp(due_ms / 1000, tz=timezone.utc)
+    deadline = due + timedelta(hours=pending_hours)
+    payload: dict[str, object] = {
+        "target_point_id": decision["recommendation_point_id"],
+        "arm": arm,
+        "trading_date": decision["trading_date"],
+        "fill_date": decision["trading_date"],
+        "fill_price": candidate["sell_limit"],
+        "contract_symbol": candidate["contract_symbol"],
+        "stock_owner": candidate["stock_owner"],
+        "expiration": candidate["expiration"],
+        "strike": candidate["strike"],
+        "multiplier": candidate["multiplier"],
+        "currency": candidate["currency"],
+        "opening_net_premium": candidate["opening_net_premium"],
+        "net_cash_basis": candidate["net_cash_basis"],
+        "account_fee_plan": candidate["account_fee_plan"],
+        "fee_schedule_version": candidate["fee_schedule_version"],
+        "source_ref": decision["source_ref"],
+        "source_content_sha256": decision["source_content_sha256"],
+        "terms_capture_trading_date": candidate["expiration"],
+        "due_at_utc": due.isoformat().replace("+00:00", "Z"),
+        "deadline_at_utc": deadline.isoformat().replace("+00:00", "Z"),
+    }
+    return {
+        **payload,
+        "job_json": compact_json(payload),
+        "job_sha256": canonical_sha256(payload),
+    }
+
+
+def _day(
+    decisions: list[dict[str, Any]],
+    *,
+    expectation_row: Mapping[str, Any],
+    expected_count: int,
+    updates: list[dict[str, object]],
+) -> dict[str, object]:
+    status_by_key = {
+        (str(row["target_point_id"]), str(row["arm"])): row["fill_status"]
+        for row in updates
+    }
+    terminal_statuses: list[str] = []
+    for decision in decisions:
+        for arm in ("baseline", "challenger"):
+            current = decision[f"{arm}_fill_status"]
+            if current is not None:
+                terminal_statuses.append(
+                    str(
+                        status_by_key.get(
+                            (str(decision["recommendation_point_id"]), arm), current
+                        )
+                    )
+                )
+    evidence_missing = any(
+        decision["hard_risk_status"] != "passed" for decision in decisions
+    ) or any(status == "not_evaluable" for status in terminal_statuses)
+    hard_risk = "missing" if evidence_missing else "passed"
+    reason = "validation_evidence_missing" if evidence_missing else None
+    daily = {
+        "status": "not_evaluable" if evidence_missing else "evaluable",
+        "decision_count": len(decisions),
+        "arm_count": len(terminal_statuses),
+        "observed_fill_count": terminal_statuses.count("observed_fill"),
+        "no_observed_fill_count": terminal_statuses.count("no_observed_fill"),
+        "not_evaluable_count": terminal_statuses.count("not_evaluable"),
+    }
+    return {
+        "trading_date": decisions[0]["trading_date"],
+        "expectation_ref": expectation_row["expectation_ref"],
+        "expectation_content_sha256": expectation_row["expectation_content_sha256"],
+        "expectation_file_sha256": expectation_row["expectation_file_sha256"],
+        "expected_point_count": expected_count,
+        "consumed_point_count": len(decisions),
+        "hard_risk_status": hard_risk,
+        "reason_code": reason,
+        "deadline_at_utc": None,
+        "daily_json": compact_json(daily),
+    }
+
+
+def observe_active_contracts(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    observed_recommendation_point_id: str,
+    gateway: Any,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    if _HASH.fullmatch(observed_recommendation_point_id) is None:
+        _fail("fill_observation_invalid", "observed point ID is invalid")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    current = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(current["market"]),
+        account=str(current["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    if _call(
+        store.validation_observation_committed,
+        experiment_id,
+        observed_recommendation_point_id,
+    ):
+        return {
+            "status": "idempotent",
+            "observations": _call(
+                store.fill_observations,
+                experiment_id,
+                observed_point_id=observed_recommendation_point_id,
+            ),
+        }
+    if current["terminal_mode"] is not None or current["validation_progress"] != (
+        "collecting_decisions"
+    ):
+        return {"status": "terminal", "observations": []}
+    try:
+        experiment, spec, _commitment, _research, trading_date = _context(
+            store,
+            experiment_id=experiment_id,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=idempotency_key,
+            artifact_root=artifact_root,
+            environ=environ,
+        )
+    except Top1ValidationError as exc:
+        raise FillObservationError(exc.reason_code, str(exc)) from exc
+    decisions = [
+        row
+        for row in _call(store.validation_decisions, experiment_id)
+        if row["trading_date"] == trading_date
+    ]
+    if not decisions or decisions[-1]["recommendation_point_id"] != (
+        observed_recommendation_point_id
+    ):
+        _fail("fill_observation_conflict", "observed point is not the latest decision")
+    observed = decisions[-1]
+    try:
+        day_source = read_validation_day_source(
+            store,
+            artifact_root,
+            market=str(experiment["market"]),
+            account=str(experiment["account"]),
+            trading_date=trading_date,
+        )
+    except CorpusError as exc:
+        raise FillObservationError(exc.reason_code, str(exc)) from exc
+    if day_source["status"] != "available":
+        _fail("fill_observation_conflict", "day expectation is unavailable")
+    expectation = cast(Mapping[str, Any], day_source["expectation"])
+    expected_ids = cast(list[str], expectation["expected_recommendation_point_ids"])
+    is_final = observed_recommendation_point_id == expected_ids[-1]
+    if [row["recommendation_point_id"] for row in decisions] != expected_ids[: len(decisions)]:
+        _fail("fill_observation_conflict", "decision sequence changed")
+
+    active: list[tuple[dict[str, Any], str, dict[str, Any]]] = []
+    for decision in decisions:
+        for arm in ("baseline", "challenger"):
+            if decision[f"{arm}_fill_status"] != "monitoring":
+                continue
+            candidate = json.loads(str(decision[f"{arm}_json"]))
+            if not isinstance(candidate, dict):
+                _fail("fill_observation_conflict", "candidate facts are invalid")
+            active.append((decision, arm, candidate))
+    codes = sorted({str(candidate["contract_symbol"]).upper() for _, _, candidate in active})
+    rows_by_code: dict[str, dict[str, Any]] = {}
+    batch_reason: str | None = None
+    timer = cast(Mapping[str, Any], spec["timer_binding"])
+    target = _utc(str(observed["target_at_utc"]))
+    command_time = _utc(occurred_at_utc)
+    if command_time < target or command_time > target + timedelta(
+        seconds=int(timer["fill_observation_duration_upper_bound_seconds"])
+    ):
+        batch_reason = "fill_observation_outside_window"
+    elif codes:
+        try:
+            rows_by_code, batch_reason = _snapshot_by_code(
+                gateway.get_snapshot(codes), codes
+            )
+        except Exception:
+            batch_reason = "snapshot_provider_error"
+
+    observations: list[dict[str, object]] = []
+    updates: list[dict[str, object]] = []
+    jobs: list[dict[str, object]] = []
+    current_observation_keys: set[tuple[str, str, str]] = set()
+    pending_hours = int(cast(Mapping[str, Any], spec["expiry_outcome"])["pending_elapsed_hours"])
+    for decision, arm, candidate in active:
+        code = str(candidate["contract_symbol"]).upper()
+        row = rows_by_code.get(code)
+        bid = _price(row.get("bid_price", row.get("bid"))) if row else None
+        ask = _price(row.get("ask_price", row.get("ask"))) if row else None
+        reason = batch_reason
+        if reason is None and row is None:
+            reason = "snapshot_missing"
+        if reason is None and (
+            bid is None or bid < 0 or ask is None or ask <= 0 or ask < bid
+        ):
+            reason = "snapshot_quote_invalid"
+        crossing = reason is None and bid is not None and bid >= float(candidate["sell_limit"])
+        receipt = {
+            "status": "evaluable" if reason is None else "not_evaluable",
+            "reason_code": reason,
+            "target_point_id": decision["recommendation_point_id"],
+            "arm": arm,
+            "observed_point_id": observed_recommendation_point_id,
+            "contract_symbol": code,
+            "captured_at_utc": occurred_at_utc,
+            "bid": bid,
+            "ask": ask,
+            "source_ref": decision["source_ref"],
+            "source_content_sha256": decision["source_content_sha256"],
+            "crossing": crossing if reason is None else None,
+        }
+        observations.append(
+            {
+                **receipt,
+                "trading_date": trading_date,
+                "observation_status": "quote",
+                "observation_json": compact_json(receipt),
+                "observation_sha256": canonical_sha256(receipt),
+            }
+        )
+        current_observation_keys.add(
+            (
+                str(decision["recommendation_point_id"]),
+                arm,
+                observed_recommendation_point_id,
+            )
+        )
+        if reason is not None:
+            updates.append(
+                {
+                    "target_point_id": decision["recommendation_point_id"],
+                    "arm": arm,
+                    "fill_status": "not_evaluable",
+                }
+            )
+        elif crossing:
+            updates.append(
+                {
+                    "target_point_id": decision["recommendation_point_id"],
+                    "arm": arm,
+                    "fill_status": "observed_fill",
+                }
+            )
+            jobs.append(
+                _job(
+                    decision=decision,
+                    arm=arm,
+                    candidate=candidate,
+                    market=str(experiment["market"]),
+                    pending_hours=pending_hours,
+                )
+            )
+
+    if is_final:
+        prior_keys = {
+            (
+                str(row["target_point_id"]),
+                str(row["arm"]),
+                str(row["observed_point_id"]),
+            )
+            for row in _call(store.fill_observations, experiment_id)
+            if row["trading_date"] == trading_date
+        }
+        update_keys = {
+            (str(row["target_point_id"]), str(row["arm"])) for row in updates
+        }
+        for decision, arm, _candidate in active:
+            key = (str(decision["recommendation_point_id"]), arm)
+            if key in update_keys:
+                continue
+            suffix = expected_ids[int(decision["point_index"]) :]
+            complete = all(
+                (key[0], arm, point_id) in prior_keys | current_observation_keys
+                for point_id in suffix
+            )
+            updates.append(
+                {
+                    "target_point_id": key[0],
+                    "arm": arm,
+                    "fill_status": (
+                        "no_observed_fill" if complete else "not_evaluable"
+                    ),
+                }
+            )
+
+    day = None
+    if is_final:
+        day = _day(
+            decisions,
+            expectation_row=cast(Mapping[str, Any], day_source["row"]),
+            expected_count=len(expected_ids),
+            updates=updates,
+        )
+    hidden = _generation(store, experiment_id, "hidden")
+    revision_args, post_generation = _revision_request(
+        artifact_root,
+        experiment_id=experiment_id,
+        generation=hidden,
+        mutation={
+            "operation": "observe_active_contracts",
+            "observed_point_id": observed_recommendation_point_id,
+            "observations": observations,
+            "fill_status_updates": updates,
+            "new_job_sha256s": [job["job_sha256"] for job in jobs],
+            "day": day,
+        },
+        occurred_at_utc=occurred_at_utc,
+    )
+    terminal = _terminal_if_final(
+        experiment,
+        post_generation,
+        day_will_seal=day is not None,
+        occurred_at_utc=occurred_at_utc,
+    )
+    result = _call(
+        store.commit_validation_observation_batch,
+        experiment_id=experiment_id,
+        expected_state_version=int(experiment["state_version"]),
+        observed_point_id=observed_recommendation_point_id,
+        observations=observations,
+        fill_status_updates=updates,
+        new_jobs=jobs,
+        day=day,
+        terminal_request=terminal,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        **revision_args,
+    )
+    return {"status": result["status"], "observations": observations}
+
+
+__all__ = ["FillObservationError", "observe_active_contracts"]

--- a/src/application/strategy_lab/top1/lifecycle.py
+++ b/src/application/strategy_lab/top1/lifecycle.py
@@ -851,124 +851,6 @@ def start_validation(
     )
 
 
-def commit_validation_point(
-    store: ExperimentStore,
-    *,
-    experiment_id: str,
-    point_id: str,
-    trading_date: str,
-    source_ref: str,
-    source_file_sha256: str,
-    revision: int,
-    manifest_ref: str,
-    manifest_file_sha256: str,
-    frozen_row_sha256: str,
-    actor: str,
-    occurred_at_utc: str,
-    idempotency_key: str,
-    artifact_root: str | Path,
-    environ: Mapping[str, str] | None = None,
-) -> dict[str, object]:
-    experiment_id = _segment(experiment_id, "experiment_id")
-    point_id = _segment(point_id, "point_id")
-    date_text = _text(trading_date, "trading_date")
-    try:
-        if date.fromisoformat(date_text).isoformat() != date_text:
-            raise ValueError
-    except ValueError:
-        _fail("experiment_invalid", "trading_date must be a canonical ISO date")
-    if isinstance(revision, bool) or not isinstance(revision, int) or revision <= 0:
-        _fail("experiment_invalid", "revision must be a positive integer")
-    actor, occurred_at_utc, idempotency_key = _command_fields(
-        actor, occurred_at_utc, idempotency_key
-    )
-    experiment = _call(store.experiment, experiment_id)
-    _require_effective(
-        store,
-        market=str(experiment["market"]),
-        account=str(experiment["account"]),
-        actor=actor,
-        occurred_at_utc=occurred_at_utc,
-        idempotency_key=idempotency_key,
-        artifact_root=artifact_root,
-        environ=environ,
-    )
-    return _call(
-        store.commit_validation_point,
-        experiment_id=experiment_id,
-        point_id=point_id,
-        trading_date=date_text,
-        source_ref=_ref(source_ref, "source_ref"),
-        source_file_sha256=_hash(source_file_sha256, "source_file_sha256"),
-        revision=revision,
-        manifest_ref=_ref(manifest_ref, "manifest_ref"),
-        manifest_file_sha256=_hash(
-            manifest_file_sha256, "manifest_file_sha256"
-        ),
-        frozen_row_sha256=_hash(frozen_row_sha256, "frozen_row_sha256"),
-        actor=actor,
-        occurred_at_utc=occurred_at_utc,
-        idempotency_key=idempotency_key,
-    )
-
-
-def seal_validation_partition(
-    store: ExperimentStore,
-    *,
-    experiment_id: str,
-    trading_date: str,
-    actor: str,
-    occurred_at_utc: str,
-    idempotency_key: str,
-    artifact_root: str | Path,
-    environ: Mapping[str, str] | None = None,
-) -> dict[str, object]:
-    experiment_id = _segment(experiment_id, "experiment_id")
-    trading_date = _text(trading_date, "trading_date")
-    try:
-        if date.fromisoformat(trading_date).isoformat() != trading_date:
-            raise ValueError
-    except ValueError:
-        _fail("experiment_invalid", "trading_date must be a canonical ISO date")
-    actor, occurred_at_utc, idempotency_key = _command_fields(
-        actor, occurred_at_utc, idempotency_key
-    )
-    experiment = _call(store.experiment, experiment_id)
-    _require_effective(
-        store,
-        market=str(experiment["market"]),
-        account=str(experiment["account"]),
-        actor=actor,
-        occurred_at_utc=occurred_at_utc,
-        idempotency_key=idempotency_key,
-        artifact_root=artifact_root,
-        environ=environ,
-    )
-    terminal_request: Mapping[str, object] | None = None
-    if int(experiment["completed_validation_partitions"]) == 19:
-        hidden = next(
-            item
-            for item in _call(store.generations, experiment_id)
-            if item["generation_kind"] == "hidden"
-        )
-        terminal_request = build_generation_terminal_request(
-            hidden,
-            terminal_mode="completed",
-            reason=None,
-            disabled_scope=None,
-            occurred_at_utc=occurred_at_utc,
-        )
-    return _call(
-        store.seal_validation_partition,
-        experiment_id=experiment_id,
-        trading_date=trading_date,
-        terminal_request=terminal_request,
-        actor=actor,
-        occurred_at_utc=occurred_at_utc,
-        idempotency_key=idempotency_key,
-    )
-
-
 def terminate_experiment(
     store: ExperimentStore,
     *,
@@ -1128,6 +1010,8 @@ def read_public_status(
         environ=environ,
     )
     generations = _call(store.generations, experiment_id)
+    decisions = _call(store.validation_decisions, experiment_id)
+    jobs = _call(store.outcome_jobs, experiment_id)
     return {
         "schema_version": PUBLIC_STATUS_SCHEMA,
         "feature": feature,
@@ -1162,12 +1046,25 @@ def read_public_status(
             "terminal_mode": experiment["terminal_mode"],
             "terminal_reason": experiment["terminal_reason"],
             "disabled_scope": experiment["disabled_scope"],
+            "final_outcome_status": (
+                experiment["final_outcome_status"]
+                if experiment["phase"] == "concluded"
+                else None
+            ),
             "projection_state": (
                 "published"
                 if experiment["phase"] == "concluded"
                 else "pending"
                 if experiment["terminal_mode"] is not None
                 else "not_requested"
+            ),
+        },
+        "validation": {
+            "consumed_point_count": len(decisions),
+            "outcome_job_count": len(jobs),
+            "pending_outcome_count": sum(
+                item["status"] in {"pending_terms", "pending_outcome"}
+                for item in jobs
             ),
         },
         "generations": [
@@ -1212,7 +1109,6 @@ __all__ = [
     "authorize_research",
     "authorize_validation",
     "build_hidden_window_commitment",
-    "commit_validation_point",
     "effective_feature_status",
     "lock_challenger",
     "prepare_experiment",
@@ -1221,7 +1117,6 @@ __all__ = [
     "reconcile_disabled_experiments",
     "record_generation_revision",
     "seal_generation",
-    "seal_validation_partition",
     "set_account_opt_in",
     "start_research",
     "start_validation",

--- a/src/application/strategy_lab/top1/outcome.py
+++ b/src/application/strategy_lab/top1/outcome.py
@@ -1,0 +1,808 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from src.application.strategy_lab.top1.contracts import (
+    EXPIRY_OUTCOME_CONTRACT_VERSION,
+    Top1CoreContractError,
+    validate_experiment_spec,
+)
+from src.application.strategy_lab.top1.corpus import (
+    CorpusError,
+    read_validation_day_source,
+    read_validation_point_source,
+)
+from src.application.strategy_lab.top1.economics import calculate_expiry_efficiency
+from src.application.strategy_lab.top1.lifecycle import (
+    Top1LifecycleError,
+    _call,
+    _command_fields,
+    _derived_key,
+    _recover_projection,
+    _require_effective,
+    _segment,
+)
+from src.application.strategy_lab.top1.statistics import (
+    summarize_paired_daily_deltas,
+)
+from src.application.strategy_lab.top1.terminal_projection import (
+    Publisher,
+    build_completed_receipt_request,
+    build_generation_terminal_request,
+)
+from src.application.strategy_lab.top1.validation import (
+    _generation,
+    _revision_request,
+    _utc,
+)
+from src.infrastructure.futu_gateway import FutuGatewayDataContractError
+from src.infrastructure.strategy_lab.experiment_store import (
+    ExperimentStore,
+    compact_json,
+)
+
+
+OUTCOME_REVISION_SCHEMA = "sell_put_top1_outcome_revision.v1"
+
+
+class Top1OutcomeError(ValueError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise Top1OutcomeError(reason_code, message)
+
+
+def _spec(experiment: Mapping[str, Any]) -> dict[str, object]:
+    try:
+        return validate_experiment_spec(json.loads(str(experiment["spec_json"])))
+    except (json.JSONDecodeError, Top1CoreContractError) as exc:
+        raise Top1OutcomeError("experiment_conflict", "experiment spec is invalid") from exc
+
+
+def _pending_update(
+    job: Mapping[str, Any],
+    *,
+    status: str | None = None,
+    reason_code: str | None = None,
+    terms_point_id: str | None = None,
+    terms: Mapping[str, object] | None = None,
+    result: Mapping[str, object] | None = None,
+    occurred_at_utc: str,
+) -> dict[str, object]:
+    return {
+        "target_point_id": job["target_point_id"],
+        "arm": job["arm"],
+        "expected_status": job["status"],
+        "status": status or job["status"],
+        "terms_point_id": terms_point_id,
+        "terms_json": compact_json(terms) if terms is not None else None,
+        "terms_sha256": canonical_sha256(terms) if terms is not None else None,
+        "result_json": compact_json(result) if result is not None else None,
+        "result_sha256": canonical_sha256(result) if result is not None else None,
+        "reason_code": reason_code,
+        "last_attempt_at_utc": occurred_at_utc,
+    }
+
+
+def _attempt_replayed(
+    events: list[dict[str, Any]],
+    *,
+    idempotency_key: str,
+    actor: str,
+    occurred_at_utc: str,
+) -> bool:
+    event = next(
+        (
+            item
+            for item in events
+            if item["command_scope"]
+            == f"experiment:{item['experiment_id']}:outcome"
+            and item["idempotency_key"] == idempotency_key
+        ),
+        None,
+    )
+    if event is None:
+        return False
+    if event["actor"] != actor or event["occurred_at_utc"] != occurred_at_utc:
+        _fail("idempotency_conflict", "outcome attempt identity changed")
+    return True
+
+
+def _commit_outcome(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    updates: list[dict[str, object]],
+    close_fact: Mapping[str, object] | None,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+) -> dict[str, Any]:
+    experiment = _call(store.experiment, experiment_id)
+    generation = _generation(store, experiment_id, "outcome")
+    revision_args, _post = _revision_request(
+        artifact_root,
+        experiment_id=experiment_id,
+        generation=generation,
+        mutation={
+            "operation": "settle_due_outcomes",
+            "job_updates": updates,
+            "close_fact_sha256": close_fact.get("fact_sha256") if close_fact else None,
+        },
+        occurred_at_utc=occurred_at_utc,
+        schema_version=OUTCOME_REVISION_SCHEMA,
+    )
+    return cast(
+        dict[str, Any],
+        _call(
+            store.commit_outcome_batch,
+            experiment_id=experiment_id,
+            expected_state_version=int(experiment["state_version"]),
+            job_updates=updates,
+            close_fact=close_fact,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=idempotency_key,
+            **revision_args,
+        ),
+    )
+
+
+def _terms_match(terms: Mapping[str, Any], job_payload: Mapping[str, Any]) -> bool:
+    return (
+        str(terms.get("contract_symbol")) == str(job_payload["contract_symbol"]).upper()
+        and str(terms.get("stock_owner")) == str(job_payload["stock_owner"]).upper()
+        and terms.get("expiration") == job_payload["expiration"]
+        and terms.get("option_type") == "PUT"
+        and terms.get("option_standard_type") == "STANDARD"
+        and float(cast(float, terms.get("strike"))) == float(job_payload["strike"])
+        and int(cast(int, terms.get("multiplier"))) == int(job_payload["multiplier"])
+        and str(terms.get("currency")) == str(job_payload["currency"]).upper()
+    )
+
+
+def _terms_source(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment: Mapping[str, Any],
+    expiration: str,
+) -> dict[str, Any] | None:
+    try:
+        day = read_validation_day_source(
+            store,
+            artifact_root,
+            market=str(experiment["market"]),
+            account=str(experiment["account"]),
+            trading_date=expiration,
+        )
+        if day["status"] != "available":
+            return None
+        expectation = cast(Mapping[str, Any], day["expectation"])
+        point_id = cast(list[str], expectation["expected_recommendation_point_ids"])[-1]
+        point = read_validation_point_source(
+            store,
+            artifact_root,
+            market=str(experiment["market"]),
+            account=str(experiment["account"]),
+            trading_date=expiration,
+            recommendation_point_id=point_id,
+        )
+    except (CorpusError, IndexError):
+        return None
+    return point if point["status"] == "available" else None
+
+
+def _calendar_has_date(value: object, expiration: str) -> bool:
+    if isinstance(value, list):
+        raw_rows = value
+    else:
+        to_dict = getattr(value, "to_dict", None)
+        if not callable(to_dict):
+            return False
+        try:
+            raw_rows = to_dict(orient="records")
+        except (TypeError, ValueError):
+            return False
+    if not isinstance(raw_rows, list):
+        return False
+    dates: set[str] = set()
+    for row in raw_rows:
+        if isinstance(row, str):
+            dates.add(row[:10])
+        elif isinstance(row, Mapping):
+            value = row.get("time") or row.get("date") or row.get("trading_date")
+            if isinstance(value, str):
+                dates.add(value[:10])
+    return dates == {expiration}
+
+
+def _close_result(
+    job: Mapping[str, Any], close: float
+) -> tuple[dict[str, object], dict[str, object]]:
+    payload = json.loads(str(job["job_json"]))
+    economic = calculate_expiry_efficiency(
+        {
+            "stage": "validation",
+            "fill_status": "observed_fill",
+            "holding_start_date": payload["fill_date"],
+            "expiration": payload["expiration"],
+            "opening_net_premium": payload["opening_net_premium"],
+            "net_cash_basis": payload["net_cash_basis"],
+            "strike": payload["strike"],
+            "multiplier": payload["multiplier"],
+            "underlier_close": close,
+            "account_fee_plan": payload["account_fee_plan"],
+        }
+    )
+    result = {
+        "target_point_id": job["target_point_id"],
+        "arm": job["arm"],
+        "close": close,
+        "economics": economic,
+    }
+    return result, payload
+
+
+def settle_due_outcomes(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    gateway: Any,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    if experiment["terminal_mode"] is not None:
+        return {"status": "terminal", "processed": 0}
+    now = _utc(occurred_at_utc)
+    processed = 0
+    committed_events = _call(store.events, experiment_id)
+    initial_jobs = _call(store.outcome_jobs, experiment_id)
+    terms_groups: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for job in initial_jobs:
+        if job["status"] == "pending_terms":
+            terms_groups.setdefault(
+                (str(job["stock_owner"]), str(job["expiration"]), str(job["contract_symbol"])),
+                [],
+            ).append(job)
+    for (stock_owner, expiration, contract_symbol), jobs in terms_groups.items():
+        due = _utc(str(jobs[0]["due_at_utc"]))
+        group_key = canonical_sha256([stock_owner, expiration, contract_symbol])
+        attempt_key = _derived_key(idempotency_key, "terms", group_key)
+        if _attempt_replayed(
+            committed_events,
+            idempotency_key=attempt_key,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+        ):
+            processed += len(jobs)
+            continue
+        if now >= due:
+            updates = [
+                _pending_update(
+                    job,
+                    status="outcome_unavailable",
+                    reason_code="expiry_terms_unavailable_at_due",
+                    occurred_at_utc=occurred_at_utc,
+                )
+                for job in jobs
+            ]
+        else:
+            source = _terms_source(
+                store,
+                artifact_root,
+                experiment=experiment,
+                expiration=expiration,
+            )
+            if source is None:
+                continue
+            point_row = cast(Mapping[str, Any], source["point_row"])
+            try:
+                raw_terms = gateway.get_exact_expiration_option_terms(
+                    code=stock_owner,
+                    expiration=expiration,
+                    contract_symbol=contract_symbol,
+                )
+            except FutuGatewayDataContractError:
+                updates = [
+                    _pending_update(
+                        job,
+                        status="outcome_unavailable",
+                        reason_code="expiry_terms_conflict",
+                        occurred_at_utc=occurred_at_utc,
+                    )
+                    for job in jobs
+                ]
+            except Exception:
+                updates = [
+                    _pending_update(
+                        job,
+                        reason_code="expiry_terms_provider_retryable",
+                        occurred_at_utc=occurred_at_utc,
+                    )
+                    for job in jobs
+                ]
+            else:
+                terms = dict(raw_terms) if isinstance(raw_terms, Mapping) else None
+                valid = terms is not None
+                if valid:
+                    try:
+                        valid = all(
+                            _terms_match(terms, json.loads(str(job["job_json"])))
+                            for job in jobs
+                        )
+                    except (KeyError, TypeError, ValueError):
+                        valid = False
+                if not valid:
+                    updates = [
+                        _pending_update(
+                            job,
+                            status="outcome_unavailable",
+                            reason_code="expiry_terms_conflict",
+                            occurred_at_utc=occurred_at_utc,
+                        )
+                        for job in jobs
+                    ]
+                else:
+                    assert terms is not None
+                    receipt = {
+                        "captured_at_utc": occurred_at_utc,
+                        "terms_point_id": point_row["recommendation_point_id"],
+                        "source_ref": point_row["projection_ref"],
+                        "source_content_sha256": point_row[
+                            "projection_content_sha256"
+                        ],
+                        "terms": terms,
+                    }
+                    updates = [
+                        _pending_update(
+                            job,
+                            status="pending_outcome",
+                            terms_point_id=str(point_row["recommendation_point_id"]),
+                            terms=receipt,
+                            occurred_at_utc=occurred_at_utc,
+                        )
+                        for job in jobs
+                    ]
+        _commit_outcome(
+            store,
+            artifact_root,
+            experiment_id=experiment_id,
+            updates=updates,
+            close_fact=None,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=attempt_key,
+        )
+        processed += len(updates)
+
+    current_jobs = _call(store.outcome_jobs, experiment_id)
+    close_groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for job in current_jobs:
+        if job["status"] == "pending_outcome":
+            close_groups.setdefault(
+                (str(job["stock_owner"]), str(job["expiration"])), []
+            ).append(job)
+    for (stock_owner, expiration), jobs in close_groups.items():
+        due = _utc(str(jobs[0]["due_at_utc"]))
+        if now < due:
+            continue
+        group_key = canonical_sha256([stock_owner, expiration])
+        attempt_key = _derived_key(idempotency_key, "close", group_key)
+        if _attempt_replayed(
+            committed_events,
+            idempotency_key=attempt_key,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+        ):
+            processed += len(jobs)
+            continue
+        deadline = min(_utc(str(job["deadline_at_utc"])) for job in jobs)
+        fact = _call(
+            store.expiry_close_fact,
+            experiment_id,
+            stock_owner,
+            expiration,
+            EXPIRY_OUTCOME_CONTRACT_VERSION,
+        )
+        close_value: float | None = None
+        provider_failed = False
+        if fact is not None and fact["status"] == "available":
+            close_value = float(json.loads(str(fact["fact_json"]))["close"])
+        elif fact is None:
+            try:
+                calendar = gateway.get_trading_days(
+                    market=str(experiment["market"]),
+                    start=expiration,
+                    end=expiration,
+                )
+                if not _calendar_has_date(calendar, expiration):
+                    raise ValueError("expiration is absent from exact calendar response")
+                close = gateway.get_exact_expiration_close(
+                    code=stock_owner,
+                    expiration=expiration,
+                )
+                if not isinstance(close, Mapping):
+                    raise ValueError("exact expiration close is unavailable")
+                close_value = float(close["close"])
+                if not math.isfinite(close_value) or close_value <= 0:
+                    raise ValueError("exact expiration close is invalid")
+            except Exception:
+                provider_failed = True
+        if provider_failed or close_value is None:
+            terminal = now >= deadline
+            updates = [
+                _pending_update(
+                    job,
+                    status="outcome_unavailable" if terminal else None,
+                    reason_code=(
+                        "expiry_close_unavailable"
+                        if terminal
+                        else "expiry_close_provider_retryable"
+                    ),
+                    occurred_at_utc=occurred_at_utc,
+                )
+                for job in jobs
+            ]
+            close_fact = None
+        else:
+            fact_payload = {
+                "stock_owner": stock_owner,
+                "expiration": expiration,
+                "contract_version": EXPIRY_OUTCOME_CONTRACT_VERSION,
+                "close": close_value,
+                "captured_at_utc": occurred_at_utc,
+                "ktype": "K_DAY",
+                "autype": "NONE",
+            }
+            close_fact = (
+                None
+                if fact is not None
+                else {
+                    **fact_payload,
+                    "status": "available",
+                    "fact_json": compact_json(fact_payload),
+                    "fact_sha256": canonical_sha256(fact_payload),
+                    "created_at_utc": occurred_at_utc,
+                }
+            )
+            updates = []
+            for job in jobs:
+                try:
+                    result, _payload = _close_result(job, close_value)
+                except (KeyError, TypeError, ValueError):
+                    result = {"economics": {"status": "not_evaluable"}}
+                economic = cast(Mapping[str, Any], result["economics"])
+                updates.append(
+                    _pending_update(
+                        job,
+                        status=(
+                            "evaluable"
+                            if economic.get("status") == "evaluable"
+                            else "outcome_unavailable"
+                        ),
+                        reason_code=(
+                            None
+                            if economic.get("status") == "evaluable"
+                            else "required_outcome_missing"
+                        ),
+                        result=(result if economic.get("status") == "evaluable" else None),
+                        occurred_at_utc=occurred_at_utc,
+                    )
+                )
+        _commit_outcome(
+            store,
+            artifact_root,
+            experiment_id=experiment_id,
+            updates=updates,
+            close_fact=close_fact,
+            actor=actor,
+            occurred_at_utc=occurred_at_utc,
+            idempotency_key=attempt_key,
+        )
+        processed += len(updates)
+    return {
+        "status": "processed" if processed else "pending",
+        "processed": processed,
+        "pending": sum(
+            job["status"] in {"pending_terms", "pending_outcome"}
+            for job in _call(store.outcome_jobs, experiment_id)
+        ),
+    }
+
+
+def _statistics_rows(
+    store: ExperimentStore, experiment_id: str
+) -> tuple[list[dict[str, object]], bool]:
+    jobs = {
+        (str(job["target_point_id"]), str(job["arm"])): job
+        for job in _call(store.outcome_jobs, experiment_id)
+    }
+    rows: list[dict[str, object]] = []
+    evidence_missing = any(
+        day["hard_risk_status"] == "missing"
+        for day in _call(store.validation_days, experiment_id)
+    )
+    for decision in _call(store.validation_decisions, experiment_id):
+        candidates: dict[str, Mapping[str, Any] | None] = {}
+        efficiencies: dict[str, float | None] = {}
+        row_missing = False
+        for arm in ("baseline", "challenger"):
+            raw = decision[f"{arm}_json"]
+            candidate = json.loads(str(raw)) if raw is not None else None
+            candidates[arm] = candidate
+            status = decision[f"{arm}_fill_status"]
+            if candidate is None:
+                efficiencies[arm] = None
+            elif status == "no_observed_fill":
+                efficiencies[arm] = float(
+                    calculate_expiry_efficiency(
+                        {"stage": "validation", "fill_status": "no_observed_fill"}
+                    )["efficiency"]
+                )
+            elif status == "observed_fill":
+                job = jobs.get((str(decision["recommendation_point_id"]), arm))
+                if job is None or job["status"] != "evaluable":
+                    efficiencies[arm] = None
+                    row_missing = True
+                else:
+                    result = json.loads(str(job["result_json"]))
+                    efficiencies[arm] = float(result["economics"]["efficiency"])
+            else:
+                efficiencies[arm] = None
+                row_missing = True
+        evidence_missing = evidence_missing or row_missing
+        baseline = candidates["baseline"]
+        challenger = candidates["challenger"]
+        rows.append(
+            {
+                "recommendation_point_id": decision["recommendation_point_id"],
+                "trading_date": decision["trading_date"],
+                "baseline_candidate_id": baseline.get("candidate_id") if baseline else None,
+                "challenger_candidate_id": (
+                    challenger.get("candidate_id") if challenger else None
+                ),
+                "baseline_efficiency": efficiencies["baseline"],
+                "challenger_efficiency": efficiencies["challenger"],
+                "hard_risk_status": (
+                    "missing" if row_missing else decision["hard_risk_status"]
+                ),
+                "baseline_concentration": (
+                    baseline.get("concentration") if baseline else None
+                ),
+                "challenger_concentration": (
+                    challenger.get("concentration") if challenger else None
+                ),
+            }
+        )
+    return rows, evidence_missing
+
+
+def conclude_validation(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None = None,
+    publisher: Publisher | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    initial = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(initial["market"]),
+        account=str(initial["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    if initial["terminal_mode"] is not None:
+        if initial["terminal_mode"] != "completed":
+            _fail("terminal_conflict", "experiment was aborted")
+        _recover_projection(
+            store, artifact_root, experiment_id=experiment_id, publisher=publisher
+        )
+        return {"status": str(initial["final_outcome_status"]), "idempotent": True}
+    for _attempt in range(3):
+        experiment = _call(store.experiment, experiment_id)
+        if not (
+            experiment["validation_progress"] == "ready_to_conclude"
+            and int(experiment["completed_validation_partitions"]) == 20
+        ):
+            return {
+                "status": "blocked",
+                "reason_code": "validation_not_ready",
+                "completed_days": experiment["completed_validation_partitions"],
+            }
+        spec = _spec(experiment)
+        rows, evidence_missing = _statistics_rows(store, experiment_id)
+        days = _call(store.validation_days, experiment_id)
+        for day in days:
+            if day["expected_point_count"] is None:
+                rows.append(
+                    {
+                        "recommendation_point_id": f"day-gap:{day['trading_date']}",
+                        "trading_date": day["trading_date"],
+                        "baseline_candidate_id": None,
+                        "challenger_candidate_id": None,
+                        "baseline_efficiency": None,
+                        "challenger_efficiency": None,
+                        "hard_risk_status": "missing",
+                        "baseline_concentration": None,
+                        "challenger_concentration": None,
+                    }
+                )
+        metrics_policy = cast(Mapping[str, Any], spec["validation_metrics"])
+        result = summarize_paired_daily_deltas(
+            rows,
+            {
+                "required_days": 20,
+                "confidence_level": metrics_policy["confidence_level"],
+                "worst_fraction": metrics_policy["worst_fraction"],
+                "require_concentration_non_increase": True,
+            },
+        )
+        if evidence_missing and result["decision"] != "insufficient_evidence":
+            _fail("experiment_conflict", "missing evidence produced a decisive result")
+        final_status = (
+            "candidate_for_adoption"
+            if result["decision"] == "pass"
+            else str(result["decision"])
+        )
+        summary = {
+            key: result[key]
+            for key in (
+                "decision",
+                "reason_codes",
+                "required_days",
+                "effective_days",
+                "mean_daily_delta",
+                "sample_std",
+                "standard_error",
+                "t_critical",
+                "one_sided_lower_bound",
+                "worst_k",
+                "worst_tail_mean",
+                "serial_correlation_unadjusted",
+            )
+        }
+        jobs = _call(store.outcome_jobs, experiment_id)
+        decisions = _call(store.validation_decisions, experiment_id)
+        coverage = {
+            "committed_days": len(days),
+            "expected_points": sum(
+                int(day["expected_point_count"] or 0) for day in days
+            ),
+            "consumed_points": len(decisions),
+            "observed_fill_arms": sum(
+                decision[f"{arm}_fill_status"] == "observed_fill"
+                for decision in decisions
+                for arm in ("baseline", "challenger")
+            ),
+            "no_observed_fill_arms": sum(
+                decision[f"{arm}_fill_status"] == "no_observed_fill"
+                for decision in decisions
+                for arm in ("baseline", "challenger")
+            ),
+            "not_evaluable_arms": sum(
+                decision[f"{arm}_fill_status"] == "not_evaluable"
+                for decision in decisions
+                for arm in ("baseline", "challenger")
+            ),
+            "outcome_jobs": len(jobs),
+            "evaluable_outcomes": sum(job["status"] == "evaluable" for job in jobs),
+        }
+        generations = _call(store.generations, experiment_id)
+        outcome = next(
+            row for row in generations if row["generation_kind"] == "outcome"
+        )
+        revision_args, post_generation = _revision_request(
+            artifact_root,
+            experiment_id=experiment_id,
+            generation=outcome,
+            mutation={
+                "operation": "conclude_validation",
+                "final_outcome_status": final_status,
+                "result": summary,
+                "coverage": coverage,
+            },
+            occurred_at_utc=occurred_at_utc,
+            schema_version=OUTCOME_REVISION_SCHEMA,
+        )
+        terminal = build_generation_terminal_request(
+            post_generation,
+            terminal_mode="completed",
+            reason=None,
+            disabled_scope=None,
+            occurred_at_utc=occurred_at_utc,
+        )
+        versions = {
+            "fill": cast(Mapping[str, Any], spec["fill_observation"])[
+                "contract_version"
+            ],
+            "metrics": metrics_policy["contract_version"],
+            "expiry_outcome": cast(Mapping[str, Any], spec["expiry_outcome"])[
+                "contract_version"
+            ],
+            "fee_schedule": cast(Mapping[str, Any], spec["economics_contracts"])[
+                "fee_schedule_version"
+            ],
+        }
+        receipt = build_completed_receipt_request(
+            experiment,
+            generations,
+            terminal,
+            final_outcome_status=final_status,
+            result=summary,
+            coverage=coverage,
+            contract_versions=versions,
+            occurred_at_utc=occurred_at_utc,
+        )
+        try:
+            _call(
+                store.complete_validation,
+                experiment_id=experiment_id,
+                expected_state_version=int(experiment["state_version"]),
+                final_outcome_status=final_status,
+                result_sha256=canonical_sha256(summary),
+                outcome_terminal_request=terminal,
+                receipt_request=receipt,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=idempotency_key,
+                **revision_args,
+            )
+            break
+        except Top1LifecycleError as exc:
+            if exc.reason_code != "generation_conflict":
+                raise
+    else:
+        _fail("terminal_conflict", "experiment changed during conclusion")
+    _recover_projection(
+        store, artifact_root, experiment_id=experiment_id, publisher=publisher
+    )
+    return {"status": final_status, "result": summary, "coverage": coverage}
+
+
+__all__ = [
+    "OUTCOME_REVISION_SCHEMA",
+    "Top1OutcomeError",
+    "conclude_validation",
+    "settle_due_outcomes",
+]

--- a/src/application/strategy_lab/top1/terminal_projection.py
+++ b/src/application/strategy_lab/top1/terminal_projection.py
@@ -125,15 +125,9 @@ def build_generation_terminal_request(
     }
 
 
-def build_aborted_receipt_request(
-    experiment: Mapping[str, object],
+def _generation_views(
     generations: Sequence[Mapping[str, object]],
     generation_requests: Sequence[Mapping[str, object]],
-    *,
-    reason: str,
-    disabled_scope: str | None,
-    occurred_at_utc: str,
-    terminated_at_partition: int | None,
 ) -> dict[str, object]:
     request_by_kind = {
         str(item["generation_kind"]): item for item in generation_requests
@@ -168,6 +162,20 @@ def build_aborted_receipt_request(
             "content_sha256": row["terminal_content_sha256"],
             "file_sha256": row["terminal_file_sha256"],
         }
+    return generation_views
+
+
+def build_aborted_receipt_request(
+    experiment: Mapping[str, object],
+    generations: Sequence[Mapping[str, object]],
+    generation_requests: Sequence[Mapping[str, object]],
+    *,
+    reason: str,
+    disabled_scope: str | None,
+    occurred_at_utc: str,
+    terminated_at_partition: int | None,
+) -> dict[str, object]:
+    generation_views = _generation_views(generations, generation_requests)
 
     experiment_id = str(experiment["experiment_id"])
     payload: dict[str, Any] = {
@@ -194,6 +202,61 @@ def build_aborted_receipt_request(
         "generations": generation_views,
         "outcome_status": "insufficient_evidence",
         "metrics": None,
+    }
+    attach_artifact_provenance(
+        payload,
+        artifact_kind="sell_put_top1_experiment_receipt",
+        source_generation={"generation_id": f"experiment:{experiment_id}:terminal"},
+    )
+    ref = f"strategy_lab/top1/experiments/{experiment_id}/experiment_receipt.json"
+    return {"experiment_id": experiment_id, **_projection_request(ref, payload)}
+
+
+def build_completed_receipt_request(
+    experiment: Mapping[str, object],
+    generations: Sequence[Mapping[str, object]],
+    outcome_terminal_request: Mapping[str, object],
+    *,
+    final_outcome_status: str,
+    result: Mapping[str, object],
+    coverage: Mapping[str, object],
+    contract_versions: Mapping[str, object],
+    occurred_at_utc: str,
+) -> dict[str, object]:
+    if final_outcome_status not in {
+        "candidate_for_adoption",
+        "keep_baseline",
+        "insufficient_evidence",
+    }:
+        raise ValueError("completed outcome status is invalid")
+    generation_views = _generation_views(generations, [outcome_terminal_request])
+    experiment_id = str(experiment["experiment_id"])
+    payload: dict[str, Any] = {
+        "schema_version": EXPERIMENT_RECEIPT_SCHEMA,
+        "experiment_id": experiment_id,
+        "topic_id": experiment["topic_id"],
+        "market": experiment["market"],
+        "account": experiment["account"],
+        "strategy_family": experiment["strategy_family"],
+        "terminal": {
+            "mode": "completed",
+            "reason": None,
+            "disabled_scope": None,
+            "occurred_at_utc": occurred_at_utc,
+            "terminated_at_partition": 20,
+        },
+        "bindings": {
+            "research_spec_sha256": experiment["research_spec_sha256"],
+            "validation_spec_sha256": experiment["validation_spec_sha256"],
+            "hidden_window_commitment_sha256": experiment[
+                "proposed_commitment_sha256"
+            ],
+        },
+        "contract_versions": dict(contract_versions),
+        "generations": generation_views,
+        "outcome_status": final_outcome_status,
+        "coverage": dict(coverage),
+        "metrics": dict(result),
     }
     attach_artifact_provenance(
         payload,
@@ -313,6 +376,7 @@ __all__ = [
     "EXPERIMENT_RECEIPT_SCHEMA",
     "GENERATION_TERMINAL_SCHEMA",
     "build_aborted_receipt_request",
+    "build_completed_receipt_request",
     "build_generation_terminal_request",
     "publish_exact_text",
     "recover_terminal_projection",

--- a/src/application/strategy_lab/top1/validation.py
+++ b/src/application/strategy_lab/top1/validation.py
@@ -1,0 +1,678 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any, NoReturn, cast
+from zoneinfo import ZoneInfo
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.fee_calc import FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
+from src.application.shadow_replay.common import render_json_text
+from src.application.strategy_lab.top1.contracts import (
+    Top1CoreContractError,
+    build_validation_spec_sha256,
+    validate_experiment_spec,
+)
+from src.application.strategy_lab.top1.corpus import (
+    CorpusError,
+    read_validation_day_source,
+    read_validation_point_source,
+)
+from src.application.strategy_lab.top1.lifecycle import (
+    _call,
+    _command_fields,
+    _require_effective,
+    _segment,
+)
+from src.application.strategy_lab.top1.ranking import (
+    Top1RankingError,
+    rerank_recommendation_point,
+)
+from src.application.strategy_lab.top1.research_artifacts import (
+    ResearchArtifactError,
+    load_recorded_research_revision,
+)
+from src.application.strategy_lab.top1.terminal_projection import (
+    build_generation_terminal_request,
+    publish_exact_text,
+)
+from src.infrastructure.strategy_lab.experiment_store import (
+    ExperimentStore,
+    compact_json,
+)
+
+
+VALIDATION_REVISION_SCHEMA = "sell_put_top1_validation_revision.v1"
+_SOURCE_STATUSES = {"available", "missing_after_deadline", "not_evaluable"}
+_HASH = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class Top1ValidationError(ValueError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise Top1ValidationError(reason_code, message)
+
+
+def _utc(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise Top1ValidationError(
+            "validation_input_invalid", "timestamp must be ISO-8601 UTC"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() != timedelta(0):
+        _fail("validation_input_invalid", "timestamp must be ISO-8601 UTC")
+    return parsed.astimezone(timezone.utc)
+
+
+def _generation(store: ExperimentStore, experiment_id: str, kind: str) -> dict[str, Any]:
+    row = next(
+        (item for item in _call(store.generations, experiment_id) if item["generation_kind"] == kind),
+        None,
+    )
+    if row is None:
+        _fail("generation_conflict", f"{kind} generation is missing")
+    return row
+
+
+def _context(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    artifact_root: str | Path,
+    environ: Mapping[str, str] | None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], str]:
+    experiment = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(experiment["market"]),
+        account=str(experiment["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    if experiment["terminal_mode"] is not None or not (
+        experiment["phase"] == "validation"
+        and experiment["validation_progress"] == "collecting_decisions"
+    ):
+        _fail("late_write", "validation intake is closed")
+    try:
+        spec = validate_experiment_spec(json.loads(str(experiment["spec_json"])))
+    except (json.JSONDecodeError, Top1CoreContractError) as exc:
+        raise Top1ValidationError("experiment_conflict", "experiment spec is invalid") from exc
+    commitment = json.loads(str(experiment["proposed_commitment_json"]))
+    research = _generation(store, experiment_id, "research")
+    try:
+        expected_validation_hash = build_validation_spec_sha256(
+            spec,
+            research_terminal_sha256=str(research["terminal_file_sha256"]),
+            challenger_variant_id=str(experiment["research_leader"]),
+            hidden_window_commitment_sha256=str(experiment["proposed_commitment_sha256"]),
+        )
+    except Top1CoreContractError as exc:
+        raise Top1ValidationError(
+            "experiment_conflict", "validation authorization binding is invalid"
+        ) from exc
+    if expected_validation_hash != experiment["validation_spec_sha256"]:
+        _fail("experiment_conflict", "validation authorization binding changed")
+    dates = _call(store.commitment_dates, experiment_id)
+    completed = int(experiment["completed_validation_partitions"])
+    if completed >= len(dates):
+        _fail("late_write", "validation commitment is complete")
+    return experiment, spec, commitment, research, str(dates[completed])
+
+
+def _challenger_profile(spec: Mapping[str, Any], variant_id: str) -> str:
+    for raw in cast(list[object], spec["variants"]):
+        variant = cast(Mapping[str, Any], raw)
+        if variant["variant_id"] == variant_id:
+            patch = cast(Mapping[str, Any], variant["patch"])
+            profile = patch.get("ranking_profile")
+            if isinstance(profile, str) and profile:
+                return profile
+    _fail("experiment_conflict", "locked challenger profile is missing")
+
+
+def _fee_plan(
+    artifact_root: str | Path,
+    research_generation: Mapping[str, Any],
+    *,
+    market: str,
+    account: str,
+) -> Mapping[str, object] | None:
+    try:
+        revision = load_recorded_research_revision(artifact_root, research_generation)
+    except ResearchArtifactError as exc:
+        raise Top1ValidationError("experiment_conflict", str(exc)) from exc
+    fee = revision.get("fee_contract")
+    if not isinstance(fee, Mapping) or set(fee) != {
+        "market",
+        "account",
+        "fee_schedule_version",
+        "account_fee_plan",
+    }:
+        _fail("experiment_conflict", "research fee contract is invalid")
+    if (
+        fee["market"] != market
+        or fee["account"] != account
+        or fee["fee_schedule_version"] != FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
+    ):
+        _fail("experiment_conflict", "research fee contract binding changed")
+    raw_plan = fee["account_fee_plan"]
+    if raw_plan is None:
+        return None
+    if not isinstance(raw_plan, Mapping) or not set(raw_plan).issubset(
+        {"commission_free", "platform_fee", "fee_plan_ref"}
+    ):
+        _fail("experiment_conflict", "research account fee plan is invalid")
+    return dict(raw_plan)
+
+
+def _candidate(projection: Mapping[str, Any], candidate_id: str | None) -> Mapping[str, Any] | None:
+    if candidate_id is None:
+        return None
+    for raw in cast(list[object], projection["candidates"]):
+        candidate = cast(Mapping[str, Any], raw)
+        if candidate["candidate_id"] == candidate_id:
+            return candidate
+    _fail("ranking_projection_incomplete", "selected candidate is absent")
+
+
+def _arm(candidate: Mapping[str, Any] | None, fee_plan: Mapping[str, object] | None) -> dict[str, object] | None:
+    if candidate is None:
+        return None
+    return {
+        "candidate_id": candidate["candidate_id"],
+        "contract_symbol": candidate["contract_symbol"],
+        "stock_owner": candidate["stock_owner"],
+        "expiration": candidate["expiration"],
+        "sell_limit": candidate["sell_limit"],
+        "opening_net_premium": candidate["net_premium"],
+        "net_cash_basis": candidate["net_cash_basis"],
+        "strike": candidate["strike"],
+        "multiplier": candidate["multiplier"],
+        "currency": candidate["currency"],
+        "concentration": candidate["symbol_concentration_after"],
+        "fee_schedule_version": candidate["fee_schedule_version"],
+        "fee_basis": candidate["fee_basis"],
+        "fee_schedule_url": candidate["fee_schedule_url"],
+        "account_fee_plan": dict(fee_plan) if fee_plan is not None else None,
+    }
+
+
+def _revision_request(
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    generation: Mapping[str, Any],
+    mutation: Mapping[str, object],
+    occurred_at_utc: str,
+    schema_version: str = VALIDATION_REVISION_SCHEMA,
+) -> tuple[dict[str, object], dict[str, object]]:
+    revision = int(generation["revision"]) + 1
+    generation_kind = str(generation["generation_kind"])
+    payload: dict[str, object] = {
+        "schema_version": schema_version,
+        "experiment_id": experiment_id,
+        "generation_kind": generation_kind,
+        "revision": revision,
+        "previous_frozen_row_sha256": generation["frozen_row_content_sha256"],
+        "mutation": dict(mutation),
+        "occurred_at_utc": occurred_at_utc,
+    }
+    payload["content_sha256"] = canonical_sha256(payload)
+    text = render_json_text(payload)
+    file_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    ref = (
+        f"strategy_lab/top1/experiments/{experiment_id}/generations/{generation_kind}/"
+        f"revisions/{revision:06d}-{payload['content_sha256']}.json"
+    )
+    try:
+        publish_exact_text(artifact_root, ref, text.encode("utf-8"))
+    except (OSError, ValueError) as exc:
+        raise Top1ValidationError(
+            "projection_conflict", "validation revision cannot be published"
+        ) from exc
+    frozen_hash = canonical_sha256(
+        {
+            "previous": generation["frozen_row_content_sha256"],
+            "revision_content_sha256": payload["content_sha256"],
+        }
+    )
+    post_generation = {
+        **generation,
+        "revision": revision,
+        "last_revision_ref": ref,
+        "last_revision_file_sha256": file_hash,
+        "frozen_row_content_sha256": frozen_hash,
+    }
+    return (
+        {
+            "revision": revision,
+            "revision_ref": ref,
+            "revision_file_sha256": file_hash,
+            "frozen_row_sha256": frozen_hash,
+        },
+        post_generation,
+    )
+
+
+def _terminal_if_final(
+    experiment: Mapping[str, Any],
+    post_generation: Mapping[str, Any],
+    *,
+    day_will_seal: bool,
+    occurred_at_utc: str,
+) -> Mapping[str, object] | None:
+    if not day_will_seal or int(experiment["completed_validation_partitions"]) != 19:
+        return None
+    return build_generation_terminal_request(
+        post_generation,
+        terminal_mode="completed",
+        reason=None,
+        disabled_scope=None,
+        occurred_at_utc=occurred_at_utc,
+    )
+
+
+def _gap_observations(
+    store: ExperimentStore,
+    *,
+    experiment_id: str,
+    trading_date: str,
+    observed_point_id: str,
+    reason_code: str,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    observations: list[dict[str, object]] = []
+    updates: list[dict[str, object]] = []
+    for decision in _call(store.validation_decisions, experiment_id):
+        if decision["trading_date"] != trading_date:
+            continue
+        for arm in ("baseline", "challenger"):
+            if decision[f"{arm}_fill_status"] != "monitoring":
+                continue
+            receipt = {
+                "status": "gap",
+                "reason_code": reason_code,
+                "target_point_id": decision["recommendation_point_id"],
+                "arm": arm,
+                "observed_point_id": observed_point_id,
+            }
+            observations.append(
+                {
+                    **receipt,
+                    "trading_date": trading_date,
+                    "observation_status": "gap",
+                    "crossing": None,
+                    "observation_json": compact_json(receipt),
+                    "observation_sha256": canonical_sha256(receipt),
+                }
+            )
+            updates.append(
+                {
+                    "target_point_id": decision["recommendation_point_id"],
+                    "arm": arm,
+                    "fill_status": "not_evaluable",
+                }
+            )
+    return observations, updates
+
+
+def consume_validation_point(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    recommendation_point_id: str,
+    source_status: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    if source_status not in _SOURCE_STATUSES:
+        _fail("validation_input_invalid", "source_status is unsupported")
+    if (
+        not isinstance(recommendation_point_id, str)
+        or _HASH.fullmatch(recommendation_point_id) is None
+    ):
+        _fail("validation_input_invalid", "recommendation_point_id is invalid")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    current = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(current["market"]),
+        account=str(current["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    existing = _call(store.validation_decision, experiment_id, recommendation_point_id)
+    if existing is not None:
+        if existing["source_status"] != source_status:
+            _fail("validation_conflict", "point source status changed")
+        return {"status": "idempotent", "decision": existing}
+    experiment, spec, _commitment, research, trading_date = _context(
+        store,
+        experiment_id=experiment_id,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    try:
+        source = read_validation_point_source(
+            store,
+            artifact_root,
+            market=str(experiment["market"]),
+            account=str(experiment["account"]),
+            trading_date=trading_date,
+            recommendation_point_id=recommendation_point_id,
+        )
+    except CorpusError as exc:
+        raise Top1ValidationError(exc.reason_code, str(exc)) from exc
+    observed_source_status = (
+        "missing_after_deadline" if source["status"] == "missing" else source["status"]
+    )
+    if observed_source_status != source_status:
+        _fail("validation_source_conflict", "declared source status does not match corpus")
+    if not isinstance(source.get("expectation"), dict) or not isinstance(
+        source.get("row"), dict
+    ):
+        _fail(
+            "validation_source_conflict",
+            "point intake requires a clean canonical day expectation",
+        )
+    expectation = cast(dict[str, Any], source["expectation"])
+    expected_ids = cast(list[str], expectation["expected_recommendation_point_ids"])
+    consumed = [
+        row
+        for row in _call(store.validation_decisions, experiment_id)
+        if row["trading_date"] == trading_date
+    ]
+    point_index = len(consumed)
+    if point_index >= len(expected_ids) or expected_ids[point_index] != recommendation_point_id:
+        _fail("validation_point_out_of_order", "point is not the next expectation")
+    target_at_utc = str(expectation["scheduled_scan_targets_market"][point_index])
+    if source_status == "missing_after_deadline":
+        timer = cast(Mapping[str, Any], spec["timer_binding"])
+        deadline = _utc(target_at_utc) + timedelta(
+            seconds=int(timer["producer_catchup_grace_seconds"])
+            + int(timer["producer_run_timeout_upper_bound_seconds"])
+        )
+        if _utc(occurred_at_utc) < deadline:
+            _fail("validation_deadline_not_reached", "point gap deadline has not passed")
+
+    baseline: dict[str, object] | None = None
+    challenger: dict[str, object] | None = None
+    hard_risk_status = "missing"
+    reason_code = cast(str | None, source.get("reason_code"))
+    if source_status == "available":
+        projection = cast(Mapping[str, Any], source["projection"])
+        try:
+            baseline_rank = rerank_recommendation_point(
+                projection, ranking_profile="current_tie_break"
+            )
+            challenger_rank = rerank_recommendation_point(
+                projection,
+                ranking_profile=_challenger_profile(
+                    spec, str(experiment["research_leader"])
+                ),
+            )
+        except Top1RankingError as exc:
+            raise Top1ValidationError(exc.reason_code, str(exc)) from exc
+        baseline_id = cast(str | None, baseline_rank["top1_candidate_id"])
+        challenger_id = cast(str | None, challenger_rank["top1_candidate_id"])
+        if (baseline_id is None) != (challenger_id is None):
+            _fail("official_decision_incomplete", "Top1 selection is one-sided")
+        fee_plan = _fee_plan(
+            artifact_root,
+            research,
+            market=str(experiment["market"]),
+            account=str(experiment["account"]),
+        )
+        baseline = _arm(_candidate(projection, baseline_id), fee_plan)
+        challenger = _arm(_candidate(projection, challenger_id), fee_plan)
+        selected = [item for item in (baseline, challenger) if item is not None]
+        hard_risk_status = (
+            "passed"
+            if all(item["concentration"] is not None for item in selected)
+            else "missing"
+        )
+        reason_code = None if hard_risk_status == "passed" else "risk_evidence_missing"
+
+    day_row = cast(Mapping[str, Any], source["row"])
+    decision = {
+        "recommendation_point_id": recommendation_point_id,
+        "trading_date": trading_date,
+        "point_index": point_index,
+        "source_status": source_status,
+        "expectation_ref": day_row["expectation_ref"],
+        "expectation_content_sha256": day_row["expectation_content_sha256"],
+        "target_at_utc": target_at_utc,
+        "source_ref": (
+            cast(Mapping[str, Any], source["point_row"])["projection_ref"]
+            if source_status == "available"
+            else cast(Mapping[str, Any], source.get("point_row") or {}).get("source_point_ref")
+        ),
+        "source_file_sha256": (
+            cast(Mapping[str, Any], source["point_row"])["projection_file_sha256"]
+            if source_status == "available"
+            else None
+        ),
+        "source_content_sha256": (
+            cast(Mapping[str, Any], source["point_row"])["projection_content_sha256"]
+            if source_status == "available"
+            else cast(Mapping[str, Any], source.get("point_row") or {}).get(
+                "source_point_content_sha256"
+            )
+        ),
+        "hard_risk_status": hard_risk_status,
+        "baseline_json": compact_json(baseline) if baseline is not None else None,
+        "challenger_json": compact_json(challenger) if challenger is not None else None,
+        "baseline_fill_status": "monitoring" if baseline is not None else None,
+        "challenger_fill_status": "monitoring" if challenger is not None else None,
+        "reason_code": reason_code,
+    }
+    gap_observations: list[dict[str, object]] = []
+    fill_updates: list[dict[str, object]] = []
+    if source_status != "available":
+        gap_observations, fill_updates = _gap_observations(
+            store,
+            experiment_id=experiment_id,
+            trading_date=trading_date,
+            observed_point_id=recommendation_point_id,
+            reason_code=reason_code or "validation_source_missing",
+        )
+    is_final_point = point_index + 1 == len(expected_ids)
+    day: dict[str, object] | None = None
+    if source_status != "available" and is_final_point:
+        day = {
+            "trading_date": trading_date,
+            "expectation_ref": day_row["expectation_ref"],
+            "expectation_content_sha256": day_row["expectation_content_sha256"],
+            "expectation_file_sha256": day_row["expectation_file_sha256"],
+            "expected_point_count": len(expected_ids),
+            "consumed_point_count": point_index + 1,
+            "hard_risk_status": "missing",
+            "reason_code": reason_code or "validation_source_missing",
+            "deadline_at_utc": None,
+            "daily_json": compact_json({"status": "not_evaluable"}),
+        }
+    hidden = _generation(store, experiment_id, "hidden")
+    revision_args, post_generation = _revision_request(
+        artifact_root,
+        experiment_id=experiment_id,
+        generation=hidden,
+        mutation={
+            "operation": "consume_validation_point",
+            "decision": decision,
+            "gap_observations": gap_observations,
+            "day": day,
+        },
+        occurred_at_utc=occurred_at_utc,
+    )
+    terminal = _terminal_if_final(
+        experiment,
+        post_generation,
+        day_will_seal=day is not None,
+        occurred_at_utc=occurred_at_utc,
+    )
+    committed = _call(
+        store.commit_validation_decision,
+        experiment_id=experiment_id,
+        expected_state_version=int(experiment["state_version"]),
+        decision=decision,
+        gap_observations=gap_observations,
+        fill_status_updates=fill_updates,
+        day=day,
+        terminal_request=terminal,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        **revision_args,
+    )
+    return {"status": "committed", "decision": committed}
+
+
+def record_validation_day_gap(
+    store: ExperimentStore,
+    artifact_root: str | Path,
+    *,
+    experiment_id: str,
+    trading_date: str,
+    actor: str,
+    occurred_at_utc: str,
+    idempotency_key: str,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    experiment_id = _segment(experiment_id, "experiment_id")
+    try:
+        if date.fromisoformat(trading_date).isoformat() != trading_date:
+            raise ValueError
+    except (TypeError, ValueError):
+        _fail("validation_input_invalid", "trading_date must be a canonical ISO date")
+    actor, occurred_at_utc, idempotency_key = _command_fields(
+        actor, occurred_at_utc, idempotency_key
+    )
+    current = _call(store.experiment, experiment_id)
+    _require_effective(
+        store,
+        market=str(current["market"]),
+        account=str(current["account"]),
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    existing = _call(store.validation_day, experiment_id, trading_date)
+    if existing is not None:
+        if existing["expected_point_count"] is not None:
+            _fail("validation_conflict", "date was sealed from point evidence")
+        return {"status": "idempotent", "day": existing}
+    experiment, spec, _commitment, _research, open_date = _context(
+        store,
+        experiment_id=experiment_id,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        artifact_root=artifact_root,
+        environ=environ,
+    )
+    if trading_date != open_date:
+        _fail("validation_conflict", "trading_date is not the open commitment date")
+    if any(
+        row["trading_date"] == trading_date
+        for row in _call(store.validation_decisions, experiment_id)
+    ):
+        _fail("validation_conflict", "point intake already began for this date")
+    try:
+        source = read_validation_day_source(
+            store,
+            artifact_root,
+            market=str(experiment["market"]),
+            account=str(experiment["account"]),
+            trading_date=trading_date,
+        )
+    except CorpusError:
+        source = {"status": "not_evaluable", "reason_code": "corpus_artifact_invalid"}
+    if source["status"] == "available":
+        _fail("validation_conflict", "canonical day expectation is available")
+    timer = cast(Mapping[str, Any], spec["timer_binding"])
+    day_date = date.fromisoformat(trading_date)
+    deadline = datetime.combine(
+        day_date + timedelta(days=1),
+        time.min,
+        tzinfo=ZoneInfo("Asia/Hong_Kong"),
+    ).astimezone(timezone.utc) + timedelta(
+        seconds=int(timer["producer_catchup_grace_seconds"])
+        + int(timer["producer_run_timeout_upper_bound_seconds"])
+    )
+    if _utc(occurred_at_utc) < deadline:
+        _fail("validation_deadline_not_reached", "whole-day gap deadline has not passed")
+    day = {
+        "trading_date": trading_date,
+        "expectation_ref": None,
+        "expectation_content_sha256": None,
+        "expectation_file_sha256": None,
+        "expected_point_count": None,
+        "consumed_point_count": 0,
+        "hard_risk_status": "missing",
+        "reason_code": source.get("reason_code") or "corpus_day_expectation_missing",
+        "deadline_at_utc": deadline.isoformat().replace("+00:00", "Z"),
+        "daily_json": compact_json({"status": "not_evaluable"}),
+    }
+    hidden = _generation(store, experiment_id, "hidden")
+    revision_args, post_generation = _revision_request(
+        artifact_root,
+        experiment_id=experiment_id,
+        generation=hidden,
+        mutation={"operation": "record_validation_day_gap", "day": day},
+        occurred_at_utc=occurred_at_utc,
+    )
+    terminal = _terminal_if_final(
+        experiment,
+        post_generation,
+        day_will_seal=True,
+        occurred_at_utc=occurred_at_utc,
+    )
+    result = _call(
+        store.commit_validation_day_gap,
+        experiment_id=experiment_id,
+        expected_state_version=int(experiment["state_version"]),
+        day=day,
+        terminal_request=terminal,
+        actor=actor,
+        occurred_at_utc=occurred_at_utc,
+        idempotency_key=idempotency_key,
+        **revision_args,
+    )
+    return {"status": "committed", "experiment": result}
+
+
+__all__ = [
+    "Top1ValidationError",
+    "VALIDATION_REVISION_SCHEMA",
+    "consume_validation_point",
+    "record_validation_day_gap",
+]

--- a/src/infrastructure/futu_gateway.py
+++ b/src/infrastructure/futu_gateway.py
@@ -566,6 +566,10 @@ class FutuGatewayTransientError(FutuGatewayError):
     code = "TRANSIENT"
 
 
+class FutuGatewayDataContractError(FutuGatewayError):
+    code = "DATA_CONTRACT"
+
+
 class FutuGatewayCapabilityUnavailableError(FutuGatewayError):
     code = "CAPABILITY_UNAVAILABLE"
 
@@ -913,6 +917,45 @@ class FutuGateway:
             self._raise_mapped(exc, action=action)
         raise AssertionError("unreachable")
 
+    def get_exact_expiration_option_terms(
+        self,
+        *,
+        code: str,
+        expiration: str,
+        contract_symbol: str,
+    ) -> dict[str, Any] | None:
+        action = "get_exact_expiration_option_terms"
+        try:
+            normalized_code, normalized_expiration = (
+                _normalize_exact_expiration_close_request(code, expiration)
+            )
+            normalized_contract = _non_empty_upper(
+                contract_symbol, "exact-expiration contract_symbol"
+            )
+        except Exception as exc:
+            self._raise_mapped(exc, action=action)
+        try:
+            result = self.get_option_chain(
+                code=normalized_code,
+                start=normalized_expiration,
+                end=normalized_expiration,
+                option_type="PUT",
+                is_force_refresh=True,
+            )
+        except Exception as exc:
+            self._raise_mapped(exc, action=action)
+        try:
+            return _normalize_exact_expiration_option_terms_response(
+                result,
+                code=normalized_code,
+                expiration=normalized_expiration,
+                contract_symbol=normalized_contract,
+            )
+        except ValueError as exc:
+            raise FutuGatewayDataContractError(
+                f"{action} failed: {exc}", raw_error=exc
+            ) from exc
+
     def get_history_kl_quota(self) -> dict[str, Any]:
         quote = self._quote_client()
         try:
@@ -1005,6 +1048,90 @@ def _normalize_exact_expiration_close_request(
             "exact-expiration close expiration must use YYYY-MM-DD"
         )
     return code.strip().upper(), expiration
+
+
+def _non_empty_upper(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be non-empty text")
+    return value.strip().upper()
+
+
+def _provider_rows(value: Any, label: str) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        if any(not isinstance(row, dict) for row in value):
+            raise ValueError(f"{label} rows must be objects")
+        return [dict(row) for row in value]
+    to_dict = getattr(value, "to_dict", None)
+    columns = getattr(value, "columns", None)
+    if not callable(to_dict) or columns is None:
+        raise ValueError(f"{label} must be a DataFrame or row list")
+    names = list(columns)
+    if len(names) != len(set(names)):
+        raise ValueError(f"{label} columns must be unique")
+    rows = to_dict(orient="records")
+    if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+        raise ValueError(f"{label} rows must be objects")
+    return [dict(row) for row in rows]
+
+
+def _positive_real(value: Any, label: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(float(value))
+        or float(value) <= 0
+    ):
+        raise ValueError(f"{label} must be a positive finite number")
+    return float(value)
+
+
+def _normalize_exact_expiration_option_terms_response(
+    value: Any,
+    *,
+    code: str,
+    expiration: str,
+    contract_symbol: str,
+) -> dict[str, Any] | None:
+    matches = [
+        row
+        for row in _provider_rows(value, "exact-expiration option terms")
+        if str(row.get("code") or "").strip().upper() == contract_symbol
+    ]
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError("exact-expiration option terms must uniquely match contract")
+    row = matches[0]
+    owner = _non_empty_upper(row.get("stock_owner"), "option stock_owner")
+    observed_expiration = str(
+        row.get("strike_time") or row.get("expiration") or ""
+    ).strip()
+    if owner != code or observed_expiration != expiration:
+        raise ValueError("exact-expiration option identity does not match request")
+    option_type = _non_empty_upper(row.get("option_type"), "option_type").rsplit(
+        ".", 1
+    )[-1]
+    standard_type = _non_empty_upper(
+        row.get("option_standard_type"), "option_standard_type"
+    ).rsplit(".", 1)[-1]
+    if option_type != "PUT" or standard_type != "STANDARD":
+        raise ValueError("exact-expiration option must be a standard PUT")
+    multiplier_value = row.get("lot_size", row.get("option_contract_size"))
+    multiplier = _positive_real(multiplier_value, "option multiplier")
+    if not multiplier.is_integer():
+        raise ValueError("option multiplier must be an integer")
+    return {
+        "contract_symbol": contract_symbol,
+        "stock_owner": owner,
+        "expiration": expiration,
+        "option_type": option_type,
+        "option_standard_type": standard_type,
+        "strike": _positive_real(
+            row.get("strike_price", row.get("strike")), "option strike"
+        ),
+        "multiplier": int(multiplier),
+        "currency": _non_empty_upper(row.get("currency"), "option currency"),
+    }
 
 
 def _normalize_exact_expiration_close_response(

--- a/src/infrastructure/strategy_lab/experiment_store.py
+++ b/src/infrastructure/strategy_lab/experiment_store.py
@@ -16,7 +16,7 @@ from src.infrastructure.private_storage import (
 
 
 SCHEMA_COMPONENT = "sell_put_top1_experiment_store"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 _V1_REQUIRED_TABLES = {
     "strategy_lab_schema",
@@ -26,16 +26,29 @@ _V1_REQUIRED_TABLES = {
     "strategy_lab_hidden_commitments",
     "strategy_lab_events",
 }
-_REQUIRED_TABLES = {
+_V2_REQUIRED_TABLES = {
     *_V1_REQUIRED_TABLES,
     "strategy_lab_corpus_days",
     "strategy_lab_corpus_points",
 }
-_REQUIRED_INDEXES = {
+_REQUIRED_TABLES = {
+    *_V2_REQUIRED_TABLES,
+    "strategy_lab_validation_decisions",
+    "strategy_lab_validation_days",
+    "strategy_lab_fill_observations",
+    "strategy_lab_outcome_jobs",
+    "strategy_lab_expiry_close_facts",
+}
+_V2_REQUIRED_INDEXES = {
     "strategy_lab_one_active_validation",
     "strategy_lab_hidden_date_unique",
     "strategy_lab_event_subject_unique",
     "strategy_lab_event_idempotency_unique",
+}
+_REQUIRED_INDEXES = {
+    *_V2_REQUIRED_INDEXES,
+    "strategy_lab_validation_decision_order",
+    "strategy_lab_outcome_job_status",
 }
 _V1_EXPECTED_FOREIGN_KEYS = {
     "strategy_lab_experiments": {
@@ -52,7 +65,7 @@ _V1_EXPECTED_FOREIGN_KEYS = {
     },
     "strategy_lab_events": set(),
 }
-_EXPECTED_FOREIGN_KEYS = {
+_V2_EXPECTED_FOREIGN_KEYS = {
     **_V1_EXPECTED_FOREIGN_KEYS,
     "strategy_lab_corpus_days": set(),
     "strategy_lab_corpus_points": {
@@ -61,6 +74,72 @@ _EXPECTED_FOREIGN_KEYS = {
         ("trading_date", "strategy_lab_corpus_days", "trading_date"),
     },
 }
+_EXPECTED_FOREIGN_KEYS = {
+    **_V2_EXPECTED_FOREIGN_KEYS,
+    "strategy_lab_validation_decisions": {
+        ("experiment_id", "strategy_lab_experiments", "experiment_id"),
+    },
+    "strategy_lab_validation_days": {
+        ("experiment_id", "strategy_lab_experiments", "experiment_id"),
+    },
+    "strategy_lab_fill_observations": {
+        ("experiment_id", "strategy_lab_experiments", "experiment_id"),
+    },
+    "strategy_lab_outcome_jobs": {
+        ("experiment_id", "strategy_lab_experiments", "experiment_id"),
+    },
+    "strategy_lab_expiry_close_facts": {
+        ("experiment_id", "strategy_lab_experiments", "experiment_id"),
+    },
+}
+
+_EXPERIMENT_COLUMNS = (
+    "experiment_id",
+    "topic_id",
+    "market",
+    "account",
+    "strategy_family",
+    "spec_json",
+    "research_spec_sha256",
+    "validation_spec_sha256",
+    "source_provenance_json",
+    "phase",
+    "research_progress",
+    "validation_progress",
+    "blocked_reason",
+    "completed_validation_partitions",
+    "research_authorization_status",
+    "research_authorized_hash",
+    "research_authorized_actor",
+    "research_authorized_at_utc",
+    "validation_authorization_status",
+    "validation_authorized_hash",
+    "validation_authorized_actor",
+    "validation_authorized_at_utc",
+    "research_leader",
+    "research_receipt_ref",
+    "research_receipt_file_sha256",
+    "proposed_commitment_json",
+    "proposed_commitment_sha256",
+    "proposed_commitment_ref",
+    "proposed_commitment_content_sha256",
+    "proposed_commitment_file_sha256",
+    "terminal_mode",
+    "terminal_reason",
+    "disabled_scope",
+    "terminal_at_utc",
+    "terminated_at_partition",
+    "final_outcome_status",
+    "receipt_request_event_id",
+    "receipt_published_event_id",
+    "receipt_ref",
+    "receipt_content_sha256",
+    "receipt_file_sha256",
+    "receipt_published_at_utc",
+    "created_at_utc",
+    "updated_at_utc",
+    "state_version",
+)
 
 
 class ExperimentStoreError(RuntimeError):
@@ -120,9 +199,12 @@ class ExperimentStore:
                 if version == 1:
                     self._validate_v1(connection, deep=True)
                     return {"status": "migration_required", "schema_version": 1}
+                if version == 2:
+                    self._validate_v2(connection, deep=True)
+                    return {"status": "migration_required", "schema_version": 2}
                 if version != SCHEMA_VERSION:
                     return {"status": "schema_unsupported", "schema_version": version}
-                self._validate_v2(connection, deep=True)
+                self._validate_v3(connection, deep=True)
                 return {"status": "ready", "schema_version": version}
             finally:
                 connection.close()
@@ -132,8 +214,15 @@ class ExperimentStore:
     def migrate(self, *, migrated_at_utc: str) -> dict[str, object]:
         connection = connect_private_sqlite(self.path, isolation_level=None)
         connection.row_factory = sqlite3.Row
+        committed = False
+        foreign_keys = int(connection.execute("PRAGMA foreign_keys").fetchone()[0])
+        legacy_alter = int(
+            connection.execute("PRAGMA legacy_alter_table").fetchone()[0]
+        )
         try:
-            self._configure(connection)
+            connection.execute("PRAGMA busy_timeout=5000")
+            connection.execute("PRAGMA foreign_keys=OFF")
+            connection.execute("PRAGMA legacy_alter_table=ON")
             connection.execute("BEGIN IMMEDIATE")
             tables = self._tables(connection)
             if not tables:
@@ -142,7 +231,7 @@ class ExperimentStore:
                 connection.execute(
                     "INSERT INTO strategy_lab_schema(component, schema_version, migrated_at_utc) "
                     "VALUES (?, ?, ?)",
-                    (SCHEMA_COMPONENT, SCHEMA_VERSION, migrated_at_utc),
+                    (SCHEMA_COMPONENT, 2, migrated_at_utc),
                 )
             elif tables == {"strategy_lab_schema"}:
                 metadata = connection.execute(
@@ -159,7 +248,7 @@ class ExperimentStore:
                 connection.execute(
                     "INSERT INTO strategy_lab_schema(component, schema_version, migrated_at_utc) "
                     "VALUES (?, ?, ?)",
-                    (SCHEMA_COMPONENT, SCHEMA_VERSION, migrated_at_utc),
+                    (SCHEMA_COMPONENT, 2, migrated_at_utc),
                 )
             else:
                 metadata = (
@@ -182,25 +271,55 @@ class ExperimentStore:
                         "UPDATE strategy_lab_schema "
                         "SET schema_version = ?, migrated_at_utc = ? "
                         "WHERE component = ?",
-                        (SCHEMA_VERSION, migrated_at_utc, SCHEMA_COMPONENT),
+                        (2, migrated_at_utc, SCHEMA_COMPONENT),
                     )
-                elif version == SCHEMA_VERSION:
+                elif version == 2:
                     self._validate_v2(connection, deep=True)
+                elif version == SCHEMA_VERSION:
+                    self._validate_v3(connection, deep=True)
                 else:
                     raise ExperimentStoreError(
                         "schema_unsupported", "existing schema cannot be migrated"
                     )
+            metadata = connection.execute(
+                "SELECT schema_version FROM strategy_lab_schema WHERE component = ?",
+                (SCHEMA_COMPONENT,),
+            ).fetchone()
+            if metadata is None:
+                raise ExperimentStoreError(
+                    "schema_unsupported", "schema metadata is missing"
+                )
+            if int(metadata[0]) == 2:
+                self._migrate_v2_to_v3(connection)
+                connection.execute(
+                    "UPDATE strategy_lab_schema "
+                    "SET schema_version = ?, migrated_at_utc = ? WHERE component = ?",
+                    (SCHEMA_VERSION, migrated_at_utc, SCHEMA_COMPONENT),
+                )
+            self._validate_v3(connection, deep=True)
             connection.commit()
-            self._validate_v2(connection, deep=True)
+            committed = True
         except (sqlite3.DatabaseError, ValueError) as exc:
-            connection.rollback()
+            if connection.in_transaction:
+                connection.rollback()
             raise ExperimentStoreError("schema_unsupported", "SQLite schema is invalid") from exc
         except BaseException:
-            connection.rollback()
+            if connection.in_transaction:
+                connection.rollback()
             raise
         finally:
+            if connection.in_transaction:
+                connection.rollback()
+            connection.execute(f"PRAGMA legacy_alter_table={legacy_alter}")
+            connection.execute(f"PRAGMA foreign_keys={foreign_keys}")
             connection.close()
             secure_sqlite_artifacts(self.path)
+        if committed:
+            verify = self._readonly_connection()
+            try:
+                self._validate_v3(verify, deep=True)
+            finally:
+                verify.close()
         return {"status": "ready", "schema_version": SCHEMA_VERSION}
 
     def feature(self, market: str, account: str) -> dict[str, Any] | None:
@@ -1120,6 +1239,23 @@ class ExperimentStore:
             )
             connection.execute(
                 """
+                INSERT INTO strategy_lab_generations(
+                    experiment_id, generation_kind, state, revision,
+                    last_revision_ref, last_revision_file_sha256,
+                    frozen_row_content_sha256, created_at_utc, updated_at_utc
+                ) VALUES (?, 'outcome', 'open', 0, ?, ?, ?, ?, ?)
+                """,
+                (
+                    experiment_id,
+                    current["proposed_commitment_ref"],
+                    current["proposed_commitment_file_sha256"],
+                    current["proposed_commitment_content_sha256"],
+                    occurred_at_utc,
+                    occurred_at_utc,
+                ),
+            )
+            connection.execute(
+                """
                 UPDATE strategy_lab_experiments SET
                     phase = 'validation', validation_progress = 'collecting_decisions',
                     completed_validation_partitions = 0,
@@ -1130,44 +1266,75 @@ class ExperimentStore:
             )
             return self._required_experiment(connection, experiment_id)
 
-    def commit_validation_point(
+    def commit_validation_decision(
         self,
         *,
         experiment_id: str,
-        point_id: str,
-        trading_date: str,
-        source_ref: str,
-        source_file_sha256: str,
+        expected_state_version: int,
+        decision: Mapping[str, object],
+        gap_observations: Sequence[Mapping[str, object]],
+        fill_status_updates: Sequence[Mapping[str, object]],
+        day: Mapping[str, object] | None,
         revision: int,
-        manifest_ref: str,
-        manifest_file_sha256: str,
+        revision_ref: str,
+        revision_file_sha256: str,
         frozen_row_sha256: str,
+        terminal_request: Mapping[str, object] | None,
         actor: str,
         occurred_at_utc: str,
         idempotency_key: str,
     ) -> dict[str, Any]:
+        point_id = str(decision["recommendation_point_id"])
         request = {
             "experiment_id": experiment_id,
-            "point_id": point_id,
-            "trading_date": trading_date,
-            "source_ref": source_ref,
-            "source_file_sha256": source_file_sha256,
+            "expected_state_version": expected_state_version,
+            "decision_sha256": _sha256_text(compact_json(decision)),
+            "gap_observations_sha256": _sha256_text(compact_json(gap_observations)),
+            "fill_status_updates_sha256": _sha256_text(
+                compact_json(fill_status_updates)
+            ),
+            "day_sha256": _sha256_text(compact_json(day)) if day else None,
             "revision": revision,
-            "manifest_ref": manifest_ref,
-            "manifest_file_sha256": manifest_file_sha256,
+            "revision_ref": revision_ref,
+            "revision_file_sha256": revision_file_sha256,
             "frozen_row_sha256": frozen_row_sha256,
+            "terminal_request_sha256": (
+                _sha256_text(compact_json(terminal_request))
+                if terminal_request is not None
+                else None
+            ),
         }
-        scope = f"experiment:{experiment_id}:validation-point"
+        scope = f"experiment:{experiment_id}:validation-decision"
         with self._write() as connection:
             replay = self._command_event(connection, scope, idempotency_key)
             if replay is not None:
                 self._assert_event_replay(replay, request, actor, occurred_at_utc)
-                return self._required_generation(connection, experiment_id, "hidden")
-            experiment = self._required_experiment(connection, experiment_id)
-            generation = self._required_generation(connection, experiment_id, "hidden")
+                return self._required_validation_decision(
+                    connection, experiment_id, point_id
+                )
+            experiment, generation, open_date = self._validation_open_state(
+                connection, experiment_id, expected_state_version
+            )
+            if str(decision["trading_date"]) != open_date:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "decision date is not open"
+                )
+            observed_index = int(
+                connection.execute(
+                    """
+                    SELECT COUNT(*) FROM strategy_lab_validation_decisions
+                    WHERE experiment_id = ? AND trading_date = ?
+                    """,
+                    (experiment_id, open_date),
+                ).fetchone()[0]
+            )
+            if int(decision["point_index"]) != observed_index:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "decision point is out of order"
+                )
             _, inserted = self._claim_event(
                 connection,
-                event_type="validation_point_committed",
+                event_type="validation_decision_committed",
                 subject_key=f"experiment:{experiment_id}:point:{point_id}",
                 command_scope=scope,
                 idempotency_key=idempotency_key,
@@ -1178,139 +1345,64 @@ class ExperimentStore:
                 generation_kind="hidden",
             )
             if not inserted:
-                return generation
-            if experiment["terminal_mode"] is not None or not (
-                experiment["phase"] == "validation"
-                and experiment["validation_progress"] == "collecting_decisions"
-                and generation["terminal_request_event_id"] is None
-            ):
-                raise ExperimentStoreError("late_write", "validation intake is closed")
-            committed_date = connection.execute(
-                """
-                SELECT 1 FROM strategy_lab_hidden_commitments
-                WHERE experiment_id = ? AND trading_date = ?
-                """,
-                (experiment_id, trading_date),
-            ).fetchone()
-            if committed_date is None:
-                raise ExperimentStoreError(
-                    "experiment_conflict", "point date is outside commitment"
-                )
-            next_date = connection.execute(
-                """
-                SELECT trading_date FROM strategy_lab_hidden_commitments
-                WHERE experiment_id = ? ORDER BY trading_date LIMIT 1 OFFSET ?
-                """,
-                (experiment_id, int(experiment["completed_validation_partitions"])),
-            ).fetchone()
-            if next_date is None or str(next_date[0]) != trading_date:
-                raise ExperimentStoreError(
-                    "late_write", "point date partition is not open"
-                )
-            if revision != int(generation["revision"]) + 1:
-                raise ExperimentStoreError(
-                    "generation_conflict", "hidden revision is not next"
+                return self._required_validation_decision(
+                    connection, experiment_id, point_id
                 )
             connection.execute(
                 """
-                UPDATE strategy_lab_generations SET
-                    revision = ?, last_revision_ref = ?,
-                    last_revision_file_sha256 = ?, frozen_row_content_sha256 = ?,
-                    updated_at_utc = ?
-                WHERE experiment_id = ? AND generation_kind = 'hidden'
+                INSERT INTO strategy_lab_validation_decisions(
+                    experiment_id, recommendation_point_id, trading_date,
+                    point_index, source_status, expectation_ref,
+                    expectation_content_sha256, target_at_utc, source_ref,
+                    source_file_sha256, source_content_sha256, hard_risk_status,
+                    baseline_json, challenger_json, baseline_fill_status,
+                    challenger_fill_status, reason_code, created_at_utc,
+                    updated_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    revision,
-                    manifest_ref,
-                    manifest_file_sha256,
-                    frozen_row_sha256,
-                    occurred_at_utc,
                     experiment_id,
+                    point_id,
+                    decision["trading_date"],
+                    decision["point_index"],
+                    decision["source_status"],
+                    decision["expectation_ref"],
+                    decision["expectation_content_sha256"],
+                    decision["target_at_utc"],
+                    decision.get("source_ref"),
+                    decision.get("source_file_sha256"),
+                    decision.get("source_content_sha256"),
+                    decision["hard_risk_status"],
+                    decision.get("baseline_json"),
+                    decision.get("challenger_json"),
+                    decision.get("baseline_fill_status"),
+                    decision.get("challenger_fill_status"),
+                    decision.get("reason_code"),
+                    occurred_at_utc,
+                    occurred_at_utc,
                 ),
             )
-            return self._required_generation(connection, experiment_id, "hidden")
-
-    def seal_validation_partition(
-        self,
-        *,
-        experiment_id: str,
-        trading_date: str,
-        terminal_request: Mapping[str, object] | None,
-        actor: str,
-        occurred_at_utc: str,
-        idempotency_key: str,
-    ) -> dict[str, Any]:
-        request = {
-            "experiment_id": experiment_id,
-            "trading_date": trading_date,
-            "terminal_request_sha256": (
-                _sha256_text(compact_json(terminal_request))
-                if terminal_request is not None
-                else None
-            ),
-        }
-        scope = f"experiment:{experiment_id}:validation-partition"
-        with self._write() as connection:
-            replay = self._command_event(connection, scope, idempotency_key)
-            if replay is not None:
-                self._assert_event_replay(replay, request, actor, occurred_at_utc)
-                return self._required_experiment(connection, experiment_id)
-            experiment = self._required_experiment(connection, experiment_id)
-            generation = self._required_generation(connection, experiment_id, "hidden")
-            _, inserted = self._claim_event(
-                connection,
-                event_type="validation_partition_sealed",
-                subject_key=f"experiment:{experiment_id}:partition:{trading_date}",
-                command_scope=scope,
-                idempotency_key=idempotency_key,
-                actor=actor,
-                occurred_at_utc=occurred_at_utc,
-                payload=request,
-                experiment_id=experiment_id,
-                generation_kind="hidden",
+            self._insert_fill_observations(
+                connection, experiment_id, gap_observations, occurred_at_utc
             )
-            if not inserted:
-                return experiment
-            if experiment["terminal_mode"] is not None or not (
-                experiment["phase"] == "validation"
-                and experiment["validation_progress"] == "collecting_decisions"
-                and generation["terminal_request_event_id"] is None
-            ):
-                raise ExperimentStoreError("late_write", "validation intake is closed")
-            dates = [
-                str(row[0])
-                for row in connection.execute(
-                    """
-                    SELECT trading_date FROM strategy_lab_hidden_commitments
-                    WHERE experiment_id = ? ORDER BY trading_date
-                    """,
-                    (experiment_id,),
-                ).fetchall()
-            ]
-            completed = int(experiment["completed_validation_partitions"])
-            if completed >= len(dates) or dates[completed] != trading_date:
-                raise ExperimentStoreError(
-                    "experiment_conflict", "partition is not the next commitment date"
-                )
-            point_rows = connection.execute(
-                """
-                SELECT payload_json FROM strategy_lab_events
-                WHERE experiment_id = ? AND event_type = 'validation_point_committed'
-                """,
-                (experiment_id,),
-            ).fetchall()
-            if not any(
-                json.loads(str(row[0])).get("trading_date") == trading_date
-                for row in point_rows
-            ):
-                raise ExperimentStoreError(
-                    "experiment_conflict", "partition has no committed point"
-                )
-            is_final = completed + 1 == 20
-            if is_final != (terminal_request is not None):
-                raise ExperimentStoreError(
-                    "experiment_conflict", "terminal request is required only on day 20"
-                )
+            self._apply_fill_status_updates(
+                connection, experiment_id, fill_status_updates, occurred_at_utc
+            )
+            completed, progress = self._apply_validation_day(
+                connection,
+                experiment=experiment,
+                day=day,
+                occurred_at_utc=occurred_at_utc,
+            )
+            self._advance_generation(
+                connection,
+                generation=generation,
+                revision=revision,
+                revision_ref=revision_ref,
+                revision_file_sha256=revision_file_sha256,
+                frozen_row_sha256=frozen_row_sha256,
+                occurred_at_utc=occurred_at_utc,
+            )
             if terminal_request is not None:
                 self._request_generation_terminal(
                     connection,
@@ -1321,16 +1413,528 @@ class ExperimentStore:
                     occurred_at_utc=occurred_at_utc,
                     idempotency_key=f"{idempotency_key}:hidden-terminal",
                 )
+            if (completed == 20) != (terminal_request is not None):
+                raise ExperimentStoreError(
+                    "experiment_conflict", "day-20 terminal binding is invalid"
+                )
             connection.execute(
                 """
                 UPDATE strategy_lab_experiments SET
-                    completed_validation_partitions = ?,
-                    validation_progress = CASE WHEN ? THEN 'awaiting_outcomes'
-                                               ELSE validation_progress END,
+                    completed_validation_partitions = ?, validation_progress = ?,
                     updated_at_utc = ?, state_version = state_version + 1
                 WHERE experiment_id = ?
                 """,
-                (completed + 1, int(is_final), occurred_at_utc, experiment_id),
+                (completed, progress, occurred_at_utc, experiment_id),
+            )
+            return self._required_validation_decision(
+                connection, experiment_id, point_id
+            )
+
+    def commit_validation_observation_batch(
+        self,
+        *,
+        experiment_id: str,
+        expected_state_version: int,
+        observed_point_id: str,
+        observations: Sequence[Mapping[str, object]],
+        fill_status_updates: Sequence[Mapping[str, object]],
+        new_jobs: Sequence[Mapping[str, object]],
+        day: Mapping[str, object] | None,
+        revision: int,
+        revision_ref: str,
+        revision_file_sha256: str,
+        frozen_row_sha256: str,
+        terminal_request: Mapping[str, object] | None,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "expected_state_version": expected_state_version,
+            "observed_point_id": observed_point_id,
+            "observations_sha256": _sha256_text(compact_json(observations)),
+            "fill_status_updates_sha256": _sha256_text(
+                compact_json(fill_status_updates)
+            ),
+            "new_jobs_sha256": _sha256_text(compact_json(new_jobs)),
+            "day_sha256": _sha256_text(compact_json(day)) if day else None,
+            "revision": revision,
+            "revision_ref": revision_ref,
+            "revision_file_sha256": revision_file_sha256,
+            "frozen_row_sha256": frozen_row_sha256,
+            "terminal_request_sha256": (
+                _sha256_text(compact_json(terminal_request))
+                if terminal_request is not None
+                else None
+            ),
+        }
+        scope = f"experiment:{experiment_id}:validation-observation"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return {"status": "idempotent", "observed_point_id": observed_point_id}
+            experiment, generation, open_date = self._validation_open_state(
+                connection, experiment_id, expected_state_version
+            )
+            decision = self._required_validation_decision(
+                connection, experiment_id, observed_point_id
+            )
+            if decision["trading_date"] != open_date:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "observation point date is not open"
+                )
+            _, inserted = self._claim_event(
+                connection,
+                event_type="validation_observation_committed",
+                subject_key=f"experiment:{experiment_id}:observation:{observed_point_id}",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="hidden",
+            )
+            if not inserted:
+                return {"status": "idempotent", "observed_point_id": observed_point_id}
+            self._insert_fill_observations(
+                connection, experiment_id, observations, occurred_at_utc
+            )
+            self._apply_fill_status_updates(
+                connection, experiment_id, fill_status_updates, occurred_at_utc
+            )
+            self._insert_outcome_jobs(
+                connection, experiment_id, new_jobs, occurred_at_utc
+            )
+            completed, progress = self._apply_validation_day(
+                connection,
+                experiment=experiment,
+                day=day,
+                occurred_at_utc=occurred_at_utc,
+            )
+            self._advance_generation(
+                connection,
+                generation=generation,
+                revision=revision,
+                revision_ref=revision_ref,
+                revision_file_sha256=revision_file_sha256,
+                frozen_row_sha256=frozen_row_sha256,
+                occurred_at_utc=occurred_at_utc,
+            )
+            if terminal_request is not None:
+                self._request_generation_terminal(
+                    connection,
+                    experiment_id=experiment_id,
+                    generation_kind="hidden",
+                    request=terminal_request,
+                    actor=actor,
+                    occurred_at_utc=occurred_at_utc,
+                    idempotency_key=f"{idempotency_key}:hidden-terminal",
+                )
+            if (completed == 20) != (terminal_request is not None):
+                raise ExperimentStoreError(
+                    "experiment_conflict", "day-20 terminal binding is invalid"
+                )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    completed_validation_partitions = ?, validation_progress = ?,
+                    updated_at_utc = ?, state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (completed, progress, occurred_at_utc, experiment_id),
+            )
+            return {"status": "committed", "observed_point_id": observed_point_id}
+
+    def commit_validation_day_gap(
+        self,
+        *,
+        experiment_id: str,
+        expected_state_version: int,
+        day: Mapping[str, object],
+        revision: int,
+        revision_ref: str,
+        revision_file_sha256: str,
+        frozen_row_sha256: str,
+        terminal_request: Mapping[str, object] | None,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        trading_date = str(day["trading_date"])
+        request = {
+            "experiment_id": experiment_id,
+            "expected_state_version": expected_state_version,
+            "day_sha256": _sha256_text(compact_json(day)),
+            "revision": revision,
+            "revision_ref": revision_ref,
+            "revision_file_sha256": revision_file_sha256,
+            "frozen_row_sha256": frozen_row_sha256,
+            "terminal_request_sha256": (
+                _sha256_text(compact_json(terminal_request))
+                if terminal_request is not None
+                else None
+            ),
+        }
+        scope = f"experiment:{experiment_id}:validation-day-gap"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            experiment, generation, open_date = self._validation_open_state(
+                connection, experiment_id, expected_state_version
+            )
+            if trading_date != open_date or not (
+                day.get("expected_point_count") is None
+                and int(day["consumed_point_count"]) == 0
+                and day["hard_risk_status"] == "missing"
+            ):
+                raise ExperimentStoreError(
+                    "experiment_conflict", "whole-day gap is invalid"
+                )
+            _, inserted = self._claim_event(
+                connection,
+                event_type="validation_day_gap_committed",
+                subject_key=f"experiment:{experiment_id}:day-gap:{trading_date}",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="hidden",
+            )
+            if not inserted:
+                return self._required_experiment(connection, experiment_id)
+            completed, progress = self._apply_validation_day(
+                connection,
+                experiment=experiment,
+                day=day,
+                occurred_at_utc=occurred_at_utc,
+            )
+            self._advance_generation(
+                connection,
+                generation=generation,
+                revision=revision,
+                revision_ref=revision_ref,
+                revision_file_sha256=revision_file_sha256,
+                frozen_row_sha256=frozen_row_sha256,
+                occurred_at_utc=occurred_at_utc,
+            )
+            if terminal_request is not None:
+                self._request_generation_terminal(
+                    connection,
+                    experiment_id=experiment_id,
+                    generation_kind="hidden",
+                    request=terminal_request,
+                    actor=actor,
+                    occurred_at_utc=occurred_at_utc,
+                    idempotency_key=f"{idempotency_key}:hidden-terminal",
+                )
+            if (completed == 20) != (terminal_request is not None):
+                raise ExperimentStoreError(
+                    "experiment_conflict", "day-20 terminal binding is invalid"
+                )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    completed_validation_partitions = ?, validation_progress = ?,
+                    updated_at_utc = ?, state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (completed, progress, occurred_at_utc, experiment_id),
+            )
+            return self._required_experiment(connection, experiment_id)
+
+    def commit_outcome_batch(
+        self,
+        *,
+        experiment_id: str,
+        expected_state_version: int,
+        job_updates: Sequence[Mapping[str, object]],
+        close_fact: Mapping[str, object] | None,
+        revision: int,
+        revision_ref: str,
+        revision_file_sha256: str,
+        frozen_row_sha256: str,
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "expected_state_version": expected_state_version,
+            "job_updates_sha256": _sha256_text(compact_json(job_updates)),
+            "close_fact_sha256": (
+                _sha256_text(compact_json(close_fact)) if close_fact else None
+            ),
+            "revision": revision,
+            "revision_ref": revision_ref,
+            "revision_file_sha256": revision_file_sha256,
+            "frozen_row_sha256": frozen_row_sha256,
+        }
+        scope = f"experiment:{experiment_id}:outcome"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            experiment = self._required_experiment(connection, experiment_id)
+            generation = self._required_generation(connection, experiment_id, "outcome")
+            if int(experiment["state_version"]) != expected_state_version:
+                raise ExperimentStoreError("stale_snapshot", "experiment changed")
+            if experiment["terminal_mode"] is not None or not (
+                experiment["phase"] == "validation"
+                and experiment["validation_progress"]
+                in {"collecting_decisions", "awaiting_outcomes"}
+                and generation["terminal_request_event_id"] is None
+            ):
+                raise ExperimentStoreError("late_write", "outcome intake is closed")
+            self._claim_event(
+                connection,
+                event_type="outcome_batch_committed",
+                subject_key=f"experiment:{experiment_id}:outcome-revision:{revision}",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="outcome",
+            )
+            if close_fact is not None:
+                self._insert_expiry_close_fact(connection, experiment_id, close_fact)
+            evidence_failed = False
+            for update in job_updates:
+                job = self._required_outcome_job(
+                    connection,
+                    experiment_id,
+                    str(update["target_point_id"]),
+                    str(update["arm"]),
+                )
+                expected = str(update["expected_status"])
+                target = str(update["status"])
+                if job["status"] != expected or (expected, target) not in {
+                    ("pending_terms", "pending_terms"),
+                    ("pending_terms", "pending_outcome"),
+                    ("pending_terms", "outcome_unavailable"),
+                    ("pending_outcome", "pending_outcome"),
+                    ("pending_outcome", "evaluable"),
+                    ("pending_outcome", "outcome_unavailable"),
+                }:
+                    raise ExperimentStoreError(
+                        "stale_snapshot", "outcome job transition changed"
+                    )
+                if target == "evaluable" and (
+                    update.get("result_json") is None
+                    or update.get("result_sha256") is None
+                ):
+                    raise ExperimentStoreError(
+                        "experiment_conflict", "evaluable outcome result is missing"
+                    )
+                if target == "outcome_unavailable" and not update.get("reason_code"):
+                    raise ExperimentStoreError(
+                        "experiment_conflict", "unavailable outcome reason is missing"
+                    )
+                connection.execute(
+                    """
+                    UPDATE strategy_lab_outcome_jobs SET
+                        status = ?, terms_point_id = COALESCE(?, terms_point_id),
+                        terms_json = COALESCE(?, terms_json),
+                        terms_sha256 = COALESCE(?, terms_sha256),
+                        result_json = COALESCE(?, result_json),
+                        result_sha256 = COALESCE(?, result_sha256),
+                        reason_code = ?, last_attempt_at_utc = ?, updated_at_utc = ?
+                    WHERE experiment_id = ? AND target_point_id = ? AND arm = ?
+                    """,
+                    (
+                        target,
+                        update.get("terms_point_id"),
+                        update.get("terms_json"),
+                        update.get("terms_sha256"),
+                        update.get("result_json"),
+                        update.get("result_sha256"),
+                        update.get("reason_code"),
+                        update.get("last_attempt_at_utc"),
+                        occurred_at_utc,
+                        experiment_id,
+                        update["target_point_id"],
+                        update["arm"],
+                    ),
+                )
+                evidence_failed = evidence_failed or target == "outcome_unavailable"
+            completed = int(experiment["completed_validation_partitions"])
+            if completed == 20 and evidence_failed:
+                connection.execute(
+                    """
+                    UPDATE strategy_lab_outcome_jobs SET
+                        status = 'not_required_after_evidence_failure',
+                        reason_code = 'required_outcome_missing', updated_at_utc = ?
+                    WHERE experiment_id = ?
+                      AND status IN ('pending_terms','pending_outcome')
+                    """,
+                    (occurred_at_utc, experiment_id),
+                )
+            pending = connection.execute(
+                """
+                SELECT 1 FROM strategy_lab_outcome_jobs
+                WHERE experiment_id = ?
+                  AND status IN ('pending_terms','pending_outcome') LIMIT 1
+                """,
+                (experiment_id,),
+            ).fetchone()
+            progress = (
+                "collecting_decisions"
+                if completed < 20
+                else "awaiting_outcomes"
+                if pending is not None
+                else "ready_to_conclude"
+            )
+            self._advance_generation(
+                connection,
+                generation=generation,
+                revision=revision,
+                revision_ref=revision_ref,
+                revision_file_sha256=revision_file_sha256,
+                frozen_row_sha256=frozen_row_sha256,
+                occurred_at_utc=occurred_at_utc,
+            )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    validation_progress = ?, updated_at_utc = ?,
+                    state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (progress, occurred_at_utc, experiment_id),
+            )
+            return self._required_experiment(connection, experiment_id)
+
+    def complete_validation(
+        self,
+        *,
+        experiment_id: str,
+        expected_state_version: int,
+        final_outcome_status: str,
+        result_sha256: str,
+        revision: int,
+        revision_ref: str,
+        revision_file_sha256: str,
+        frozen_row_sha256: str,
+        outcome_terminal_request: Mapping[str, object],
+        receipt_request: Mapping[str, object],
+        actor: str,
+        occurred_at_utc: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        request = {
+            "experiment_id": experiment_id,
+            "expected_state_version": expected_state_version,
+            "final_outcome_status": final_outcome_status,
+            "result_sha256": result_sha256,
+            "revision": revision,
+            "revision_ref": revision_ref,
+            "revision_file_sha256": revision_file_sha256,
+            "frozen_row_sha256": frozen_row_sha256,
+            "outcome_terminal_request_sha256": _sha256_text(
+                compact_json(outcome_terminal_request)
+            ),
+            "receipt_request_sha256": _sha256_text(compact_json(receipt_request)),
+        }
+        scope = f"experiment:{experiment_id}:complete-validation"
+        with self._write() as connection:
+            replay = self._command_event(connection, scope, idempotency_key)
+            if replay is not None:
+                self._assert_event_replay(replay, request, actor, occurred_at_utc)
+                return self._required_experiment(connection, experiment_id)
+            experiment = self._required_experiment(connection, experiment_id)
+            generation = self._required_generation(connection, experiment_id, "outcome")
+            hidden = self._required_generation(connection, experiment_id, "hidden")
+            if int(experiment["state_version"]) != expected_state_version:
+                raise ExperimentStoreError("stale_snapshot", "experiment changed")
+            if final_outcome_status not in {
+                "candidate_for_adoption",
+                "keep_baseline",
+                "insufficient_evidence",
+            }:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "final outcome status is invalid"
+                )
+            pending = connection.execute(
+                """
+                SELECT 1 FROM strategy_lab_outcome_jobs
+                WHERE experiment_id = ?
+                  AND status IN ('pending_terms','pending_outcome') LIMIT 1
+                """,
+                (experiment_id,),
+            ).fetchone()
+            if experiment["terminal_mode"] is not None or not (
+                experiment["phase"] == "validation"
+                and experiment["validation_progress"] == "ready_to_conclude"
+                and int(experiment["completed_validation_partitions"]) == 20
+                and hidden["terminal_request_event_id"] is not None
+                and generation["terminal_request_event_id"] is None
+                and pending is None
+            ):
+                raise ExperimentStoreError(
+                    "invalid_transition", "validation is not ready to conclude"
+                )
+            self._claim_event(
+                connection,
+                event_type="validation_completed",
+                subject_key=f"experiment:{experiment_id}:completed",
+                command_scope=scope,
+                idempotency_key=idempotency_key,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                payload=request,
+                experiment_id=experiment_id,
+                generation_kind="outcome",
+            )
+            self._advance_generation(
+                connection,
+                generation=generation,
+                revision=revision,
+                revision_ref=revision_ref,
+                revision_file_sha256=revision_file_sha256,
+                frozen_row_sha256=frozen_row_sha256,
+                occurred_at_utc=occurred_at_utc,
+            )
+            connection.execute(
+                """
+                UPDATE strategy_lab_experiments SET
+                    terminal_mode = 'completed', terminal_at_utc = ?,
+                    final_outcome_status = ?, updated_at_utc = ?,
+                    state_version = state_version + 1
+                WHERE experiment_id = ?
+                """,
+                (
+                    occurred_at_utc,
+                    final_outcome_status,
+                    occurred_at_utc,
+                    experiment_id,
+                ),
+            )
+            self._request_generation_terminal(
+                connection,
+                experiment_id=experiment_id,
+                generation_kind="outcome",
+                request=outcome_terminal_request,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=f"{idempotency_key}:outcome-terminal",
+                allow_experiment_terminal=True,
+            )
+            self._request_receipt(
+                connection,
+                experiment_id=experiment_id,
+                request=receipt_request,
+                actor=actor,
+                occurred_at_utc=occurred_at_utc,
+                idempotency_key=f"{idempotency_key}:receipt",
             )
             return self._required_experiment(connection, experiment_id)
 
@@ -1425,6 +2029,16 @@ class ExperimentStore:
                     experiment_id,
                 ),
             )
+            connection.execute(
+                """
+                UPDATE strategy_lab_outcome_jobs SET
+                    status = 'not_required_after_evidence_failure',
+                    reason_code = ?, updated_at_utc = ?
+                WHERE experiment_id = ?
+                  AND status IN ('pending_terms','pending_outcome')
+                """,
+                (reason, occurred_at_utc, experiment_id),
+            )
             for item in generation_requests:
                 self._request_generation_terminal(
                     connection,
@@ -1490,6 +2104,141 @@ class ExperimentStore:
                     (experiment_id,),
                 ).fetchall()
             ]
+
+    def validation_decision(
+        self, experiment_id: str, recommendation_point_id: str
+    ) -> dict[str, Any] | None:
+        with self._read() as connection:
+            return _row(
+                connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_validation_decisions
+                    WHERE experiment_id = ? AND recommendation_point_id = ?
+                    """,
+                    (experiment_id, recommendation_point_id),
+                ).fetchone()
+            )
+
+    def validation_decisions(self, experiment_id: str) -> list[dict[str, Any]]:
+        with self._read() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_validation_decisions
+                    WHERE experiment_id = ?
+                    ORDER BY trading_date, point_index
+                    """,
+                    (experiment_id,),
+                ).fetchall()
+            ]
+
+    def validation_days(self, experiment_id: str) -> list[dict[str, Any]]:
+        with self._read() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_validation_days
+                    WHERE experiment_id = ? ORDER BY trading_date
+                    """,
+                    (experiment_id,),
+                ).fetchall()
+            ]
+
+    def validation_day(
+        self, experiment_id: str, trading_date: str
+    ) -> dict[str, Any] | None:
+        with self._read() as connection:
+            return _row(
+                connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_validation_days
+                    WHERE experiment_id = ? AND trading_date = ?
+                    """,
+                    (experiment_id, trading_date),
+                ).fetchone()
+            )
+
+    def fill_observations(
+        self,
+        experiment_id: str,
+        *,
+        observed_point_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        query = (
+            "SELECT * FROM strategy_lab_fill_observations "
+            "WHERE experiment_id = ?"
+        )
+        params: tuple[object, ...] = (experiment_id,)
+        if observed_point_id is not None:
+            query += " AND observed_point_id = ?"
+            params += (observed_point_id,)
+        query += " ORDER BY trading_date, target_point_id, arm, observed_point_id"
+        with self._read() as connection:
+            return [dict(row) for row in connection.execute(query, params).fetchall()]
+
+    def validation_observation_committed(
+        self, experiment_id: str, observed_point_id: str
+    ) -> bool:
+        with self._read() as connection:
+            return (
+                connection.execute(
+                    """
+                    SELECT 1 FROM strategy_lab_events
+                    WHERE event_type = 'validation_observation_committed'
+                      AND subject_key = ?
+                    """,
+                    (f"experiment:{experiment_id}:observation:{observed_point_id}",),
+                ).fetchone()
+                is not None
+            )
+
+    def outcome_jobs(self, experiment_id: str) -> list[dict[str, Any]]:
+        with self._read() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_outcome_jobs
+                    WHERE experiment_id = ? ORDER BY due_at_utc, target_point_id, arm
+                    """,
+                    (experiment_id,),
+                ).fetchall()
+            ]
+
+    def outcome_job(
+        self, experiment_id: str, target_point_id: str, arm: str
+    ) -> dict[str, Any] | None:
+        with self._read() as connection:
+            return _row(
+                connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_outcome_jobs
+                    WHERE experiment_id = ? AND target_point_id = ? AND arm = ?
+                    """,
+                    (experiment_id, target_point_id, arm),
+                ).fetchone()
+            )
+
+    def expiry_close_fact(
+        self,
+        experiment_id: str,
+        stock_owner: str,
+        expiration: str,
+        contract_version: str,
+    ) -> dict[str, Any] | None:
+        with self._read() as connection:
+            return _row(
+                connection.execute(
+                    """
+                    SELECT * FROM strategy_lab_expiry_close_facts
+                    WHERE experiment_id = ? AND stock_owner = ?
+                      AND expiration = ? AND contract_version = ?
+                    """,
+                    (experiment_id, stock_owner, expiration, contract_version),
+                ).fetchone()
+            )
 
     def pending_projections(
         self, *, experiment_id: str | None = None
@@ -1921,6 +2670,373 @@ class ExperimentStore:
             (command_scope, idempotency_key),
         ).fetchone()
 
+    def _validation_open_state(
+        self,
+        connection: sqlite3.Connection,
+        experiment_id: str,
+        expected_state_version: int,
+    ) -> tuple[dict[str, Any], dict[str, Any], str]:
+        experiment = self._required_experiment(connection, experiment_id)
+        if int(experiment["state_version"]) != expected_state_version:
+            raise ExperimentStoreError("stale_snapshot", "experiment changed")
+        generation = self._required_generation(connection, experiment_id, "hidden")
+        if experiment["terminal_mode"] is not None or not (
+            experiment["phase"] == "validation"
+            and experiment["validation_progress"] == "collecting_decisions"
+            and generation["terminal_request_event_id"] is None
+        ):
+            raise ExperimentStoreError("late_write", "validation intake is closed")
+        next_date = connection.execute(
+            """
+            SELECT trading_date FROM strategy_lab_hidden_commitments
+            WHERE experiment_id = ? ORDER BY trading_date LIMIT 1 OFFSET ?
+            """,
+            (experiment_id, int(experiment["completed_validation_partitions"])),
+        ).fetchone()
+        if next_date is None:
+            raise ExperimentStoreError(
+                "experiment_conflict", "no validation date is open"
+            )
+        return experiment, generation, str(next_date[0])
+
+    @staticmethod
+    def _advance_generation(
+        connection: sqlite3.Connection,
+        *,
+        generation: Mapping[str, object],
+        revision: int,
+        revision_ref: str,
+        revision_file_sha256: str,
+        frozen_row_sha256: str,
+        occurred_at_utc: str,
+    ) -> None:
+        if revision != int(generation["revision"]) + 1:
+            raise ExperimentStoreError(
+                "generation_conflict", "generation revision is not next"
+            )
+        connection.execute(
+            """
+            UPDATE strategy_lab_generations SET
+                revision = ?, last_revision_ref = ?,
+                last_revision_file_sha256 = ?, frozen_row_content_sha256 = ?,
+                updated_at_utc = ?
+            WHERE experiment_id = ? AND generation_kind = ?
+              AND terminal_request_event_id IS NULL
+            """,
+            (
+                revision,
+                revision_ref,
+                revision_file_sha256,
+                frozen_row_sha256,
+                occurred_at_utc,
+                generation["experiment_id"],
+                generation["generation_kind"],
+            ),
+        )
+        if connection.execute("SELECT changes()").fetchone()[0] != 1:
+            raise ExperimentStoreError("late_write", "generation is terminal")
+
+    @staticmethod
+    def _insert_fill_observations(
+        connection: sqlite3.Connection,
+        experiment_id: str,
+        observations: Sequence[Mapping[str, object]],
+        occurred_at_utc: str,
+    ) -> None:
+        for observation in observations:
+            connection.execute(
+                """
+                INSERT INTO strategy_lab_fill_observations(
+                    experiment_id, target_point_id, arm, observed_point_id,
+                    trading_date, observation_status, crossing,
+                    observation_json, observation_sha256, created_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    experiment_id,
+                    observation["target_point_id"],
+                    observation["arm"],
+                    observation["observed_point_id"],
+                    observation["trading_date"],
+                    observation["observation_status"],
+                    observation.get("crossing"),
+                    observation["observation_json"],
+                    observation["observation_sha256"],
+                    occurred_at_utc,
+                ),
+            )
+
+    @staticmethod
+    def _apply_fill_status_updates(
+        connection: sqlite3.Connection,
+        experiment_id: str,
+        updates: Sequence[Mapping[str, object]],
+        occurred_at_utc: str,
+    ) -> None:
+        for update in updates:
+            arm = str(update["arm"])
+            if arm not in {"baseline", "challenger"}:
+                raise ExperimentStoreError(
+                    "experiment_conflict", "fill update arm is invalid"
+                )
+            column = f"{arm}_fill_status"
+            row = connection.execute(
+                f"""
+                SELECT {column} FROM strategy_lab_validation_decisions
+                WHERE experiment_id = ? AND recommendation_point_id = ?
+                """,
+                (experiment_id, update["target_point_id"]),
+            ).fetchone()
+            if row is None or row[0] != "monitoring":
+                raise ExperimentStoreError(
+                    "experiment_conflict", "fill monitor is not active"
+                )
+            connection.execute(
+                f"""
+                UPDATE strategy_lab_validation_decisions
+                SET {column} = ?, updated_at_utc = ?
+                WHERE experiment_id = ? AND recommendation_point_id = ?
+                """,
+                (
+                    update["fill_status"],
+                    occurred_at_utc,
+                    experiment_id,
+                    update["target_point_id"],
+                ),
+            )
+
+    @staticmethod
+    def _insert_outcome_jobs(
+        connection: sqlite3.Connection,
+        experiment_id: str,
+        jobs: Sequence[Mapping[str, object]],
+        occurred_at_utc: str,
+    ) -> None:
+        for job in jobs:
+            connection.execute(
+                """
+                INSERT INTO strategy_lab_outcome_jobs(
+                    experiment_id, target_point_id, arm, trading_date,
+                    contract_symbol, stock_owner, expiration, due_at_utc,
+                    deadline_at_utc, status, job_json, job_sha256,
+                    created_at_utc, updated_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending_terms', ?, ?, ?, ?)
+                """,
+                (
+                    experiment_id,
+                    job["target_point_id"],
+                    job["arm"],
+                    job["trading_date"],
+                    job["contract_symbol"],
+                    job["stock_owner"],
+                    job["expiration"],
+                    job["due_at_utc"],
+                    job["deadline_at_utc"],
+                    job["job_json"],
+                    job["job_sha256"],
+                    occurred_at_utc,
+                    occurred_at_utc,
+                ),
+            )
+
+    @staticmethod
+    def _insert_expiry_close_fact(
+        connection: sqlite3.Connection,
+        experiment_id: str,
+        fact: Mapping[str, object],
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO strategy_lab_expiry_close_facts(
+                experiment_id, stock_owner, expiration, contract_version,
+                status, fact_json, fact_sha256, created_at_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(experiment_id, stock_owner, expiration, contract_version)
+            DO NOTHING
+            """,
+            (
+                experiment_id,
+                fact["stock_owner"],
+                fact["expiration"],
+                fact["contract_version"],
+                fact["status"],
+                fact["fact_json"],
+                fact["fact_sha256"],
+                fact["created_at_utc"],
+            ),
+        )
+        existing = connection.execute(
+            """
+            SELECT status, fact_json, fact_sha256
+            FROM strategy_lab_expiry_close_facts
+            WHERE experiment_id = ? AND stock_owner = ?
+              AND expiration = ? AND contract_version = ?
+            """,
+            (
+                experiment_id,
+                fact["stock_owner"],
+                fact["expiration"],
+                fact["contract_version"],
+            ),
+        ).fetchone()
+        if existing is None or (
+            existing["status"], existing["fact_json"], existing["fact_sha256"]
+        ) != (fact["status"], fact["fact_json"], fact["fact_sha256"]):
+            raise ExperimentStoreError(
+                "natural_fact_conflict", "expiration close fact changed"
+            )
+
+    def _apply_validation_day(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        experiment: Mapping[str, object],
+        day: Mapping[str, object] | None,
+        occurred_at_utc: str,
+    ) -> tuple[int, str]:
+        completed = int(experiment["completed_validation_partitions"])
+        if day is None:
+            return completed, "collecting_decisions"
+        experiment_id = str(experiment["experiment_id"])
+        dates = [
+            str(row[0])
+            for row in connection.execute(
+                """
+                SELECT trading_date FROM strategy_lab_hidden_commitments
+                WHERE experiment_id = ? ORDER BY trading_date
+                """,
+                (experiment_id,),
+            ).fetchall()
+        ]
+        if completed >= len(dates) or str(day["trading_date"]) != dates[completed]:
+            raise ExperimentStoreError(
+                "experiment_conflict", "validation day is not the next commitment date"
+            )
+        decision_count = int(
+            connection.execute(
+                """
+                SELECT COUNT(*) FROM strategy_lab_validation_decisions
+                WHERE experiment_id = ? AND trading_date = ?
+                """,
+                (experiment_id, day["trading_date"]),
+            ).fetchone()[0]
+        )
+        if int(day["consumed_point_count"]) != decision_count:
+            raise ExperimentStoreError(
+                "experiment_conflict", "validation day point count changed"
+            )
+        expected_count = day.get("expected_point_count")
+        if expected_count is not None and int(expected_count) != decision_count:
+            raise ExperimentStoreError(
+                "experiment_conflict", "validation day is not complete"
+            )
+        connection.execute(
+            """
+            INSERT INTO strategy_lab_validation_days(
+                experiment_id, trading_date, expectation_ref,
+                expectation_content_sha256, expectation_file_sha256,
+                expected_point_count, consumed_point_count, hard_risk_status,
+                reason_code, deadline_at_utc, daily_json, sealed_at_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                experiment_id,
+                day["trading_date"],
+                day.get("expectation_ref"),
+                day.get("expectation_content_sha256"),
+                day.get("expectation_file_sha256"),
+                expected_count,
+                day["consumed_point_count"],
+                day["hard_risk_status"],
+                day.get("reason_code"),
+                day.get("deadline_at_utc"),
+                day.get("daily_json"),
+                occurred_at_utc,
+            ),
+        )
+        completed += 1
+        if completed < 20:
+            return completed, "collecting_decisions"
+        missing = connection.execute(
+            """
+            SELECT 1 FROM strategy_lab_validation_days
+            WHERE experiment_id = ? AND hard_risk_status = 'missing' LIMIT 1
+            """,
+            (experiment_id,),
+        ).fetchone()
+        outcome_failure = connection.execute(
+            """
+            SELECT 1 FROM strategy_lab_outcome_jobs
+            WHERE experiment_id = ? AND status = 'outcome_unavailable' LIMIT 1
+            """,
+            (experiment_id,),
+        ).fetchone()
+        if missing is not None or outcome_failure is not None:
+            connection.execute(
+                """
+                UPDATE strategy_lab_outcome_jobs SET
+                    status = 'not_required_after_evidence_failure',
+                    reason_code = ?, updated_at_utc = ?
+                WHERE experiment_id = ? AND status IN ('pending_terms','pending_outcome')
+                """,
+                (
+                    "risk_evidence_missing"
+                    if missing is not None
+                    else "required_outcome_missing",
+                    occurred_at_utc,
+                    experiment_id,
+                ),
+            )
+            return completed, "ready_to_conclude"
+        pending = connection.execute(
+            """
+            SELECT 1 FROM strategy_lab_outcome_jobs
+            WHERE experiment_id = ? AND status IN ('pending_terms','pending_outcome')
+            LIMIT 1
+            """,
+            (experiment_id,),
+        ).fetchone()
+        return completed, "awaiting_outcomes" if pending is not None else "ready_to_conclude"
+
+    @staticmethod
+    def _required_validation_decision(
+        connection: sqlite3.Connection,
+        experiment_id: str,
+        recommendation_point_id: str,
+    ) -> dict[str, Any]:
+        row = connection.execute(
+            """
+            SELECT * FROM strategy_lab_validation_decisions
+            WHERE experiment_id = ? AND recommendation_point_id = ?
+            """,
+            (experiment_id, recommendation_point_id),
+        ).fetchone()
+        if row is None:
+            raise ExperimentStoreError(
+                "experiment_conflict", "validation decision does not exist"
+            )
+        return dict(row)
+
+    @staticmethod
+    def _required_outcome_job(
+        connection: sqlite3.Connection,
+        experiment_id: str,
+        target_point_id: str,
+        arm: str,
+    ) -> dict[str, Any]:
+        row = connection.execute(
+            """
+            SELECT * FROM strategy_lab_outcome_jobs
+            WHERE experiment_id = ? AND target_point_id = ? AND arm = ?
+            """,
+            (experiment_id, target_point_id, arm),
+        ).fetchone()
+        if row is None:
+            raise ExperimentStoreError(
+                "experiment_conflict", "outcome job does not exist"
+            )
+        return dict(row)
+
     @staticmethod
     def _required_experiment(
         connection: sqlite3.Connection, experiment_id: str
@@ -1979,7 +3095,7 @@ class ExperimentStore:
         connection = connect_private_sqlite(self.path, isolation_level=None)
         connection.row_factory = sqlite3.Row
         self._configure(connection)
-        self._validate_v2(connection)
+        self._validate_v3(connection)
         return connection
 
     def _readonly_connection(self) -> sqlite3.Connection:
@@ -2019,6 +3135,7 @@ class ExperimentStore:
             connection,
             expected_version=1,
             required_tables=_V1_REQUIRED_TABLES,
+            required_indexes=_V2_REQUIRED_INDEXES,
             expected_foreign_keys=_V1_EXPECTED_FOREIGN_KEYS,
             deep=deep,
         )
@@ -2028,8 +3145,21 @@ class ExperimentStore:
     ) -> None:
         self._validate_schema(
             connection,
+            expected_version=2,
+            required_tables=_V2_REQUIRED_TABLES,
+            required_indexes=_V2_REQUIRED_INDEXES,
+            expected_foreign_keys=_V2_EXPECTED_FOREIGN_KEYS,
+            deep=deep,
+        )
+
+    def _validate_v3(
+        self, connection: sqlite3.Connection, *, deep: bool = False
+    ) -> None:
+        self._validate_schema(
+            connection,
             expected_version=SCHEMA_VERSION,
             required_tables=_REQUIRED_TABLES,
+            required_indexes=_REQUIRED_INDEXES,
             expected_foreign_keys=_EXPECTED_FOREIGN_KEYS,
             deep=deep,
         )
@@ -2040,6 +3170,7 @@ class ExperimentStore:
         *,
         expected_version: int,
         required_tables: set[str],
+        required_indexes: set[str],
         expected_foreign_keys: Mapping[str, set[tuple[str, str, str]]],
         deep: bool,
     ) -> None:
@@ -2052,7 +3183,7 @@ class ExperimentStore:
         ).fetchone()
         if metadata is None or int(metadata[0]) != expected_version:
             raise ExperimentStoreError("schema_unsupported", "schema version is unsupported")
-        if not _REQUIRED_INDEXES.issubset(self._indexes(connection)):
+        if not required_indexes.issubset(self._indexes(connection)):
             raise ExperimentStoreError("schema_unsupported", "required index is missing")
         for table, expected in expected_foreign_keys.items():
             observed = {
@@ -2289,6 +3420,225 @@ class ExperimentStore:
                 )
             );
             """
+        for statement in ddl.split(";"):
+            if statement.strip():
+                connection.execute(statement)
+
+    @staticmethod
+    def _migrate_v2_to_v3(connection: sqlite3.Connection) -> None:
+        connection.execute("DROP INDEX strategy_lab_one_active_validation")
+        connection.execute(
+            "ALTER TABLE strategy_lab_experiments "
+            "RENAME TO strategy_lab_experiments_v2"
+        )
+        ExperimentStore._create_v3_experiment_table(connection)
+        columns = ", ".join(_EXPERIMENT_COLUMNS)
+        connection.execute(
+            f"INSERT INTO strategy_lab_experiments({columns}) "
+            f"SELECT {columns} FROM strategy_lab_experiments_v2"
+        )
+        connection.execute(
+            """
+            CREATE UNIQUE INDEX strategy_lab_one_active_validation
+            ON strategy_lab_experiments(market, account, strategy_family)
+            WHERE terminal_mode IS NULL
+              AND phase = 'validation'
+              AND validation_progress = 'collecting_decisions'
+            """
+        )
+        ExperimentStore._create_v3_validation_tables(connection)
+        connection.execute("DROP TABLE strategy_lab_experiments_v2")
+
+    @staticmethod
+    def _create_v3_experiment_table(connection: sqlite3.Connection) -> None:
+        connection.execute(
+            """
+            CREATE TABLE strategy_lab_experiments(
+                experiment_id TEXT PRIMARY KEY,
+                topic_id TEXT NOT NULL,
+                market TEXT NOT NULL CHECK(market = 'HK'),
+                account TEXT NOT NULL,
+                strategy_family TEXT NOT NULL CHECK(strategy_family = 'sell_put'),
+                spec_json TEXT NOT NULL,
+                research_spec_sha256 TEXT NOT NULL,
+                validation_spec_sha256 TEXT,
+                source_provenance_json TEXT NOT NULL,
+                phase TEXT NOT NULL CHECK(phase IN ('draft','research','validation','concluded')),
+                research_progress TEXT CHECK(research_progress IS NULL OR research_progress IN (
+                    'building_dataset','ready_to_compare','challenger_locked'
+                )),
+                validation_progress TEXT CHECK(validation_progress IS NULL OR validation_progress IN (
+                    'collecting_decisions','awaiting_outcomes','ready_to_conclude'
+                )),
+                blocked_reason TEXT,
+                completed_validation_partitions INTEGER NOT NULL DEFAULT 0
+                    CHECK(completed_validation_partitions BETWEEN 0 AND 20),
+                research_authorization_status TEXT NOT NULL
+                    CHECK(research_authorization_status IN ('unconfirmed','confirmed')),
+                research_authorized_hash TEXT,
+                research_authorized_actor TEXT,
+                research_authorized_at_utc TEXT,
+                validation_authorization_status TEXT NOT NULL
+                    CHECK(validation_authorization_status IN ('unconfirmed','confirmed')),
+                validation_authorized_hash TEXT,
+                validation_authorized_actor TEXT,
+                validation_authorized_at_utc TEXT,
+                research_leader TEXT,
+                research_receipt_ref TEXT,
+                research_receipt_file_sha256 TEXT,
+                proposed_commitment_json TEXT,
+                proposed_commitment_sha256 TEXT,
+                proposed_commitment_ref TEXT,
+                proposed_commitment_content_sha256 TEXT,
+                proposed_commitment_file_sha256 TEXT,
+                terminal_mode TEXT CHECK(
+                    terminal_mode IS NULL OR terminal_mode IN ('completed','aborted')
+                ),
+                terminal_reason TEXT,
+                disabled_scope TEXT CHECK(
+                    disabled_scope IS NULL OR disabled_scope IN ('user','maintainer')
+                ),
+                terminal_at_utc TEXT,
+                terminated_at_partition INTEGER CHECK(
+                    terminated_at_partition IS NULL OR terminated_at_partition BETWEEN 0 AND 20
+                ),
+                final_outcome_status TEXT CHECK(
+                    final_outcome_status IS NULL OR final_outcome_status IN (
+                        'candidate_for_adoption','keep_baseline','insufficient_evidence'
+                    )
+                ),
+                receipt_request_event_id TEXT,
+                receipt_published_event_id TEXT,
+                receipt_ref TEXT,
+                receipt_content_sha256 TEXT,
+                receipt_file_sha256 TEXT,
+                receipt_published_at_utc TEXT,
+                created_at_utc TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL,
+                state_version INTEGER NOT NULL CHECK(state_version >= 1),
+                FOREIGN KEY(receipt_request_event_id) REFERENCES strategy_lab_events(event_id),
+                FOREIGN KEY(receipt_published_event_id) REFERENCES strategy_lab_events(event_id)
+            )
+            """
+        )
+
+    @staticmethod
+    def _create_v3_validation_tables(connection: sqlite3.Connection) -> None:
+        ddl = """
+            CREATE TABLE strategy_lab_validation_decisions(
+                experiment_id TEXT NOT NULL,
+                recommendation_point_id TEXT NOT NULL,
+                trading_date TEXT NOT NULL CHECK(length(trading_date) = 10),
+                point_index INTEGER NOT NULL CHECK(point_index >= 0),
+                source_status TEXT NOT NULL CHECK(source_status IN (
+                    'available','not_evaluable','missing_after_deadline'
+                )),
+                expectation_ref TEXT NOT NULL,
+                expectation_content_sha256 TEXT NOT NULL CHECK(length(expectation_content_sha256) = 64),
+                target_at_utc TEXT NOT NULL,
+                source_ref TEXT,
+                source_file_sha256 TEXT CHECK(source_file_sha256 IS NULL OR length(source_file_sha256) = 64),
+                source_content_sha256 TEXT CHECK(source_content_sha256 IS NULL OR length(source_content_sha256) = 64),
+                hard_risk_status TEXT NOT NULL CHECK(hard_risk_status IN ('passed','violated','missing')),
+                baseline_json TEXT CHECK(baseline_json IS NULL OR length(baseline_json) <= 4096),
+                challenger_json TEXT CHECK(challenger_json IS NULL OR length(challenger_json) <= 4096),
+                baseline_fill_status TEXT CHECK(baseline_fill_status IS NULL OR baseline_fill_status IN (
+                    'monitoring','observed_fill','no_observed_fill','not_evaluable'
+                )),
+                challenger_fill_status TEXT CHECK(challenger_fill_status IS NULL OR challenger_fill_status IN (
+                    'monitoring','observed_fill','no_observed_fill','not_evaluable'
+                )),
+                reason_code TEXT,
+                created_at_utc TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL,
+                PRIMARY KEY(experiment_id, recommendation_point_id),
+                FOREIGN KEY(experiment_id) REFERENCES strategy_lab_experiments(experiment_id)
+            );
+
+            CREATE TABLE strategy_lab_validation_days(
+                experiment_id TEXT NOT NULL,
+                trading_date TEXT NOT NULL CHECK(length(trading_date) = 10),
+                expectation_ref TEXT,
+                expectation_content_sha256 TEXT CHECK(
+                    expectation_content_sha256 IS NULL OR length(expectation_content_sha256) = 64
+                ),
+                expectation_file_sha256 TEXT CHECK(
+                    expectation_file_sha256 IS NULL OR length(expectation_file_sha256) = 64
+                ),
+                expected_point_count INTEGER CHECK(expected_point_count IS NULL OR expected_point_count > 0),
+                consumed_point_count INTEGER NOT NULL CHECK(consumed_point_count >= 0),
+                hard_risk_status TEXT NOT NULL CHECK(hard_risk_status IN ('passed','violated','missing')),
+                reason_code TEXT,
+                deadline_at_utc TEXT,
+                daily_json TEXT CHECK(daily_json IS NULL OR length(daily_json) <= 8192),
+                sealed_at_utc TEXT NOT NULL,
+                PRIMARY KEY(experiment_id, trading_date),
+                FOREIGN KEY(experiment_id) REFERENCES strategy_lab_experiments(experiment_id)
+            );
+
+            CREATE TABLE strategy_lab_fill_observations(
+                experiment_id TEXT NOT NULL,
+                target_point_id TEXT NOT NULL,
+                arm TEXT NOT NULL CHECK(arm IN ('baseline','challenger')),
+                observed_point_id TEXT NOT NULL,
+                trading_date TEXT NOT NULL CHECK(length(trading_date) = 10),
+                observation_status TEXT NOT NULL CHECK(observation_status IN ('quote','gap')),
+                crossing INTEGER CHECK(crossing IS NULL OR crossing IN (0, 1)),
+                observation_json TEXT NOT NULL CHECK(length(observation_json) <= 4096),
+                observation_sha256 TEXT NOT NULL CHECK(length(observation_sha256) = 64),
+                created_at_utc TEXT NOT NULL,
+                PRIMARY KEY(experiment_id, target_point_id, arm, observed_point_id),
+                FOREIGN KEY(experiment_id) REFERENCES strategy_lab_experiments(experiment_id)
+            );
+
+            CREATE TABLE strategy_lab_outcome_jobs(
+                experiment_id TEXT NOT NULL,
+                target_point_id TEXT NOT NULL,
+                arm TEXT NOT NULL CHECK(arm IN ('baseline','challenger')),
+                trading_date TEXT NOT NULL CHECK(length(trading_date) = 10),
+                contract_symbol TEXT NOT NULL,
+                stock_owner TEXT NOT NULL,
+                expiration TEXT NOT NULL CHECK(length(expiration) = 10),
+                due_at_utc TEXT NOT NULL,
+                deadline_at_utc TEXT NOT NULL,
+                status TEXT NOT NULL CHECK(status IN (
+                    'pending_terms','pending_outcome','evaluable','outcome_unavailable',
+                    'not_required_after_evidence_failure'
+                )),
+                job_json TEXT NOT NULL CHECK(length(job_json) <= 4096),
+                job_sha256 TEXT NOT NULL CHECK(length(job_sha256) = 64),
+                terms_point_id TEXT,
+                terms_json TEXT CHECK(terms_json IS NULL OR length(terms_json) <= 4096),
+                terms_sha256 TEXT CHECK(terms_sha256 IS NULL OR length(terms_sha256) = 64),
+                result_json TEXT CHECK(result_json IS NULL OR length(result_json) <= 4096),
+                result_sha256 TEXT CHECK(result_sha256 IS NULL OR length(result_sha256) = 64),
+                reason_code TEXT,
+                last_attempt_at_utc TEXT,
+                created_at_utc TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL,
+                PRIMARY KEY(experiment_id, target_point_id, arm),
+                FOREIGN KEY(experiment_id) REFERENCES strategy_lab_experiments(experiment_id)
+            );
+
+            CREATE TABLE strategy_lab_expiry_close_facts(
+                experiment_id TEXT NOT NULL,
+                stock_owner TEXT NOT NULL,
+                expiration TEXT NOT NULL CHECK(length(expiration) = 10),
+                contract_version TEXT NOT NULL,
+                status TEXT NOT NULL CHECK(status IN ('available','unavailable')),
+                fact_json TEXT NOT NULL CHECK(length(fact_json) <= 4096),
+                fact_sha256 TEXT NOT NULL CHECK(length(fact_sha256) = 64),
+                created_at_utc TEXT NOT NULL,
+                PRIMARY KEY(experiment_id, stock_owner, expiration, contract_version),
+                FOREIGN KEY(experiment_id) REFERENCES strategy_lab_experiments(experiment_id)
+            );
+
+            CREATE UNIQUE INDEX strategy_lab_validation_decision_order
+            ON strategy_lab_validation_decisions(experiment_id, trading_date, point_index);
+
+            CREATE INDEX strategy_lab_outcome_job_status
+            ON strategy_lab_outcome_jobs(experiment_id, status, due_at_utc);
+        """
         for statement in ddl.split(";"):
             if statement.strip():
                 connection.execute(statement)

--- a/tests/test_futu_gateway_minimal.py
+++ b/tests/test_futu_gateway_minimal.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 def test_build_gateway_with_mock_backend_and_snapshot_call() -> None:
     import sys
@@ -210,6 +212,73 @@ def test_get_trading_days_rejects_unknown_market() -> None:
 
     with pytest.raises(Exception, match="unsupported trade date market"):
         gw.get_trading_days(market="MOON", start="2026-08-01")
+
+
+def test_exact_expiration_option_terms_force_refresh_and_fail_closed() -> None:
+    from src.infrastructure.futu_gateway import (
+        FutuGatewayDataContractError,
+        build_futu_gateway,
+    )
+
+    row = {
+        "code": "HK.TCH261218P400000",
+        "stock_owner": "HK.0700",
+        "strike_time": "2026-12-18",
+        "option_type": "PUT",
+        "option_standard_type": "STANDARD",
+        "strike_price": 400.0,
+        "lot_size": 100,
+        "currency": "HKD",
+    }
+
+    class FakeBackend:
+        def __init__(self, *, host: str, port: int) -> None:
+            self.host = host
+            self.port = port
+
+    class FakeClient:
+        def __init__(self, _backend, *, is_option_chain_cache_enabled: bool) -> None:
+            self.calls: list[dict[str, object]] = []
+            self.rows = [row]
+
+        def get_option_chain(self, **kwargs: object) -> list[dict[str, object]]:
+            self.calls.append(dict(kwargs))
+            return self.rows
+
+    gateway = build_futu_gateway(backend_cls=FakeBackend, client_cls=FakeClient)
+    terms = gateway.get_exact_expiration_option_terms(
+        code="hk.0700",
+        expiration="2026-12-18",
+        contract_symbol="hk.tch261218p400000",
+    )
+
+    assert terms == {
+        "contract_symbol": "HK.TCH261218P400000",
+        "stock_owner": "HK.0700",
+        "expiration": "2026-12-18",
+        "option_type": "PUT",
+        "option_standard_type": "STANDARD",
+        "strike": 400.0,
+        "multiplier": 100,
+        "currency": "HKD",
+    }
+    assert gateway.client.calls == [
+        {
+            "code": "HK.0700",
+            "start": "2026-12-18",
+            "end": "2026-12-18",
+            "option_type": "PUT",
+            "is_force_refresh": True,
+        }
+    ]
+
+    gateway.client.rows = [row, dict(row)]
+    with pytest.raises(FutuGatewayDataContractError):
+        gateway.get_exact_expiration_option_terms(
+            code="HK.0700",
+            expiration="2026-12-18",
+            contract_symbol="HK.TCH261218P400000",
+        )
 
 
 def test_gateway_error_mapping_need_2fa() -> None:

--- a/tests/test_strategy_lab_top1_architecture.py
+++ b/tests/test_strategy_lab_top1_architecture.py
@@ -26,6 +26,11 @@ TERMINAL_PROJECTION_MODULE = (
     ROOT / "src/application/strategy_lab/top1/terminal_projection.py"
 )
 CORPUS_MODULE = ROOT / "src/application/strategy_lab/top1/corpus.py"
+VALIDATION_MODULE = ROOT / "src/application/strategy_lab/top1/validation.py"
+FILL_OBSERVATION_MODULE = (
+    ROOT / "src/application/strategy_lab/top1/fill_observation.py"
+)
+OUTCOME_MODULE = ROOT / "src/application/strategy_lab/top1/outcome.py"
 PRODUCTION_TICK_MODULES = (
     ROOT / "src/application/multi_account_tick.py",
     ROOT / "src/application/tick_account_execution.py",
@@ -241,6 +246,65 @@ def test_top1_lifecycle_and_terminal_projection_keep_dependency_direction() -> N
     }
 
 
+def test_w6_validation_modules_keep_narrow_dependency_direction() -> None:
+    assert _imports(VALIDATION_MODULE) <= {
+        "__future__",
+        "hashlib",
+        "json",
+        "re",
+        "collections.abc",
+        "datetime",
+        "pathlib",
+        "typing",
+        "zoneinfo",
+        "domain.domain.decision_state_fingerprint",
+        "domain.domain.fee_calc",
+        "src.application.shadow_replay.common",
+        "src.application.strategy_lab.top1.contracts",
+        "src.application.strategy_lab.top1.corpus",
+        "src.application.strategy_lab.top1.lifecycle",
+        "src.application.strategy_lab.top1.ranking",
+        "src.application.strategy_lab.top1.research_artifacts",
+        "src.application.strategy_lab.top1.terminal_projection",
+        "src.infrastructure.strategy_lab.experiment_store",
+    }
+    assert _imports(FILL_OBSERVATION_MODULE) <= {
+        "__future__",
+        "json",
+        "math",
+        "re",
+        "collections.abc",
+        "datetime",
+        "pathlib",
+        "typing",
+        "domain.domain.decision_state_fingerprint",
+        "domain.domain.option_lifecycle",
+        "src.application.strategy_lab.top1.corpus",
+        "src.application.strategy_lab.top1.lifecycle",
+        "src.application.strategy_lab.top1.validation",
+        "src.infrastructure.strategy_lab.experiment_store",
+    }
+    assert _imports(OUTCOME_MODULE) <= {
+        "__future__",
+        "json",
+        "math",
+        "collections.abc",
+        "datetime",
+        "pathlib",
+        "typing",
+        "domain.domain.decision_state_fingerprint",
+        "src.application.strategy_lab.top1.contracts",
+        "src.application.strategy_lab.top1.corpus",
+        "src.application.strategy_lab.top1.economics",
+        "src.application.strategy_lab.top1.lifecycle",
+        "src.application.strategy_lab.top1.statistics",
+        "src.application.strategy_lab.top1.terminal_projection",
+        "src.application.strategy_lab.top1.validation",
+        "src.infrastructure.futu_gateway",
+        "src.infrastructure.strategy_lab.experiment_store",
+    }
+
+
 def test_production_tick_does_not_depend_on_top1_experiment_store() -> None:
     for path in PRODUCTION_TICK_MODULES:
         imports = _imports(path)
@@ -248,4 +312,7 @@ def test_production_tick_does_not_depend_on_top1_experiment_store() -> None:
         assert "src.application.strategy_lab.top1.corpus" not in imports
         assert "src.application.strategy_lab.top1.research" not in imports
         assert "src.application.strategy_lab.top1.research_artifacts" not in imports
+        assert "src.application.strategy_lab.top1.validation" not in imports
+        assert "src.application.strategy_lab.top1.fill_observation" not in imports
+        assert "src.application.strategy_lab.top1.outcome" not in imports
         assert "src.infrastructure.strategy_lab.experiment_store" not in imports

--- a/tests/test_strategy_lab_top1_store.py
+++ b/tests/test_strategy_lab_top1_store.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import os
 import sqlite3
-from concurrent.futures import ThreadPoolExecutor
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
@@ -36,13 +35,11 @@ from src.application.strategy_lab.top1.lifecycle import (
     authorize_research,
     authorize_validation,
     build_hidden_window_commitment,
-    commit_validation_point,
     effective_feature_status,
     prepare_experiment,
     read_public_receipt,
     read_public_status,
     seal_generation,
-    seal_validation_partition,
     set_account_opt_in,
     start_research,
     start_validation,
@@ -343,8 +340,8 @@ def test_schema_migration_is_explicit_private_and_fail_closed(tmp_path: Path) ->
     store = ExperimentStore(path)
     assert store.schema_state() == {"status": "not_initialized", "schema_version": None}
     assert not path.exists()
-    assert store.migrate(migrated_at_utc=NOW) == {"status": "ready", "schema_version": 2}
-    assert store.migrate(migrated_at_utc=NOW) == {"status": "ready", "schema_version": 2}
+    assert store.migrate(migrated_at_utc=NOW) == {"status": "ready", "schema_version": 3}
+    assert store.migrate(migrated_at_utc=NOW) == {"status": "ready", "schema_version": 3}
     assert stat_mode(path) == 0o600
     assert not Path(f"{path}-wal").exists()
     with sqlite3.connect(path) as connection:
@@ -363,6 +360,11 @@ def test_schema_migration_is_explicit_private_and_fail_closed(tmp_path: Path) ->
             "strategy_lab_events",
             "strategy_lab_corpus_days",
             "strategy_lab_corpus_points",
+            "strategy_lab_validation_decisions",
+            "strategy_lab_validation_days",
+            "strategy_lab_fill_observations",
+            "strategy_lab_outcome_jobs",
+            "strategy_lab_expiry_close_facts",
         }
 
     v0_path = tmp_path / "v0.sqlite3"
@@ -374,7 +376,7 @@ def test_schema_migration_is_explicit_private_and_fail_closed(tmp_path: Path) ->
             "INSERT INTO strategy_lab_schema VALUES (?, 0, ?)",
             ("sell_put_top1_experiment_store", NOW),
         )
-    assert ExperimentStore(v0_path).migrate(migrated_at_utc=NOW)["schema_version"] == 2
+    assert ExperimentStore(v0_path).migrate(migrated_at_utc=NOW)["schema_version"] == 3
 
     v1_path = tmp_path / "v1.sqlite3"
     v1_store = ExperimentStore(v1_path)
@@ -388,15 +390,48 @@ def test_schema_migration_is_explicit_private_and_fail_closed(tmp_path: Path) ->
         idempotency_key="legacy-feature",
     )
     with sqlite3.connect(v1_path) as connection:
+        connection.execute("DROP TABLE strategy_lab_expiry_close_facts")
+        connection.execute("DROP TABLE strategy_lab_outcome_jobs")
+        connection.execute("DROP TABLE strategy_lab_fill_observations")
+        connection.execute("DROP TABLE strategy_lab_validation_days")
+        connection.execute("DROP TABLE strategy_lab_validation_decisions")
         connection.execute("DROP TABLE strategy_lab_corpus_points")
         connection.execute("DROP TABLE strategy_lab_corpus_days")
         connection.execute("UPDATE strategy_lab_schema SET schema_version = 1")
     assert v1_store.schema_state() == {"status": "migration_required", "schema_version": 1}
     assert v1_store.migrate(migrated_at_utc=NOW) == {
         "status": "ready",
-        "schema_version": 2,
+        "schema_version": 3,
     }
     assert v1_store.feature("HK", "lx")["user_opt_in"] == 1
+
+    v2_path = tmp_path / "v2.sqlite3"
+    v2_store = ExperimentStore(v2_path)
+    v2_store.migrate(migrated_at_utc=NOW)
+    _enable(v2_store, tmp_path / "v2-artifacts", idempotency_key="v2-feature")
+    prepare_experiment(
+        v2_store,
+        _spec("v2-preserved"),
+        provenance={"source_commit_sha": "commit-v2", "config_sha256": SHA_B},
+        actor="human",
+        occurred_at_utc=NOW,
+        idempotency_key="v2-prepare",
+        artifact_root=tmp_path / "v2-artifacts",
+        environ=AVAILABLE,
+    )
+    with sqlite3.connect(v2_path) as connection:
+        connection.execute("DROP TABLE strategy_lab_expiry_close_facts")
+        connection.execute("DROP TABLE strategy_lab_outcome_jobs")
+        connection.execute("DROP TABLE strategy_lab_fill_observations")
+        connection.execute("DROP TABLE strategy_lab_validation_days")
+        connection.execute("DROP TABLE strategy_lab_validation_decisions")
+        connection.execute("UPDATE strategy_lab_schema SET schema_version = 2")
+    assert v2_store.migrate(migrated_at_utc=NOW) == {
+        "status": "ready",
+        "schema_version": 3,
+    }
+    assert v2_store.experiment("v2-preserved")["topic_id"] == "topic-v2-preserved"
+    assert v2_store.events("v2-preserved")[0]["event_type"] == "experiment_prepared"
 
     partial = tmp_path / "partial.sqlite3"
     with sqlite3.connect(partial) as connection:
@@ -454,7 +489,7 @@ def test_exact_publisher_adopts_bytes_and_rejects_conflict_or_symlink(
         publish_exact_text(root, "unsafe/result.json", b"{}\n")
 
 
-def test_separate_authorization_day20_and_hidden_status(tmp_path: Path) -> None:
+def test_separate_authorization_starts_evidence_bound_validation(tmp_path: Path) -> None:
     store = _store(tmp_path)
     root = tmp_path / "artifacts"
     _enable(store, root)
@@ -483,112 +518,17 @@ def test_separate_authorization_day20_and_hidden_status(tmp_path: Path) -> None:
         artifact_root=root,
         environ=AVAILABLE,
     )
-    for index, trading_date in enumerate(dates, start=1):
-        kwargs = dict(
-            experiment_id="experiment-a",
-            point_id=f"point-{index}",
-            trading_date=trading_date,
-            source_ref=f"points/{index}.json",
-            source_file_sha256=SHA_A,
-            revision=index,
-            manifest_ref=f"hidden/{index}.json",
-            manifest_file_sha256=SHA_B,
-            frozen_row_sha256=SHA_C,
-            actor="runner",
-            occurred_at_utc=NOW,
-            idempotency_key=f"point-{index}",
-            artifact_root=root,
-            environ=AVAILABLE,
-        )
-        if index == 1:
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                futures = [
-                    executor.submit(commit_validation_point, store, **kwargs),
-                    executor.submit(
-                        commit_validation_point,
-                        store,
-                        **{**kwargs, "idempotency_key": "point-1-alias"},
-                    ),
-                ]
-                for future in futures:
-                    future.result()
-            assert len(
-                [
-                    event
-                    for event in store.events("experiment-a")
-                    if event["event_type"] == "validation_point_committed"
-                ]
-            ) == 1
-            with pytest.raises(Top1LifecycleError) as conflict_info:
-                commit_validation_point(
-                    store,
-                    **{
-                        **kwargs,
-                        "point_id": "different-point",
-                        "source_file_sha256": SHA_C,
-                        "idempotency_key": "point-1-alias",
-                    },
-                )
-            assert conflict_info.value.reason_code == "experiment_conflict"
-        else:
-            commit_validation_point(store, **kwargs)
-        seal_validation_partition(
-            store,
-            experiment_id="experiment-a",
-            trading_date=trading_date,
-            actor="runner",
-            occurred_at_utc=NOW,
-            idempotency_key=f"partition-{index}",
-            artifact_root=root,
-            environ=AVAILABLE,
-        )
-        if index == 1:
-            with pytest.raises(Top1LifecycleError) as late_info:
-                commit_validation_point(
-                    store,
-                    experiment_id="experiment-a",
-                    point_id="late-day-one",
-                    trading_date=trading_date,
-                    source_ref="points/late-day-one.json",
-                    source_file_sha256=SHA_A,
-                    revision=2,
-                    manifest_ref="hidden/late-day-one.json",
-                    manifest_file_sha256=SHA_B,
-                    frozen_row_sha256=SHA_C,
-                    actor="runner",
-                    occurred_at_utc=NOW,
-                    idempotency_key="late-day-one",
-                    artifact_root=root,
-                    environ=AVAILABLE,
-                )
-            assert late_info.value.reason_code == "late_write"
-        state = store.experiment("experiment-a")
-        if index == 19:
-            assert state["validation_progress"] == "collecting_decisions"
     state = store.experiment("experiment-a")
-    assert state["completed_validation_partitions"] == 20
-    assert state["validation_progress"] == "awaiting_outcomes"
-    with pytest.raises(Top1LifecycleError) as exc_info:
-        commit_validation_point(
-            store,
-            experiment_id="experiment-a",
-            point_id="late-point",
-            trading_date=dates[-1],
-            source_ref="points/late.json",
-            source_file_sha256=SHA_A,
-            revision=21,
-            manifest_ref="hidden/late.json",
-            manifest_file_sha256=SHA_B,
-            frozen_row_sha256=SHA_C,
-            actor="runner",
-            occurred_at_utc=NOW,
-            idempotency_key="late-point",
-            artifact_root=root,
-            environ=AVAILABLE,
-        )
-    assert exc_info.value.reason_code == "late_write"
+    assert state["completed_validation_partitions"] == 0
+    assert state["validation_progress"] == "collecting_decisions"
+    assert {row["generation_kind"] for row in store.generations("experiment-a")} == {
+        "research",
+        "hidden",
+        "outcome",
+    }
+    assert not hasattr(store, "commit_validation_point")
+    assert not hasattr(store, "seal_validation_partition")
     public = json.dumps(read_public_status(store, experiment_id="experiment-a"))
-    assert "point-1" not in public
     assert "daily_delta" not in public
     assert read_public_receipt(store, experiment_id="experiment-a") is None
 

--- a/tests/test_strategy_lab_top1_validation.py
+++ b/tests/test_strategy_lab_top1_validation.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import src.application.strategy_lab.top1.research_runner as runner_module
+import tests.test_strategy_lab_top1_research as research_fixture
+from src.application.recommendation_point import (
+    RECOMMENDATION_POINT_FILE,
+    capture_scheduled_recommendation_point,
+)
+from src.application.strategy_lab.top1.corpus import capture_recommendation_point
+from src.application.strategy_lab.top1.fill_observation import observe_active_contracts
+from src.application.strategy_lab.top1.lifecycle import (
+    authorize_validation,
+    lock_challenger,
+    read_public_receipt,
+    read_public_status,
+    start_validation,
+)
+from src.application.strategy_lab.top1.outcome import (
+    conclude_validation,
+    settle_due_outcomes,
+)
+from src.application.strategy_lab.top1.validation import (
+    Top1ValidationError,
+    consume_validation_point,
+    record_validation_day_gap,
+)
+from src.infrastructure.strategy_lab.experiment_store import ExperimentStore
+from tests.candidate_evidence_helpers import seal_opening_candidate_fixture
+from tests.test_strategy_lab_top1_corpus import (
+    _publish_source_point,
+    _seal,
+    _scheduler,
+)
+from tests.test_strategy_lab_top1_research_runner import (
+    AVAILABLE,
+    FakeGateway,
+    _direct_limiter,
+    _prepared,
+    _run,
+)
+
+
+EXPERIMENT_ID = "experiment-w5-evaluator"
+
+
+class NoSnapshotGateway:
+    def get_snapshot(self, _codes: list[str]) -> object:  # pragma: no cover
+        raise AssertionError("an empty candidate set must not call the provider")
+
+
+class OutcomeGateway:
+    def __init__(self, candidate: dict[str, Any]) -> None:
+        self.candidate = candidate
+        self.terms_error = False
+        self.snapshot_calls: list[list[str]] = []
+        self.terms_calls = 0
+        self.calendar_calls = 0
+        self.close_calls = 0
+
+    def get_snapshot(self, codes: list[str]) -> list[dict[str, object]]:
+        self.snapshot_calls.append(codes)
+        return [
+            {
+                "code": codes[0],
+                "bid_price": self.candidate["sell_limit"],
+                "ask_price": float(self.candidate["sell_limit"]) + 0.01,
+            }
+        ]
+
+    def get_exact_expiration_option_terms(self, **_kwargs: object) -> dict[str, object]:
+        self.terms_calls += 1
+        if self.terms_error:
+            raise RuntimeError("temporary terms failure")
+        return {
+            "contract_symbol": str(self.candidate["contract_symbol"]).upper(),
+            "stock_owner": str(self.candidate["stock_owner"]).upper(),
+            "expiration": self.candidate["expiration"],
+            "option_type": "PUT",
+            "option_standard_type": "STANDARD",
+            "strike": self.candidate["strike"],
+            "multiplier": self.candidate["multiplier"],
+            "currency": self.candidate["currency"],
+        }
+
+    def get_trading_days(self, **_kwargs: object) -> list[dict[str, str]]:
+        self.calendar_calls += 1
+        return [{"trading_date": str(self.candidate["expiration"])}]
+
+    def get_exact_expiration_close(self, **_kwargs: object) -> dict[str, object]:
+        self.close_calls += 1
+        return {"close": 390.0}
+
+
+def _trading_days(start: str, count: int) -> list[str]:
+    current = date.fromisoformat(start)
+    days: list[str] = []
+    while len(days) < count:
+        if current.weekday() < 5:
+            days.append(current.isoformat())
+        current += timedelta(days=1)
+    return days
+
+
+def _start_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[ExperimentStore, Path, Path, list[str]]:
+    monkeypatch.setattr(research_fixture, "EXPIRATION", "2026-12-18")
+    store, artifact_root, case, research_hash = _prepared(tmp_path)
+    monkeypatch.setattr(runner_module, "rate_limited_opend_call", _direct_limiter)
+    result = _run(store, artifact_root, case, research_hash, FakeGateway())
+    assert result["selection"] == "research_leader"
+
+    dates = _trading_days("2026-10-05", 20)
+    validation_spec = research_fixture._spec(
+        case["sealed_dataset"],
+        variants=(
+            ("without", "without_concentration"),
+            ("concentration", "concentration_first"),
+        ),
+        validation=True,
+    )
+    locked = lock_challenger(
+        store,
+        validation_spec,
+        challenger_variant_id="concentration",
+        trading_dates=dates,
+        actor="human",
+        occurred_at_utc="2026-10-02T01:00:00Z",
+        idempotency_key="lock-validation",
+        artifact_root=artifact_root,
+        environ=AVAILABLE,
+    )
+    validation_hash = str(locked["validation_spec_sha256"])
+    authorize_validation(
+        store,
+        experiment_id=EXPERIMENT_ID,
+        validation_spec_sha256=validation_hash,
+        actor="human",
+        occurred_at_utc="2026-10-02T01:01:00Z",
+        idempotency_key="authorize-validation",
+        artifact_root=artifact_root,
+        environ=AVAILABLE,
+    )
+    start_validation(
+        store,
+        experiment_id=EXPERIMENT_ID,
+        validation_spec_sha256=validation_hash,
+        actor="human",
+        occurred_at_utc="2026-10-02T01:02:00Z",
+        idempotency_key="start-validation",
+        artifact_root=artifact_root,
+        environ=AVAILABLE,
+    )
+    return store, artifact_root, tmp_path / "source", dates
+
+
+def _publish_candidate_point(
+    source_root: Path,
+    *,
+    trading_date: str,
+    run_id: str,
+    candidate: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    seal_opening_candidate_fixture(
+        source_root,
+        run_id=run_id,
+        market="HK",
+        accepted_rows=[candidate],
+    )
+    publication, point = capture_scheduled_recommendation_point(
+        source_root,
+        run_id,
+        "lx",
+        _scheduler(trading_date),
+        source_commit_sha="c" * 40,
+    )
+    assert publication == "published"
+    return (
+        f"output_runs/{run_id}/accounts/lx/state/{RECOMMENDATION_POINT_FILE}",
+        point,
+    )
+
+
+def test_twenty_day_empty_candidate_run_concludes_without_provider_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, artifact_root, source_root, dates = _start_validation(
+        tmp_path, monkeypatch
+    )
+    gateway = NoSnapshotGateway()
+
+    for index, trading_date in enumerate(dates):
+        assert _seal(store, artifact_root, day=trading_date)["status"] == "published"
+        point_ref, point = _publish_source_point(
+            source_root,
+            run_id=f"validation-{index}",
+            day=trading_date,
+            accepted=False,
+        )
+        captured = capture_recommendation_point(
+            store,
+            source_root,
+            artifact_root,
+            point_ref=point_ref,
+            trading_date=trading_date,
+            captured_at_utc=f"{trading_date}T02:00:30Z",
+            environ=AVAILABLE,
+        )
+        point_id = str(captured["recommendation_point_id"])
+        consume_validation_point(
+            store,
+            artifact_root,
+            experiment_id=EXPERIMENT_ID,
+            recommendation_point_id=point_id,
+            source_status="available",
+            actor="runner",
+            occurred_at_utc=f"{trading_date}T02:00:45Z",
+            idempotency_key=f"consume-{index}",
+            environ=AVAILABLE,
+        )
+        observe_active_contracts(
+            store,
+            artifact_root,
+            experiment_id=EXPERIMENT_ID,
+            observed_recommendation_point_id=point_id,
+            gateway=gateway,
+            actor="runner",
+            occurred_at_utc=f"{trading_date}T02:01:00Z",
+            idempotency_key=f"observe-{index}",
+            environ=AVAILABLE,
+        )
+
+    experiment = store.experiment(EXPERIMENT_ID)
+    assert experiment["completed_validation_partitions"] == 20
+    assert experiment["validation_progress"] == "ready_to_conclude"
+    before = read_public_status(
+        store, experiment_id=EXPERIMENT_ID, environ=AVAILABLE
+    )
+    assert before["experiment"]["final_outcome_status"] is None
+    assert before["validation"] == {
+        "consumed_point_count": 20,
+        "outcome_job_count": 0,
+        "pending_outcome_count": 0,
+    }
+
+    concluded = conclude_validation(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        actor="runner",
+        occurred_at_utc="2026-11-02T03:00:00Z",
+        idempotency_key="conclude",
+        environ=AVAILABLE,
+    )
+
+    assert concluded["status"] == "insufficient_evidence"
+    assert concluded["result"]["effective_days"] == 0
+    assert store.experiment(EXPERIMENT_ID)["phase"] == "concluded"
+    assert read_public_receipt(store, experiment_id=EXPERIMENT_ID) is not None
+
+
+def test_fill_terms_and_shared_close_are_observed_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, artifact_root, source_root, dates = _start_validation(
+        tmp_path, monkeypatch
+    )
+    trading_date = dates[0]
+    candidate = research_fixture._candidates()[0]
+    gateway = OutcomeGateway(candidate)
+    _seal(store, artifact_root, day=trading_date)
+    point_ref, _point = _publish_candidate_point(
+        source_root,
+        trading_date=trading_date,
+        run_id="validation-fill",
+        candidate=candidate,
+    )
+    captured = capture_recommendation_point(
+        store,
+        source_root,
+        artifact_root,
+        point_ref=point_ref,
+        trading_date=trading_date,
+        captured_at_utc=f"{trading_date}T02:00:30Z",
+        environ=AVAILABLE,
+    )
+    point_id = str(captured["recommendation_point_id"])
+    consume_validation_point(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        recommendation_point_id=point_id,
+        source_status="available",
+        actor="runner",
+        occurred_at_utc=f"{trading_date}T02:00:45Z",
+        idempotency_key="consume-fill",
+        environ=AVAILABLE,
+    )
+    observe_active_contracts(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        observed_recommendation_point_id=point_id,
+        gateway=gateway,
+        actor="runner",
+        occurred_at_utc=f"{trading_date}T02:01:00Z",
+        idempotency_key="observe-fill",
+        environ=AVAILABLE,
+    )
+
+    assert gateway.snapshot_calls == [[str(candidate["contract_symbol"]).upper()]]
+    observe_active_contracts(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        observed_recommendation_point_id=point_id,
+        gateway=gateway,
+        actor="runner",
+        occurred_at_utc=f"{trading_date}T02:01:00Z",
+        idempotency_key="observe-fill",
+        environ=AVAILABLE,
+    )
+    assert gateway.snapshot_calls == [[str(candidate["contract_symbol"]).upper()]]
+    assert {job["status"] for job in store.outcome_jobs(EXPERIMENT_ID)} == {
+        "pending_terms"
+    }
+
+    expiration = str(candidate["expiration"])
+    _seal(store, artifact_root, day=expiration)
+    terms_ref, _terms_point = _publish_source_point(
+        source_root,
+        run_id="expiration-terms",
+        day=expiration,
+        accepted=False,
+    )
+    capture_recommendation_point(
+        store,
+        source_root,
+        artifact_root,
+        point_ref=terms_ref,
+        trading_date=expiration,
+        captured_at_utc=f"{expiration}T02:00:30Z",
+        environ=AVAILABLE,
+    )
+    gateway.terms_error = True
+    retryable = settle_due_outcomes(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        gateway=gateway,
+        actor="runner",
+        occurred_at_utc=f"{expiration}T02:30:00Z",
+        idempotency_key="settle-retryable",
+        environ=AVAILABLE,
+    )
+    assert retryable == {"status": "processed", "processed": 2, "pending": 2}
+    assert gateway.terms_calls == 1
+    assert settle_due_outcomes(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        gateway=gateway,
+        actor="runner",
+        occurred_at_utc=f"{expiration}T02:30:00Z",
+        idempotency_key="settle-retryable",
+        environ=AVAILABLE,
+    ) == retryable
+    assert gateway.terms_calls == 1
+
+    gateway.terms_error = False
+    before_due = settle_due_outcomes(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        gateway=gateway,
+        actor="runner",
+        occurred_at_utc=f"{expiration}T03:00:00Z",
+        idempotency_key="settle-before-due",
+        environ=AVAILABLE,
+    )
+    assert before_due == {"status": "processed", "processed": 2, "pending": 2}
+    assert gateway.terms_calls == 2
+    assert gateway.calendar_calls == gateway.close_calls == 0
+
+    at_due = settle_due_outcomes(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        gateway=gateway,
+        actor="runner",
+        occurred_at_utc=f"{expiration}T16:00:00Z",
+        idempotency_key="settle-at-due",
+        environ=AVAILABLE,
+    )
+    assert at_due == {"status": "processed", "processed": 2, "pending": 0}
+    assert gateway.calendar_calls == gateway.close_calls == 1
+    assert {job["status"] for job in store.outcome_jobs(EXPERIMENT_ID)} == {
+        "evaluable"
+    }
+
+    settled_calls = (
+        gateway.terms_calls,
+        gateway.calendar_calls,
+        gateway.close_calls,
+    )
+    assert settle_due_outcomes(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        gateway=gateway,
+        actor="runner",
+        occurred_at_utc=f"{expiration}T17:00:00Z",
+        idempotency_key="settle-replay",
+        environ=AVAILABLE,
+    ) == {"status": "pending", "processed": 0, "pending": 0}
+    assert (
+        gateway.terms_calls,
+        gateway.calendar_calls,
+        gateway.close_calls,
+    ) == settled_calls
+
+
+def test_missing_day_and_point_seal_only_after_derived_deadlines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, artifact_root, source_root, dates = _start_validation(
+        tmp_path, monkeypatch
+    )
+    first = dates[0]
+    with pytest.raises(Top1ValidationError) as too_early:
+        record_validation_day_gap(
+            store,
+            artifact_root,
+            experiment_id=EXPERIMENT_ID,
+            trading_date=first,
+            actor="runner",
+            occurred_at_utc=f"{first}T16:02:29Z",
+            idempotency_key="day-gap-early",
+            environ=AVAILABLE,
+        )
+    assert too_early.value.reason_code == "validation_deadline_not_reached"
+    committed = record_validation_day_gap(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        trading_date=first,
+        actor="runner",
+        occurred_at_utc=f"{first}T16:02:30Z",
+        idempotency_key="day-gap",
+        environ=AVAILABLE,
+    )
+    assert committed["status"] == "committed"
+    assert record_validation_day_gap(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        trading_date=first,
+        actor="runner",
+        occurred_at_utc=f"{first}T16:02:30Z",
+        idempotency_key="day-gap",
+        environ=AVAILABLE,
+    )["status"] == "idempotent"
+
+    second = dates[1]
+    _seal(store, artifact_root, day=second)
+    _point_ref, point = _publish_source_point(
+        source_root,
+        run_id="missing-validation-point",
+        day=second,
+        accepted=False,
+    )
+    point_id = str(point["recommendation_point_id"])
+    with pytest.raises(Top1ValidationError) as point_early:
+        consume_validation_point(
+            store,
+            artifact_root,
+            experiment_id=EXPERIMENT_ID,
+            recommendation_point_id=point_id,
+            source_status="missing_after_deadline",
+            actor="runner",
+            occurred_at_utc=f"{second}T02:02:29Z",
+            idempotency_key="point-gap-early",
+            environ=AVAILABLE,
+        )
+    assert point_early.value.reason_code == "validation_deadline_not_reached"
+    consume_validation_point(
+        store,
+        artifact_root,
+        experiment_id=EXPERIMENT_ID,
+        recommendation_point_id=point_id,
+        source_status="missing_after_deadline",
+        actor="runner",
+        occurred_at_utc=f"{second}T02:02:30Z",
+        idempotency_key="point-gap",
+        environ=AVAILABLE,
+    )
+
+    days = store.validation_days(EXPERIMENT_ID)
+    assert [row["expected_point_count"] for row in days] == [None, 1]
+    assert all(row["hard_risk_status"] == "missing" for row in days)


### PR DESCRIPTION
## Summary

- add the production-grade 20-trading-day Sell Put Top1 hidden-validation core
- persist compact decision, fill, day, terms, close, job, and final-result evidence in ExperimentStore schema v3
- add strict exact-expiration option-terms normalization and deterministic tri-state conclusion
- remove the obsolete metadata-only validation advancement bypass

## Boundaries

- no live OpenD calls
- no timer, CLI, Agent/LLM loop, automatic adoption, release, deployment, notification, or production config change
- raw provider payloads are intentionally not persisted

## Verification

- focused W6 suite: 43 passed
- broader Top1/research suite: 169 passed
- full repository suite: 4919 passed, 10 skipped
- Ruff passed for changed Python source/tests
- dependency graph current with 0 production cycles
- git diff --check passed

## Review note

DeepSeek V4 Pro returned PASS on the compact architecture/evidence packet and found no material overdesign. Three attempts at a full-source review exhausted the model response budget, so this is not represented as a completed line-by-line external review. Local diff review and the full repository suite found no blocking issue.

## Residual boundaries

- expiration-only outcome proxy; early exercise and roll behavior remain out of scope
- no process-kill crash integration test; durable retry/idempotency behavior is covered with fake providers
- no live OpenD canary while W0R remains runtime_no_go
