### PR TITLE
fix(application): import Any for alert sort key

### DIFF
--- a/src/application/alert_engine.py
+++ b/src/application/alert_engine.py
@@ -6,6 +6,7 @@ import json
 import shutil
 import sys
 from pathlib import Path
+from typing import Any
 
 repo_base = Path(__file__).resolve().parents[2]
 if str(repo_base) not in sys.path:


### PR DESCRIPTION
## Summary

- import `typing.Any` for `_alert_row_sort_key`
- restore the repository-wide Ruff guardrail after the existing type annotation was added without its import

## Verification

- `python -m ruff check .`
- `32 passed` across alert policy, CLI domain split, and notification formatting tests
- `git diff --check`

This is an isolated baseline fix; it contains no W6 Strategy Lab changes.
