### PR TITLE
feat: add W0R HK calendar evidence producer

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -46,10 +46,10 @@ flowchart LR
   scripts -->|1| infrastructure
   storage -->|1| domain
   tests -->|2648| application
-  tests -->|437| domain
+  tests -->|436| domain
   tests -->|2| domain_services
-  tests -->|179| infrastructure
-  tests -->|227| interfaces
+  tests -->|178| infrastructure
+  tests -->|229| interfaces
   tests -->|15| scripts
   tests -->|18| storage
 ```
@@ -78,9 +78,9 @@ flowchart LR
 | from | to | imports |
 |---|---|---|
 | tests | application | 2648 |
-| tests | domain | 437 |
-| tests | interfaces | 227 |
-| tests | infrastructure | 179 |
+| tests | domain | 436 |
+| tests | interfaces | 229 |
+| tests | infrastructure | 178 |
 | tests | storage | 18 |
 | tests | scripts | 15 |
 | tests | domain_services | 2 |

--- a/docs/STRATEGY_LAB_DESIGN.md
+++ b/docs/STRATEGY_LAB_DESIGN.md
@@ -717,7 +717,8 @@ HK 交易日历证据由操作员显式刷新，不随 loop 自动运行：
 ```
 
 该命令使用 profile 已绑定的 OpenD，只落内容寻址的紧凑日历快照和 `current`
-指针；原始响应不落盘，只保留规范化来源回执哈希。相同证据重复刷新不会新增文件。
+指针；快照保留每个交易日的 `WHOLE/MORNING/AFTERNOON` 时段类型，原始响应不落盘，
+只保留规范化来源回执哈希。相同证据重复刷新不会新增文件。
 它只关闭 calendar blocker，不代表其余 W0R capability 已就绪。
 
 定时 source delivery 必须显式提供 cadence、timeout 和 env file：

--- a/docs/STRATEGY_LAB_DESIGN.md
+++ b/docs/STRATEGY_LAB_DESIGN.md
@@ -710,6 +710,16 @@ Top1 loop 是独立的实验功能，固定绑定 `HK/lx`，默认不渲染、�
 ./om research strategy-lab top1-loop readiness --market hk --account lx --profile-path <runtime>/service.profile.json
 ```
 
+HK 交易日历证据由操作员显式刷新，不随 loop 自动运行：
+
+```bash
+./om research strategy-lab top1-loop calendar refresh --market hk --account lx --profile-path <runtime>/service.profile.json --coverage-start <YYYY-MM-DD> --coverage-end <YYYY-MM-DD> --calendar-version <version> --write
+```
+
+该命令使用 profile 已绑定的 OpenD，只落内容寻址的紧凑日历快照和 `current`
+指针；原始响应不落盘，只保留规范化来源回执哈希。相同证据重复刷新不会新增文件。
+它只关闭 calendar blocker，不代表其余 W0R capability 已就绪。
+
 定时 source delivery 必须显式提供 cadence、timeout 和 env file：
 
 ```bash

--- a/src/application/scan_scheduler.py
+++ b/src/application/scan_scheduler.py
@@ -418,6 +418,8 @@ def _scheduled_scan_targets(
 def scheduled_scan_targets_for_date(
     schedule_cfg: dict[str, Any],
     trading_date: date | str,
+    *,
+    trade_date_type: str = 'WHOLE',
 ) -> list[datetime]:
     """Return the scheduler's exact scan targets for one declared trading date."""
 
@@ -434,6 +436,8 @@ def scheduled_scan_targets_for_date(
         raise ValueError("trading_date must be an ISO date") from exc
     if raw_day is not None and day.isoformat() != raw_day:
         raise ValueError("trading_date must be a canonical ISO date")
+    if trade_date_type not in {'WHOLE', 'MORNING', 'AFTERNOON'}:
+        raise ValueError("trade_date_type is invalid")
     if not bool(schedule_cfg.get('enabled', True)):
         return []
 
@@ -460,6 +464,21 @@ def scheduled_scan_targets_for_date(
         )
     except ZoneInfoNotFoundError as exc:
         raise ValueError("schedule gate timezone is invalid") from exc
+    if trade_date_type != 'WHOLE':
+        if len(breaks) != 1:
+            raise ValueError("partial trading day requires one session break")
+        break_start, break_end = breaks[0]
+        if not run_start < break_start < break_end < run_end:
+            raise ValueError("partial trading day session break is invalid")
+        targets = [
+            target
+            for target in targets
+            if (
+                target.time() < break_start
+                if trade_date_type == 'MORNING'
+                else target.time() >= break_end
+            )
+        ]
     return targets
 
 

--- a/src/application/strategy_lab/top1/advance.py
+++ b/src/application/strategy_lab/top1/advance.py
@@ -232,6 +232,11 @@ def advance_scheduled(
                     "current date is outside market calendar coverage",
                 )
             if today in calendar["trading_dates"]:
+                session_type = next(
+                    item["trade_date_type"]
+                    for item in calendar["trading_sessions"]
+                    if item["trading_date"] == today
+                )
                 sealed = seal_day_expectation(
                     store,
                     artifact_root,
@@ -246,6 +251,7 @@ def advance_scheduled(
                         calendar["snapshot_content_sha256"]
                     ),
                     sealed_at_utc=occurred_at_utc,
+                    trade_date_type=str(session_type),
                     environ=environ,
                 )
                 result["corpus"].append(sealed)

--- a/src/application/strategy_lab/top1/corpus.py
+++ b/src/application/strategy_lab/top1/corpus.py
@@ -57,7 +57,7 @@ CORPUS_STATUS_SCHEMA = "sell_put_top1_corpus_status.v1"
 RESEARCH_WINDOW_FACTS_SCHEMA = "sell_put_top1_research_window_facts.v1"
 DATASET_FREEZE_RESULT_SCHEMA = "sell_put_top1_dataset_freeze_result.v1"
 MARKET_CALENDAR_POINTER_SCHEMA = "sell_put_top1_market_calendar_pointer.v1"
-MARKET_CALENDAR_SNAPSHOT_SCHEMA = "sell_put_top1_market_calendar_snapshot.v1"
+MARKET_CALENDAR_SNAPSHOT_SCHEMA = "sell_put_top1_market_calendar_snapshot.v2"
 _MARKET_CALENDAR_SOURCE_RECEIPT_SCHEMA = (
     "sell_put_top1_market_calendar_source_receipt.v1"
 )
@@ -79,7 +79,7 @@ _CALENDAR_SNAPSHOT_FIELDS = frozenset(
         "market_calendar_version",
         "coverage_start",
         "coverage_end",
-        "trading_dates",
+        "trading_sessions",
         "source_receipt_sha256",
         "observed_at_utc",
         "content_sha256",
@@ -298,10 +298,19 @@ def _validate_calendar_snapshot(
         coverage_end = _trading_date(item["coverage_end"])
         if coverage_start > coverage_end:
             raise ValueError("snapshot coverage is reversed")
-        values = item["trading_dates"]
+        values = item["trading_sessions"]
         if not isinstance(values, list) or not values:
-            raise ValueError("snapshot trading dates are missing")
-        trading_dates = [_trading_date(value) for value in values]
+            raise ValueError("snapshot trading sessions are missing")
+        trading_dates: list[str] = []
+        for raw_session in values:
+            if not isinstance(raw_session, Mapping):
+                raise ValueError("snapshot trading session must be an object")
+            session = dict(raw_session)
+            if set(session) != {"trading_date", "trade_date_type"}:
+                raise ValueError("snapshot trading session keys are invalid")
+            trading_dates.append(_trading_date(session["trading_date"]))
+            if session["trade_date_type"] not in _CALENDAR_SESSION_TYPES:
+                raise ValueError("snapshot trade date type is invalid")
         if trading_dates != sorted(set(trading_dates)):
             raise ValueError("snapshot trading dates are not ordered and unique")
         if trading_dates[0] < coverage_start or trading_dates[-1] > coverage_end:
@@ -317,7 +326,7 @@ def _validate_calendar_snapshot(
             "market_calendar_binding_unavailable",
             f"market calendar snapshot is invalid: {exc}",
         ) from exc
-    return item
+    return {**item, "trading_dates": trading_dates}
 
 
 def read_bound_market_calendar_snapshot(
@@ -503,22 +512,26 @@ def refresh_market_calendar_binding(
         coverage_end=end,
     )
     sessions = normalized_receipt["trading_sessions"]
-    trading_dates = [item["trading_date"] for item in sessions]
     source_receipt_sha256 = canonical_sha256(normalized_receipt)
 
     pointer_ref = _calendar_pointer_ref(market)
     pointer_path = private_path(artifact_root).joinpath(*pointer_ref.split("/"))
     if pointer_path.exists() or pointer_path.is_symlink():
-        current = read_market_calendar_binding(artifact_root, market=market)
+        try:
+            current = read_market_calendar_binding(artifact_root, market=market)
+        except CorpusError:
+            current = None
         expected = {
             "market": market,
             "market_calendar_version": version,
             "coverage_start": start,
             "coverage_end": end,
-            "trading_dates": trading_dates,
+            "trading_sessions": sessions,
             "source_receipt_sha256": source_receipt_sha256,
         }
-        if all(current[key] == value for key, value in expected.items()):
+        if current is not None and all(
+            current[key] == value for key, value in expected.items()
+        ):
             return {"status": "unchanged", "binding": current}
 
     snapshot: dict[str, Any] = {
@@ -527,7 +540,7 @@ def refresh_market_calendar_binding(
         "market_calendar_version": version,
         "coverage_start": start,
         "coverage_end": end,
-        "trading_dates": trading_dates,
+        "trading_sessions": sessions,
         "source_receipt_sha256": source_receipt_sha256,
         "observed_at_utc": observed_at,
     }
@@ -961,6 +974,7 @@ def seal_day_expectation(
     market_calendar_version: str,
     market_calendar_sha256: str,
     sealed_at_utc: str,
+    trade_date_type: str = "WHOLE",
     environ: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     market, account = _identity(market, account)
@@ -983,7 +997,9 @@ def seal_day_expectation(
         )
 
     try:
-        targets = scheduled_scan_targets_for_date(dict(schedule), day)
+        targets = scheduled_scan_targets_for_date(
+            dict(schedule), day, trade_date_type=trade_date_type
+        )
         schedule_hash = canonical_sha256(dict(schedule))
     except (TypeError, ValueError) as exc:
         raise CorpusError("corpus_input_invalid", "schedule is invalid") from exc

--- a/src/application/strategy_lab/top1/corpus.py
+++ b/src/application/strategy_lab/top1/corpus.py
@@ -40,7 +40,11 @@ from src.application.strategy_lab.top1.ranking import (
     validate_ranking_projection,
 )
 from src.application.strategy_lab.top1.terminal_projection import publish_exact_text
-from src.infrastructure.private_storage import open_private_text, private_path
+from src.infrastructure.private_storage import (
+    atomic_write_private_text,
+    open_private_text,
+    private_path,
+)
 from src.infrastructure.strategy_lab.experiment_store import (
     ExperimentStore,
     ExperimentStoreError,
@@ -54,6 +58,9 @@ RESEARCH_WINDOW_FACTS_SCHEMA = "sell_put_top1_research_window_facts.v1"
 DATASET_FREEZE_RESULT_SCHEMA = "sell_put_top1_dataset_freeze_result.v1"
 MARKET_CALENDAR_POINTER_SCHEMA = "sell_put_top1_market_calendar_pointer.v1"
 MARKET_CALENDAR_SNAPSHOT_SCHEMA = "sell_put_top1_market_calendar_snapshot.v1"
+_MARKET_CALENDAR_SOURCE_RECEIPT_SCHEMA = (
+    "sell_put_top1_market_calendar_source_receipt.v1"
+)
 
 _CALENDAR_POINTER_FIELDS = frozenset(
     {
@@ -78,6 +85,17 @@ _CALENDAR_SNAPSHOT_FIELDS = frozenset(
         "content_sha256",
     }
 )
+_CALENDAR_SOURCE_FIELDS = frozenset(
+    {
+        "retcode",
+        "rows",
+        "coverage_complete",
+        "pagination_complete",
+        "page_count",
+    }
+)
+_CALENDAR_SOURCE_ROW_FIELDS = frozenset({"time", "trade_date_type"})
+_CALENDAR_SESSION_TYPES = frozenset({"WHOLE", "MORNING", "AFTERNOON"})
 
 _EXPECTATION_FIELDS = frozenset(
     {
@@ -385,6 +403,160 @@ def read_market_calendar_binding(
         snapshot_content_sha256=snapshot_content_hash,
         snapshot_file_sha256=snapshot_file_hash,
     )
+
+
+def _normalized_calendar_source_receipt(
+    receipt: object,
+    *,
+    market: str,
+    coverage_start: str,
+    coverage_end: str,
+) -> dict[str, Any]:
+    try:
+        if not isinstance(receipt, Mapping):
+            raise ValueError("receipt must be an object")
+        item = dict(receipt)
+        if set(item) != _CALENDAR_SOURCE_FIELDS:
+            raise ValueError("receipt keys are invalid")
+        if type(item["retcode"]) is not int or item["retcode"] != 0:
+            raise ValueError("receipt retcode is invalid")
+        if item["coverage_complete"] is not True:
+            raise ValueError("receipt coverage is incomplete")
+        if item["pagination_complete"] is not True:
+            raise ValueError("receipt pagination is incomplete")
+        if type(item["page_count"]) is not int or item["page_count"] != 1:
+            raise ValueError("receipt page count is invalid")
+        rows = item["rows"]
+        if not isinstance(rows, list) or not rows:
+            raise ValueError("receipt rows are missing")
+        sessions: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for raw_row in rows:
+            if not isinstance(raw_row, Mapping):
+                raise ValueError("receipt row must be an object")
+            row = dict(raw_row)
+            if set(row) != _CALENDAR_SOURCE_ROW_FIELDS:
+                raise ValueError("receipt row keys are invalid")
+            trading_date = _trading_date(row["time"])
+            session_type = _text(row["trade_date_type"], "trade_date_type")
+            if trading_date < coverage_start or trading_date > coverage_end:
+                raise ValueError("receipt row exceeds requested coverage")
+            if trading_date in seen:
+                raise ValueError("receipt contains duplicate trading dates")
+            if session_type not in _CALENDAR_SESSION_TYPES:
+                raise ValueError("receipt trade date type is invalid")
+            seen.add(trading_date)
+            sessions.append(
+                {"trading_date": trading_date, "trade_date_type": session_type}
+            )
+    except (CorpusError, KeyError, TypeError, ValueError) as exc:
+        raise CorpusError(
+            "market_calendar_source_invalid",
+            f"HK market calendar source receipt is invalid: {exc}",
+        ) from exc
+    return {
+        "schema_version": _MARKET_CALENDAR_SOURCE_RECEIPT_SCHEMA,
+        "source": "futu.request_trading_days",
+        "market": market,
+        "coverage_start": coverage_start,
+        "coverage_end": coverage_end,
+        "trading_sessions": sorted(
+            sessions, key=lambda value: value["trading_date"]
+        ),
+    }
+
+
+def refresh_market_calendar_binding(
+    artifact_root: str | Path,
+    *,
+    gateway: Any,
+    market: str,
+    market_calendar_version: str,
+    coverage_start: str,
+    coverage_end: str,
+    observed_at_utc: str,
+) -> dict[str, Any]:
+    """Collect and publish one compact, hash-bound HK trading calendar."""
+
+    market, _ = _identity(market, "calendar")
+    version = _text(market_calendar_version, "market_calendar_version")
+    start = _trading_date(coverage_start)
+    end = _trading_date(coverage_end)
+    observed_at = _timestamp(observed_at_utc, "observed_at_utc")
+    if start > end:
+        _fail("corpus_input_invalid", "market calendar coverage is reversed")
+    try:
+        receipt = gateway.get_trading_days_with_receipt(
+            market=market,
+            start=start,
+            end=end,
+        )
+    except Exception as exc:
+        raise CorpusError(
+            "market_calendar_source_unavailable",
+            "HK market calendar source is unavailable",
+        ) from exc
+    normalized_receipt = _normalized_calendar_source_receipt(
+        receipt,
+        market=market,
+        coverage_start=start,
+        coverage_end=end,
+    )
+    sessions = normalized_receipt["trading_sessions"]
+    trading_dates = [item["trading_date"] for item in sessions]
+    source_receipt_sha256 = canonical_sha256(normalized_receipt)
+
+    pointer_ref = _calendar_pointer_ref(market)
+    pointer_path = private_path(artifact_root).joinpath(*pointer_ref.split("/"))
+    if pointer_path.exists() or pointer_path.is_symlink():
+        current = read_market_calendar_binding(artifact_root, market=market)
+        expected = {
+            "market": market,
+            "market_calendar_version": version,
+            "coverage_start": start,
+            "coverage_end": end,
+            "trading_dates": trading_dates,
+            "source_receipt_sha256": source_receipt_sha256,
+        }
+        if all(current[key] == value for key, value in expected.items()):
+            return {"status": "unchanged", "binding": current}
+
+    snapshot: dict[str, Any] = {
+        "schema_version": MARKET_CALENDAR_SNAPSHOT_SCHEMA,
+        "market": market,
+        "market_calendar_version": version,
+        "coverage_start": start,
+        "coverage_end": end,
+        "trading_dates": trading_dates,
+        "source_receipt_sha256": source_receipt_sha256,
+        "observed_at_utc": observed_at,
+    }
+    snapshot["content_sha256"] = canonical_sha256(snapshot)
+    snapshot_content = _render(snapshot)
+    snapshot_ref = _calendar_snapshot_ref(market, snapshot["content_sha256"])
+    pointer: dict[str, Any] = {
+        "schema_version": MARKET_CALENDAR_POINTER_SCHEMA,
+        "market": market,
+        "snapshot_ref": snapshot_ref,
+        "snapshot_content_sha256": snapshot["content_sha256"],
+        "snapshot_file_sha256": _file_sha256(snapshot_content),
+    }
+    pointer["content_sha256"] = canonical_sha256(pointer)
+    try:
+        publish_exact_text(artifact_root, snapshot_ref, snapshot_content)
+        atomic_write_private_text(pointer_path, render_json_text(pointer))
+        binding = read_market_calendar_binding(artifact_root, market=market)
+    except (CorpusError, OSError, ValueError) as exc:
+        raise CorpusError(
+            "market_calendar_artifact_conflict",
+            "market calendar artifact cannot be published",
+        ) from exc
+    if binding["snapshot_content_sha256"] != snapshot["content_sha256"]:
+        _fail(
+            "market_calendar_artifact_conflict",
+            "published market calendar does not match the collected evidence",
+        )
+    return {"status": "published", "binding": binding}
 
 
 def _command_result(
@@ -1819,6 +1991,7 @@ __all__ = [
     "read_bound_market_calendar_snapshot",
     "read_corpus_status",
     "read_market_calendar_binding",
+    "refresh_market_calendar_binding",
     "read_validation_day_source",
     "read_validation_point_source",
     "seal_committed_day_expectation",

--- a/src/application/strategy_lab/top1/lifecycle.py
+++ b/src/application/strategy_lab/top1/lifecycle.py
@@ -658,6 +658,34 @@ def build_hidden_window_commitment(
     ]
     if calendar_dates != sorted(set(calendar_dates)):
         _fail("experiment_invalid", "market calendar trading dates are invalid")
+    raw_sessions = market_calendar_binding.get("trading_sessions")
+    if not isinstance(raw_sessions, list):
+        _fail("experiment_invalid", "market calendar trading sessions are missing")
+    session_dates: list[str] = []
+    session_types: list[str] = []
+    for index, raw_session in enumerate(raw_sessions):
+        if not isinstance(raw_session, Mapping) or set(raw_session) != {
+            "trading_date",
+            "trade_date_type",
+        }:
+            _fail("experiment_invalid", "market calendar trading sessions are invalid")
+        session_dates.append(
+            _iso_date(
+                raw_session["trading_date"],
+                f"market_calendar_binding.trading_sessions[{index}].trading_date",
+            )
+        )
+        session_types.append(
+            _text(
+                raw_session["trade_date_type"],
+                f"market_calendar_binding.trading_sessions[{index}].trade_date_type",
+            )
+        )
+    if session_dates != calendar_dates or any(
+        value not in {"WHOLE", "MORNING", "AFTERNOON"} for value in session_types
+    ):
+        _fail("experiment_invalid", "market calendar trading sessions are invalid")
+    session_by_date = dict(zip(session_dates, session_types, strict=True))
     try:
         start_index = calendar_dates.index(start)
     except ValueError:
@@ -676,7 +704,11 @@ def build_hidden_window_commitment(
         try:
             targets = [
                 target.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-                for target in scheduled_scan_targets_for_date(schedule_payload, day)
+                for target in scheduled_scan_targets_for_date(
+                    schedule_payload,
+                    day,
+                    trade_date_type=session_by_date[day],
+                )
             ]
         except (TypeError, ValueError) as exc:
             raise Top1LifecycleError(

--- a/src/application/strategy_lab/top1/readiness.py
+++ b/src/application/strategy_lab/top1/readiness.py
@@ -76,18 +76,35 @@ def _calendar_ready(value: Mapping[str, Any] | None) -> bool:
     coverage_start = _date(value.get("coverage_start"))
     coverage_end = _date(value.get("coverage_end"))
     raw_dates = value.get("trading_dates")
-    if not isinstance(raw_dates, list):
+    raw_sessions = value.get("trading_sessions")
+    if not isinstance(raw_dates, list) or not isinstance(raw_sessions, list):
         return False
     trading_dates = [_date(item) for item in raw_dates]
+    session_dates: list[date | None] = []
+    for raw_session in raw_sessions:
+        if not isinstance(raw_session, Mapping) or set(raw_session) != {
+            "trading_date",
+            "trade_date_type",
+        }:
+            return False
+        if raw_session["trade_date_type"] not in {
+            "WHOLE",
+            "MORNING",
+            "AFTERNOON",
+        }:
+            return False
+        session_dates.append(_date(raw_session["trading_date"]))
     if coverage_start is None or coverage_end is None or any(
-        item is None for item in trading_dates
+        item is None for item in [*trading_dates, *session_dates]
     ):
         return False
     dates = [item for item in trading_dates if item is not None]
+    sessions = [item for item in session_dates if item is not None]
     return bool(
         coverage_start <= coverage_end
         and dates
         and dates == sorted(set(dates))
+        and sessions == dates
         and coverage_start <= dates[0] <= dates[-1] <= coverage_end
     )
 

--- a/src/interfaces/cli/strategy_lab_top1.py
+++ b/src/interfaces/cli/strategy_lab_top1.py
@@ -13,15 +13,20 @@ from src.application.service_deploy import load_service_profile, service_status_
 from src.application.service_drift import service_drift
 from src.application.strategy_lab.top1.advance import ADVANCE_REVISION, advance_scheduled
 from src.application.strategy_lab.top1.corpus import (
+    CorpusError,
     read_corpus_status,
     read_market_calendar_binding,
+    refresh_market_calendar_binding,
 )
 from src.application.strategy_lab.top1.lifecycle import (
     effective_feature_status,
     read_public_status,
 )
 from src.application.strategy_lab.top1.readiness import build_top1_readiness
-from src.infrastructure.futu_gateway import build_ready_futu_quote_gateway
+from src.infrastructure.futu_gateway import (
+    FutuGatewayError,
+    build_ready_futu_quote_gateway,
+)
 from src.infrastructure.strategy_lab.experiment_store import ExperimentStore
 
 
@@ -52,6 +57,17 @@ def add_top1_commands(strategy_lab_subparsers: Any) -> None:
     _add_identity(advance)
     advance.add_argument("--scheduled", action="store_true")
     advance.add_argument("--write", action="store_true")
+
+    calendar = commands.add_parser("calendar", help="manage HK calendar evidence")
+    calendar_commands = calendar.add_subparsers(required=True)
+    calendar_refresh = calendar_commands.add_parser(
+        "refresh", help="collect and publish HK calendar evidence"
+    )
+    _add_identity(calendar_refresh)
+    calendar_refresh.add_argument("--coverage-start", required=True)
+    calendar_refresh.add_argument("--coverage-end", required=True)
+    calendar_refresh.add_argument("--calendar-version", required=True)
+    calendar_refresh.add_argument("--write", action="store_true")
 
     feature = commands.add_parser("feature", help="inspect the experimental feature gate")
     feature_commands = feature.add_subparsers(
@@ -229,7 +245,68 @@ def _store_not_ready(tool_name: str, store: ExperimentStore) -> dict[str, Any]:
 
 def handle_top1_command(args: argparse.Namespace) -> dict[str, Any]:
     command = args.top1_loop_command
-    context = _profile_context(args, require_top1=command == "advance")
+    context = _profile_context(args, require_top1=command in {"advance", "calendar"})
+
+    if command == "calendar":
+        if not args.write:
+            raise AgentToolError(
+                code="INPUT_ERROR", message="Top1 calendar refresh requires --write"
+            )
+        top1 = context["top1"]
+        binding = top1["opend_binding"]
+        gateway = None
+        try:
+            gateway = build_ready_futu_quote_gateway(
+                host=str(binding["host"]),
+                port=int(binding["port"]),
+                is_option_chain_cache_enabled=False,
+            )
+            result = refresh_market_calendar_binding(
+                context["artifact_root"],
+                gateway=gateway,
+                market=args.market.upper(),
+                market_calendar_version=args.calendar_version,
+                coverage_start=args.coverage_start,
+                coverage_end=args.coverage_end,
+                observed_at_utc=datetime.now(timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+            )
+        except (CorpusError, FutuGatewayError) as exc:
+            raise AgentToolError(
+                code=str(getattr(exc, "reason_code", getattr(exc, "code", "ERROR"))),
+                message=str(exc),
+            ) from exc
+        finally:
+            if gateway is not None:
+                gateway.close()
+        calendar_binding = result["binding"]
+        return build_response(
+            tool_name="research.strategy-lab.top1-loop.calendar.refresh",
+            ok=True,
+            data={
+                "status": result["status"],
+                "market": calendar_binding["market"],
+                "market_calendar_version": calendar_binding[
+                    "market_calendar_version"
+                ],
+                "coverage_start": calendar_binding["coverage_start"],
+                "coverage_end": calendar_binding["coverage_end"],
+                "trading_date_count": len(calendar_binding["trading_dates"]),
+                "source_receipt_sha256": calendar_binding[
+                    "source_receipt_sha256"
+                ],
+                "observed_at_utc": calendar_binding["observed_at_utc"],
+                "snapshot_ref": calendar_binding["snapshot_ref"],
+                "snapshot_content_sha256": calendar_binding[
+                    "snapshot_content_sha256"
+                ],
+                "snapshot_file_sha256": calendar_binding[
+                    "snapshot_file_sha256"
+                ],
+            },
+        )
+
     store = ExperimentStore(context["store_path"])
 
     if command == "readiness":

--- a/tests/candidate_evidence_helpers.py
+++ b/tests/candidate_evidence_helpers.py
@@ -51,6 +51,7 @@ def seal_market_calendar_fixture(
     version: str = "hk-calendar.v1",
     coverage_start: str | None = None,
     coverage_end: str | None = None,
+    trade_date_types: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     start = coverage_start or trading_dates[0]
     end = coverage_end or trading_dates[-1]
@@ -61,7 +62,12 @@ def seal_market_calendar_fixture(
             return {
                 "retcode": 0,
                 "rows": [
-                    {"time": trading_date, "trade_date_type": "WHOLE"}
+                    {
+                        "time": trading_date,
+                        "trade_date_type": (trade_date_types or {}).get(
+                            trading_date, "WHOLE"
+                        ),
+                    }
                     for trading_date in trading_dates
                 ],
                 "coverage_complete": True,

--- a/tests/candidate_evidence_helpers.py
+++ b/tests/candidate_evidence_helpers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -23,21 +22,13 @@ from src.application.opening_candidate_snapshot import (
 )
 from src.application.shadow_replay.common import (
     DATASET_FILES,
-    render_json_text,
     refresh_dataset_manifest,
 )
-from src.application.strategy_lab.top1.corpus import (
-    MARKET_CALENDAR_POINTER_SCHEMA,
-    MARKET_CALENDAR_SNAPSHOT_SCHEMA,
-    read_market_calendar_binding,
-)
-from src.application.strategy_lab.top1.terminal_projection import publish_exact_text
+from src.application.strategy_lab.top1.corpus import refresh_market_calendar_binding
 from src.application.strategy_scan_status import (
     publish_strategy_scan_status,
     publish_strategy_scan_status_index_v2,
 )
-from src.infrastructure.private_storage import atomic_write_private_text
-from domain.domain.decision_state_fingerprint import canonical_sha256
 
 
 CONFIG_HASH = "a" * 64
@@ -61,37 +52,33 @@ def seal_market_calendar_fixture(
     coverage_start: str | None = None,
     coverage_end: str | None = None,
 ) -> dict[str, Any]:
-    snapshot: dict[str, Any] = {
-        "schema_version": MARKET_CALENDAR_SNAPSHOT_SCHEMA,
-        "market": "HK",
-        "market_calendar_version": version,
-        "coverage_start": coverage_start or trading_dates[0],
-        "coverage_end": coverage_end or trading_dates[-1],
-        "trading_dates": trading_dates,
-        "source_receipt_sha256": "d" * 64,
-        "observed_at_utc": "2026-08-15T00:00:00Z",
-    }
-    snapshot["content_sha256"] = canonical_sha256(snapshot)
-    snapshot_content = render_json_text(snapshot).encode("utf-8")
-    snapshot_ref = (
-        "strategy_lab/top1/capabilities/market-calendar/hk/snapshots/"
-        f"{snapshot['content_sha256']}.json"
+    start = coverage_start or trading_dates[0]
+    end = coverage_end or trading_dates[-1]
+
+    class FakeCalendarGateway:
+        def get_trading_days_with_receipt(self, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs == {"market": "HK", "start": start, "end": end}
+            return {
+                "retcode": 0,
+                "rows": [
+                    {"time": trading_date, "trade_date_type": "WHOLE"}
+                    for trading_date in trading_dates
+                ],
+                "coverage_complete": True,
+                "pagination_complete": True,
+                "page_count": 1,
+            }
+
+    result = refresh_market_calendar_binding(
+        artifact_root,
+        gateway=FakeCalendarGateway(),
+        market="HK",
+        market_calendar_version=version,
+        coverage_start=start,
+        coverage_end=end,
+        observed_at_utc="2026-08-15T00:00:00Z",
     )
-    publish_exact_text(artifact_root, snapshot_ref, snapshot_content)
-    pointer: dict[str, Any] = {
-        "schema_version": MARKET_CALENDAR_POINTER_SCHEMA,
-        "market": "HK",
-        "snapshot_ref": snapshot_ref,
-        "snapshot_content_sha256": snapshot["content_sha256"],
-        "snapshot_file_sha256": hashlib.sha256(snapshot_content).hexdigest(),
-    }
-    pointer["content_sha256"] = canonical_sha256(pointer)
-    pointer_path = (
-        artifact_root
-        / "strategy_lab/top1/capabilities/market-calendar/hk/current.json"
-    )
-    atomic_write_private_text(pointer_path, render_json_text(pointer))
-    return read_market_calendar_binding(artifact_root, market="HK")
+    return dict(result["binding"])
 
 
 def seal_opening_candidate_fixture(

--- a/tests/test_strategy_lab_top1_advance.py
+++ b/tests/test_strategy_lab_top1_advance.py
@@ -25,6 +25,9 @@ def _calendar() -> dict[str, object]:
         "coverage_start": "2026-08-16",
         "coverage_end": "2026-08-18",
         "trading_dates": ["2026-08-17"],
+        "trading_sessions": [
+            {"trading_date": "2026-08-17", "trade_date_type": "MORNING"}
+        ],
         "market_calendar_version": "hk-calendar.v1",
         "snapshot_content_sha256": "a" * 64,
     }
@@ -574,6 +577,7 @@ def test_corpus_conflicts_make_advance_partial(
     seal_status: str,
     capture_status: str,
 ) -> None:
+    seal_calls: list[dict[str, object]] = []
     monkeypatch.setattr(advance_module, "effective_feature_status", _enabled)
     monkeypatch.setattr(
         advance_module, "read_active_experiment_ids", lambda *_args, **_kwargs: []
@@ -586,10 +590,8 @@ def test_corpus_conflicts_make_advance_partial(
     monkeypatch.setattr(
         advance_module,
         "seal_day_expectation",
-        lambda *_args, **_kwargs: {
-            "operation": "seal_day_expectation",
-            "status": seal_status,
-        },
+        lambda *_args, **kwargs: seal_calls.append(kwargs)
+        or {"operation": "seal_day_expectation", "status": seal_status},
     )
     monkeypatch.setattr(
         advance_module,
@@ -634,4 +636,5 @@ def test_corpus_conflicts_make_advance_partial(
     )
 
     assert result["status"] == "partial"
+    assert seal_calls[0]["trade_date_type"] == "MORNING"
     assert any(item.get("status") == "conflict" for item in result["corpus"])

--- a/tests/test_strategy_lab_top1_corpus.py
+++ b/tests/test_strategy_lab_top1_corpus.py
@@ -28,6 +28,7 @@ from src.application.strategy_lab.top1.corpus import (
     freeze_research_dataset,
     read_market_calendar_binding,
     read_corpus_status,
+    refresh_market_calendar_binding,
     seal_committed_day_expectation,
     seal_day_expectation,
 )
@@ -46,6 +47,16 @@ from tests.candidate_evidence_helpers import (
 AVAILABLE = {"OM_STRATEGY_LAB_TOP1_AVAILABLE": "1"}
 CALENDAR_HASH = "a" * 64
 SOURCE_SHA = "c" * 40
+
+
+class _CalendarGateway:
+    def __init__(self, receipt: dict[str, Any]) -> None:
+        self.receipt = receipt
+        self.calls: list[dict[str, Any]] = []
+
+    def get_trading_days_with_receipt(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return self.receipt
 
 
 def _schedule(*, start_plus_min: int = 10, enabled: bool = True) -> dict[str, Any]:
@@ -329,6 +340,114 @@ def test_calendar_binding_is_content_addressed_and_fails_closed(
     with pytest.raises(CorpusError) as tampered:
         read_market_calendar_binding(tmp_path, market="HK")
     assert tampered.value.reason_code == "market_calendar_binding_unavailable"
+
+
+def test_calendar_refresh_publishes_compact_evidence_without_duplicate_growth(
+    tmp_path: Path,
+) -> None:
+    gateway = _CalendarGateway(
+        {
+            "retcode": 0,
+            "rows": [
+                {"time": "2026-08-04", "trade_date_type": "MORNING"},
+                {"time": "2026-08-03", "trade_date_type": "WHOLE"},
+            ],
+            "coverage_complete": True,
+            "pagination_complete": True,
+            "page_count": 1,
+        }
+    )
+    kwargs = {
+        "gateway": gateway,
+        "market": "HK",
+        "market_calendar_version": "hk-calendar.opend.v1",
+        "coverage_start": "2026-08-03",
+        "coverage_end": "2026-08-31",
+    }
+
+    first = refresh_market_calendar_binding(
+        tmp_path,
+        **kwargs,
+        observed_at_utc="2026-08-16T01:00:00Z",
+    )
+    assert first["status"] == "published"
+    assert first["binding"]["trading_dates"] == ["2026-08-03", "2026-08-04"]
+    assert gateway.calls == [
+        {"market": "HK", "start": "2026-08-03", "end": "2026-08-31"}
+    ]
+    capability_root = (
+        tmp_path / "strategy_lab/top1/capabilities/market-calendar/hk"
+    )
+    files_before = sorted(
+        path.relative_to(tmp_path) for path in capability_root.rglob("*.json")
+    )
+    assert len(files_before) == 2
+    assert all("receipt" not in path.name for path in files_before)
+
+    second = refresh_market_calendar_binding(
+        tmp_path,
+        **kwargs,
+        observed_at_utc="2026-08-16T02:00:00Z",
+    )
+    assert second["status"] == "unchanged"
+    assert second["binding"] == first["binding"]
+    assert sorted(
+        path.relative_to(tmp_path) for path in capability_root.rglob("*.json")
+    ) == files_before
+
+
+@pytest.mark.parametrize(
+    "receipt",
+    [
+        {
+            "retcode": 0,
+            "rows": [{"time": "2026-08-03", "trade_date_type": "WHOLE"}],
+            "coverage_complete": False,
+            "pagination_complete": True,
+            "page_count": 1,
+        },
+        {
+            "retcode": 0,
+            "rows": [
+                {"time": "2026-08-03", "trade_date_type": "WHOLE"},
+                {"time": "2026-08-03", "trade_date_type": "MORNING"},
+            ],
+            "coverage_complete": True,
+            "pagination_complete": True,
+            "page_count": 1,
+        },
+        {
+            "retcode": 0,
+            "rows": [{"time": "2026-09-01", "trade_date_type": "WHOLE"}],
+            "coverage_complete": True,
+            "pagination_complete": True,
+            "page_count": 1,
+        },
+        {
+            "retcode": 0,
+            "rows": [{"time": "2026-08-03", "trade_date_type": "UNKNOWN"}],
+            "coverage_complete": True,
+            "pagination_complete": True,
+            "page_count": 1,
+        },
+    ],
+)
+def test_calendar_refresh_rejects_untrustworthy_source_without_writing(
+    tmp_path: Path,
+    receipt: dict[str, Any],
+) -> None:
+    with pytest.raises(CorpusError) as raised:
+        refresh_market_calendar_binding(
+            tmp_path,
+            gateway=_CalendarGateway(receipt),
+            market="HK",
+            market_calendar_version="hk-calendar.opend.v1",
+            coverage_start="2026-08-03",
+            coverage_end="2026-08-31",
+            observed_at_utc="2026-08-16T01:00:00Z",
+        )
+    assert raised.value.reason_code == "market_calendar_source_invalid"
+    assert not (tmp_path / "strategy_lab").exists()
 
 
 def test_committed_denominator_rejects_later_schedule_drift(tmp_path: Path) -> None:

--- a/tests/test_strategy_lab_top1_corpus.py
+++ b/tests/test_strategy_lab_top1_corpus.py
@@ -6,6 +6,7 @@ import sqlite3
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -73,6 +74,23 @@ def _multi_point_schedule() -> dict[str, Any]:
         "enabled": True,
         "timezone": "Asia/Hong_Kong",
         "run_window": {"start": "09:30", "end": "10:20"},
+        "run_points": {
+            "start_plus_min": 10,
+            "hourly_minute": 0,
+            "end_minus_min": 10,
+        },
+    }
+
+
+def _hk_full_day_schedule() -> dict[str, Any]:
+    return {
+        "enabled": True,
+        "timezone": "Asia/Hong_Kong",
+        "run_window": {
+            "start": "09:30",
+            "end": "16:00",
+            "breaks": [{"start": "12:00", "end": "13:00"}],
+        },
         "run_points": {
             "start_plus_min": 10,
             "hourly_minute": 0,
@@ -266,6 +284,10 @@ def test_target_wrapper_and_feature_off_are_side_effect_free(tmp_path: Path) -> 
             },
             "2026-07-21",
         )
+    with pytest.raises(ValueError, match="session break"):
+        scheduled_scan_targets_for_date(
+            _schedule(), "2026-07-21", trade_date_type="MORNING"
+        )
 
     store = _store(tmp_path)
     artifact_root = tmp_path / "artifacts"
@@ -340,6 +362,11 @@ def test_calendar_binding_is_content_addressed_and_fails_closed(
     with pytest.raises(CorpusError) as tampered:
         read_market_calendar_binding(tmp_path, market="HK")
     assert tampered.value.reason_code == "market_calendar_binding_unavailable"
+    recovered = seal_market_calendar_fixture(
+        tmp_path, days, version="hk-calendar.fixture.v2"
+    )
+    assert recovered["market_calendar_version"] == "hk-calendar.fixture.v2"
+    assert recovered["snapshot_ref"] != binding["snapshot_ref"]
 
 
 def test_calendar_refresh_publishes_compact_evidence_without_duplicate_growth(
@@ -372,6 +399,10 @@ def test_calendar_refresh_publishes_compact_evidence_without_duplicate_growth(
     )
     assert first["status"] == "published"
     assert first["binding"]["trading_dates"] == ["2026-08-03", "2026-08-04"]
+    assert first["binding"]["trading_sessions"] == [
+        {"trading_date": "2026-08-03", "trade_date_type": "WHOLE"},
+        {"trading_date": "2026-08-04", "trade_date_type": "MORNING"},
+    ]
     assert gateway.calls == [
         {"market": "HK", "start": "2026-08-03", "end": "2026-08-31"}
     ]
@@ -383,6 +414,13 @@ def test_calendar_refresh_publishes_compact_evidence_without_duplicate_growth(
     )
     assert len(files_before) == 2
     assert all("receipt" not in path.name for path in files_before)
+    snapshot = json.loads(
+        tmp_path.joinpath(*str(first["binding"]["snapshot_ref"]).split("/")).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert snapshot["trading_sessions"] == first["binding"]["trading_sessions"]
+    assert "trading_dates" not in snapshot
 
     second = refresh_market_calendar_binding(
         tmp_path,
@@ -450,25 +488,66 @@ def test_calendar_refresh_rejects_untrustworthy_source_without_writing(
     assert not (tmp_path / "strategy_lab").exists()
 
 
-def test_committed_denominator_rejects_later_schedule_drift(tmp_path: Path) -> None:
+def test_committed_denominator_honors_sessions_and_rejects_schedule_drift(
+    tmp_path: Path,
+) -> None:
     store = _store(tmp_path)
     artifact_root = tmp_path / "artifacts"
     _enable(store, artifact_root)
     days = _trading_days("2026-07-21", 20)
     binding = seal_market_calendar_fixture(
-        artifact_root, days, version="hk-calendar.fixture.v1"
+        artifact_root,
+        days,
+        version="hk-calendar.fixture.v1",
+        trade_date_types={days[0]: "MORNING", days[1]: "AFTERNOON"},
     )
     commitment = build_hidden_window_commitment(
         experiment_id="experiment-denominator",
         account="lx",
         validation_start_trading_date=days[0],
         market_calendar_binding=binding,
-        schedule=_multi_point_schedule(),
+        schedule=_hk_full_day_schedule(),
         challenger_variant_id="challenger",
         research_spec_sha256="a" * 64,
         research_terminal_file_sha256="b" * 64,
         behavior_binding_sha256="c" * 64,
     )
+    hk_tz = ZoneInfo("Asia/Hong_Kong")
+
+    def local_times(index: int) -> list[str]:
+        return [
+            datetime.fromisoformat(str(target).replace("Z", "+00:00"))
+            .astimezone(hk_tz)
+            .strftime("%H:%M")
+            for target in commitment["days"][index][
+                "scheduled_scan_targets_market"
+            ]
+        ]
+
+    assert local_times(0) == ["09:40", "10:00", "10:30", "11:00", "11:30"]
+    assert local_times(1) == [
+        "13:00",
+        "13:30",
+        "14:00",
+        "14:30",
+        "15:00",
+        "15:30",
+        "15:50",
+    ]
+    assert local_times(2) == [
+        "09:40",
+        "10:00",
+        "10:30",
+        "11:00",
+        "11:30",
+        "13:00",
+        "13:30",
+        "14:00",
+        "14:30",
+        "15:00",
+        "15:30",
+        "15:50",
+    ]
     committed_day = commitment["days"][0]
     sealed = seal_committed_day_expectation(
         store,

--- a/tests/test_strategy_lab_top1_readiness.py
+++ b/tests/test_strategy_lab_top1_readiness.py
@@ -73,6 +73,10 @@ def test_readiness_requires_every_live_capability_fact(tmp_path: Path) -> None:
             "coverage_start": "2026-08-01",
             "coverage_end": "2026-12-31",
             "trading_dates": ["2026-08-01", "2026-12-31"],
+            "trading_sessions": [
+                {"trading_date": "2026-08-01", "trade_date_type": "WHOLE"},
+                {"trading_date": "2026-12-31", "trade_date_type": "WHOLE"},
+            ],
             "snapshot_ref": "calendar.json",
             "snapshot_content_sha256": "a" * 64,
             "snapshot_file_sha256": "c" * 64,
@@ -121,7 +125,18 @@ def test_readiness_requires_every_live_capability_fact(tmp_path: Path) -> None:
         "source_delivery_blockers"
     ]
 
-    for invalid_calendar in ({}, {"market": "HK"}, {**common["calendar_binding"], "trading_dates": []}):
+    for invalid_calendar in (
+        {},
+        {"market": "HK"},
+        {**common["calendar_binding"], "trading_dates": []},
+        {
+            **common["calendar_binding"],
+            "trading_sessions": [
+                {"trading_date": "2026-08-01", "trade_date_type": "UNKNOWN"},
+                {"trading_date": "2026-12-31", "trade_date_type": "WHOLE"},
+            ],
+        },
+    ):
         blocked_calendar = build_top1_readiness(
             **{**common, "calendar_binding": invalid_calendar},
             capability_facts={name: True for name in CAPABILITY_FACTS},

--- a/tests/test_strategy_lab_top1_readiness.py
+++ b/tests/test_strategy_lab_top1_readiness.py
@@ -182,6 +182,80 @@ def test_readiness_cli_is_read_only_and_reports_uninitialized_store(
     assert not store_path.exists()
 
 
+def test_calendar_refresh_cli_requires_write_and_closes_gateway(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import src.interfaces.cli.strategy_lab_top1 as cli
+    from src.application.agent_tool_contracts import AgentToolError
+    from src.interfaces.cli.main import parse_args
+
+    profile_path = tmp_path / "service.profile.json"
+    profile_path.write_text(json.dumps(_profile(tmp_path)), encoding="utf-8")
+    command = [
+        "research",
+        "strategy-lab",
+        "top1-loop",
+        "calendar",
+        "refresh",
+        "--market",
+        "hk",
+        "--account",
+        "lx",
+        "--profile-path",
+        str(profile_path),
+        "--coverage-start",
+        "2026-08-03",
+        "--coverage-end",
+        "2026-08-31",
+        "--calendar-version",
+        "hk-calendar.opend.v1",
+    ]
+
+    def explode(**_kwargs: object) -> None:
+        raise AssertionError("missing --write must not build an OpenD gateway")
+
+    monkeypatch.setattr(cli, "build_ready_futu_quote_gateway", explode)
+    with pytest.raises(AgentToolError, match="requires --write"):
+        cli.handle_top1_command(parse_args(command))
+
+    class FakeGateway:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def get_trading_days_with_receipt(
+            self, **_kwargs: object
+        ) -> dict[str, object]:
+            return {
+                "retcode": 0,
+                "rows": [
+                    {"time": "2026-08-03", "trade_date_type": "WHOLE"},
+                    {"time": "2026-08-04", "trade_date_type": "WHOLE"},
+                ],
+                "coverage_complete": True,
+                "pagination_complete": True,
+                "page_count": 1,
+            }
+
+        def close(self) -> None:
+            self.closed = True
+
+    gateway = FakeGateway()
+    monkeypatch.setattr(
+        cli, "build_ready_futu_quote_gateway", lambda **_kwargs: gateway
+    )
+    response = cli.handle_top1_command(parse_args([*command, "--write"]))
+
+    assert response["ok"] is True
+    assert response["data"]["status"] == "published"
+    assert response["data"]["trading_date_count"] == 2
+    assert "trading_dates" not in response["data"]
+    assert gateway.closed is True
+    assert not (
+        tmp_path
+        / "runtime/output_shared/research/strategy_lab/experiments.sqlite3"
+    ).exists()
+
+
 def test_disabled_advance_migrates_store_but_loads_no_runtime_dependencies(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Add an explicit HK/lx Top1 calendar refresh command backed by the profile-bound OpenD gateway.
- Publish only a compact content-addressed snapshot plus current pointer; raw provider responses are not persisted and identical evidence creates no new files.
- Bind the existing Top1 readiness/lifecycle path to versioned calendar evidence and reuse the real producer in fixtures.

## Safety boundaries

- Refresh requires explicit --write and remains operator-triggered; the scheduled loop does not refresh the calendar.
- This PR does not call live providers, install/start services, change runtime config, send notifications, or write trade/broker state.
- It closes only the calendar blocker; all other W0R capability facts remain fail-closed and runtime_no_go.

## Verification

- 350 Top1 and service-deploy tests passed.
- 26 Futu gateway tests passed.
- Ruff passed.
- Dependency graph current: 598 production modules, 0 cycles.
- git diff --check passed.
- DeepSeek V4 Pro Ponytail review completed; two safe reductions accepted, one unsafe evidence-hash reduction rejected.