### PR TITLE
feat(strategy-lab): add W0R capability receipts

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 951 (`src`: 514, `domain`: 75, `scripts`: 9, `tests`: 353)
-- Internal import edges: 6228 total, 2654 production/script edges excluding tests
+- Python files scanned: 953 (`src`: 515, `domain`: 75, `scripts`: 9, `tests`: 354)
+- Internal import edges: 6241 total, 2662 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,25 +31,25 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|396| domain
+  application -->|398| domain
   application -->|4| domain_services
-  application -->|146| infrastructure
+  application -->|147| infrastructure
   application -->|41| storage
   domain_services -->|5| domain
   domain_services -->|2| storage
   infrastructure -->|13| application
   infrastructure -->|3| domain
-  interfaces -->|148| application
+  interfaces -->|149| application
   interfaces -->|1| domain
   interfaces -->|5| infrastructure
   scripts -->|13| application
   scripts -->|1| infrastructure
   storage -->|1| domain
-  tests -->|2648| application
+  tests -->|2651| application
   tests -->|436| domain
   tests -->|2| domain_services
   tests -->|178| infrastructure
-  tests -->|229| interfaces
+  tests -->|231| interfaces
   tests -->|15| scripts
   tests -->|18| storage
 ```
@@ -58,9 +58,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 396 |
-| interfaces | application | 148 |
-| application | infrastructure | 146 |
+| application | domain | 398 |
+| interfaces | application | 149 |
+| application | infrastructure | 147 |
 | application | storage | 41 |
 | infrastructure | application | 13 |
 | scripts | application | 13 |
@@ -77,9 +77,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2648 |
+| tests | application | 2651 |
 | tests | domain | 436 |
-| tests | interfaces | 229 |
+| tests | interfaces | 231 |
 | tests | infrastructure | 178 |
 | tests | storage | 18 |
 | tests | scripts | 15 |
@@ -91,9 +91,9 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 
 | from | to | imports |
 |---|---|---|
-| src.application | domain.domain | 209 |
-| src.interfaces | src.application | 121 |
-| src.application | src.infrastructure | 107 |
+| src.application | domain.domain | 211 |
+| src.interfaces | src.application | 122 |
+| src.application | src.infrastructure | 108 |
 | src.application.ledger | domain.domain | 49 |
 | src.application.ledger | domain.domain.ledger | 38 |
 | src.application | domain.storage | 32 |
@@ -178,7 +178,7 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | module | incoming imports |
 |---|---|
 | src.application.agent_tool_contracts | 97 |
-| domain.domain.symbol_identity | 66 |
+| domain.domain.symbol_identity | 67 |
 | src.application.agent_tool_config | 57 |
 | src.application.ledger.api | 49 |
 | src.application.payload_helpers | 47 |
@@ -186,8 +186,8 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | domain.domain.ledger.position_fields | 43 |
 | domain.domain.option_position_identity | 40 |
 | src.application.account_config | 38 |
-| src.application.shadow_replay.common | 32 |
-| domain.domain.decision_state_fingerprint | 28 |
+| src.application.shadow_replay.common | 33 |
+| domain.domain.decision_state_fingerprint | 29 |
 | domain.domain.engine | 25 |
 | src.application.settings | 23 |
 | domain.domain.trade_contract_identity | 23 |

--- a/docs/STRATEGY_LAB_DESIGN.md
+++ b/docs/STRATEGY_LAB_DESIGN.md
@@ -721,6 +721,28 @@ HK 交易日历证据由操作员显式刷新，不随 loop 自动运行：
 只保留规范化来源回执哈希。相同证据重复刷新不会新增文件。
 它只关闭 calendar blocker，不代表其余 W0R capability 已就绪。
 
+其余 W0R 回执由操作员显式刷新，不由 readiness 或 timer 自动探测：
+
+```bash
+./om research strategy-lab top1-loop capabilities refresh \
+  --market hk --account lx --profile-path <runtime>/service.profile.json \
+  --fee-plan-receipt-path <account-fee-plan-receipt.json> \
+  --stock-owner HK.00700 --contract-symbol <HK-put-contract> \
+  --terms-expiration <YYYY-MM-DD> --close-expiration <YYYY-MM-DD> --write
+```
+
+费用套餐输入固定为 `sell_put_top1_account_fee_plan_receipt.v1`，必须包含
+`HK/lx`、`commission_free`、`platform_fee`、`fee_plan_ref`、观察时间，以及原始人工
+证据的 ref/SHA-256；普通 event、position 或 CLI 标量不能代替这份回执。命令复用
+现有 gateway，依次验证 quote、exact-expiration terms、history K-Line quota 和
+exact-expiration close，只把规范化标量与来源 hash 写入
+`strategy_lab/top1/capabilities/w0r/hk/lx/current.json`。该文件最多 8 KiB，每次成功
+刷新原子替换，不保存 raw snapshot、option chain、quota detail 或历史回执序列。
+
+readiness 只读并严格校验该文件；文件缺失、篡改、OpenD host/port 漂移或任一子回执
+无效时，五项 capability fact 全部保持 false。真实预检调用与刷新写入仍需要单独的
+操作授权。该回执只证明最近一次显式预检通过，不替代实验执行时的 gateway 与配额检查。
+
 定时 source delivery 必须显式提供 cadence、timeout 和 env file：
 
 ```bash

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,7 +1,7 @@
 flowchart LR
-  src_application["src.application"] -->|209| domain_domain["domain.domain"]
-  src_interfaces["src.interfaces"] -->|121| src_application["src.application"]
-  src_application["src.application"] -->|107| src_infrastructure["src.infrastructure"]
+  src_application["src.application"] -->|211| domain_domain["domain.domain"]
+  src_interfaces["src.interfaces"] -->|122| src_application["src.application"]
+  src_application["src.application"] -->|108| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|49| domain_domain["domain.domain"]
   src_application_ledger["src.application.ledger"] -->|38| domain_domain_ledger["domain.domain.ledger"]
   src_application["src.application"] -->|32| domain_storage["domain.storage"]

--- a/src/application/strategy_lab/top1/capability_receipts.py
+++ b/src/application/strategy_lab/top1/capability_receipts.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from datetime import date
+from pathlib import Path
+from typing import Any, NoReturn
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.symbol_identity import OPTION_CODE_RE, resolve_symbol_identity
+from src.application.candidate_snapshot_contract import (
+    CandidateSnapshotContractError,
+    utc_timestamp,
+)
+from src.application.shadow_replay.common import render_json_text
+from src.application.strategy_lab.top1.fill_observation import (
+    _price,
+    _snapshot_by_code,
+)
+from src.application.strategy_lab.top1.readiness import CAPABILITY_FACTS
+from src.infrastructure.private_storage import (
+    atomic_write_private_text,
+    open_private_text,
+    private_path,
+)
+
+
+ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA = "sell_put_top1_account_fee_plan_receipt.v1"
+CAPABILITY_RECEIPT_SCHEMA = "sell_put_top1_w0r_capability_receipt.v1"
+MAX_CAPABILITY_RECEIPT_BYTES = 8 * 1024
+
+_FEE_PLAN_FIELDS = frozenset(
+    {
+        "schema_version",
+        "market",
+        "account",
+        "commission_free",
+        "platform_fee",
+        "fee_plan_ref",
+        "observed_at_utc",
+        "evidence_ref",
+        "evidence_sha256",
+    }
+)
+_RECORDED_FEE_PLAN_FIELDS = _FEE_PLAN_FIELDS | {"source_receipt_sha256"}
+_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "market",
+        "account",
+        "observed_at_utc",
+        "opend_binding",
+        *CAPABILITY_FACTS,
+        "content_sha256",
+    }
+)
+_TERMS_FIELDS = frozenset(
+    {
+        "contract_symbol",
+        "stock_owner",
+        "expiration",
+        "option_type",
+        "option_standard_type",
+        "strike",
+        "multiplier",
+        "currency",
+    }
+)
+_HASH = frozenset("0123456789abcdef")
+
+
+class Top1CapabilityReceiptError(ValueError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _fail(reason_code: str, message: str) -> NoReturn:
+    raise Top1CapabilityReceiptError(reason_code, message)
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("top1_capability_input_invalid", f"{label} must be canonical text")
+    return value
+
+
+def _sha256(value: object, label: str) -> str:
+    text = _text(value, label)
+    if len(text) != 64 or set(text) - _HASH:
+        _fail("top1_capability_input_invalid", f"{label} must be a lowercase SHA-256")
+    return text
+
+
+def _timestamp(value: object, label: str) -> str:
+    try:
+        normalized = utc_timestamp(value, label)
+    except CandidateSnapshotContractError as exc:
+        raise Top1CapabilityReceiptError("top1_capability_input_invalid", str(exc)) from exc
+    if value != normalized:
+        _fail("top1_capability_input_invalid", f"{label} must be canonical UTC")
+    return normalized
+
+
+def _expiration(value: object, label: str) -> str:
+    text = _text(value, label)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as exc:
+        raise Top1CapabilityReceiptError("top1_capability_input_invalid", f"{label} must use YYYY-MM-DD") from exc
+    if parsed.isoformat() != text:
+        _fail("top1_capability_input_invalid", f"{label} must use YYYY-MM-DD")
+    return text
+
+
+def _nonnegative_number(value: object, label: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) < 0
+    ):
+        _fail("top1_capability_input_invalid", f"{label} must be non-negative")
+    return float(value)
+
+
+def _positive_number(value: object, label: str) -> float:
+    result = _nonnegative_number(value, label)
+    if result <= 0:
+        _fail("top1_capability_input_invalid", f"{label} must be positive")
+    return result
+
+
+def _identity(market: object, account: object) -> tuple[str, str]:
+    if market != "HK" or account != "lx":
+        _fail("top1_capability_input_invalid", "capability identity must equal HK/lx")
+    return "HK", "lx"
+
+
+def _opend_binding(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping) or set(value) != {"host", "port"}:
+        _fail("top1_capability_input_invalid", "OpenD binding is invalid")
+    host = _text(value["host"], "opend_binding.host")
+    port = value["port"]
+    if type(port) is not int or not 0 < port <= 65535:
+        _fail("top1_capability_input_invalid", "opend_binding.port is invalid")
+    return {"host": host, "port": port}
+
+
+def _fee_plan_receipt(value: object, *, recorded: bool) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        _fail("top1_capability_input_invalid", "account fee-plan receipt must be an object")
+    item = dict(value)
+    expected = _RECORDED_FEE_PLAN_FIELDS if recorded else _FEE_PLAN_FIELDS
+    if set(item) != expected or item.get("schema_version") != ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA:
+        _fail("top1_capability_input_invalid", "account fee-plan receipt schema is invalid")
+    _identity(item.get("market"), item.get("account"))
+    if type(item.get("commission_free")) is not bool:
+        _fail("top1_capability_input_invalid", "commission_free must be boolean")
+    normalized: dict[str, object] = {
+        "schema_version": ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA,
+        "market": "HK",
+        "account": "lx",
+        "commission_free": item["commission_free"],
+        "platform_fee": _nonnegative_number(item.get("platform_fee"), "platform_fee"),
+        "fee_plan_ref": _text(item.get("fee_plan_ref"), "fee_plan_ref"),
+        "observed_at_utc": _timestamp(item.get("observed_at_utc"), "observed_at_utc"),
+        "evidence_ref": _text(item.get("evidence_ref"), "evidence_ref"),
+        "evidence_sha256": _sha256(item.get("evidence_sha256"), "evidence_sha256"),
+    }
+    source_hash = canonical_sha256(normalized)
+    if recorded and _sha256(item.get("source_receipt_sha256"), "source_receipt_sha256") != source_hash:
+        _fail("top1_capability_input_invalid", "account fee-plan receipt hash changed")
+    return {**normalized, "source_receipt_sha256": source_hash}
+
+
+def load_account_fee_plan_receipt(path: str | Path) -> dict[str, object]:
+    try:
+        with open_private_text(private_path(path)) as handle:
+            content = handle.read(MAX_CAPABILITY_RECEIPT_BYTES + 1)
+        if len(content.encode("utf-8")) > MAX_CAPABILITY_RECEIPT_BYTES:
+            raise ValueError("account fee-plan receipt is too large")
+        payload = json.loads(content)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise Top1CapabilityReceiptError(
+            "account_fee_plan_receipt_unavailable",
+            "account fee-plan receipt cannot be read",
+        ) from exc
+    return _fee_plan_receipt(payload, recorded=False)
+
+
+def _capability_ref(market: str, account: str) -> str:
+    return f"strategy_lab/top1/capabilities/w0r/{market.lower()}/{account}/current.json"
+
+
+def _provider_receipts(
+    gateway: Any,
+    *,
+    stock_owner: str,
+    contract_symbol: str,
+    terms_expiration: str,
+    close_expiration: str,
+) -> dict[str, object]:
+    try:
+        rows, reason = _snapshot_by_code(gateway.get_snapshot([contract_symbol]), [contract_symbol])
+    except Exception as exc:
+        raise Top1CapabilityReceiptError(
+            "quote_observation_receipt_unavailable",
+            "quote observation capability probe failed",
+        ) from exc
+    quote = rows.get(contract_symbol)
+    bid = _price(quote.get("bid_price", quote.get("bid"))) if quote else None
+    ask = _price(quote.get("ask_price", quote.get("ask"))) if quote else None
+    if reason is not None or bid is None or bid < 0 or ask is None or ask <= 0 or ask < bid:
+        _fail(
+            "quote_observation_receipt_unavailable",
+            "quote observation capability receipt is invalid",
+        )
+
+    try:
+        terms_raw = gateway.get_exact_expiration_option_terms(
+            code=stock_owner,
+            expiration=terms_expiration,
+            contract_symbol=contract_symbol,
+        )
+    except Exception as exc:
+        raise Top1CapabilityReceiptError(
+            "exact_expiration_terms_receipt_unavailable",
+            "exact-expiration terms capability probe failed",
+        ) from exc
+    if not isinstance(terms_raw, Mapping):
+        _fail(
+            "exact_expiration_terms_receipt_unavailable",
+            "exact-expiration terms capability receipt is invalid",
+        )
+    terms = dict(terms_raw)
+
+    try:
+        quota_raw = gateway.get_history_kl_quota()
+    except Exception as exc:
+        raise Top1CapabilityReceiptError(
+            "history_kline_quota_receipt_unavailable",
+            "history K-line quota capability probe failed",
+        ) from exc
+    if not isinstance(quota_raw, Mapping):
+        _fail(
+            "history_kline_quota_receipt_unavailable",
+            "history K-line quota capability receipt is invalid",
+        )
+    used = quota_raw.get("used_quota")
+    remaining = quota_raw.get("remain_quota")
+    details = quota_raw.get("detail_list")
+    if not isinstance(details, list):
+        _fail(
+            "history_kline_quota_receipt_unavailable",
+            "history K-line quota capability facts are invalid",
+        )
+
+    try:
+        close_raw = gateway.get_exact_expiration_close(
+            code=stock_owner,
+            expiration=close_expiration,
+        )
+    except Exception as exc:
+        raise Top1CapabilityReceiptError(
+            "exact_expiration_close_receipt_unavailable",
+            "exact-expiration close capability probe failed",
+        ) from exc
+    if not isinstance(close_raw, Mapping):
+        _fail(
+            "exact_expiration_close_receipt_unavailable",
+            "exact-expiration close capability receipt is invalid",
+        )
+
+    return {
+        "quote_observation_receipt": {
+            "contract_symbol": contract_symbol,
+            "bid": bid,
+            "ask": ask,
+        },
+        "exact_expiration_terms_receipt": terms,
+        "history_kline_quota_receipt": {
+            "used_quota": used,
+            "remain_quota": remaining,
+            "detail_count": len(details),
+            "detail_sha256": canonical_sha256(details),
+        },
+        "exact_expiration_close_receipt": {key: close_raw.get(key) for key in ("code", "expiration", "close")},
+    }
+
+
+def refresh_top1_capability_receipt(
+    artifact_root: str | Path,
+    *,
+    gateway: Any,
+    market: str,
+    account: str,
+    opend_binding: Mapping[str, object],
+    account_fee_plan_receipt: Mapping[str, object],
+    stock_owner: str,
+    contract_symbol: str,
+    terms_expiration: str,
+    close_expiration: str,
+    observed_at_utc: str,
+) -> dict[str, object]:
+    """Run one explicit compact W0R probe and replace only its current receipt."""
+
+    market, account = _identity(market, account)
+    binding = _opend_binding(opend_binding)
+    fee_plan = _fee_plan_receipt(account_fee_plan_receipt, recorded=True)
+    observed_at = _timestamp(observed_at_utc, "observed_at_utc")
+    owner_identity = resolve_symbol_identity(stock_owner)
+    if (
+        owner_identity is None
+        or owner_identity.market != "HK"
+        or owner_identity.futu_code != str(stock_owner).strip().upper()
+    ):
+        _fail("top1_capability_input_invalid", "stock_owner must be a canonical HK Futu code")
+    owner = owner_identity.futu_code
+    contract = str(contract_symbol).strip().upper()
+    match = OPTION_CODE_RE.fullmatch(contract)
+    if match is None or match.group("market") != "HK" or match.group("cp") != "P":
+        _fail("top1_capability_input_invalid", "contract_symbol must be a canonical HK PUT code")
+    terms_date = _expiration(terms_expiration, "terms_expiration")
+    close_date = _expiration(close_expiration, "close_expiration")
+    receipts = _provider_receipts(
+        gateway,
+        stock_owner=owner,
+        contract_symbol=contract,
+        terms_expiration=terms_date,
+        close_expiration=close_date,
+    )
+    payload: dict[str, object] = {
+        "schema_version": CAPABILITY_RECEIPT_SCHEMA,
+        "market": market,
+        "account": account,
+        "observed_at_utc": observed_at,
+        "opend_binding": binding,
+        "account_fee_plan_receipt": fee_plan,
+        **receipts,
+    }
+    try:
+        _validate_recorded_provider_receipts(payload)
+    except ValueError as exc:
+        raise Top1CapabilityReceiptError(
+            "top1_capability_receipt_conflict",
+            "provider capability receipt is invalid",
+        ) from exc
+    payload["content_sha256"] = canonical_sha256(payload)
+    content = render_json_text(payload)
+    if len(content.encode("utf-8")) > MAX_CAPABILITY_RECEIPT_BYTES:
+        _fail("top1_capability_receipt_conflict", "capability receipt exceeds 8 KiB")
+    ref = _capability_ref(market, account)
+    target = private_path(artifact_root).joinpath(*ref.split("/"))
+    try:
+        # ponytail: refresh is operator-serialized; add an account lock only if concurrent refresh is supported.
+        atomic_write_private_text(target, content)
+        return read_top1_capability_receipt(
+            artifact_root,
+            market=market,
+            account=account,
+            expected_opend_binding=binding,
+        )
+    except (OSError, ValueError) as exc:
+        raise Top1CapabilityReceiptError(
+            "top1_capability_receipt_conflict",
+            "capability receipt cannot be published",
+        ) from exc
+
+
+def read_top1_capability_receipt(
+    artifact_root: str | Path,
+    *,
+    market: str,
+    account: str,
+    expected_opend_binding: Mapping[str, object],
+) -> dict[str, object]:
+    """Read and verify the current receipt without probing a provider."""
+
+    market, account = _identity(market, account)
+    expected_binding = _opend_binding(expected_opend_binding)
+    ref = _capability_ref(market, account)
+    path = private_path(artifact_root).joinpath(*ref.split("/"))
+    try:
+        with open_private_text(path) as handle:
+            content = handle.read(MAX_CAPABILITY_RECEIPT_BYTES + 1)
+        if len(content.encode("utf-8")) > MAX_CAPABILITY_RECEIPT_BYTES:
+            raise ValueError("receipt is too large")
+        payload = json.loads(content)
+        if not isinstance(payload, dict) or content != render_json_text(payload):
+            raise ValueError("receipt bytes are not canonical")
+        if set(payload) != _RECEIPT_FIELDS:
+            raise ValueError("receipt fields are invalid")
+        if payload.get("schema_version") != CAPABILITY_RECEIPT_SCHEMA:
+            raise ValueError("receipt schema is invalid")
+        _identity(payload.get("market"), payload.get("account"))
+        _timestamp(payload.get("observed_at_utc"), "observed_at_utc")
+        if _opend_binding(payload.get("opend_binding")) != expected_binding:
+            raise ValueError("OpenD binding changed")
+        _fee_plan_receipt(payload.get("account_fee_plan_receipt"), recorded=True)
+        expected_hash = canonical_sha256({key: value for key, value in payload.items() if key != "content_sha256"})
+        if _sha256(payload.get("content_sha256"), "content_sha256") != expected_hash:
+            raise ValueError("receipt content hash changed")
+        validated = _validate_recorded_provider_receipts(payload)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise Top1CapabilityReceiptError(
+            "top1_capability_receipt_unavailable",
+            "current capability receipt is unavailable or invalid",
+        ) from exc
+    return {
+        **validated,
+        "receipt_ref": ref,
+        "receipt_file_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    }
+
+
+def _validate_recorded_provider_receipts(payload: Mapping[str, object]) -> dict[str, object]:
+    quote = payload.get("quote_observation_receipt")
+    terms = payload.get("exact_expiration_terms_receipt")
+    quota = payload.get("history_kline_quota_receipt")
+    close = payload.get("exact_expiration_close_receipt")
+    if not isinstance(quote, Mapping) or set(quote) != {"contract_symbol", "bid", "ask"}:
+        raise ValueError("quote receipt is invalid")
+    contract = _text(quote.get("contract_symbol"), "contract_symbol")
+    match = OPTION_CODE_RE.fullmatch(contract)
+    if match is None or match.group("market") != "HK" or match.group("cp") != "P":
+        raise ValueError("quote contract is invalid")
+    bid = _nonnegative_number(quote.get("bid"), "bid")
+    ask = _positive_number(quote.get("ask"), "ask")
+    if ask < bid:
+        raise ValueError("quote spread is invalid")
+    if not isinstance(terms, Mapping) or set(terms) != _TERMS_FIELDS:
+        raise ValueError("terms receipt is invalid")
+    if terms.get("contract_symbol") != contract:
+        raise ValueError("terms contract changed")
+    owner = resolve_symbol_identity(terms.get("stock_owner"))
+    if owner is None or owner.market != "HK" or owner.futu_code != terms.get("stock_owner"):
+        raise ValueError("terms stock owner is invalid")
+    _expiration(terms.get("expiration"), "terms.expiration")
+    _positive_number(terms.get("strike"), "terms.strike")
+    if (
+        terms.get("option_type") != "PUT"
+        or terms.get("option_standard_type") != "STANDARD"
+        or type(terms.get("multiplier")) is not int
+        or int(terms["multiplier"]) <= 0
+        or terms.get("currency") != "HKD"
+    ):
+        raise ValueError("terms facts are invalid")
+    if not isinstance(quota, Mapping) or set(quota) != {
+        "used_quota",
+        "remain_quota",
+        "detail_count",
+        "detail_sha256",
+    }:
+        raise ValueError("quota receipt is invalid")
+    if (
+        type(quota.get("used_quota")) is not int
+        or int(quota["used_quota"]) < 0
+        or type(quota.get("remain_quota")) is not int
+        or int(quota["remain_quota"]) < 0
+        or quota.get("detail_count") != quota.get("used_quota")
+    ):
+        raise ValueError("quota facts are invalid")
+    _sha256(quota.get("detail_sha256"), "detail_sha256")
+    if not isinstance(close, Mapping) or set(close) != {"code", "expiration", "close"}:
+        raise ValueError("close receipt is invalid")
+    if close.get("code") != terms.get("stock_owner"):
+        raise ValueError("close owner changed")
+    _expiration(close.get("expiration"), "close.expiration")
+    _positive_number(close.get("close"), "close")
+    return dict(payload)
+
+
+def capability_facts_from_receipt(receipt: Mapping[str, object]) -> dict[str, bool]:
+    return {name: isinstance(receipt.get(name), Mapping) for name in CAPABILITY_FACTS}
+
+
+__all__ = [
+    "ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA",
+    "CAPABILITY_FACTS",
+    "CAPABILITY_RECEIPT_SCHEMA",
+    "MAX_CAPABILITY_RECEIPT_BYTES",
+    "Top1CapabilityReceiptError",
+    "capability_facts_from_receipt",
+    "load_account_fee_plan_receipt",
+    "read_top1_capability_receipt",
+    "refresh_top1_capability_receipt",
+]

--- a/src/interfaces/cli/strategy_lab_top1.py
+++ b/src/interfaces/cli/strategy_lab_top1.py
@@ -12,6 +12,13 @@ from src.application.agent_tool_contracts import AgentToolError, build_response
 from src.application.service_deploy import load_service_profile, service_status_from_profile
 from src.application.service_drift import service_drift
 from src.application.strategy_lab.top1.advance import ADVANCE_REVISION, advance_scheduled
+from src.application.strategy_lab.top1.capability_receipts import (
+    Top1CapabilityReceiptError,
+    capability_facts_from_receipt,
+    load_account_fee_plan_receipt,
+    read_top1_capability_receipt,
+    refresh_top1_capability_receipt,
+)
 from src.application.strategy_lab.top1.corpus import (
     CorpusError,
     read_corpus_status,
@@ -22,7 +29,10 @@ from src.application.strategy_lab.top1.lifecycle import (
     effective_feature_status,
     read_public_status,
 )
-from src.application.strategy_lab.top1.readiness import build_top1_readiness
+from src.application.strategy_lab.top1.readiness import (
+    CAPABILITY_FACTS,
+    build_top1_readiness,
+)
 from src.infrastructure.futu_gateway import (
     FutuGatewayError,
     build_ready_futu_quote_gateway,
@@ -68,6 +78,21 @@ def add_top1_commands(strategy_lab_subparsers: Any) -> None:
     calendar_refresh.add_argument("--coverage-end", required=True)
     calendar_refresh.add_argument("--calendar-version", required=True)
     calendar_refresh.add_argument("--write", action="store_true")
+
+    capabilities = commands.add_parser(
+        "capabilities", help="manage compact W0R capability evidence"
+    )
+    capability_commands = capabilities.add_subparsers(required=True)
+    capability_refresh = capability_commands.add_parser(
+        "refresh", help="run one explicit W0R provider probe"
+    )
+    _add_identity(capability_refresh)
+    capability_refresh.add_argument("--fee-plan-receipt-path", required=True)
+    capability_refresh.add_argument("--stock-owner", required=True)
+    capability_refresh.add_argument("--contract-symbol", required=True)
+    capability_refresh.add_argument("--terms-expiration", required=True)
+    capability_refresh.add_argument("--close-expiration", required=True)
+    capability_refresh.add_argument("--write", action="store_true")
 
     feature = commands.add_parser("feature", help="inspect the experimental feature gate")
     feature_commands = feature.add_subparsers(
@@ -216,6 +241,18 @@ def _readiness(context: Mapping[str, Any], store: ExperimentStore) -> dict[str, 
         errors.append(
             {"reason_code": "market_calendar_binding_unavailable", "message": str(exc)}
         )
+    capability_receipt: dict[str, object] | None = None
+    binding = context["top1"].get("opend_binding")
+    if isinstance(binding, Mapping):
+        try:
+            capability_receipt = read_top1_capability_receipt(
+                context["artifact_root"],
+                market="HK",
+                account="lx",
+                expected_opend_binding=binding,
+            )
+        except Top1CapabilityReceiptError as exc:
+            errors.append({"reason_code": exc.reason_code, "message": str(exc)})
     result = build_top1_readiness(
         profile=profile,
         drift=drift,
@@ -224,6 +261,24 @@ def _readiness(context: Mapping[str, Any], store: ExperimentStore) -> dict[str, 
         feature_status=feature,
         corpus_status=corpus,
         calendar_binding=calendar,
+        capability_facts=(
+            capability_facts_from_receipt(capability_receipt)
+            if capability_receipt is not None
+            else None
+        ),
+    )
+    result["facts"]["capability_receipt"] = (
+        {
+            key: capability_receipt[key]
+            for key in (
+                "observed_at_utc",
+                "receipt_ref",
+                "content_sha256",
+                "receipt_file_sha256",
+            )
+        }
+        if capability_receipt is not None
+        else None
     )
     if errors:
         result["fact_errors"] = errors
@@ -245,7 +300,9 @@ def _store_not_ready(tool_name: str, store: ExperimentStore) -> dict[str, Any]:
 
 def handle_top1_command(args: argparse.Namespace) -> dict[str, Any]:
     command = args.top1_loop_command
-    context = _profile_context(args, require_top1=command in {"advance", "calendar"})
+    context = _profile_context(
+        args, require_top1=command in {"advance", "calendar", "capabilities"}
+    )
 
     if command == "calendar":
         if not args.write:
@@ -304,6 +361,64 @@ def handle_top1_command(args: argparse.Namespace) -> dict[str, Any]:
                 "snapshot_file_sha256": calendar_binding[
                     "snapshot_file_sha256"
                 ],
+            },
+        )
+
+    if command == "capabilities":
+        if not args.write:
+            raise AgentToolError(
+                code="INPUT_ERROR", message="Top1 capability refresh requires --write"
+            )
+        try:
+            fee_plan = load_account_fee_plan_receipt(
+                Path(args.fee_plan_receipt_path).expanduser()
+            )
+        except Top1CapabilityReceiptError as exc:
+            raise AgentToolError(code=exc.reason_code, message=str(exc)) from exc
+        top1 = context["top1"]
+        binding = top1["opend_binding"]
+        gateway = None
+        try:
+            gateway = build_ready_futu_quote_gateway(
+                host=str(binding["host"]),
+                port=int(binding["port"]),
+                is_option_chain_cache_enabled=False,
+            )
+            receipt = refresh_top1_capability_receipt(
+                context["artifact_root"],
+                gateway=gateway,
+                market=args.market.upper(),
+                account=args.account,
+                opend_binding=binding,
+                account_fee_plan_receipt=fee_plan,
+                stock_owner=args.stock_owner,
+                contract_symbol=args.contract_symbol,
+                terms_expiration=args.terms_expiration,
+                close_expiration=args.close_expiration,
+                observed_at_utc=datetime.now(timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+            )
+        except (Top1CapabilityReceiptError, FutuGatewayError) as exc:
+            raise AgentToolError(
+                code=str(getattr(exc, "reason_code", getattr(exc, "code", "ERROR"))),
+                message=str(exc),
+            ) from exc
+        finally:
+            if gateway is not None:
+                gateway.close()
+        return build_response(
+            tool_name="research.strategy-lab.top1-loop.capabilities.refresh",
+            ok=True,
+            data={
+                "status": "published",
+                "market": receipt["market"],
+                "account": receipt["account"],
+                "observed_at_utc": receipt["observed_at_utc"],
+                "receipt_ref": receipt["receipt_ref"],
+                "receipt_content_sha256": receipt["content_sha256"],
+                "receipt_file_sha256": receipt["receipt_file_sha256"],
+                "capabilities": capability_facts_from_receipt(receipt),
             },
         )
 

--- a/tests/test_strategy_lab_top1_capability_receipts.py
+++ b/tests/test_strategy_lab_top1_capability_receipts.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.application.strategy_lab.top1.capability_receipts import (
+    ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA,
+    CAPABILITY_FACTS,
+    MAX_CAPABILITY_RECEIPT_BYTES,
+    Top1CapabilityReceiptError,
+    capability_facts_from_receipt,
+    load_account_fee_plan_receipt,
+    read_top1_capability_receipt,
+    refresh_top1_capability_receipt,
+)
+
+
+CONTRACT = "HK.00700260828P00400000"
+BINDING = {"host": "127.0.0.1", "port": 11111}
+
+
+class FakeGateway:
+    def __init__(self) -> None:
+        self.fail_terms = False
+
+    def get_snapshot(self, codes: list[str]) -> list[dict[str, object]]:
+        return [{"code": codes[0], "bid_price": 1.2, "ask_price": 1.3}]
+
+    def get_exact_expiration_option_terms(self, **_kwargs: object) -> dict[str, object] | None:
+        if self.fail_terms:
+            return None
+        return {
+            "contract_symbol": CONTRACT,
+            "stock_owner": "HK.00700",
+            "expiration": "2026-08-28",
+            "option_type": "PUT",
+            "option_standard_type": "STANDARD",
+            "strike": 400.0,
+            "multiplier": 100,
+            "currency": "HKD",
+        }
+
+    def get_history_kl_quota(self) -> dict[str, object]:
+        return {
+            "used_quota": 1,
+            "remain_quota": 99,
+            "detail_list": [
+                {
+                    "code": "HK.00700",
+                    "request_time": "2026-08-15 09:31:00",
+                }
+            ],
+        }
+
+    def get_exact_expiration_close(self, **_kwargs: object) -> dict[str, object]:
+        return {
+            "code": "HK.00700",
+            "expiration": "2026-08-14",
+            "close": 600.0,
+        }
+
+
+def _fee_plan_payload() -> dict[str, object]:
+    return {
+        "schema_version": ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA,
+        "market": "HK",
+        "account": "lx",
+        "commission_free": True,
+        "platform_fee": 15.0,
+        "fee_plan_ref": "futu-hk-plan.v1",
+        "observed_at_utc": "2026-08-16T01:00:00Z",
+        "evidence_ref": "operator://futu/lx/fee-plan/2026-08-16",
+        "evidence_sha256": "a" * 64,
+    }
+
+
+def _fee_plan(tmp_path: Path) -> dict[str, object]:
+    path = tmp_path / "fee-plan.json"
+    path.write_text(json.dumps(_fee_plan_payload()), encoding="utf-8")
+    return load_account_fee_plan_receipt(path)
+
+
+def _refresh(tmp_path: Path, gateway: Any, observed_at_utc: str) -> dict[str, object]:
+    return refresh_top1_capability_receipt(
+        tmp_path,
+        gateway=gateway,
+        market="HK",
+        account="lx",
+        opend_binding=BINDING,
+        account_fee_plan_receipt=_fee_plan(tmp_path),
+        stock_owner="HK.00700",
+        contract_symbol=CONTRACT,
+        terms_expiration="2026-08-28",
+        close_expiration="2026-08-14",
+        observed_at_utc=observed_at_utc,
+    )
+
+
+def test_refresh_publishes_one_compact_receipt_and_readiness_facts(tmp_path: Path) -> None:
+    first = _refresh(tmp_path, FakeGateway(), "2026-08-16T02:00:00Z")
+
+    receipt_path = tmp_path.joinpath(*str(first["receipt_ref"]).split("/"))
+    assert receipt_path.stat().st_size <= MAX_CAPABILITY_RECEIPT_BYTES
+    assert capability_facts_from_receipt(first) == {name: True for name in CAPABILITY_FACTS}
+    assert "request_time" not in receipt_path.read_text(encoding="utf-8")
+
+    second = _refresh(tmp_path, FakeGateway(), "2026-08-16T03:00:00Z")
+    assert second["receipt_ref"] == first["receipt_ref"]
+    assert second["receipt_file_sha256"] != first["receipt_file_sha256"]
+    assert list(receipt_path.parent.glob("*.json")) == [receipt_path]
+    assert (
+        read_top1_capability_receipt(
+            tmp_path,
+            market="HK",
+            account="lx",
+            expected_opend_binding=BINDING,
+        )
+        == second
+    )
+
+
+def test_receipt_fails_closed_for_provider_failure_binding_drift_and_tamper(
+    tmp_path: Path,
+) -> None:
+    gateway = FakeGateway()
+    gateway.fail_terms = True
+    with pytest.raises(Top1CapabilityReceiptError) as failed:
+        _refresh(tmp_path, gateway, "2026-08-16T02:00:00Z")
+    assert failed.value.reason_code == "exact_expiration_terms_receipt_unavailable"
+    assert not (tmp_path / "strategy_lab").exists()
+
+    receipt = _refresh(tmp_path, FakeGateway(), "2026-08-16T02:00:00Z")
+    with pytest.raises(Top1CapabilityReceiptError) as drifted:
+        read_top1_capability_receipt(
+            tmp_path,
+            market="HK",
+            account="lx",
+            expected_opend_binding={"host": "127.0.0.1", "port": 22222},
+        )
+    assert drifted.value.reason_code == "top1_capability_receipt_unavailable"
+
+    receipt_path = tmp_path.joinpath(*str(receipt["receipt_ref"]).split("/"))
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    payload["quote_observation_receipt"]["ask"] = 0
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(Top1CapabilityReceiptError) as tampered:
+        read_top1_capability_receipt(
+            tmp_path,
+            market="HK",
+            account="lx",
+            expected_opend_binding=BINDING,
+        )
+    assert tampered.value.reason_code == "top1_capability_receipt_unavailable"
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"commission_free": 1},
+        {"platform_fee": -1},
+        {"fee_plan_ref": ""},
+        {"evidence_sha256": "bad"},
+    ],
+)
+def test_fee_plan_receipt_requires_auditable_exact_facts(tmp_path: Path, change: dict[str, object]) -> None:
+    payload = {**_fee_plan_payload(), **change}
+    path = tmp_path / "fee-plan.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(Top1CapabilityReceiptError):
+        load_account_fee_plan_receipt(path)

--- a/tests/test_strategy_lab_top1_readiness.py
+++ b/tests/test_strategy_lab_top1_readiness.py
@@ -271,6 +271,152 @@ def test_calendar_refresh_cli_requires_write_and_closes_gateway(
     ).exists()
 
 
+def test_capability_refresh_cli_requires_write_and_readiness_only_reads_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import src.interfaces.cli.strategy_lab_top1 as cli
+    from src.application.agent_tool_contracts import AgentToolError
+    from src.application.strategy_lab.top1.capability_receipts import (
+        ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA,
+    )
+    from src.interfaces.cli.main import parse_args
+
+    profile_path = tmp_path / "service.profile.json"
+    profile_path.write_text(json.dumps(_profile(tmp_path)), encoding="utf-8")
+    fee_plan_path = tmp_path / "fee-plan.json"
+    fee_plan_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ACCOUNT_FEE_PLAN_RECEIPT_SCHEMA,
+                "market": "HK",
+                "account": "lx",
+                "commission_free": True,
+                "platform_fee": 15.0,
+                "fee_plan_ref": "futu-hk-plan.v1",
+                "observed_at_utc": "2026-08-16T01:00:00Z",
+                "evidence_ref": "operator://futu/lx/fee-plan/2026-08-16",
+                "evidence_sha256": "a" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+    command = [
+        "research",
+        "strategy-lab",
+        "top1-loop",
+        "capabilities",
+        "refresh",
+        "--market",
+        "hk",
+        "--account",
+        "lx",
+        "--profile-path",
+        str(profile_path),
+        "--fee-plan-receipt-path",
+        str(fee_plan_path),
+        "--stock-owner",
+        "HK.00700",
+        "--contract-symbol",
+        "HK.00700260828P00400000",
+        "--terms-expiration",
+        "2026-08-28",
+        "--close-expiration",
+        "2026-08-14",
+    ]
+
+    def explode(**_kwargs: object) -> None:
+        raise AssertionError("missing --write or readiness must not build a gateway")
+
+    monkeypatch.setattr(cli, "build_ready_futu_quote_gateway", explode)
+    with pytest.raises(AgentToolError, match="requires --write"):
+        cli.handle_top1_command(parse_args(command))
+
+    fee_plan_link = tmp_path / "fee-plan-link.json"
+    fee_plan_link.symlink_to(fee_plan_path)
+    linked_command = list(command)
+    linked_command[linked_command.index("--fee-plan-receipt-path") + 1] = str(
+        fee_plan_link
+    )
+    with pytest.raises(AgentToolError, match="cannot be read"):
+        cli.handle_top1_command(parse_args([*linked_command, "--write"]))
+
+    class FakeGateway:
+        closed = False
+
+        def get_snapshot(self, codes: list[str]) -> list[dict[str, object]]:
+            return [{"code": codes[0], "bid_price": 1.2, "ask_price": 1.3}]
+
+        def get_exact_expiration_option_terms(
+            self, **_kwargs: object
+        ) -> dict[str, object]:
+            return {
+                "contract_symbol": "HK.00700260828P00400000",
+                "stock_owner": "HK.00700",
+                "expiration": "2026-08-28",
+                "option_type": "PUT",
+                "option_standard_type": "STANDARD",
+                "strike": 400.0,
+                "multiplier": 100,
+                "currency": "HKD",
+            }
+
+        def get_history_kl_quota(self) -> dict[str, object]:
+            return {"used_quota": 0, "remain_quota": 100, "detail_list": []}
+
+        def get_exact_expiration_close(self, **_kwargs: object) -> dict[str, object]:
+            return {
+                "code": "HK.00700",
+                "expiration": "2026-08-14",
+                "close": 600.0,
+            }
+
+        def close(self) -> None:
+            self.closed = True
+
+    gateway = FakeGateway()
+    monkeypatch.setattr(
+        cli, "build_ready_futu_quote_gateway", lambda **_kwargs: gateway
+    )
+    refreshed = cli.handle_top1_command(parse_args([*command, "--write"]))
+    assert refreshed["ok"] is True
+    assert refreshed["data"]["capabilities"] == {
+        name: True for name in CAPABILITY_FACTS
+    }
+    assert gateway.closed is True
+
+    drift, status = _source_facts()
+    monkeypatch.setattr(cli, "service_drift", lambda **_kwargs: drift)
+    monkeypatch.setattr(
+        cli, "service_status_from_profile", lambda *_args, **_kwargs: status
+    )
+    monkeypatch.setattr(
+        cli,
+        "read_market_calendar_binding",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("missing")),
+    )
+    monkeypatch.setattr(cli, "build_ready_futu_quote_gateway", explode)
+    readiness = cli.handle_top1_command(
+        parse_args(
+            [
+                "research",
+                "strategy-lab",
+                "top1-loop",
+                "readiness",
+                "--market",
+                "hk",
+                "--account",
+                "lx",
+                "--profile-path",
+                str(profile_path),
+            ]
+        )
+    )
+    assert readiness["data"]["facts"]["capabilities"] == {
+        name: True for name in CAPABILITY_FACTS
+    }
+    assert readiness["data"]["facts"]["capability_receipt"] is not None
+
+
 def test_disabled_advance_migrates_store_but_loads_no_runtime_dependencies(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- add an explicit HK/lx W0R capability refresh command
- validate and atomically replace one compact private capability receipt
- make Top1 readiness consume receipt evidence without probing OpenD

## Safety

- requires explicit `--write`
- stores no raw snapshot, option chain, quota detail, or receipt history
- does not change runtime strategy config or execute broker/trading writes

## Validation

- 322 tests passed (1 existing deprecation warning)
- Ruff check and format check passed
- guardrails passed
- dependency graph current: 599 production modules, 0 cycles
- `git diff --check` passed
