### PR TITLE
fix(evidence): fail closed and preserve quote snapshots

### DIFF
--- a/src/application/copilot/engine.py
+++ b/src/application/copilot/engine.py
@@ -111,6 +111,8 @@ def run_engine(
                 error={"code": "MODEL_ERROR", "message": "model response was blocked by content filtering"},
             )
         if turn.text and not turn.tool_calls:
+            if fresh_evidence_recheck_used and not state.observations:
+                break
             if turn.finish_reason == "length" and state.iterations < max_iterations:
                 state.accumulated_text_parts.append(turn.text)
                 state.continuation_count += 1
@@ -250,6 +252,16 @@ def run_engine(
 
     if is_cancelled and is_cancelled():
         return AgentRunResult(status="cancelled", error={"code": "CANCELLED", "message": "run cancelled"})
+    if fresh_evidence_recheck_used and not state.observations:
+        record_event(
+            "fresh_evidence_recheck_failed",
+            {"reason": "no_current_observation", "iteration": state.iterations},
+            None,
+        )
+        return AgentRunResult(
+            status="insufficient_evidence",
+            text="本轮未取得可验证的当前证据，无法给出事实结论。",
+        )
     final_turn = _call_model(
         state,
         model_runner,

--- a/src/application/multiplier_steps.py
+++ b/src/application/multiplier_steps.py
@@ -43,6 +43,8 @@ def apply_multiplier_cache_to_required_data_csv(*, base: Path, required_data_dir
                 bad = mm.isna() | (mm <= 0)
                 if bad.any():
                     df.loc[bad, 'multiplier'] = float(m)
+                else:
+                    return
             except Exception:
                 df['multiplier'] = float(m)
 

--- a/src/application/required_data_blobs.py
+++ b/src/application/required_data_blobs.py
@@ -518,7 +518,12 @@ def _projection_overrides(
         provider_identity = _row_identity(provider)
         if _row_identity(final) != provider_identity:
             raise RequiredDataBlobError("required-data CSV row order or identity mismatch")
-        changed = [column for column in columns if provider[column] != final[column]]
+        changed = [
+            column
+            for column in columns
+            if provider[column] != final[column]
+            and not _equivalent_csv_number(provider[column], final[column])
+        ]
         if not changed:
             continue
         if changed != ["multiplier"]:
@@ -546,6 +551,20 @@ def _projection_overrides(
             }
         )
     return overrides
+
+
+def _equivalent_csv_number(left: str, right: str) -> bool:
+    try:
+        left_number = float(left)
+        right_number = float(right)
+    except (TypeError, ValueError):
+        return False
+    return (
+        math.isfinite(left_number)
+        and math.isfinite(right_number)
+        and abs(left_number - right_number)
+        <= max(math.ulp(left_number), math.ulp(right_number))
+    )
 
 
 def _csv_rows(payload: bytes, *, columns: list[str]) -> list[dict[str, str]]:

--- a/tests/test_copilot_phase1.py
+++ b/tests/test_copilot_phase1.py
@@ -1413,6 +1413,37 @@ def test_stale_no_evidence_answer_rechecks_with_current_tool(
     assert event.payload["reason"] == expected_reason
 
 
+def test_stale_no_evidence_answer_fails_closed_when_model_skips_recheck() -> None:
+    stale_answer = (
+        "结论：当前环境没有可用的运行快照（output_runs 目录不存在，runtime_runs 返回 0 条），"
+        "因此无法确认 0700.HK 被哪些条件过滤。"
+    )
+    model_calls = 0
+
+    def model(_request: ModelRequest) -> ModelTurn:
+        nonlocal model_calls
+        model_calls += 1
+        return ModelTurn(text=stale_answer)
+
+    prepared = prepare_contract(
+        _request(
+            "0700.HK 在 lx 账户为什么被过滤？",
+            context=(
+                {"role": "user", "content": "0700.HK 在 lx 账户为什么被过滤？"},
+                {"role": "assistant", "content": stale_answer},
+            ),
+        ),
+        reference_year=2026,
+    )
+    assert not isinstance(prepared, AppResult)
+    result = run_contract(prepared, model_runner=model)
+
+    assert result.status == "insufficient_evidence"
+    assert result.user_response == "本轮未取得可验证的当前证据，无法给出事实结论。"
+    assert model_calls == 2
+    assert any(event.type == "fresh_evidence_recheck_failed" for event in result.events)
+
+
 def test_same_tool_can_retry_with_changed_arguments(monkeypatch) -> None:
     calls: list[dict] = []
 

--- a/tests/test_required_data_output_integrity.py
+++ b/tests/test_required_data_output_integrity.py
@@ -11,6 +11,7 @@ import pytest
 
 from conftest import phase2_opening_row
 from domain.domain.engine import calculate_opening_candidate_metrics
+from src.application import multiplier_cache
 from src.application.candidate_models import CandidateContractInput
 from src.application.close_advice_quote_cache import quote_cache_metadata_path
 from src.application.opend_symbol_outputs import (
@@ -1145,14 +1146,13 @@ def test_finalizer_attests_multiplier_and_final_csv_hash(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    from src.application import multiplier_cache
-
     monkeypatch.setattr(
         multiplier_cache,
         "resolve_multiplier",
         lambda **_kwargs: 100.0,
     )
     payload = _payload(multiplier=None)
+    payload["rows"][0]["implied_volatility"] = 0.13436424411240122
     result = finalize_required_data_quote_candidate(
         base=tmp_path,
         producer_root=tmp_path,
@@ -1177,6 +1177,33 @@ def test_finalizer_attests_multiplier_and_final_csv_hash(
     assert datetime.fromisoformat(
         metadata["source_observed_at"].replace("Z", "+00:00")
     ) == NOW
+    assert result["quote_receipt_path"].is_file()
+
+
+def test_finalizer_keeps_valid_multiplier_csv_canonical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        multiplier_cache,
+        "resolve_multiplier",
+        lambda **_kwargs: 100.0,
+    )
+    payload = _payload(multiplier=100.0)
+    payload["rows"][0]["implied_volatility"] = 0.13436424411240122
+
+    result = finalize_required_data_quote_candidate(
+        base=tmp_path,
+        producer_root=tmp_path,
+        producer_run_id="run-valid-multiplier",
+        symbol="NVDA",
+        expected_fetch_contract=_contract(),
+        fetch_policy=_policy(),
+        mode="fresh",
+        payload=payload,
+        now=COMPLETED_AT,
+    )
+
     assert result["quote_receipt_path"].is_file()
 
 


### PR DESCRIPTION
## Summary

- fail closed when Copilot repeats an unsupported answer after a fresh-evidence recheck
- avoid rewriting required-data CSV files when multiplier values are already valid
- accept only one-ULP pandas numeric rendering drift while retaining exact blob materialization and hash binding

## Verification

- 5238 passed, 10 skipped
- ruff check .
- compileall src domain scripts
- dependency graph check
- git diff --check

Source delivery only; no release or production upgrade.