### PR TITLE
feat(pi-agent): integrate core runtime and read-only tool bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ logs/
 
 # webui build
 scripts/webui/frontend/node_modules/
+agent-runtime/node_modules/
 
 # local config backups
 config.*.bak.*

--- a/agent-runtime/main.ts
+++ b/agent-runtime/main.ts
@@ -553,6 +553,11 @@ async function run(): Promise<void> {
   const text = extractText(finalMessage);
 
   if (stopReason === "stop" || stopReason === "length") {
+    if (text === "") {
+      emitRun("run.error", safeError("MODEL_ERROR", "model", "empty answer", false));
+      process.exitCode = 1;
+      return;
+    }
     emitRun("run.proposed", {
       status: "answered",
       text,

--- a/agent-runtime/main.ts
+++ b/agent-runtime/main.ts
@@ -1,8 +1,9 @@
-// S1 Node runtime: one real Pi Agent run over `om-pi-ipc.v1` JSONL stdio.
+// S2 Node runtime: one real Pi Agent run with sequential Host tools over
+// `om-pi-ipc.v1` JSONL stdio.
 //
 // Pinned to @earendil-works/pi-agent-core@0.84.2 and @earendil-works/pi-ai@0.84.2.
 // The protocol (envelope, start payload, terminal payload) is specified by
-// docs/PI_AGENT_CORE_INTEGRATION.md sections 5 and 11 and mirrored by
+// docs/PI_AGENT_CORE_INTEGRATION.md sections 5, 11, and 12 and mirrored by
 // src/infrastructure/pi_agent_process.py.
 
 import process from "node:process";
@@ -12,12 +13,12 @@ import type {
   Api,
   AssistantMessage,
   AssistantMessageEventStream,
+  Context,
   Model,
   StreamFn,
-  TextContent,
   Usage,
 } from "@earendil-works/pi-ai";
-import type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentEvent, AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 
 const PROTOCOL = "om-pi-ipc.v1";
 const MAX_LINE_BYTES = 1_048_576;
@@ -53,6 +54,23 @@ interface Identity {
 interface Envelope {
   type: string;
   payload: JsonObject;
+}
+
+interface FixtureToolCall {
+  call_id: string;
+  tool_name: string;
+  arguments: JsonObject;
+}
+
+type FixtureTurn = { text: string } | { tool_calls: FixtureToolCall[] };
+
+interface PendingTool {
+  callId: string;
+  toolName: string;
+  resolve: (observation: JsonObject) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  abortListener?: () => void;
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -181,11 +199,23 @@ function validateStart(payload: JsonObject): void {
     }
   }
 
-  if (!Array.isArray(payload.tools) || payload.tools.length !== 0) {
-    throw new Error("S1 requires an empty tools array");
+  if (!Array.isArray(payload.tools)) throw new Error("tools must be an array");
+  const toolNames = new Set<string>();
+  for (const tool of payload.tools) {
+    if (
+      !isRecord(tool) ||
+      !exactKeys(tool, ["name", "description", "input_schema"]) ||
+      !isNonEmptyString(tool.name) ||
+      !isNonEmptyString(tool.description) ||
+      !isRecord(tool.input_schema) ||
+      toolNames.has(tool.name)
+    ) {
+      throw new Error("tool definition is invalid");
+    }
+    toolNames.add(tool.name);
   }
   if (!Array.isArray(payload.recovered_observations) || payload.recovered_observations.length !== 0) {
-    throw new Error("S1 requires an empty recovered_observations array");
+    throw new Error("S1/S2 require an empty recovered_observations array");
   }
 
   if (!isRecord(payload.model)) throw new Error("model must be an object");
@@ -240,10 +270,43 @@ function validateStart(payload: JsonObject): void {
 
   if (!isRecord(payload.debug)) throw new Error("debug must be an object");
   const debug = payload.debug;
-  if (!exactKeys(debug, ["fixture_response", "delay_ms"])) {
-    throw new Error("debug fields are not closed");
+  if (Object.hasOwn(debug, "fixture_response")) {
+    if (!exactKeys(debug, ["fixture_response", "delay_ms"])) {
+      throw new Error("debug fields are not closed");
+    }
+    if (typeof debug.fixture_response !== "string") {
+      throw new Error("debug.fixture_response must be a string");
+    }
+  } else if (Object.hasOwn(debug, "fixture_turns")) {
+    if (!exactKeys(debug, ["fixture_turns", "delay_ms"]) || !Array.isArray(debug.fixture_turns)) {
+      throw new Error("debug.fixture_turns must be a closed array fixture");
+    }
+    for (const turn of debug.fixture_turns) {
+      if (!isRecord(turn) || Object.keys(turn).length !== 1) {
+        throw new Error("fixture turn must hold exactly one field");
+      }
+      if (Object.hasOwn(turn, "text")) {
+        if (typeof turn.text !== "string") throw new Error("fixture turn text must be a string");
+        continue;
+      }
+      if (!Array.isArray(turn.tool_calls) || turn.tool_calls.length === 0) {
+        throw new Error("fixture turn tool_calls must be a non-empty array");
+      }
+      for (const call of turn.tool_calls) {
+        if (
+          !isRecord(call) ||
+          !exactKeys(call, ["call_id", "tool_name", "arguments"]) ||
+          !isNonEmptyString(call.call_id) ||
+          !isNonEmptyString(call.tool_name) ||
+          !isRecord(call.arguments)
+        ) {
+          throw new Error("fixture tool call is invalid");
+        }
+      }
+    }
+  } else {
+    throw new Error("debug fixture is missing");
   }
-  if (typeof debug.fixture_response !== "string") throw new Error("debug.fixture_response must be a string");
   const delay = debug.delay_ms;
   if (
     typeof delay !== "number" ||
@@ -307,7 +370,7 @@ function emptyUsage(): Usage {
 
 function makeAssistantMessage(
   model: Model<Api>,
-  content: TextContent[],
+  content: AssistantMessage["content"],
   stopReason: AssistantMessage["stopReason"],
   errorMessage?: string
 ): AssistantMessage {
@@ -325,6 +388,15 @@ function makeAssistantMessage(
   return message;
 }
 
+function stableJson(value: unknown): string {
+  const text = JSON.stringify(value, (_key, current) => {
+    if (!isRecord(current)) return current;
+    return Object.fromEntries(Object.keys(current).sort().map((key) => [key, current[key]]));
+  });
+  if (text === undefined) throw new Error("observation is not JSON serializable");
+  return text;
+}
+
 function waitAbortOrDelay(signal: AbortSignal | undefined, ms: number): Promise<void> {
   const sources: AbortSignal[] = [AbortSignal.timeout(ms)];
   if (signal) sources.push(signal);
@@ -335,34 +407,192 @@ function waitAbortOrDelay(signal: AbortSignal | undefined, ms: number): Promise<
   });
 }
 
+function fixtureContextHasResults(context: Context, calls: FixtureToolCall[]): boolean {
+  return calls.every((call) => {
+    const message = context.messages.find(
+      (item) =>
+        item.role === "toolResult" &&
+        item.toolCallId === call.call_id &&
+        item.toolName === call.tool_name
+    );
+    if (!message || message.role !== "toolResult") return false;
+    const details = message.details;
+    if (!isRecord(details) || !isRecord(details.observation)) return true;
+    return (
+      exactKeys(details, ["observation"]) &&
+      message.content.length === 1 &&
+      message.content[0].type === "text" &&
+      message.content[0].text === stableJson(details.observation) &&
+      message.isError === (details.observation.ok === false)
+    );
+  });
+}
+
 // StreamFn contract (pi-agent-core/types.ts): must not throw or reject; failures
 // are encoded as an event stream ending in done(stop/length/toolUse/deferred) or
 // error(aborted/error). We drive the fixture entirely through pushed events.
 function createFixtureStream(start: JsonObject): StreamFn {
   const debug = start.debug as JsonObject;
-  const text = debug.fixture_response as string;
+  const turns: FixtureTurn[] = Object.hasOwn(debug, "fixture_response")
+    ? [{ text: debug.fixture_response as string }]
+    : (debug.fixture_turns as FixtureTurn[]);
   const delayMs = debug.delay_ms as number;
-  return (model, _context, options) => {
+  let turnIndex = 0;
+  let expectedResults: FixtureToolCall[] = [];
+  return (model, context, options) => {
     const stream: AssistantMessageEventStream = createAssistantMessageEventStream();
     const empty = makeAssistantMessage(model, [], "pending");
-    const final = makeAssistantMessage(model, [{ type: "text", text }], "stop");
+    const turn = turns[turnIndex++];
     void (async () => {
       stream.push({ type: "start", partial: empty });
-      stream.push({ type: "text_start", contentIndex: 0, partial: empty });
       await waitAbortOrDelay(options?.signal, delayMs);
       if (options?.signal?.aborted) {
         const aborted = makeAssistantMessage(model, [], "aborted", "aborted");
         stream.push({ type: "error", reason: "aborted", error: aborted });
         return;
       }
-      stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: final });
-      stream.push({ type: "text_end", contentIndex: 0, content: text, partial: final });
-      stream.push({ type: "done", reason: "stop", message: final });
-    })().catch((err) => {
-      const failed = makeAssistantMessage(model, [], "error", String(err));
+      if (!turn) throw new Error("fixture turns exhausted");
+      if (expectedResults.length > 0 && !fixtureContextHasResults(context, expectedResults)) {
+        throw new Error("fixture context mismatch");
+      }
+      if ("text" in turn) {
+        expectedResults = [];
+        const final = makeAssistantMessage(model, [{ type: "text", text: turn.text }], "stop");
+        stream.push({ type: "text_start", contentIndex: 0, partial: empty });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: turn.text, partial: final });
+        stream.push({ type: "text_end", contentIndex: 0, content: turn.text, partial: final });
+        stream.push({ type: "done", reason: "stop", message: final });
+        return;
+      }
+      expectedResults = turn.tool_calls;
+      const content: AssistantMessage["content"] = turn.tool_calls.map((call) => ({
+        type: "toolCall",
+        id: call.call_id,
+        name: call.tool_name,
+        arguments: call.arguments,
+      }));
+      const partial = makeAssistantMessage(model, content, "pending");
+      const final = makeAssistantMessage(model, content, "toolUse");
+      for (let index = 0; index < turn.tool_calls.length; index += 1) {
+        const toolCall = content[index];
+        if (toolCall.type !== "toolCall") continue;
+        stream.push({ type: "toolcall_start", contentIndex: index, partial });
+        stream.push({
+          type: "toolcall_delta",
+          contentIndex: index,
+          delta: JSON.stringify(toolCall.arguments),
+          partial,
+        });
+        stream.push({ type: "toolcall_end", contentIndex: index, toolCall, partial });
+      }
+      stream.push({ type: "done", reason: "toolUse", message: final });
+    })().catch(() => {
+      const failed = makeAssistantMessage(model, [], "error", "fixture stream failed");
       stream.push({ type: "error", reason: "error", error: failed });
     });
     return stream;
+  };
+}
+
+function createToolBridge(
+  start: JsonObject,
+  emitRun: (type: string, payload: JsonObject) => void,
+  onFailure: (message: string) => void
+): {
+  tools: AgentTool[];
+  acceptResult: (payload: JsonObject) => void;
+  cancelPending: () => void;
+  rejectPending: () => void;
+  hasPending: () => boolean;
+} {
+  let pending: PendingTool | null = null;
+
+  const settlePending = (error?: Error): void => {
+    const current = pending;
+    if (!current) return;
+    pending = null;
+    if (current.signal && current.abortListener) {
+      current.signal.removeEventListener("abort", current.abortListener);
+    }
+    if (error) current.reject(error);
+  };
+
+  const tools = (start.tools as JsonObject[]).map((spec): AgentTool => ({
+    name: spec.name as string,
+    label: spec.name as string,
+    description: spec.description as string,
+    parameters: spec.input_schema as AgentTool["parameters"],
+    executionMode: "sequential",
+    execute: async (toolCallId, params, signal) => {
+      if (pending) {
+        onFailure("second outstanding tool call");
+        throw new Error("tool bridge failed");
+      }
+      if (signal?.aborted) throw new Error("tool call aborted");
+      const observation = await new Promise<JsonObject>((resolve, reject) => {
+        const abortListener = (): void => {
+          if (pending?.callId !== toolCallId) return;
+          pending = null;
+          reject(new Error("tool call aborted"));
+        };
+        pending = {
+          callId: toolCallId,
+          toolName: spec.name as string,
+          resolve,
+          reject,
+          signal,
+          abortListener,
+        };
+        signal?.addEventListener("abort", abortListener, { once: true });
+        try {
+          emitRun("tool.call", {
+            call_id: toolCallId,
+            tool_name: spec.name as string,
+            arguments: params as JsonObject,
+          });
+        } catch {
+          pending = null;
+          signal?.removeEventListener("abort", abortListener);
+          onFailure("tool call emit failed");
+          reject(new Error("tool bridge failed"));
+        }
+      });
+      return {
+        content: [{ type: "text", text: stableJson(observation) }],
+        details: { observation },
+        terminate: false,
+      };
+    },
+  }));
+
+  return {
+    tools,
+    acceptResult(result) {
+      if (
+        !exactKeys(result, ["call_id", "tool_name", "observation"]) ||
+        !isNonEmptyString(result.call_id) ||
+        !isNonEmptyString(result.tool_name) ||
+        !isRecord(result.observation) ||
+        !pending ||
+        result.call_id !== pending.callId ||
+        result.tool_name !== pending.toolName
+      ) {
+        throw new Error("tool result mismatch");
+      }
+      const current = pending;
+      pending = null;
+      if (current.signal && current.abortListener) {
+        current.signal.removeEventListener("abort", current.abortListener);
+      }
+      current.resolve(result.observation);
+    },
+    cancelPending() {
+      settlePending(new Error("tool call aborted"));
+    },
+    rejectPending() {
+      settlePending(new Error("tool bridge failed"));
+    },
+    hasPending: () => pending !== null,
   };
 }
 
@@ -394,9 +624,8 @@ function turnData(message: AgentMessage): JsonObject {
   };
 }
 
-// AgentEvent union (pi-agent-core/types.ts). message_start/message_update and
-// tool_execution_* are intentionally skipped: the S1 protocol exposes only the
-// lifecycle and turn-terminal events listed in _EVENT_TYPES on the Python side.
+// AgentEvent union (pi-agent-core/types.ts). Message updates, arguments,
+// observations, and tool update events stay inside the Node process.
 function normalizeAgentEvent(event: AgentEvent): { event_type: string; data: JsonObject } | null {
   switch (event.type) {
     case "agent_start":
@@ -410,6 +639,16 @@ function normalizeAgentEvent(event: AgentEvent): { event_type: string; data: Jso
       return { event_type: "model_turn_completed", data: turnData(event.message) };
     case "turn_end":
       return { event_type: "turn_end", data: turnData(event.message) };
+    case "tool_execution_start":
+      return {
+        event_type: "tool_execution_start",
+        data: { call_id: event.toolCallId, tool_name: event.toolName },
+      };
+    case "tool_execution_end":
+      return {
+        event_type: "tool_execution_end",
+        data: { call_id: event.toolCallId, tool_name: event.toolName, ok: !event.isError },
+      };
     default:
       return null;
   }
@@ -425,32 +664,7 @@ function lastAssistant(agent: Agent): AssistantMessage | undefined {
 }
 
 function extractText(message: AssistantMessage): string {
-  return message.content
-    .filter((block) => block.type === "text")
-    .map((block) => (block as TextContent).text)
-    .join("");
-}
-
-async function readActionLine(
-  lines: AsyncGenerator<string, void, unknown>,
-  expectedSeq: number,
-  identity: Identity,
-  cancelState: { cancelled: boolean },
-  agent: Agent
-): Promise<Envelope> {
-  const next = await lines.next();
-  if (next.done) throw new Error("stdin closed before action");
-  const envelope = parseEnvelope(
-    next.value,
-    expectedSeq,
-    identity,
-    new Set(["run.cancel", "run.commit", "run.discard"])
-  );
-  if (envelope.type === "run.cancel" && !cancelState.cancelled) {
-    cancelState.cancelled = true;
-    agent.abort();
-  }
-  return envelope;
+  return message.content.flatMap((block) => (block.type === "text" ? [block.text] : [])).join("");
 }
 
 async function run(): Promise<void> {
@@ -491,29 +705,148 @@ async function run(): Promise<void> {
     payload.system_prompt as string,
     payload.runtime_context as JsonObject[]
   );
-  const agent = new Agent({
+  const limits = payload.limits as JsonObject;
+  const startedAt = performance.now();
+  let assistantTurns = 0;
+  let finalizedToolCalls = 0;
+  let consecutiveFailedToolBatches = 0;
+  let forcedFinalAtTurn: number | null = null;
+  let bridgeFailure: JsonObject | null = null;
+  let agent: Agent | undefined;
+
+  const inbound = {
+    expectedSeq: 2,
+    cancelled: false,
+    terminal: false,
+    awaitingAdmission: false,
+    action: null as string | null,
+    error: null as JsonObject | null,
+  };
+  let resolveAction!: (action: string | null) => void;
+  const actionPromise = new Promise<string | null>((resolve) => {
+    resolveAction = resolve;
+  });
+
+  const bridge = createToolBridge(payload, emitRun, (message) => {
+    if (!bridgeFailure) {
+      bridgeFailure = safeError("TOOL_BRIDGE_ERROR", "tool", message, false);
+      agent?.abort();
+    }
+  });
+
+  agent = new Agent({
     initialState: {
       systemPrompt,
       model,
       thinkingLevel: "off",
-      tools: [],
+      tools: bridge.tools,
       messages: [],
     },
     streamFn: createFixtureStream(payload),
     toolExecution: "sequential",
+    afterToolCall: async ({ result }) => {
+      const details = result.details;
+      return isRecord(details) &&
+        isRecord(details.observation) &&
+        details.observation.ok === false
+        ? { isError: true }
+        : undefined;
+    },
+    prepareNextTurnWithContext: ({ context, toolResults }) => {
+      if (forcedFinalAtTurn !== null || toolResults.length === 0) return undefined;
+      const remainingMs =
+        (limits.timeout_seconds as number) * 1000 - (performance.now() - startedAt);
+      const exhausted =
+        assistantTurns >= (limits.max_iterations as number) ||
+        finalizedToolCalls >= (limits.max_tool_calls as number) ||
+        consecutiveFailedToolBatches >=
+          (limits.max_consecutive_failed_tool_batches as number) ||
+        remainingMs <= (limits.final_answer_reserve_seconds as number) * 1000;
+      if (!exhausted) return undefined;
+      forcedFinalAtTurn = assistantTurns;
+      return { context: { ...context, tools: [] } };
+    },
+    shouldStopAfterTurn: () =>
+      forcedFinalAtTurn !== null && assistantTurns > forcedFinalAtTurn,
   });
 
   agent.subscribe((event) => {
+    if (event.type === "message_end" && event.message.role === "assistant") {
+      assistantTurns += 1;
+    } else if (event.type === "tool_execution_end") {
+      finalizedToolCalls += 1;
+    } else if (event.type === "turn_end" && event.toolResults.length > 0) {
+      consecutiveFailedToolBatches = event.toolResults.every((result) => result.isError)
+        ? consecutiveFailedToolBatches + 1
+        : 0;
+    }
     const normalized = normalizeAgentEvent(event);
     if (normalized) emitRun("agent.event", normalized);
   });
 
-  const cancelState = { cancelled: false };
+  const failInbound = (): void => {
+    if (inbound.terminal || inbound.error) return;
+    inbound.error = safeError("PROTOCOL_ERROR", "protocol", "invalid host record", false);
+    bridge.rejectPending();
+    resolveAction(null);
+    agent?.abort();
+  };
+
+  const pumpInbound = async (): Promise<void> => {
+    try {
+      for await (const line of lines) {
+        if (inbound.terminal) throw new Error("record after terminal");
+        const envelope = parseEnvelope(
+          line,
+          inbound.expectedSeq,
+          identity,
+          new Set(["tool.result", "run.cancel", "run.commit", "run.discard"])
+        );
+        inbound.expectedSeq += 1;
+
+        if (envelope.type === "tool.result") {
+          if (inbound.cancelled || inbound.awaitingAdmission || inbound.action) {
+            throw new Error("tool result outside active tool call");
+          }
+          bridge.acceptResult(envelope.payload);
+          continue;
+        }
+        if (envelope.type === "run.cancel") {
+          if (
+            !exactKeys(envelope.payload, ["reason"]) ||
+            !isNonEmptyString(envelope.payload.reason) ||
+            inbound.cancelled ||
+            inbound.action
+          ) {
+            throw new Error("invalid cancellation");
+          }
+          inbound.cancelled = true;
+          inbound.action = envelope.type;
+          bridge.cancelPending();
+          resolveAction(envelope.type);
+          agent?.abort();
+          continue;
+        }
+        if (
+          !exactKeys(envelope.payload, []) ||
+          !inbound.awaitingAdmission ||
+          inbound.cancelled ||
+          inbound.action ||
+          bridge.hasPending()
+        ) {
+          throw new Error("invalid admission action");
+        }
+        inbound.action = envelope.type;
+        resolveAction(envelope.type);
+      }
+      if (!inbound.terminal) throw new Error("stdin closed before terminal");
+    } catch {
+      failInbound();
+    }
+  };
+
   const promptPromise = agent.prompt(payload.user_message as string);
-  const actionPromise = readActionLine(lines, 2, identity, cancelState, agent).then(
-    (env) => ({ env, err: null as Error | null }),
-    (err) => ({ env: null as Envelope | null, err: err as Error })
-  );
+  void pumpInbound();
 
   let promptFailed = false;
   try {
@@ -522,7 +855,22 @@ async function run(): Promise<void> {
     promptFailed = true;
   }
 
-  if (cancelState.cancelled) {
+  const finishError = (error: JsonObject): void => {
+    inbound.terminal = true;
+    emitRun("run.error", error);
+    process.exitCode = 1;
+  };
+
+  if (inbound.error) {
+    finishError(inbound.error);
+    return;
+  }
+  if (bridgeFailure) {
+    finishError(bridgeFailure);
+    return;
+  }
+  if (inbound.cancelled) {
+    inbound.terminal = true;
     emitRun("run.final", {
       status: "cancelled",
       text: "",
@@ -536,28 +884,40 @@ async function run(): Promise<void> {
   }
 
   if (promptFailed) {
-    emitRun("run.error", safeError("INTERNAL_ERROR", "runtime", "agent prompt failed", false));
-    process.exitCode = 1;
+    finishError(safeError("INTERNAL_ERROR", "runtime", "agent prompt failed", false));
     return;
   }
 
   const finalMessage = lastAssistant(agent);
   if (!finalMessage) {
-    emitRun("run.error", safeError("INTERNAL_ERROR", "runtime", "no assistant message", false));
-    process.exitCode = 1;
+    finishError(safeError("INTERNAL_ERROR", "runtime", "no assistant message", false));
     return;
   }
 
   const stopReason = finalMessage.stopReason;
   const usage = normalizeUsage(finalMessage.usage ?? {});
   const text = extractText(finalMessage);
+  const forcedFinalCompleted =
+    forcedFinalAtTurn !== null && assistantTurns > forcedFinalAtTurn;
+
+  if (forcedFinalCompleted && text.trim() === "") {
+    finishError(
+      safeError(
+        "BUDGET_EXHAUSTED",
+        "budget",
+        "agent budget exhausted without a final answer",
+        false
+      )
+    );
+    return;
+  }
 
   if (stopReason === "stop" || stopReason === "length") {
     if (text === "") {
-      emitRun("run.error", safeError("MODEL_ERROR", "model", "empty answer", false));
-      process.exitCode = 1;
+      finishError(safeError("MODEL_ERROR", "model", "empty answer", false));
       return;
     }
+    inbound.awaitingAdmission = true;
     emitRun("run.proposed", {
       status: "answered",
       text,
@@ -565,13 +925,18 @@ async function run(): Promise<void> {
       termination_reason: stopReason,
       usage,
     });
-    const { env: action, err: actionErr } = await actionPromise;
-    if (!action) {
-      emitRun("run.error", safeError("PROTOCOL_ERROR", "protocol", actionErr?.message ?? "missing action", false));
-      process.exitCode = 1;
+    const action = inbound.action ?? (await actionPromise);
+    inbound.awaitingAdmission = false;
+    if (inbound.error) {
+      finishError(inbound.error);
       return;
     }
-    if (action.type === "run.cancel") {
+    if (!action) {
+      finishError(safeError("PROTOCOL_ERROR", "protocol", "missing action", false));
+      return;
+    }
+    inbound.terminal = true;
+    if (action === "run.cancel") {
       emitRun("run.final", {
         status: "cancelled",
         text: "",
@@ -587,15 +952,14 @@ async function run(): Promise<void> {
         control_request: null,
         termination_reason: stopReason,
         usage,
-        committed: action.type === "run.commit",
+        committed: action === "run.commit",
       });
     }
     process.exitCode = 0;
     return;
   }
 
-  emitRun("run.error", safeError("MODEL_ERROR", "model", "fixture stream error", false));
-  process.exitCode = 1;
+  finishError(safeError("MODEL_ERROR", "model", "fixture stream error", false));
 }
 
 process.stdin.on("error", () => {});

--- a/agent-runtime/main.ts
+++ b/agent-runtime/main.ts
@@ -326,28 +326,12 @@ function makeAssistantMessage(
 }
 
 function waitAbortOrDelay(signal: AbortSignal | undefined, ms: number): Promise<void> {
+  const sources: AbortSignal[] = [AbortSignal.timeout(ms)];
+  if (signal) sources.push(signal);
+  const combined = AbortSignal.any(sources);
+  if (combined.aborted) return Promise.resolve();
   return new Promise((resolve) => {
-    if (signal?.aborted) {
-      resolve();
-      return;
-    }
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const onAbort = () => {
-      if (timer) clearTimeout(timer);
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
-    };
-    timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
-    }, ms);
-    signal?.addEventListener("abort", onAbort, { once: true });
+    combined.addEventListener("abort", () => resolve(), { once: true });
   });
 }
 
@@ -610,7 +594,11 @@ async function run(): Promise<void> {
 }
 
 process.stdin.on("error", () => {});
-run().catch((err) => {
-  process.stderr.write(`diagnostic: ${String(err)}\n`);
-  process.exitCode = 1;
-});
+run().then(
+  () => process.stdin.destroy(),
+  (err) => {
+    process.stderr.write(`diagnostic: ${String(err)}\n`);
+    process.exitCode = 1;
+    process.stdin.destroy();
+  }
+);

--- a/agent-runtime/main.ts
+++ b/agent-runtime/main.ts
@@ -1,0 +1,616 @@
+// S1 Node runtime: one real Pi Agent run over `om-pi-ipc.v1` JSONL stdio.
+//
+// Pinned to @earendil-works/pi-agent-core@0.84.2 and @earendil-works/pi-ai@0.84.2.
+// The protocol (envelope, start payload, terminal payload) is specified by
+// docs/PI_AGENT_CORE_INTEGRATION.md sections 5 and 11 and mirrored by
+// src/infrastructure/pi_agent_process.py.
+
+import process from "node:process";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import type {
+  Api,
+  AssistantMessage,
+  AssistantMessageEventStream,
+  Model,
+  StreamFn,
+  TextContent,
+  Usage,
+} from "@earendil-works/pi-ai";
+import type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";
+
+const PROTOCOL = "om-pi-ipc.v1";
+const MAX_LINE_BYTES = 1_048_576;
+const MAX_SAFE_MESSAGE_CHARS = 240;
+const MAX_FIXTURE_DELAY_MS = 300_000;
+
+const ALLOWED_ERROR_CODES = new Set([
+  "PROTOCOL_ERROR",
+  "CONFIG_ERROR",
+  "MODEL_ERROR",
+  "SESSION_ERROR",
+  "TOOL_BRIDGE_ERROR",
+  "BUDGET_EXHAUSTED",
+  "INTERNAL_ERROR",
+]);
+const ALLOWED_ERROR_STAGES = new Set([
+  "protocol",
+  "config",
+  "model",
+  "session",
+  "tool",
+  "budget",
+  "runtime",
+]);
+
+type JsonObject = Record<string, unknown>;
+
+interface Identity {
+  requestId: string;
+  runId: string;
+}
+
+interface Envelope {
+  type: string;
+  payload: JsonObject;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+  const own = Object.keys(value);
+  return own.length === keys.length && keys.every((k) => Object.hasOwn(value, k));
+}
+
+// Incremental line reader. Must yield each complete line as it arrives rather
+// than draining stdin to EOF: the Python parent keeps stdin open until it sees
+// a terminal envelope, so the naive EOF loop deadlocks.
+async function* readJsonLines(
+  input: NodeJS.ReadableStream
+): AsyncGenerator<string, void, unknown> {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let buffer = Buffer.alloc(0);
+  for await (const chunk of input) {
+    const part = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
+    buffer = Buffer.concat([buffer, part]);
+    let idx: number;
+    while ((idx = buffer.indexOf(0x0a)) !== -1) {
+      let end = idx;
+      if (end > 0 && buffer[end - 1] === 0x0d) end -= 1;
+      const lineBytes = buffer.subarray(0, end);
+      if (lineBytes.length === 0) throw new Error("blank record");
+      if (lineBytes.length > MAX_LINE_BYTES) throw new Error("line exceeds ceiling");
+      yield decoder.decode(lineBytes);
+      buffer = buffer.subarray(idx + 1);
+    }
+    if (buffer.length > MAX_LINE_BYTES) throw new Error("line exceeds ceiling");
+  }
+  if (buffer.length > 0) throw new Error("missing final newline");
+}
+
+function parseStartEnvelope(line: string): { identity: Identity; payload: JsonObject } {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    throw new Error("malformed JSON");
+  }
+  if (!isRecord(obj)) throw new Error("record is not an object");
+  if (!exactKeys(obj, ["protocol", "type", "request_id", "run_id", "seq", "payload"])) {
+    throw new Error("envelope fields are not closed");
+  }
+  if (obj.protocol !== PROTOCOL) throw new Error("unknown protocol");
+  if (obj.type !== "run.start") throw new Error("expected run.start");
+  if (!isNonEmptyString(obj.request_id)) throw new Error("request_id must be non-empty");
+  if (!isNonEmptyString(obj.run_id)) throw new Error("run_id must be non-empty");
+  if (obj.seq !== 1) throw new Error("start sequence must be 1");
+  if (!isRecord(obj.payload)) throw new Error("payload is not an object");
+  validateStart(obj.payload);
+  return {
+    identity: { requestId: obj.request_id, runId: obj.run_id },
+    payload: obj.payload,
+  };
+}
+
+function parseEnvelope(
+  line: string,
+  expectedSeq: number,
+  identity: Identity,
+  allowedTypes: Set<string>
+): Envelope {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    throw new Error("malformed JSON");
+  }
+  if (!isRecord(obj)) throw new Error("record is not an object");
+  if (!exactKeys(obj, ["protocol", "type", "request_id", "run_id", "seq", "payload"])) {
+    throw new Error("envelope fields are not closed");
+  }
+  if (obj.protocol !== PROTOCOL) throw new Error("unknown protocol");
+  if (!isNonEmptyString(obj.type) || !allowedTypes.has(obj.type)) {
+    throw new Error("unknown or empty type");
+  }
+  if (obj.request_id !== identity.requestId || obj.run_id !== identity.runId) {
+    throw new Error("mismatched identity");
+  }
+  if (obj.seq !== expectedSeq) throw new Error("sequence is not contiguous");
+  if (!isRecord(obj.payload)) throw new Error("payload is not an object");
+  return { type: obj.type, payload: obj.payload };
+}
+
+function validateStart(payload: JsonObject): void {
+  const keys = [
+    "execution_environment",
+    "session_id",
+    "system_prompt",
+    "runtime_context",
+    "user_message",
+    "model",
+    "tools",
+    "limits",
+    "recovered_observations",
+    "debug",
+  ];
+  if (!exactKeys(payload, keys)) throw new Error("start payload keys are not closed");
+  if (payload.execution_environment !== "eval") throw new Error("execution_environment must be eval");
+  if (payload.session_id !== null) throw new Error("session_id must be null");
+  if (!isNonEmptyString(payload.system_prompt)) throw new Error("system_prompt must be non-empty");
+  if (!isNonEmptyString(payload.user_message)) throw new Error("user_message must be non-empty");
+
+  if (!Array.isArray(payload.runtime_context)) throw new Error("runtime_context must be an array");
+  for (const item of payload.runtime_context) {
+    if (
+      !isRecord(item) ||
+      !exactKeys(item, ["role", "content"]) ||
+      item.role !== "system" ||
+      !isNonEmptyString(item.content)
+    ) {
+      throw new Error("runtime_context item is not a closed system message");
+    }
+  }
+
+  if (!Array.isArray(payload.tools) || payload.tools.length !== 0) {
+    throw new Error("S1 requires an empty tools array");
+  }
+  if (!Array.isArray(payload.recovered_observations) || payload.recovered_observations.length !== 0) {
+    throw new Error("S1 requires an empty recovered_observations array");
+  }
+
+  if (!isRecord(payload.model)) throw new Error("model must be an object");
+  const model = payload.model;
+  if (
+    !exactKeys(model, [
+      "provider",
+      "api_kind",
+      "model",
+      "base_url",
+      "timeout_seconds",
+      "context_window_tokens",
+      "max_output_tokens",
+      "max_attempts",
+    ])
+  ) {
+    throw new Error("model fields are not closed");
+  }
+  for (const key of ["provider", "model", "base_url"] as const) {
+    if (!isNonEmptyString(model[key])) throw new Error(`model.${key} must be non-empty`);
+  }
+  if (model.api_kind !== "openai-responses" && model.api_kind !== "openai-completions") {
+    throw new Error("model.api_kind is not allowed");
+  }
+  for (const key of ["timeout_seconds", "context_window_tokens", "max_output_tokens", "max_attempts"] as const) {
+    if (!isPositiveInteger(model[key])) throw new Error(`model.${key} must be a positive integer`);
+  }
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(model.base_url as string);
+  } catch {
+    throw new Error("model.base_url is not a valid URL");
+  }
+  if (baseUrl.protocol !== "http:" && baseUrl.protocol !== "https:") {
+    throw new Error("model.base_url must be http or https");
+  }
+
+  if (!isRecord(payload.limits)) throw new Error("limits must be an object");
+  const limits = payload.limits;
+  const limitKeys = [
+    "timeout_seconds",
+    "max_iterations",
+    "max_tool_calls",
+    "max_context_tokens",
+    "max_consecutive_failed_tool_batches",
+    "final_answer_reserve_seconds",
+  ];
+  if (!exactKeys(limits, limitKeys)) throw new Error("limits fields are not closed");
+  for (const key of limitKeys) {
+    if (!isPositiveInteger(limits[key])) throw new Error(`limits.${key} must be a positive integer`);
+  }
+
+  if (!isRecord(payload.debug)) throw new Error("debug must be an object");
+  const debug = payload.debug;
+  if (!exactKeys(debug, ["fixture_response", "delay_ms"])) {
+    throw new Error("debug fields are not closed");
+  }
+  if (typeof debug.fixture_response !== "string") throw new Error("debug.fixture_response must be a string");
+  const delay = debug.delay_ms;
+  if (
+    typeof delay !== "number" ||
+    !Number.isInteger(delay) ||
+    delay < 0 ||
+    delay > MAX_FIXTURE_DELAY_MS
+  ) {
+    throw new Error("debug.delay_ms must be within [0, 300000]");
+  }
+}
+
+function emit(type: string, payload: JsonObject, identity: Identity, seq: number): void {
+  const record = {
+    protocol: PROTOCOL,
+    type,
+    request_id: identity.requestId,
+    run_id: identity.runId,
+    seq,
+    payload,
+  };
+  const line = JSON.stringify(record) + "\n";
+  if (Buffer.byteLength(line, "utf-8") > MAX_LINE_BYTES) {
+    throw new Error("outbound envelope exceeds line ceiling");
+  }
+  process.stdout.write(line);
+}
+
+function safeError(code: string, stage: string, message: string, retryable: boolean): JsonObject {
+  if (!ALLOWED_ERROR_CODES.has(code) || !ALLOWED_ERROR_STAGES.has(stage)) {
+    return { code: "INTERNAL_ERROR", stage: "runtime", message: "invalid error", retryable: false };
+  }
+  return { code, stage, message: message.slice(0, MAX_SAFE_MESSAGE_CHARS), retryable };
+}
+
+function modelFromStart(start: JsonObject): Model<Api> {
+  const model = start.model as JsonObject;
+  return {
+    id: model.model as string,
+    name: model.model as string,
+    api: model.api_kind as Api,
+    provider: model.provider as string,
+    baseUrl: model.base_url as string,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: model.context_window_tokens as number,
+    maxTokens: model.max_output_tokens as number,
+  };
+}
+
+function emptyUsage(): Usage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function makeAssistantMessage(
+  model: Model<Api>,
+  content: TextContent[],
+  stopReason: AssistantMessage["stopReason"],
+  errorMessage?: string
+): AssistantMessage {
+  const message: AssistantMessage = {
+    role: "assistant",
+    content,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: emptyUsage(),
+    stopReason,
+    timestamp: Date.now(),
+  };
+  if (errorMessage !== undefined) message.errorMessage = errorMessage;
+  return message;
+}
+
+function waitAbortOrDelay(signal: AbortSignal | undefined, ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = () => {
+      if (timer) clearTimeout(timer);
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+// StreamFn contract (pi-agent-core/types.ts): must not throw or reject; failures
+// are encoded as an event stream ending in done(stop/length/toolUse/deferred) or
+// error(aborted/error). We drive the fixture entirely through pushed events.
+function createFixtureStream(start: JsonObject): StreamFn {
+  const debug = start.debug as JsonObject;
+  const text = debug.fixture_response as string;
+  const delayMs = debug.delay_ms as number;
+  return (model, _context, options) => {
+    const stream: AssistantMessageEventStream = createAssistantMessageEventStream();
+    const empty = makeAssistantMessage(model, [], "pending");
+    const final = makeAssistantMessage(model, [{ type: "text", text }], "stop");
+    void (async () => {
+      stream.push({ type: "start", partial: empty });
+      stream.push({ type: "text_start", contentIndex: 0, partial: empty });
+      await waitAbortOrDelay(options?.signal, delayMs);
+      if (options?.signal?.aborted) {
+        const aborted = makeAssistantMessage(model, [], "aborted", "aborted");
+        stream.push({ type: "error", reason: "aborted", error: aborted });
+        return;
+      }
+      stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: final });
+      stream.push({ type: "text_end", contentIndex: 0, content: text, partial: final });
+      stream.push({ type: "done", reason: "stop", message: final });
+    })().catch((err) => {
+      const failed = makeAssistantMessage(model, [], "error", String(err));
+      stream.push({ type: "error", reason: "error", error: failed });
+    });
+    return stream;
+  };
+}
+
+function effectiveSystemPrompt(systemPrompt: string, runtimeContext: JsonObject[]): string {
+  const parts = [systemPrompt];
+  for (const item of runtimeContext) {
+    if (typeof item.content === "string") parts.push(item.content);
+  }
+  return parts.join("\n\n");
+}
+
+function normalizeUsage(usage: Record<string, unknown>): JsonObject {
+  const keys = ["input", "output", "cacheRead", "cacheWrite", "totalTokens"] as const;
+  const out: JsonObject = {};
+  for (const key of keys) {
+    const value = usage[key];
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+function turnData(message: AgentMessage): JsonObject {
+  const assistant = message as unknown as AssistantMessage;
+  return {
+    stop_reason: assistant.stopReason,
+    usage: normalizeUsage(assistant.usage ?? {}),
+  };
+}
+
+// AgentEvent union (pi-agent-core/types.ts). message_start/message_update and
+// tool_execution_* are intentionally skipped: the S1 protocol exposes only the
+// lifecycle and turn-terminal events listed in _EVENT_TYPES on the Python side.
+function normalizeAgentEvent(event: AgentEvent): { event_type: string; data: JsonObject } | null {
+  switch (event.type) {
+    case "agent_start":
+      return { event_type: "agent_start", data: {} };
+    case "turn_start":
+      return { event_type: "turn_start", data: {} };
+    case "agent_end":
+      return { event_type: "agent_end", data: {} };
+    case "message_end":
+      if ((event.message as { role?: unknown }).role !== "assistant") return null;
+      return { event_type: "model_turn_completed", data: turnData(event.message) };
+    case "turn_end":
+      return { event_type: "turn_end", data: turnData(event.message) };
+    default:
+      return null;
+  }
+}
+
+function lastAssistant(agent: Agent): AssistantMessage | undefined {
+  const messages = agent.state.messages;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "assistant") return message as AssistantMessage;
+  }
+  return undefined;
+}
+
+function extractText(message: AssistantMessage): string {
+  return message.content
+    .filter((block) => block.type === "text")
+    .map((block) => (block as TextContent).text)
+    .join("");
+}
+
+async function readActionLine(
+  lines: AsyncGenerator<string, void, unknown>,
+  expectedSeq: number,
+  identity: Identity,
+  cancelState: { cancelled: boolean },
+  agent: Agent
+): Promise<Envelope> {
+  const next = await lines.next();
+  if (next.done) throw new Error("stdin closed before action");
+  const envelope = parseEnvelope(
+    next.value,
+    expectedSeq,
+    identity,
+    new Set(["run.cancel", "run.commit", "run.discard"])
+  );
+  if (envelope.type === "run.cancel" && !cancelState.cancelled) {
+    cancelState.cancelled = true;
+    agent.abort();
+  }
+  return envelope;
+}
+
+async function run(): Promise<void> {
+  const lines = readJsonLines(process.stdin);
+  const first = await lines.next();
+  if (first.done) {
+    process.stderr.write("diagnostic: missing run.start\n");
+    process.exitCode = 2;
+    return;
+  }
+
+  let identity: Identity;
+  let payload: JsonObject;
+  try {
+    const start = parseStartEnvelope(first.value);
+    identity = start.identity;
+    payload = start.payload;
+  } catch (err) {
+    process.stderr.write(`diagnostic: ${String(err)}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  let nodeSeq = 0;
+  const emitRun = (type: string, p: JsonObject): void => {
+    nodeSeq += 1;
+    emit(type, p, identity, nodeSeq);
+  };
+
+  emitRun("run.accepted", {
+    runtime: "pi-agent-core",
+    runtime_version: "0.84.2",
+    session_id: null,
+  });
+
+  const model = modelFromStart(payload);
+  const systemPrompt = effectiveSystemPrompt(
+    payload.system_prompt as string,
+    payload.runtime_context as JsonObject[]
+  );
+  const agent = new Agent({
+    initialState: {
+      systemPrompt,
+      model,
+      thinkingLevel: "off",
+      tools: [],
+      messages: [],
+    },
+    streamFn: createFixtureStream(payload),
+    toolExecution: "sequential",
+  });
+
+  agent.subscribe((event) => {
+    const normalized = normalizeAgentEvent(event);
+    if (normalized) emitRun("agent.event", normalized);
+  });
+
+  const cancelState = { cancelled: false };
+  const promptPromise = agent.prompt(payload.user_message as string);
+  const actionPromise = readActionLine(lines, 2, identity, cancelState, agent).then(
+    (env) => ({ env, err: null as Error | null }),
+    (err) => ({ env: null as Envelope | null, err: err as Error })
+  );
+
+  let promptFailed = false;
+  try {
+    await promptPromise;
+  } catch {
+    promptFailed = true;
+  }
+
+  if (cancelState.cancelled) {
+    emitRun("run.final", {
+      status: "cancelled",
+      text: "",
+      control_request: null,
+      termination_reason: "aborted",
+      usage: {},
+      committed: false,
+    });
+    process.exitCode = 0;
+    return;
+  }
+
+  if (promptFailed) {
+    emitRun("run.error", safeError("INTERNAL_ERROR", "runtime", "agent prompt failed", false));
+    process.exitCode = 1;
+    return;
+  }
+
+  const finalMessage = lastAssistant(agent);
+  if (!finalMessage) {
+    emitRun("run.error", safeError("INTERNAL_ERROR", "runtime", "no assistant message", false));
+    process.exitCode = 1;
+    return;
+  }
+
+  const stopReason = finalMessage.stopReason;
+  const usage = normalizeUsage(finalMessage.usage ?? {});
+  const text = extractText(finalMessage);
+
+  if (stopReason === "stop" || stopReason === "length") {
+    emitRun("run.proposed", {
+      status: "answered",
+      text,
+      control_request: null,
+      termination_reason: stopReason,
+      usage,
+    });
+    const { env: action, err: actionErr } = await actionPromise;
+    if (!action) {
+      emitRun("run.error", safeError("PROTOCOL_ERROR", "protocol", actionErr?.message ?? "missing action", false));
+      process.exitCode = 1;
+      return;
+    }
+    if (action.type === "run.cancel") {
+      emitRun("run.final", {
+        status: "cancelled",
+        text: "",
+        control_request: null,
+        termination_reason: "aborted",
+        usage,
+        committed: false,
+      });
+    } else {
+      emitRun("run.final", {
+        status: "answered",
+        text,
+        control_request: null,
+        termination_reason: stopReason,
+        usage,
+        committed: action.type === "run.commit",
+      });
+    }
+    process.exitCode = 0;
+    return;
+  }
+
+  emitRun("run.error", safeError("MODEL_ERROR", "model", "fixture stream error", false));
+  process.exitCode = 1;
+}
+
+process.stdin.on("error", () => {});
+run().catch((err) => {
+  process.stderr.write(`diagnostic: ${String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -1,0 +1,1227 @@
+{
+  "name": "agent-runtime",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "0.84.2",
+        "@earendil-works/pi-ai": "0.84.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.33.tgz",
+      "integrity": "sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.28.tgz",
+      "integrity": "sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.51.tgz",
+      "integrity": "sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
+      "integrity": "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@google/genai": "1.52.0",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/agent-runtime/package.json
+++ b/agent-runtime/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "dependencies": {
+    "@earendil-works/pi-agent-core": "0.84.2",
+    "@earendil-works/pi-ai": "0.84.2"
+  }
+}

--- a/docs/PI_AGENT_CORE_INTEGRATION.md
+++ b/docs/PI_AGENT_CORE_INTEGRATION.md
@@ -828,8 +828,8 @@ Required behavior:
 - send one `run.start` envelope;
 - validate every child envelope and monotonic sequence;
 - forward normalized `agent.event` payloads to `on_event`;
-- in S1, reject any `tool.call` as a local `TOOL_BRIDGE_ERROR` unless a
-  callback was explicitly supplied by a test;
+- in S1, reject any `tool.call` as a local `TOOL_BRIDGE_ERROR` (no tools in
+  S1; `on_tool_call` is wired in S2);
 - forward `run.proposed` to `on_proposed` and send exactly the returned closed
   decision; the production Host callback performs the durable compare-and-set
   and never exposes an unclaimed Boolean decision;

--- a/docs/PI_AGENT_CORE_INTEGRATION.md
+++ b/docs/PI_AGENT_CORE_INTEGRATION.md
@@ -1349,10 +1349,15 @@ details = {observation: compact observation}
 terminate = false
 ```
 
-`observation.ok == false` is a normal error tool result (`isError: true`) so the
-model may repair invalid arguments. Raw executor output never enters content,
-details, Session, or IPC. Cancellation rejects the pending promise, removes its
-listener, and prevents a later result from being accepted.
+`observation.ok == false` is promoted to `isError: true` by a global
+`afterToolCall` hook that returns `{ isError: true }` when
+`details.observation.ok === false`; this preserves the compact content and
+details while letting the model repair invalid arguments. `execute()` returns
+the same normal result for `ok: true` and `ok: false` and never throws for a
+valid observation: throwing would make Pi replace `content` with the thrown
+message, breaking the compact-observation guarantee. Raw executor output never
+enters content, details, Session, or IPC. Cancellation rejects the pending
+promise, removes its listener, and prevents a later result from being accepted.
 
 Python changes `run_pi_agent(..., on_tool_call=...)` from a synchronous callback
 inside the selector loop to one daemon worker for the single outstanding read.
@@ -1379,10 +1384,11 @@ verify manifest allowlist and pure_read capability
 -> tools.compact_observation(tool_name, result)
 ```
 
-An `AgentToolError` becomes a bounded compact observation with its safe code,
-message, status, and reference. An unknown/non-read tool, callback exception,
-protocol mismatch, or invalid callback return is terminal
-`TOOL_BRIDGE_ERROR`; callback exception text is discarded.
+`execute()` throws only for bridge failures: an unknown/non-read tool, callback
+exception, protocol mismatch, or invalid callback return. These are terminal
+`TOOL_BRIDGE_ERROR`; the run fails closed without committing a successful turn,
+and callback exception text is discarded rather than becoming a model-visible
+compact observation.
 
 ### 12.4 Budget behavior
 

--- a/src/infrastructure/pi_agent_process.py
+++ b/src/infrastructure/pi_agent_process.py
@@ -1,0 +1,722 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import selectors
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Callable, Literal, Mapping
+
+PROTOCOL = "om-pi-ipc.v1"
+MAX_LINE_BYTES = 1_048_576
+MAX_SAFE_MESSAGE_CHARS = 240
+MIN_NODE_VERSION = (22, 19, 0)
+MAX_FIXTURE_DELAY_MS = 300_000
+
+_CHILD_ENV_ALLOW = frozenset(
+    {
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "TZ",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "NODE_EXTRA_CA_CERTS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "OM_PI_MODEL_API_KEY",
+        "OM_PI_SESSION_DB",
+    }
+)
+
+_NODE_ERROR_CODES = frozenset(
+    {
+        "PROTOCOL_ERROR",
+        "CONFIG_ERROR",
+        "MODEL_ERROR",
+        "SESSION_ERROR",
+        "TOOL_BRIDGE_ERROR",
+        "BUDGET_EXHAUSTED",
+        "INTERNAL_ERROR",
+    }
+)
+
+_NODE_ERROR_STAGES = frozenset(
+    {"protocol", "config", "model", "session", "tool", "budget", "runtime"}
+)
+
+_EVENT_TYPES = frozenset(
+    {
+        "agent_start",
+        "turn_start",
+        "model_turn_completed",
+        "tool_execution_start",
+        "tool_execution_end",
+        "turn_end",
+        "agent_end",
+    }
+)
+
+_STOP_REASONS = frozenset({"stop", "length", "aborted", "error"})
+
+_StartPayload = dict[str, Any]
+_Envelope = dict[str, Any]
+
+
+def _is_pos_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _is_nonempty_str(value: Any) -> bool:
+    return isinstance(value, str) and len(value) > 0
+
+
+def _validate_usage(usage: Any) -> None:
+    allowed = {"input", "output", "cacheRead", "cacheWrite", "totalTokens"}
+    if not isinstance(usage, dict) or not set(usage) <= allowed:
+        raise ValueError("usage has unknown fields")
+    for value in usage.values():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("usage value must be a number")
+        if not math.isfinite(float(value)) or value < 0:
+            raise ValueError("usage value must be non-negative and finite")
+
+
+def _safe_failure(
+    code: str, stage: str, message: str, retryable: bool
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "error": {
+            "code": code,
+            "stage": stage,
+            "message": message[:MAX_SAFE_MESSAGE_CHARS],
+            "retryable": bool(retryable),
+        },
+    }
+
+
+def _validate_start_payload(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError("start payload must be an object")
+
+    allowed_keys = {
+        "execution_environment",
+        "session_id",
+        "system_prompt",
+        "runtime_context",
+        "user_message",
+        "model",
+        "tools",
+        "limits",
+        "recovered_observations",
+        "debug",
+    }
+    if set(payload) != allowed_keys:
+        raise ValueError("start payload has unknown or missing top-level fields")
+
+    if payload["execution_environment"] != "eval":
+        raise ValueError("S1 only accepts execution_environment 'eval'")
+    if payload["session_id"] is not None:
+        raise ValueError("S1 requires session_id null")
+    if not _is_nonempty_str(payload["system_prompt"]):
+        raise ValueError("system_prompt must be a non-empty string")
+    if not _is_nonempty_str(payload["user_message"]):
+        raise ValueError("user_message must be a non-empty string")
+
+    runtime_context = payload["runtime_context"]
+    if not isinstance(runtime_context, list):
+        raise ValueError("runtime_context must be an array")
+    for item in runtime_context:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"role", "content"}
+            or item.get("role") != "system"
+            or not _is_nonempty_str(item.get("content"))
+        ):
+            raise ValueError("runtime_context must hold closed system messages")
+
+    if payload["tools"] != []:
+        raise ValueError("S1 requires an empty tools array")
+    if payload["recovered_observations"] != []:
+        raise ValueError("S1 requires an empty recovered_observations array")
+
+    model = payload["model"]
+    if not isinstance(model, dict):
+        raise ValueError("model must be an object")
+    model_allowed = {
+        "provider",
+        "api_kind",
+        "model",
+        "base_url",
+        "timeout_seconds",
+        "context_window_tokens",
+        "max_output_tokens",
+        "max_attempts",
+    }
+    if set(model) != model_allowed:
+        raise ValueError("model has unknown or missing fields")
+    for key in ("provider", "model", "base_url"):
+        if not _is_nonempty_str(model[key]):
+            raise ValueError(f"model.{key} must be a non-empty string")
+    if model["api_kind"] not in {"openai-responses", "openai-completions"}:
+        raise ValueError("model.api_kind is not allowed")
+    for key in (
+        "timeout_seconds",
+        "context_window_tokens",
+        "max_output_tokens",
+        "max_attempts",
+    ):
+        if not _is_pos_int(model[key]):
+            raise ValueError(f"model.{key} must be a positive integer")
+
+    limits = payload["limits"]
+    if not isinstance(limits, dict):
+        raise ValueError("limits must be an object")
+    limits_allowed = {
+        "timeout_seconds",
+        "max_iterations",
+        "max_tool_calls",
+        "max_context_tokens",
+        "max_consecutive_failed_tool_batches",
+        "final_answer_reserve_seconds",
+    }
+    if set(limits) != limits_allowed:
+        raise ValueError("limits has unknown or missing fields")
+    for key in limits_allowed:
+        if not _is_pos_int(limits[key]):
+            raise ValueError(f"limits.{key} must be a positive integer")
+
+    debug = payload["debug"]
+    if not isinstance(debug, dict) or set(debug) != {"fixture_response", "delay_ms"}:
+        raise ValueError("debug must hold only fixture_response and delay_ms")
+    if not isinstance(debug["fixture_response"], str):
+        raise ValueError("debug.fixture_response must be a string")
+    delay = debug["delay_ms"]
+    if (
+        not isinstance(delay, int)
+        or isinstance(delay, bool)
+        or delay < 0
+        or delay > MAX_FIXTURE_DELAY_MS
+    ):
+        raise ValueError("debug.delay_ms must be an integer within [0, 300000]")
+
+
+def _child_env(environ: Mapping[str, str] | None) -> dict[str, str]:
+    source = os.environ if environ is None else environ
+    child = {}
+    for key in _CHILD_ENV_ALLOW:
+        value = source.get(key)
+        if value:
+            child[key] = value
+    return child
+
+
+def _runtime_command(
+    runtime_entry: Path | None, environ: Mapping[str, str] | None
+) -> tuple[list[str], Path]:
+    source = os.environ if environ is None else environ
+    node = shutil.which("node", path=source.get("PATH"))
+    if node is None:
+        raise LookupError("node executable not found")
+    try:
+        version_out = subprocess.run(
+            [node, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        ).stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        raise LookupError("node version probe failed")
+    if not version_out.startswith("v"):
+        raise LookupError("node version output is unparseable")
+    try:
+        parts = version_out[1:].split(".")
+        numeric = tuple(int(part) for part in parts[:3])
+    except ValueError:
+        raise LookupError("node version output is unparseable")
+    if numeric < MIN_NODE_VERSION:
+        raise LookupError("node is older than 22.19.0")
+
+    if runtime_entry is None:
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        entry = repo_root / "agent-runtime" / "main.ts"
+    else:
+        entry = runtime_entry
+    if not entry.is_file():
+        raise LookupError("runtime entry is missing")
+    return [node, str(entry)], entry
+
+
+def _encode_envelope(
+    type_: str, payload: dict[str, Any], identity: dict[str, str], seq: int
+) -> bytes:
+    record = {
+        "protocol": PROTOCOL,
+        "type": type_,
+        "request_id": identity["request_id"],
+        "run_id": identity["run_id"],
+        "seq": seq,
+        "payload": payload,
+    }
+    line = json.dumps(record, ensure_ascii=False) + "\n"
+    data = line.encode("utf-8")
+    if len(data) > MAX_LINE_BYTES:
+        raise ValueError("outbound envelope exceeds line ceiling")
+    return data
+
+
+def _decode_line(line: bytes) -> dict[str, Any] | None:
+    if not line.endswith(b"\n"):
+        return None
+    if line.endswith(b"\r\n"):
+        line = line[:-2] + b"\n"
+    body = line.rstrip(b"\r\n")
+    if not body:
+        return None
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ValueError("invalid UTF-8")
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        raise ValueError("malformed JSON")
+    if not isinstance(obj, dict):
+        raise ValueError("record is not an object")
+    return obj
+
+
+def _validate_envelope(
+    obj: dict[str, Any],
+    expected_seq: int,
+    identity: dict[str, str],
+    allowed_types: frozenset[str],
+) -> str:
+    if set(obj) != {"protocol", "type", "request_id", "run_id", "seq", "payload"}:
+        raise ValueError("record has unknown or missing envelope fields")
+    if obj["protocol"] != PROTOCOL:
+        raise ValueError("unknown protocol")
+    type_ = obj["type"]
+    if not _is_nonempty_str(type_) or type_ not in allowed_types:
+        raise ValueError("unknown or empty type")
+    if obj["request_id"] != identity["request_id"]:
+        raise ValueError("mismatched request_id")
+    if obj["run_id"] != identity["run_id"]:
+        raise ValueError("mismatched run_id")
+    if obj["seq"] != expected_seq:
+        raise ValueError("sequence is not contiguous")
+    if not isinstance(obj["payload"], dict):
+        raise ValueError("payload is not an object")
+    return type_
+
+
+def _stop_child(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+    except OSError:
+        pass
+    try:
+        process.wait(timeout=1)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        process.kill()
+    except OSError:
+        pass
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def _validate_run_accepted(payload: dict[str, Any]) -> None:
+    if set(payload) != {"runtime", "runtime_version", "session_id"}:
+        raise ValueError("run.accepted payload shape is invalid")
+    if payload["runtime"] != "pi-agent-core":
+        raise ValueError("run.accepted runtime is not pi-agent-core")
+    if payload["runtime_version"] != "0.84.2":
+        raise ValueError("run.accepted runtime_version is not pinned")
+    if payload["session_id"] is not None:
+        raise ValueError("run.accepted session_id must be null")
+
+
+def _validate_agent_event(payload: dict[str, Any]) -> None:
+    if set(payload) != {"event_type", "data"}:
+        raise ValueError("agent.event payload shape is invalid")
+    event_type = payload["event_type"]
+    if event_type not in _EVENT_TYPES:
+        raise ValueError("agent.event event_type is not allowed")
+    data = payload["data"]
+    if not isinstance(data, dict):
+        raise ValueError("agent.event data must be an object")
+    if event_type in {"agent_start", "turn_start", "agent_end"}:
+        if data != {}:
+            raise ValueError("lifecycle event data must be empty")
+    elif event_type in {"model_turn_completed", "turn_end"}:
+        if set(data) != {"stop_reason", "usage"}:
+            raise ValueError("turn event data shape is invalid")
+        if data["stop_reason"] not in _STOP_REASONS:
+            raise ValueError("turn event stop_reason is not allowed")
+        _validate_usage(data["usage"])
+    else:
+        raise ValueError("tool events are not allowed in S1")
+
+
+def _validate_terminal_payload(payload: dict[str, Any], final: bool) -> None:
+    status = payload.get("status")
+    if final:
+        required = {
+            "status",
+            "text",
+            "control_request",
+            "termination_reason",
+            "usage",
+            "committed",
+        }
+    else:
+        required = {
+            "status",
+            "text",
+            "control_request",
+            "termination_reason",
+            "usage",
+        }
+    if set(payload) != required:
+        raise ValueError("terminal payload has unknown or missing fields")
+    if status not in {"answered", "cancelled"}:
+        raise ValueError("S1 terminal status is not allowed")
+    if not isinstance(payload["text"], str):
+        raise ValueError("terminal text must be a string")
+    if payload["control_request"] is not None:
+        raise ValueError("S1 terminal control_request must be null")
+    reason = payload["termination_reason"]
+    _validate_usage(payload["usage"])
+    if status == "answered":
+        if reason not in {"stop", "length"}:
+            raise ValueError("answered termination_reason must be stop or length")
+    else:
+        if reason != "aborted":
+            raise ValueError("cancelled termination_reason must be aborted")
+        if payload["text"] != "":
+            raise ValueError("cancelled terminal text must be empty")
+    if not final and status != "answered":
+        raise ValueError("S1 proposal permits only an answered candidate")
+    if final:
+        if not isinstance(payload["committed"], bool):
+            raise ValueError("run.final committed must be a boolean")
+
+
+def _validate_run_error(payload: dict[str, Any]) -> None:
+    if set(payload) != {"code", "stage", "message", "retryable"}:
+        raise ValueError("run.error payload shape is invalid")
+    if payload["code"] not in _NODE_ERROR_CODES:
+        raise ValueError("run.error code is not allowed")
+    if payload["stage"] not in _NODE_ERROR_STAGES:
+        raise ValueError("run.error stage is not allowed")
+    if not isinstance(payload["message"], str) or len(payload["message"]) > MAX_SAFE_MESSAGE_CHARS:
+        raise ValueError("run.error message is not a bounded string")
+    if not isinstance(payload["retryable"], bool):
+        raise ValueError("run.error retryable must be a boolean")
+
+
+def run_pi_agent(
+    start_payload: dict[str, Any],
+    *,
+    request_id: str,
+    run_id: str,
+    timeout_seconds: int,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
+    on_tool_call: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    on_proposed: Callable[
+        [dict[str, Any]], Literal["commit", "discard", "cancel"]
+    ]
+    | None = None,
+    is_cancelled: Callable[[], bool] | None = None,
+    runtime_entry: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    if not _is_nonempty_str(request_id) or not _is_nonempty_str(run_id):
+        return _safe_failure("CONFIG_ERROR", "config", "invalid identity", False)
+    if not _is_pos_int(timeout_seconds):
+        return _safe_failure("CONFIG_ERROR", "config", "invalid timeout", False)
+
+    try:
+        _validate_start_payload(start_payload)
+    except ValueError as exc:
+        return _safe_failure("CONFIG_ERROR", "config", str(exc), False)
+
+    if start_payload["limits"]["timeout_seconds"] != timeout_seconds:
+        return _safe_failure(
+            "CONFIG_ERROR", "config", "timeout mismatch with limits", False
+        )
+    if (
+        start_payload["model"]["timeout_seconds"]
+        > start_payload["limits"]["timeout_seconds"]
+    ):
+        return _safe_failure(
+            "CONFIG_ERROR", "config", "model timeout exceeds scene timeout", False
+        )
+
+    deadline = time.monotonic() + timeout_seconds
+
+    if is_cancelled is not None:
+        try:
+            if is_cancelled():
+                return _safe_failure("CANCELLED", "cancel", "cancelled before spawn", False)
+        except Exception:
+            return _safe_failure("INTERNAL_ERROR", "runtime", "cancellation check failed", False)
+
+    try:
+        command, entry = _runtime_command(runtime_entry, environ)
+    except LookupError as exc:
+        return _safe_failure("PI_RUNTIME_UNAVAILABLE", "spawn", str(exc), False)
+
+    identity = {"request_id": request_id, "run_id": run_id}
+    try:
+        start_line = _encode_envelope("run.start", start_payload, identity, 1)
+    except ValueError as exc:
+        return _safe_failure("CONFIG_ERROR", "config", str(exc), False)
+
+    child_env = _child_env(environ)
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=str(entry.parent.parent if runtime_entry is None else entry.parent),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=child_env,
+            bufsize=0,
+        )
+    except OSError as exc:
+        return _safe_failure("PI_RUNTIME_UNAVAILABLE", "spawn", "failed to spawn child", False)
+
+    os.set_blocking(process.stdout.fileno(), False)
+    os.set_blocking(process.stderr.fileno(), False)
+
+    sel = selectors.DefaultSelector()
+    sel.register(process.stdout, selectors.EVENT_READ)
+    sel.register(process.stderr, selectors.EVENT_READ)
+
+    node_seq = 1
+    py_seq = 2
+    accepted = False
+    saw_terminal = False
+    cancel_sent = False
+    cancel_deadline: float | None = None
+    post_terminal_deadline: float | None = None
+    decision_written = False
+    decision: str | None = None
+    stdout_buffer = b""
+    final_result: dict[str, Any] | None = None
+    final_error: dict[str, Any] | None = None
+    final_ok: bool | None = None
+
+    try:
+        process.stdin.write(start_line)
+        process.stdin.flush()
+
+        while True:
+            if is_cancelled is not None and not cancel_sent and not decision_written and not saw_terminal:
+                try:
+                    if is_cancelled():
+                        cancel_line = _encode_envelope(
+                            "run.cancel", {"reason": "host_cancel_requested"}, identity, py_seq
+                        )
+                        py_seq += 1
+                        process.stdin.write(cancel_line)
+                        process.stdin.flush()
+                        cancel_sent = True
+                        cancel_deadline = time.monotonic() + 2
+                except (OSError, ValueError):
+                    _stop_child(process)
+                    return _safe_failure("INTERNAL_ERROR", "runtime", "cancellation write failed", False)
+
+            now = time.monotonic()
+            if cancel_deadline is not None and now >= cancel_deadline and not saw_terminal:
+                _stop_child(process)
+                return _safe_failure("CANCELLED", "cancel", "cancellation grace expired", False)
+            if now >= deadline and not saw_terminal:
+                if not cancel_sent:
+                    try:
+                        cancel_line = _encode_envelope(
+                            "run.cancel", {"reason": "deadline"}, identity, py_seq
+                        )
+                        process.stdin.write(cancel_line)
+                        process.stdin.flush()
+                        cancel_sent = True
+                    except (OSError, ValueError):
+                        pass
+                _stop_child(process)
+                return _safe_failure("PI_PROCESS_TIMEOUT", "deadline", "Pi Agent timed out", True)
+            if saw_terminal and post_terminal_deadline is not None and now >= post_terminal_deadline:
+                _stop_child(process)
+                break
+
+            timeout = 0.1
+            if cancel_deadline is not None:
+                timeout = min(timeout, max(0.0, cancel_deadline - now))
+            timeout = min(timeout, max(0.0, deadline - now))
+            if post_terminal_deadline is not None:
+                timeout = min(timeout, max(0.0, post_terminal_deadline - now))
+
+            events = sel.select(timeout)
+            for key, _ in events:
+                if key.fileobj is process.stderr:
+                    try:
+                        chunk = os.read(process.stderr.fileno(), 65536)
+                    except (BlockingIOError, OSError):
+                        chunk = b""
+                    if not chunk:
+                        continue
+                    continue
+                if key.fileobj is process.stdout:
+                    try:
+                        chunk = os.read(process.stdout.fileno(), 65536)
+                    except BlockingIOError:
+                        continue
+                    except OSError:
+                        chunk = b""
+                    if not chunk:
+                        sel.unregister(process.stdout)
+                        # child closed stdout: EOF
+                        if not saw_terminal:
+                            # Capture the exit code before reaping so a hard
+                            # startup failure (non-zero, zero envelopes) is not
+                            # mistaken for an in-run process death.
+                            exit_code = process.poll()
+                            _stop_child(process)
+                            if exit_code not in (None, 0):
+                                return _safe_failure(
+                                    "PI_RUNTIME_UNAVAILABLE",
+                                    "spawn",
+                                    "child failed before protocol established",
+                                    False,
+                                )
+                            return _safe_failure("PI_PROCESS_EXITED", "process", "child exited before terminal", True)
+                        continue
+                    stdout_buffer += chunk
+                    if len(stdout_buffer) > MAX_LINE_BYTES:
+                        _stop_child(process)
+                        return _safe_failure("PROTOCOL_ERROR", "protocol", "line exceeds ceiling", False)
+                    while b"\n" in stdout_buffer:
+                        line, stdout_buffer = stdout_buffer.split(b"\n", 1)
+                        line += b"\n"
+                        try:
+                            obj = _decode_line(line)
+                            if obj is None:
+                                _stop_child(process)
+                                return _safe_failure("PROTOCOL_ERROR", "protocol", "blank record", False)
+                            if saw_terminal:
+                                _stop_child(process)
+                                return _safe_failure("PROTOCOL_ERROR", "protocol", "record after terminal", False)
+                            type_ = _validate_envelope(
+                                obj, node_seq, identity, frozenset({
+                                    "run.accepted", "agent.event", "tool.call",
+                                    "run.proposed", "run.final", "run.error",
+                                })
+                            )
+                            node_seq += 1
+                            payload = obj["payload"]
+
+                            if type_ == "run.accepted":
+                                if accepted:
+                                    _stop_child(process)
+                                    return _safe_failure("PROTOCOL_ERROR", "protocol", "duplicate run.accepted", False)
+                                _validate_run_accepted(payload)
+                                accepted = True
+                            elif type_ == "agent.event":
+                                if not accepted:
+                                    _stop_child(process)
+                                    return _safe_failure("PROTOCOL_ERROR", "protocol", "event before accepted", False)
+                                _validate_agent_event(payload)
+                                if on_event is not None:
+                                    try:
+                                        on_event(payload)
+                                    except Exception:
+                                        _stop_child(process)
+                                        return _safe_failure("INTERNAL_ERROR", "runtime", "event callback failed", False)
+                            elif type_ == "tool.call":
+                                _stop_child(process)
+                                return _safe_failure("TOOL_BRIDGE_ERROR", "tool", "unexpected tool call", False)
+                            elif type_ == "run.proposed":
+                                if saw_terminal:
+                                    _stop_child(process)
+                                    return _safe_failure("PROTOCOL_ERROR", "protocol", "proposal after terminal", False)
+                                _validate_terminal_payload(payload, final=False)
+                                if on_proposed is None:
+                                    _stop_child(process)
+                                    return _safe_failure("INTERNAL_ERROR", "runtime", "missing proposal callback", False)
+                                try:
+                                    decision = on_proposed(payload)
+                                except Exception:
+                                    _stop_child(process)
+                                    return _safe_failure("INTERNAL_ERROR", "runtime", "proposal callback failed", False)
+                                if decision not in {"commit", "discard", "cancel"}:
+                                    _stop_child(process)
+                                    return _safe_failure("INTERNAL_ERROR", "runtime", "invalid proposal decision", False)
+                                type_map = {"commit": "run.commit", "discard": "run.discard", "cancel": "run.cancel"}
+                                payload_map = {"commit": {}, "discard": {}, "cancel": {"reason": "host_cancel_requested"}}
+                                line_out = _encode_envelope(type_map[decision], payload_map[decision], identity, py_seq)
+                                py_seq += 1
+                                process.stdin.write(line_out)
+                                process.stdin.flush()
+                                decision_written = True
+                                if decision == "cancel":
+                                    cancel_sent = True
+                                    cancel_deadline = time.monotonic() + 2
+                            elif type_ == "run.final":
+                                _validate_terminal_payload(payload, final=True)
+                                if decision is not None:
+                                    expected_committed = decision == "commit"
+                                    expected_status = "cancelled" if decision == "cancel" else "answered"
+                                    if payload["status"] != expected_status or payload["committed"] != expected_committed:
+                                        _stop_child(process)
+                                        return _safe_failure("PROTOCOL_ERROR", "protocol", "final does not match admission decision", False)
+                                elif payload["committed"] is not False:
+                                    _stop_child(process)
+                                    return _safe_failure("PROTOCOL_ERROR", "protocol", "unproposed final must be uncommitted", False)
+                                saw_terminal = True
+                                post_terminal_deadline = time.monotonic() + 1
+                                final_result = payload
+                                final_ok = True
+                            elif type_ == "run.error":
+                                _validate_run_error(payload)
+                                saw_terminal = True
+                                post_terminal_deadline = time.monotonic() + 1
+                                final_error = payload
+                                final_ok = False
+                        except ValueError:
+                            _stop_child(process)
+                            return _safe_failure("PROTOCOL_ERROR", "protocol", "invalid child record", False)
+
+            if saw_terminal and process.poll() is not None:
+                break
+
+        if final_ok and final_result is not None:
+            return {"ok": True, "result": final_result}
+        if final_error is not None:
+            return {"ok": False, "error": final_error}
+        return _safe_failure("PROTOCOL_ERROR", "protocol", "missing terminal", False)
+    finally:
+        try:
+            if process.stdin and not process.stdin.closed:
+                process.stdin.close()
+        except OSError:
+            pass
+        try:
+            sel.close()
+        except OSError:
+            pass
+        _stop_child(process)

--- a/src/infrastructure/pi_agent_process.py
+++ b/src/infrastructure/pi_agent_process.py
@@ -57,8 +57,6 @@ _EVENT_TYPES = frozenset(
         "agent_start",
         "turn_start",
         "model_turn_completed",
-        "tool_execution_start",
-        "tool_execution_end",
         "turn_end",
         "agent_end",
     }
@@ -101,6 +99,11 @@ def _safe_failure(
             "retryable": bool(retryable),
         },
     }
+
+
+def _stderr_summary(stderr_bytes: bytes) -> str:
+    text = stderr_bytes.decode("utf-8", errors="replace").strip()
+    return text if text else ""
 
 
 def _validate_start_payload(payload: Any) -> None:
@@ -276,8 +279,6 @@ def _encode_envelope(
 def _decode_line(line: bytes) -> dict[str, Any] | None:
     if not line.endswith(b"\n"):
         return None
-    if line.endswith(b"\r\n"):
-        line = line[:-2] + b"\n"
     body = line.rstrip(b"\r\n")
     if not body:
         return None
@@ -369,8 +370,6 @@ def _validate_agent_event(payload: dict[str, Any]) -> None:
         if data["stop_reason"] not in _STOP_REASONS:
             raise ValueError("turn event stop_reason is not allowed")
         _validate_usage(data["usage"])
-    else:
-        raise ValueError("tool events are not allowed in S1")
 
 
 def _validate_terminal_payload(payload: dict[str, Any], final: bool) -> None:
@@ -519,6 +518,7 @@ def run_pi_agent(
     decision_written = False
     decision: str | None = None
     stdout_buffer = b""
+    stderr_buffer = b""
     final_result: dict[str, Any] | None = None
     final_error: dict[str, Any] | None = None
     final_ok: bool | None = None
@@ -578,8 +578,8 @@ def run_pi_agent(
                         chunk = os.read(process.stderr.fileno(), 65536)
                     except (BlockingIOError, OSError):
                         chunk = b""
-                    if not chunk:
-                        continue
+                    if chunk:
+                        stderr_buffer += chunk
                     continue
                 if key.fileobj is process.stdout:
                     try:
@@ -596,12 +596,24 @@ def run_pi_agent(
                             # startup failure (non-zero, zero envelopes) is not
                             # mistaken for an in-run process death.
                             exit_code = process.poll()
+                            try:
+                                while True:
+                                    tail = os.read(process.stderr.fileno(), 65536)
+                                    if not tail:
+                                        break
+                                    stderr_buffer += tail
+                            except (BlockingIOError, OSError):
+                                pass
                             _stop_child(process)
                             if exit_code not in (None, 0):
+                                detail = _stderr_summary(stderr_buffer)
+                                message = "child failed before protocol established"
+                                if detail:
+                                    message = f"{message}: {detail}"
                                 return _safe_failure(
                                     "PI_RUNTIME_UNAVAILABLE",
                                     "spawn",
-                                    "child failed before protocol established",
+                                    message,
                                     False,
                                 )
                             return _safe_failure("PI_PROCESS_EXITED", "process", "child exited before terminal", True)
@@ -654,6 +666,11 @@ def run_pi_agent(
                                 if saw_terminal:
                                     _stop_child(process)
                                     return _safe_failure("PROTOCOL_ERROR", "protocol", "proposal after terminal", False)
+                                if cancel_sent:
+                                    # Host cancellation is already the durable
+                                    # winner; the buffered proposal is superseded.
+                                    # Do not open a second admission decision.
+                                    continue
                                 _validate_terminal_payload(payload, final=False)
                                 if on_proposed is None:
                                     _stop_child(process)

--- a/src/infrastructure/pi_agent_process.py
+++ b/src/infrastructure/pi_agent_process.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 import math
 import os
+import queue
 import selectors
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Literal, Mapping
@@ -59,10 +61,19 @@ _EVENT_TYPES = frozenset(
         "model_turn_completed",
         "turn_end",
         "agent_end",
+        "tool_execution_start",
+        "tool_execution_end",
     }
 )
 
-_STOP_REASONS = frozenset({"stop", "length", "aborted", "error"})
+_STOP_REASONS = frozenset({"stop", "length", "toolUse", "aborted", "error"})
+
+# Process-wide single active tool worker slot. A live worker owns the slot until
+# its callback actually returns; a second run's tool call fails retryably while
+# the slot is held (acceptance #10). Only the selector thread writes JSONL; the
+# worker reports through a stdlib queue.
+_TOOL_SLOT_LOCK = threading.Lock()
+_TOOL_SLOT_BUSY = False
 
 _StartPayload = dict[str, Any]
 _Envelope = dict[str, Any]
@@ -106,6 +117,91 @@ def _stderr_summary(stderr_bytes: bytes) -> str:
     return text if text else ""
 
 
+def _validate_tools(tools: Any) -> None:
+    # Empty is the S1 no-tools eval path; non-empty is the S2 tool bridge.
+    if not isinstance(tools, list):
+        raise ValueError("tools must be an array")
+    names: set[str] = set()
+    for tool in tools:
+        if not isinstance(tool, dict) or set(tool) != {"name", "description", "input_schema"}:
+            raise ValueError("tool must hold only name, description, input_schema")
+        if not _is_nonempty_str(tool["name"]):
+            raise ValueError("tool.name must be a non-empty string")
+        if not _is_nonempty_str(tool["description"]):
+            raise ValueError("tool.description must be a non-empty string")
+        if not isinstance(tool["input_schema"], dict):
+            raise ValueError("tool.input_schema must be an object")
+        if tool["name"] in names:
+            raise ValueError("tool names must be unique")
+        names.add(tool["name"])
+
+
+def _validate_fixture_turns(turns: Any) -> None:
+    if not isinstance(turns, list):
+        raise ValueError("debug.fixture_turns must be an array")
+    for turn in turns:
+        if not isinstance(turn, dict) or len(turn) != 1:
+            raise ValueError("fixture turn must hold exactly one field")
+        if "text" in turn:
+            if not isinstance(turn["text"], str):
+                raise ValueError("fixture turn text must be a string")
+            continue
+        if "tool_calls" not in turn:
+            raise ValueError("fixture turn must hold text or tool_calls")
+        calls = turn["tool_calls"]
+        if not isinstance(calls, list) or not calls:
+            raise ValueError("fixture turn tool_calls must be a non-empty array")
+        for call in calls:
+            if not isinstance(call, dict) or set(call) != {"call_id", "tool_name", "arguments"}:
+                raise ValueError("fixture tool call must hold call_id, tool_name, arguments")
+            if not _is_nonempty_str(call["call_id"]):
+                raise ValueError("fixture tool call_id must be a non-empty string")
+            if not _is_nonempty_str(call["tool_name"]):
+                raise ValueError("fixture tool_name must be a non-empty string")
+            if not isinstance(call["arguments"], dict):
+                raise ValueError("fixture tool arguments must be an object")
+
+
+def _validate_tool_call_payload(payload: Any) -> None:
+    if not isinstance(payload, dict) or set(payload) != {"call_id", "tool_name", "arguments"}:
+        raise ValueError("tool.call payload must hold call_id, tool_name, arguments")
+    if not _is_nonempty_str(payload["call_id"]):
+        raise ValueError("tool.call call_id must be a non-empty string")
+    if not _is_nonempty_str(payload["tool_name"]):
+        raise ValueError("tool.call tool_name must be a non-empty string")
+    if not isinstance(payload["arguments"], dict):
+        raise ValueError("tool.call arguments must be an object")
+
+
+def _run_tool_worker(
+    call_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    callback: Callable[[dict[str, Any]], dict[str, Any]],
+    result_queue: "queue.Queue[tuple[str, dict[str, Any] | None, dict[str, Any] | None]]",
+) -> None:
+    global _TOOL_SLOT_BUSY
+    observation: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    try:
+        try:
+            observation = callback(
+                {"call_id": call_id, "tool_name": tool_name, "arguments": arguments}
+            )
+        except BaseException:
+            error = _safe_failure("TOOL_BRIDGE_ERROR", "tool", "tool callback failed", False)
+        else:
+            if not isinstance(observation, dict):
+                error = _safe_failure("TOOL_BRIDGE_ERROR", "tool", "invalid callback return", False)
+                observation = None
+    finally:
+        # Deliver before releasing the slot so a second run can never claim the
+        # sole worker while this worker still owes a result.
+        result_queue.put((call_id, observation, error))
+        with _TOOL_SLOT_LOCK:
+            _TOOL_SLOT_BUSY = False
+
+
 def _validate_start_payload(payload: Any) -> None:
     if not isinstance(payload, dict):
         raise ValueError("start payload must be an object")
@@ -126,9 +222,9 @@ def _validate_start_payload(payload: Any) -> None:
         raise ValueError("start payload has unknown or missing top-level fields")
 
     if payload["execution_environment"] != "eval":
-        raise ValueError("S1 only accepts execution_environment 'eval'")
+        raise ValueError("S1/S2 only accept execution_environment 'eval'")
     if payload["session_id"] is not None:
-        raise ValueError("S1 requires session_id null")
+        raise ValueError("S1/S2 require session_id null")
     if not _is_nonempty_str(payload["system_prompt"]):
         raise ValueError("system_prompt must be a non-empty string")
     if not _is_nonempty_str(payload["user_message"]):
@@ -146,10 +242,9 @@ def _validate_start_payload(payload: Any) -> None:
         ):
             raise ValueError("runtime_context must hold closed system messages")
 
-    if payload["tools"] != []:
-        raise ValueError("S1 requires an empty tools array")
+    _validate_tools(payload["tools"])
     if payload["recovered_observations"] != []:
-        raise ValueError("S1 requires an empty recovered_observations array")
+        raise ValueError("S1/S2 require an empty recovered_observations array")
 
     model = payload["model"]
     if not isinstance(model, dict):
@@ -198,10 +293,21 @@ def _validate_start_payload(payload: Any) -> None:
             raise ValueError(f"limits.{key} must be a positive integer")
 
     debug = payload["debug"]
-    if not isinstance(debug, dict) or set(debug) != {"fixture_response", "delay_ms"}:
-        raise ValueError("debug must hold only fixture_response and delay_ms")
-    if not isinstance(debug["fixture_response"], str):
-        raise ValueError("debug.fixture_response must be a string")
+    if not isinstance(debug, dict):
+        raise ValueError("debug must be an object")
+    # S1 accepted a single string fixture; S2 adds a turn array. Keep both so
+    # the no-tools eval path stays backward compatible.
+    if "fixture_response" in debug:
+        if set(debug) != {"fixture_response", "delay_ms"}:
+            raise ValueError("debug must hold only fixture_response and delay_ms")
+        if not isinstance(debug["fixture_response"], str):
+            raise ValueError("debug.fixture_response must be a string")
+    elif "fixture_turns" in debug:
+        if set(debug) != {"fixture_turns", "delay_ms"}:
+            raise ValueError("debug must hold only fixture_turns and delay_ms")
+        _validate_fixture_turns(debug["fixture_turns"])
+    else:
+        raise ValueError("debug must hold fixture_response or fixture_turns")
     delay = debug["delay_ms"]
     if (
         not isinstance(delay, int)
@@ -269,7 +375,10 @@ def _encode_envelope(
         "seq": seq,
         "payload": payload,
     }
-    line = json.dumps(record, ensure_ascii=False) + "\n"
+    try:
+        line = json.dumps(record, ensure_ascii=False) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise ValueError("outbound envelope is not JSON serializable") from exc
     data = line.encode("utf-8")
     if len(data) > MAX_LINE_BYTES:
         raise ValueError("outbound envelope exceeds line ceiling")
@@ -370,6 +479,18 @@ def _validate_agent_event(payload: dict[str, Any]) -> None:
         if data["stop_reason"] not in _STOP_REASONS:
             raise ValueError("turn event stop_reason is not allowed")
         _validate_usage(data["usage"])
+    elif event_type == "tool_execution_start":
+        if set(data) != {"call_id", "tool_name"}:
+            raise ValueError("tool_execution_start data shape is invalid")
+        if not _is_nonempty_str(data["call_id"]) or not _is_nonempty_str(data["tool_name"]):
+            raise ValueError("tool event ids must be non-empty strings")
+    elif event_type == "tool_execution_end":
+        if set(data) != {"call_id", "tool_name", "ok"}:
+            raise ValueError("tool_execution_end data shape is invalid")
+        if not _is_nonempty_str(data["call_id"]) or not _is_nonempty_str(data["tool_name"]):
+            raise ValueError("tool event ids must be non-empty strings")
+        if not isinstance(data["ok"], bool):
+            raise ValueError("tool_execution_end ok must be a boolean")
 
 
 def _validate_terminal_payload(payload: dict[str, Any], final: bool) -> None:
@@ -394,11 +515,11 @@ def _validate_terminal_payload(payload: dict[str, Any], final: bool) -> None:
     if set(payload) != required:
         raise ValueError("terminal payload has unknown or missing fields")
     if status not in {"answered", "cancelled"}:
-        raise ValueError("S1 terminal status is not allowed")
+        raise ValueError("S1/S2 terminal status is not allowed")
     if not isinstance(payload["text"], str):
         raise ValueError("terminal text must be a string")
     if payload["control_request"] is not None:
-        raise ValueError("S1 terminal control_request must be null")
+        raise ValueError("S1/S2 terminal control_request must be null")
     reason = payload["termination_reason"]
     _validate_usage(payload["usage"])
     if status == "answered":
@@ -410,7 +531,7 @@ def _validate_terminal_payload(payload: dict[str, Any], final: bool) -> None:
         if payload["text"] != "":
             raise ValueError("cancelled terminal text must be empty")
     if not final and status != "answered":
-        raise ValueError("S1 proposal permits only an answered candidate")
+        raise ValueError("S1/S2 proposal permits only an answered candidate")
     if final:
         if not isinstance(payload["committed"], bool):
             raise ValueError("run.final committed must be a boolean")
@@ -445,6 +566,8 @@ def run_pi_agent(
     runtime_entry: Path | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
+    global _TOOL_SLOT_BUSY
+
     if not _is_nonempty_str(request_id) or not _is_nonempty_str(run_id):
         return _safe_failure("CONFIG_ERROR", "config", "invalid identity", False)
     if not _is_pos_int(timeout_seconds):
@@ -454,6 +577,8 @@ def run_pi_agent(
         _validate_start_payload(start_payload)
     except ValueError as exc:
         return _safe_failure("CONFIG_ERROR", "config", str(exc), False)
+
+    allowed_tool_names = frozenset(tool["name"] for tool in start_payload["tools"])
 
     if start_payload["limits"]["timeout_seconds"] != timeout_seconds:
         return _safe_failure(
@@ -522,6 +647,8 @@ def run_pi_agent(
     final_result: dict[str, Any] | None = None
     final_error: dict[str, Any] | None = None
     final_ok: bool | None = None
+    result_queue: "queue.Queue[tuple[str, dict[str, Any] | None, dict[str, Any] | None]]" = queue.Queue()
+    pending_tool: dict[str, str] | None = None
 
     try:
         process.stdin.write(start_line)
@@ -663,8 +790,46 @@ def run_pi_agent(
                                         _stop_child(process)
                                         return _safe_failure("INTERNAL_ERROR", "runtime", "event callback failed", False)
                             elif type_ == "tool.call":
-                                _stop_child(process)
-                                return _safe_failure("TOOL_BRIDGE_ERROR", "tool", "unexpected tool call", False)
+                                if not accepted:
+                                    _stop_child(process)
+                                    return _safe_failure("PROTOCOL_ERROR", "protocol", "tool call before accepted", False)
+                                _validate_tool_call_payload(payload)
+                                if payload["tool_name"] not in allowed_tool_names:
+                                    _stop_child(process)
+                                    return _safe_failure("TOOL_BRIDGE_ERROR", "tool", "tool outside Host allowlist", False)
+                                if on_tool_call is None:
+                                    _stop_child(process)
+                                    return _safe_failure("INTERNAL_ERROR", "runtime", "missing tool callback", False)
+                                if pending_tool is not None:
+                                    _stop_child(process)
+                                    return _safe_failure("PROTOCOL_ERROR", "protocol", "second outstanding tool call", False)
+                                with _TOOL_SLOT_LOCK:
+                                    if _TOOL_SLOT_BUSY:
+                                        _stop_child(process)
+                                        return _safe_failure("TOOL_BRIDGE_ERROR", "tool", "another tool call is outstanding", True)
+                                    _TOOL_SLOT_BUSY = True
+                                pending_tool = {
+                                    "call_id": payload["call_id"],
+                                    "tool_name": payload["tool_name"],
+                                }
+                                try:
+                                    worker = threading.Thread(
+                                        target=_run_tool_worker,
+                                        args=(
+                                            payload["call_id"],
+                                            payload["tool_name"],
+                                            payload["arguments"],
+                                            on_tool_call,
+                                            result_queue,
+                                        ),
+                                        daemon=True,
+                                    )
+                                    worker.start()
+                                except Exception:
+                                    with _TOOL_SLOT_LOCK:
+                                        _TOOL_SLOT_BUSY = False
+                                    _stop_child(process)
+                                    return _safe_failure("INTERNAL_ERROR", "runtime", "tool worker spawn failed", False)
                             elif type_ == "run.proposed":
                                 if saw_terminal:
                                     _stop_child(process)
@@ -720,6 +885,46 @@ def run_pi_agent(
                         except ValueError:
                             _stop_child(process)
                             return _safe_failure("PROTOCOL_ERROR", "protocol", "invalid child record", False)
+
+            while True:
+                try:
+                    call_id, observation, error = result_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if pending_tool is None or pending_tool["call_id"] != call_id:
+                    _stop_child(process)
+                    return _safe_failure("PROTOCOL_ERROR", "protocol", "tool result mismatch", False)
+                if error is not None:
+                    _stop_child(process)
+                    return error
+                if cancel_sent or saw_terminal:
+                    pending_tool = None
+                    continue
+                tool_name = pending_tool["tool_name"]
+                try:
+                    line_out = _encode_envelope(
+                        "tool.result",
+                        {"call_id": call_id, "tool_name": tool_name, "observation": observation},
+                        identity,
+                        py_seq,
+                    )
+                    py_seq += 1
+                    process.stdin.write(line_out)
+                    process.stdin.flush()
+                except ValueError:
+                    _stop_child(process)
+                    return _safe_failure(
+                        "TOOL_BRIDGE_ERROR",
+                        "tool",
+                        "observation is invalid or exceeds line ceiling",
+                        False,
+                    )
+                except OSError:
+                    _stop_child(process)
+                    return _safe_failure(
+                        "PI_PROCESS_EXITED", "process", "child closed stdin before tool result", True
+                    )
+                pending_tool = None
 
             if saw_terminal and process.poll() is not None:
                 break

--- a/src/infrastructure/pi_agent_process.py
+++ b/src/infrastructure/pi_agent_process.py
@@ -593,8 +593,11 @@ def run_pi_agent(
                         # child closed stdout: EOF
                         if not saw_terminal:
                             # Capture the exit code before reaping so a hard
-                            # startup failure (non-zero, zero envelopes) is not
-                            # mistaken for an in-run process death.
+                            # startup failure (non-zero, before acceptance) is
+                            # not mistaken for an in-run process death. Once
+                            # `run.accepted` was seen the protocol is
+                            # established, so a non-zero exit is a process
+                            # death, not a runtime availability failure.
                             exit_code = process.poll()
                             try:
                                 while True:
@@ -605,7 +608,7 @@ def run_pi_agent(
                             except (BlockingIOError, OSError):
                                 pass
                             _stop_child(process)
-                            if exit_code not in (None, 0):
+                            if exit_code not in (None, 0) and not accepted:
                                 detail = _stderr_summary(stderr_buffer)
                                 message = "child failed before protocol established"
                                 if detail:

--- a/tests/test_pi_agent_process.py
+++ b/tests/test_pi_agent_process.py
@@ -203,6 +203,7 @@ def test_pre_identity_nonzero_exit(tmp_path):
     assert result["error"]["code"] == "PI_RUNTIME_UNAVAILABLE"
     assert result["error"]["stage"] == "spawn"
     assert result["error"]["retryable"] is False
+    assert "boom" in result["error"]["message"]
 
 
 def test_timeout(tmp_path):
@@ -368,3 +369,75 @@ def test_terminal_then_hang_preserves_validated_result(tmp_path):
     assert result["ok"] is True
     assert result["result"]["status"] == "answered"
     assert result["result"]["text"] == "hello"
+
+
+_CANCEL_RACE_CHILD = """
+import { createInterface } from "node:readline";
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+const rec = (type, seq, payload) =>
+  process.stdout.write(JSON.stringify({
+    protocol: "om-pi-ipc.v1", type, request_id: "req_1", run_id: "run_1",
+    seq, payload,
+  }) + "\\n");
+let n = 0;
+rl.on("line", (line) => {
+  n += 1;
+  if (n === 1) {
+    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+    rec("agent.event", 2, { event_type: "agent_start", data: {} });
+    rec("agent.event", 3, { event_type: "turn_start", data: {} });
+    rec("agent.event", 4, { event_type: "model_turn_completed", data: { stop_reason: "stop", usage: {} } });
+    rec("agent.event", 5, { event_type: "turn_end", data: { stop_reason: "stop", usage: {} } });
+    rec("agent.event", 6, { event_type: "agent_end", data: {} });
+    rec("run.proposed", 7, { status: "answered", text: "hello", control_request: null, termination_reason: "stop", usage: {} });
+  } else if (n === 2) {
+    // Python already sent run.cancel before reading the proposal; the child
+    // answers with a cancelled final, not an answered commit.
+    rec("run.final", 8, { status: "cancelled", text: "", control_request: null, termination_reason: "aborted", usage: {}, committed: false });
+    process.exit(0);
+  }
+});
+"""
+
+
+def test_cancel_beats_fast_proposal(tmp_path):
+    entry = _write_fake(tmp_path, _CANCEL_RACE_CHILD)
+    calls = {"n": 0}
+
+    def is_cancelled():
+        calls["n"] += 1
+        # False for the pre-spawn check, True on the first loop iteration so
+        # the host cancellation is written before the buffered proposal.
+        return calls["n"] > 1
+
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        is_cancelled=is_cancelled,
+        on_proposed=lambda p: "commit",
+        runtime_entry=entry,
+    )
+    assert result["ok"] is True
+    assert result["result"]["status"] == "cancelled"
+    assert result["result"]["committed"] is False
+
+
+def test_real_runtime_exits_promptly_on_commit():
+    import time
+
+    t0 = time.monotonic()
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_proposed=lambda p: "commit",
+    )
+    elapsed = time.monotonic() - t0
+    assert result["ok"] is True
+    assert result["result"]["committed"] is True
+    # Before the stdin-destroy fix the child hung for the fixed 1s grace +
+    # SIGTERM. After the fix it exits cleanly well under that window.
+    assert elapsed < 0.8

--- a/tests/test_pi_agent_process.py
+++ b/tests/test_pi_agent_process.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
 import os
+import select
+import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -13,6 +18,7 @@ from src.infrastructure.pi_agent_process import (  # noqa: E402
     _runtime_command,
     run_pi_agent,
 )
+from src.infrastructure import pi_agent_process as pi_process  # noqa: E402
 
 
 def _start_payload(**overrides):
@@ -52,6 +58,159 @@ def _write_fake(tmp_path: Path, source: str) -> Path:
     entry = tmp_path / "fake.mjs"
     entry.write_text(source, encoding="utf-8")
     return entry
+
+
+_READ_TOOL = {
+    "name": "runtime_status",
+    "description": "Read runtime status",
+    "input_schema": {
+        "type": "object",
+        "properties": {"index": {"type": "integer"}},
+        "additionalProperties": False,
+    },
+}
+
+
+def _tool_payload(turns, **overrides):
+    return _start_payload(
+        tools=[_READ_TOOL],
+        debug={"fixture_turns": turns, "delay_ms": 0},
+        **overrides,
+    )
+
+
+def _tool_turn(
+    call_id: str = "call_1",
+    *,
+    tool_name: str = "runtime_status",
+    arguments: dict | None = None,
+):
+    return {
+        "tool_calls": [
+            {
+                "call_id": call_id,
+                "tool_name": tool_name,
+                "arguments": arguments or {},
+            }
+        ]
+    }
+
+
+def _wait_for_tool_slot(expected: bool, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with pi_process._TOOL_SLOT_LOCK:
+            if pi_process._TOOL_SLOT_BUSY is expected:
+                return True
+        time.sleep(0.01)
+    return False
+
+
+def _node_protocol_case(messages):
+    command, entry = _runtime_command(None, None)
+    process = subprocess.Popen(
+        command,
+        cwd=entry.parent.parent,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    identity = {"request_id": "req_1", "run_id": "run_1"}
+    start = {
+        "protocol": "om-pi-ipc.v1",
+        "type": "run.start",
+        **identity,
+        "seq": 1,
+        "payload": _tool_payload(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "call_id": "call_1",
+                            "tool_name": "runtime_status",
+                            "arguments": {},
+                        }
+                    ]
+                },
+                {"text": "done"},
+            ]
+        ),
+    }
+    buffer = b""
+
+    def read_record():
+        nonlocal buffer
+        deadline = time.monotonic() + 5
+        while b"\n" not in buffer:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError("timed out waiting for Node record")
+            ready, _, _ = select.select([process.stdout], [], [], remaining)
+            if not ready:
+                raise AssertionError("timed out waiting for Node record")
+            chunk = os.read(process.stdout.fileno(), 65536)
+            if not chunk:
+                raise AssertionError("Node exited before terminal record")
+            buffer += chunk
+        line, buffer = buffer.split(b"\n", 1)
+        return json.loads(line)
+
+    try:
+        process.stdin.write((json.dumps(start) + "\n").encode())
+        process.stdin.flush()
+        while read_record()["type"] != "tool.call":
+            pass
+        encoded = []
+        for seq, (type_, payload) in enumerate(messages, start=2):
+            encoded.append(
+                json.dumps(
+                    {
+                        "protocol": "om-pi-ipc.v1",
+                        "type": type_,
+                        **identity,
+                        "seq": seq,
+                        "payload": payload,
+                    }
+                )
+                + "\n"
+            )
+        process.stdin.write("".join(encoded).encode())
+        process.stdin.flush()
+        while True:
+            record = read_record()
+            if record["type"] in {"run.error", "run.final"}:
+                return record
+    finally:
+        if process.poll() is None:
+            process.terminate()
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=1)
+
+
+def _fake_tool_call_child(calls) -> str:
+    records = "\n".join(
+        f'rec("tool.call", {seq}, {json.dumps(call)});'
+        for seq, call in enumerate(calls, start=2)
+    )
+    return (
+        """
+import { createInterface } from "node:readline";
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+const rec = (type, seq, payload) =>
+  process.stdout.write(JSON.stringify({
+    protocol: "om-pi-ipc.v1", type, request_id: "req_1", run_id: "run_1",
+    seq, payload,
+  }) + "\\n");
+rl.once("line", () => {
+  rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+"""
+        + records
+        + "\n});\n"
+    )
 
 
 _HAPPY_CHILD = """
@@ -474,3 +633,410 @@ def test_empty_fixture_returns_model_error():
     assert result["error"]["code"] == "MODEL_ERROR"
     assert result["error"]["stage"] == "model"
     assert result["error"]["retryable"] is False
+
+
+def test_real_tool_bridge_round_trip_and_sanitized_events():
+    calls = []
+    events = []
+
+    def call_tool(payload):
+        calls.append(payload)
+        return {"ok": True, "summary": {"status": "ready"}}
+
+    result = run_pi_agent(
+        _tool_payload([_tool_turn(arguments={"index": 1}), {"text": "done"}]),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_event=events.append,
+        on_tool_call=call_tool,
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is True
+    assert result["result"]["text"] == "done"
+    assert result["result"]["committed"] is True
+    assert calls == [
+        {
+            "call_id": "call_1",
+            "tool_name": "runtime_status",
+            "arguments": {"index": 1},
+        }
+    ]
+    tool_events = [
+        event for event in events if event["event_type"].startswith("tool_execution_")
+    ]
+    assert tool_events == [
+        {
+            "event_type": "tool_execution_start",
+            "data": {"call_id": "call_1", "tool_name": "runtime_status"},
+        },
+        {
+            "event_type": "tool_execution_end",
+            "data": {"call_id": "call_1", "tool_name": "runtime_status", "ok": True},
+        },
+    ]
+    assert "arguments" not in json.dumps(events)
+    assert "ready" not in json.dumps(events)
+
+
+def test_pi_schema_rejects_invalid_arguments_before_callback():
+    calls = []
+    events = []
+    result = run_pi_agent(
+        _tool_payload([_tool_turn(arguments={"index": "bad"}), {"text": "recovered"}]),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_event=events.append,
+        on_tool_call=lambda payload: calls.append(payload) or {"ok": True},
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is True
+    assert result["result"]["text"] == "recovered"
+    assert calls == []
+    assert any(
+        event["event_type"] == "tool_execution_end" and event["data"]["ok"] is False
+        for event in events
+    )
+
+
+def test_multiple_tool_calls_run_in_source_order_without_overlap():
+    trace = []
+    active = False
+
+    def call_tool(payload):
+        nonlocal active
+        assert active is False
+        active = True
+        trace.append(("start", payload["call_id"]))
+        time.sleep(0.02)
+        trace.append(("end", payload["call_id"]))
+        active = False
+        return {"ok": True, "index": payload["arguments"]["index"]}
+
+    first = _tool_turn("call_1", arguments={"index": 1})["tool_calls"][0]
+    second = _tool_turn("call_2", arguments={"index": 2})["tool_calls"][0]
+    result = run_pi_agent(
+        _tool_payload([{"tool_calls": [first, second]}, {"text": "done"}]),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_tool_call=call_tool,
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is True
+    assert trace == [
+        ("start", "call_1"),
+        ("end", "call_1"),
+        ("start", "call_2"),
+        ("end", "call_2"),
+    ]
+
+
+def test_compact_failed_observation_becomes_error_tool_result():
+    events = []
+    result = run_pi_agent(
+        _tool_payload([_tool_turn(), {"text": "fixed"}]),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_event=events.append,
+        on_tool_call=lambda _payload: {
+            "ok": False,
+            "error": {"code": "INVALID_ARGUMENT", "message": "bad input"},
+        },
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is True
+    assert result["result"]["text"] == "fixed"
+    assert any(
+        event["event_type"] == "tool_execution_end" and event["data"]["ok"] is False
+        for event in events
+    )
+
+
+def test_tool_callback_exception_is_terminal_and_redacted():
+    def call_tool(_payload):
+        raise RuntimeError("secret /private/account.json")
+
+    result = run_pi_agent(
+        _tool_payload([_tool_turn(), {"text": "must not commit"}]),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_tool_call=call_tool,
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == {
+        "code": "TOOL_BRIDGE_ERROR",
+        "stage": "tool",
+        "message": "tool callback failed",
+        "retryable": False,
+    }
+    assert "secret" not in json.dumps(result)
+
+
+def test_non_json_callback_result_fails_closed():
+    result = run_pi_agent(
+        _tool_payload([_tool_turn(), {"text": "must not commit"}]),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_tool_call=lambda _payload: {"ok": True, "value": object()},
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "TOOL_BRIDGE_ERROR"
+    assert result["error"]["stage"] == "tool"
+
+
+def test_python_rejects_tool_outside_host_allowlist(tmp_path):
+    calls = []
+    entry = _write_fake(
+        tmp_path,
+        _fake_tool_call_child(
+            [
+                {
+                    "call_id": "call_1",
+                    "tool_name": "symbol_config_update",
+                    "arguments": {},
+                }
+            ]
+        ),
+    )
+    result = run_pi_agent(
+        _tool_payload([_tool_turn(), {"text": "unused"}]),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        runtime_entry=entry,
+        on_tool_call=lambda payload: calls.append(payload) or {"ok": True},
+    )
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "TOOL_BRIDGE_ERROR"
+    assert result["error"]["retryable"] is False
+    assert calls == []
+
+
+def test_python_rejects_second_outstanding_tool_call(tmp_path):
+    release = threading.Event()
+    calls = []
+    entry = _write_fake(
+        tmp_path,
+        _fake_tool_call_child(
+            [
+                {"call_id": "call_1", "tool_name": "runtime_status", "arguments": {}},
+                {"call_id": "call_2", "tool_name": "runtime_status", "arguments": {}},
+            ]
+        ),
+    )
+
+    def call_tool(payload):
+        calls.append(payload)
+        release.wait(2)
+        return {"ok": True}
+
+    try:
+        result = run_pi_agent(
+            _tool_payload([_tool_turn(), {"text": "unused"}]),
+            request_id="req_1",
+            run_id="run_1",
+            timeout_seconds=60,
+            runtime_entry=entry,
+            on_tool_call=call_tool,
+        )
+        assert result["ok"] is False
+        assert result["error"]["code"] == "PROTOCOL_ERROR"
+        assert calls == [
+            {"call_id": "call_1", "tool_name": "runtime_status", "arguments": {}}
+        ]
+    finally:
+        release.set()
+        assert _wait_for_tool_slot(False)
+
+
+@pytest.mark.parametrize(
+    "tool_result",
+    [
+        {"call_id": "other", "tool_name": "runtime_status", "observation": {"ok": True}},
+        {"call_id": "call_1", "tool_name": "other", "observation": {"ok": True}},
+    ],
+)
+def test_node_rejects_mismatched_tool_result(tool_result):
+    record = _node_protocol_case([("tool.result", tool_result)])
+
+    assert record["type"] == "run.error"
+    assert record["payload"]["code"] == "PROTOCOL_ERROR"
+
+
+def test_node_rejects_duplicate_tool_result():
+    tool_result = {
+        "call_id": "call_1",
+        "tool_name": "runtime_status",
+        "observation": {"ok": True},
+    }
+    record = _node_protocol_case(
+        [("tool.result", tool_result), ("tool.result", tool_result)]
+    )
+
+    assert record["type"] == "run.error"
+    assert record["payload"]["code"] == "PROTOCOL_ERROR"
+
+
+def test_node_rejects_tool_result_after_cancel():
+    record = _node_protocol_case(
+        [
+            ("run.cancel", {"reason": "host_cancel_requested"}),
+            (
+                "tool.result",
+                {
+                    "call_id": "call_1",
+                    "tool_name": "runtime_status",
+                    "observation": {"ok": True},
+                },
+            ),
+        ]
+    )
+
+    assert record["type"] == "run.error"
+    assert record["payload"]["code"] == "PROTOCOL_ERROR"
+
+
+def test_cancelled_tool_keeps_single_worker_slot_until_callback_returns():
+    entered = threading.Event()
+    release = threading.Event()
+    second_calls = []
+    payload = _tool_payload([_tool_turn(), {"text": "unused"}])
+    payload["limits"]["timeout_seconds"] = 5
+    payload["limits"]["final_answer_reserve_seconds"] = 1
+    payload["model"]["timeout_seconds"] = 5
+
+    def slow_tool(_payload):
+        entered.set()
+        release.wait()
+        return {"ok": True}
+
+    try:
+        cancelled = run_pi_agent(
+            payload,
+            request_id="req_1",
+            run_id="run_1",
+            timeout_seconds=5,
+            on_tool_call=slow_tool,
+            is_cancelled=entered.is_set,
+        )
+        assert cancelled["ok"] is True
+        assert cancelled["result"]["status"] == "cancelled"
+        assert _wait_for_tool_slot(True)
+
+        for index in (2, 3):
+            blocked = run_pi_agent(
+                payload,
+                request_id=f"req_{index}",
+                run_id=f"run_{index}",
+                timeout_seconds=5,
+                on_tool_call=lambda call: second_calls.append(call) or {"ok": True},
+            )
+            assert blocked["ok"] is False
+            assert blocked["error"] == {
+                "code": "TOOL_BRIDGE_ERROR",
+                "stage": "tool",
+                "message": "another tool call is outstanding",
+                "retryable": True,
+            }
+        assert second_calls == []
+    finally:
+        release.set()
+        assert _wait_for_tool_slot(False)
+
+
+def test_timeout_discards_late_tool_value_but_worker_owns_slot():
+    entered = threading.Event()
+    release = threading.Event()
+    payload = _tool_payload([_tool_turn(), {"text": "unused"}])
+    payload["limits"]["timeout_seconds"] = 1
+    payload["limits"]["final_answer_reserve_seconds"] = 1
+    payload["model"]["timeout_seconds"] = 1
+
+    def slow_tool(_payload):
+        entered.set()
+        release.wait()
+        return {"ok": True, "late": True}
+
+    try:
+        result = run_pi_agent(
+            payload,
+            request_id="req_1",
+            run_id="run_1",
+            timeout_seconds=1,
+            on_tool_call=slow_tool,
+        )
+        assert entered.is_set()
+        assert result["ok"] is False
+        assert result["error"]["code"] == "PI_PROCESS_TIMEOUT"
+        assert _wait_for_tool_slot(True)
+    finally:
+        release.set()
+        assert _wait_for_tool_slot(False)
+
+
+@pytest.mark.parametrize(
+    ("limit_name", "observation"),
+    [
+        ("max_iterations", {"ok": True}),
+        ("max_tool_calls", {"ok": True}),
+        ("max_consecutive_failed_tool_batches", {"ok": False}),
+        ("final_answer_reserve_seconds", {"ok": True}),
+    ],
+)
+def test_budget_limit_allows_one_tool_free_final_turn(limit_name, observation):
+    payload = _tool_payload([_tool_turn(), {"text": "forced final"}])
+    payload["limits"][limit_name] = (
+        payload["limits"]["timeout_seconds"]
+        if limit_name == "final_answer_reserve_seconds"
+        else 1
+    )
+    calls = []
+    result = run_pi_agent(
+        payload,
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_tool_call=lambda call: calls.append(call) or observation,
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is True
+    assert result["result"]["text"] == "forced final"
+    assert len(calls) == 1
+
+
+def test_budget_exhaustion_without_text_is_not_a_successful_answer():
+    payload = _tool_payload([_tool_turn(), _tool_turn("call_2")])
+    payload["limits"]["max_iterations"] = 1
+    calls = []
+    result = run_pi_agent(
+        payload,
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_tool_call=lambda call: calls.append(call) or {"ok": True},
+        on_proposed=lambda _payload: "commit",
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == {
+        "code": "BUDGET_EXHAUSTED",
+        "stage": "budget",
+        "message": "agent budget exhausted without a final answer",
+        "retryable": False,
+    }
+    assert len(calls) == 1

--- a/tests/test_pi_agent_process.py
+++ b/tests/test_pi_agent_process.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from src.infrastructure.pi_agent_process import (  # noqa: E402
+    _runtime_command,
+    run_pi_agent,
+)
+
+
+def _start_payload(**overrides):
+    base = {
+        "execution_environment": "eval",
+        "session_id": None,
+        "system_prompt": "sys",
+        "runtime_context": [],
+        "user_message": "hi",
+        "model": {
+            "provider": "deepseek",
+            "api_kind": "openai-completions",
+            "model": "deepseek-chat",
+            "base_url": "https://api.deepseek.com",
+            "timeout_seconds": 30,
+            "context_window_tokens": 24000,
+            "max_output_tokens": 2048,
+            "max_attempts": 2,
+        },
+        "tools": [],
+        "limits": {
+            "timeout_seconds": 60,
+            "max_iterations": 16,
+            "max_tool_calls": 12,
+            "max_context_tokens": 24000,
+            "max_consecutive_failed_tool_batches": 2,
+            "final_answer_reserve_seconds": 20,
+        },
+        "recovered_observations": [],
+        "debug": {"fixture_response": "hello", "delay_ms": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_fake(tmp_path: Path, source: str) -> Path:
+    entry = tmp_path / "fake.mjs"
+    entry.write_text(source, encoding="utf-8")
+    return entry
+
+
+_HAPPY_CHILD = """
+import { createInterface } from "node:readline";
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+const rec = (type, seq, payload) =>
+  process.stdout.write(JSON.stringify({
+    protocol: "om-pi-ipc.v1", type, request_id: "req_1", run_id: "run_1",
+    seq, payload,
+  }) + "\\n");
+let n = 0;
+rl.on("line", (line) => {
+  n += 1;
+  if (n === 1) {
+    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+    rec("agent.event", 2, { event_type: "agent_start", data: {} });
+    rec("agent.event", 3, { event_type: "turn_start", data: {} });
+    rec("agent.event", 4, { event_type: "model_turn_completed", data: { stop_reason: "stop", usage: { input: 1, output: 1, totalTokens: 2 } } });
+    rec("agent.event", 5, { event_type: "turn_end", data: { stop_reason: "stop", usage: { input: 1, output: 1, totalTokens: 2 } } });
+    rec("agent.event", 6, { event_type: "agent_end", data: {} });
+    rec("run.proposed", 7, { status: "answered", text: "hello", control_request: null, termination_reason: "stop", usage: { input: 1, output: 1, totalTokens: 2 } });
+  } else if (n === 2) {
+    const decision = JSON.parse(line).type;
+    const committed = decision === "run.commit";
+    rec("run.final", 8, { status: "answered", text: "hello", control_request: null, termination_reason: "stop", usage: { input: 1, output: 1, totalTokens: 2 }, committed });
+    process.exit(0);
+  }
+});
+"""
+
+
+def test_commit_and_discard():
+    events = []
+    committed = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_event=events.append,
+        on_proposed=lambda p: "commit",
+    )
+    assert committed == {
+        "ok": True,
+        "result": {
+            "status": "answered",
+            "text": "hello",
+            "control_request": None,
+            "termination_reason": "stop",
+            "usage": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 0},
+            "committed": True,
+        },
+    }
+    assert [e["event_type"] for e in events] == [
+        "agent_start",
+        "turn_start",
+        "model_turn_completed",
+        "turn_end",
+        "agent_end",
+    ]
+
+    discarded = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        on_proposed=lambda p: "discard",
+    )
+    assert discarded["ok"] is True
+    assert discarded["result"]["committed"] is False
+
+
+def test_cancel_trace():
+    import time
+
+    t0 = time.monotonic()
+
+    def is_cancelled():
+        return time.monotonic() - t0 > 0.5
+
+    result = run_pi_agent(
+        _start_payload(debug={"fixture_response": "hello", "delay_ms": 5000}),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        is_cancelled=is_cancelled,
+    )
+    assert result["ok"] is True
+    assert result["result"]["status"] == "cancelled"
+    assert result["result"]["committed"] is False
+
+
+def test_malformed_child_fails_protocol(tmp_path):
+    entry = _write_fake(tmp_path, 'process.stdout.write("not json\\n");\n')
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PROTOCOL_ERROR"
+    assert result["error"]["stage"] == "protocol"
+
+
+def test_mismatched_run_id_fails_closed(tmp_path):
+    entry = _write_fake(
+        tmp_path,
+        'process.stdout.write(JSON.stringify({protocol:"om-pi-ipc.v1",type:"run.accepted",request_id:"req_1",run_id:"OTHER",seq:1,payload:{runtime:"pi-agent-core",runtime_version:"0.84.2",session_id:null}})+"\\n");\n',
+    )
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PROTOCOL_ERROR"
+
+
+def test_premature_eof(tmp_path):
+    entry = _write_fake(tmp_path, "process.exit(0);\n")
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PI_PROCESS_EXITED"
+    assert result["error"]["retryable"] is True
+
+
+def test_pre_identity_nonzero_exit(tmp_path):
+    entry = _write_fake(
+        tmp_path,
+        'process.stderr.write("boom\\n"); process.exit(2);\n',
+    )
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PI_RUNTIME_UNAVAILABLE"
+    assert result["error"]["stage"] == "spawn"
+    assert result["error"]["retryable"] is False
+
+
+def test_timeout(tmp_path):
+    entry = _write_fake(tmp_path, "setInterval(() => {}, 1000);\n")
+    payload = _start_payload(
+        model={
+            "provider": "deepseek",
+            "api_kind": "openai-completions",
+            "model": "deepseek-chat",
+            "base_url": "https://api.deepseek.com",
+            "timeout_seconds": 1,
+            "context_window_tokens": 24000,
+            "max_output_tokens": 2048,
+            "max_attempts": 2,
+        },
+        limits={
+            "timeout_seconds": 1,
+            "max_iterations": 16,
+            "max_tool_calls": 12,
+            "max_context_tokens": 24000,
+            "max_consecutive_failed_tool_batches": 2,
+            "final_answer_reserve_seconds": 20,
+        },
+    )
+    result = run_pi_agent(
+        payload,
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=1,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PI_PROCESS_TIMEOUT"
+    assert result["error"]["stage"] == "deadline"
+
+
+def test_cooperative_cancel_before_spawn(tmp_path):
+    entry = _write_fake(tmp_path, _HAPPY_CHILD)
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        is_cancelled=lambda: True,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "CANCELLED"
+
+
+def test_invalid_start_payload_rejected():
+    result = run_pi_agent(
+        _start_payload(session_id="s1"),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "CONFIG_ERROR"
+
+
+def test_timeout_mismatch_rejected():
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=99,  # limits.timeout_seconds is 60
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "CONFIG_ERROR"
+    assert result["error"]["stage"] == "config"
+
+
+def test_missing_node_runtime():
+    entry = Path("/nonexistent/fake.mjs")
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PI_RUNTIME_UNAVAILABLE"
+
+
+def test_runtime_command_honors_injected_environ_path(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_node = bin_dir / "node"
+    fake_node.write_text("#!/bin/sh\necho v22.19.0\n", encoding="utf-8")
+    fake_node.chmod(0o755)
+    entry = tmp_path / "fake.mjs"
+    entry.write_text("", encoding="utf-8")
+
+    command, resolved_entry = _runtime_command(entry, environ={"PATH": str(bin_dir)})
+
+    assert command == [str(fake_node), str(entry)]
+    assert resolved_entry == entry
+
+
+_TRACE_HEAD = """
+import { createInterface } from "node:readline";
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+const rec = (type, seq, payload) =>
+  process.stdout.write(JSON.stringify({
+    protocol: "om-pi-ipc.v1", type, request_id: "req_1", run_id: "run_1",
+    seq, payload,
+  }) + "\\n");
+let n = 0;
+rl.on("line", (line) => {
+  n += 1;
+  if (n === 1) {
+    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+    rec("agent.event", 2, { event_type: "agent_start", data: {} });
+    rec("agent.event", 3, { event_type: "turn_start", data: {} });
+    rec("agent.event", 4, { event_type: "model_turn_completed", data: { stop_reason: "stop", usage: {} } });
+    rec("agent.event", 5, { event_type: "turn_end", data: { stop_reason: "stop", usage: {} } });
+    rec("agent.event", 6, { event_type: "agent_end", data: {} });
+    rec("run.proposed", 7, { status: "answered", text: "hello", control_request: null, termination_reason: "stop", usage: {} });
+  } else if (n === 2) {
+    rec("run.final", 8, { status: "answered", text: "hello", control_request: null, termination_reason: "stop", usage: {}, committed: true });
+"""
+
+
+def test_oversized_line_fails_protocol(tmp_path):
+    entry = _write_fake(tmp_path, 'process.stdout.write("x".repeat(1100000) + "\\n");\n')
+    result = run_pi_agent(
+        _start_payload(), request_id="req_1", run_id="run_1", timeout_seconds=60, runtime_entry=entry
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PROTOCOL_ERROR"
+    assert result["error"]["stage"] == "protocol"
+
+
+def test_record_after_terminal_fails_protocol(tmp_path):
+    child = _TRACE_HEAD + """
+    rec("run.final", 9, { status: "answered", text: "hello", control_request: null, termination_reason: "stop", usage: {}, committed: true });
+  }
+});
+"""
+    entry = _write_fake(tmp_path, child)
+    result = run_pi_agent(
+        _start_payload(), request_id="req_1", run_id="run_1", timeout_seconds=60,
+        on_proposed=lambda p: "commit", runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PROTOCOL_ERROR"
+    assert result["error"]["stage"] == "protocol"
+
+
+def test_terminal_then_hang_preserves_validated_result(tmp_path):
+    child = _TRACE_HEAD + """
+    setInterval(() => {}, 1000);
+  }
+});
+"""
+    entry = _write_fake(tmp_path, child)
+    result = run_pi_agent(
+        _start_payload(), request_id="req_1", run_id="run_1", timeout_seconds=60,
+        on_proposed=lambda p: "commit", runtime_entry=entry,
+    )
+    assert result["ok"] is True
+    assert result["result"]["status"] == "answered"
+    assert result["result"]["text"] == "hello"

--- a/tests/test_pi_agent_process.py
+++ b/tests/test_pi_agent_process.py
@@ -206,6 +206,26 @@ def test_pre_identity_nonzero_exit(tmp_path):
     assert "boom" in result["error"]["message"]
 
 
+def test_accepted_then_nonzero_exit(tmp_path):
+    child = (
+        'process.stdout.write(JSON.stringify({protocol:"om-pi-ipc.v1",type:"run.accepted",'
+        'request_id:"req_1",run_id:"run_1",seq:1,payload:{runtime:"pi-agent-core",'
+        'runtime_version:"0.84.2",session_id:null}})+"\\n", () => process.exit(2));\n'
+    )
+    entry = _write_fake(tmp_path, child)
+    result = run_pi_agent(
+        _start_payload(),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+        runtime_entry=entry,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "PI_PROCESS_EXITED"
+    assert result["error"]["stage"] == "process"
+    assert result["error"]["retryable"] is True
+
+
 def test_timeout(tmp_path):
     entry = _write_fake(tmp_path, "setInterval(() => {}, 1000);\n")
     payload = _start_payload(
@@ -441,3 +461,16 @@ def test_real_runtime_exits_promptly_on_commit():
     # Before the stdin-destroy fix the child hung for the fixed 1s grace +
     # SIGTERM. After the fix it exits cleanly well under that window.
     assert elapsed < 0.8
+
+
+def test_empty_fixture_returns_model_error():
+    result = run_pi_agent(
+        _start_payload(debug={"fixture_response": "", "delay_ms": 0}),
+        request_id="req_1",
+        run_id="run_1",
+        timeout_seconds=60,
+    )
+    assert result["ok"] is False
+    assert result["error"]["code"] == "MODEL_ERROR"
+    assert result["error"]["stage"] == "model"
+    assert result["error"]["retryable"] is False


### PR DESCRIPTION
## Summary

- add a pinned Pi Agent Core Node runtime behind the `om-pi-ipc.v1` JSONL process boundary
- add the S2 sequential read-only Host tool bridge, strict result matching, cancellation, bounded worker ownership, and budget finalization
- add deterministic real-runtime fixtures and fail-closed protocol coverage
- align the integration design with the implemented compact error-observation behavior

## Why

OM needs a production-bounded Agent loop without transferring Host identity, tool authority, result admission, or audit ownership to the model runtime. This change establishes the runtime and read-only tool boundary before Session, provider, or channel cutover work.

## Validation

- `38 passed` — `tests/test_pi_agent_process.py`
- `120 passed, 1 warning` — Agent plugin contract and smoke tests
- Ruff passed for the changed Python files
- `node --check agent-runtime/main.ts`
- `git diff --check origin/main...HEAD`

## Boundaries

- no Copilot entrypoint cutover
- no S3 Session, memory, or context migration
- no VERSION or CHANGELOG change
- no Release, deployment, service mutation, notification, or production data write
