### PR TITLE
feat(strategy-lab): add W2 historical research window

### DIFF
--- a/src/application/strategy_lab/top1/contracts.py
+++ b/src/application/strategy_lab/top1/contracts.py
@@ -30,6 +30,7 @@ VALIDATION_FILL_CONTRACT_VERSION = "scheduled_point_first_observed_cross.v1"
 VALIDATION_METRIC_CONTRACT_VERSION = "sell_put_top1_paired_daily_efficiency.v1"
 EXPIRY_OUTCOME_CONTRACT_VERSION = "expiry_outcome_at_underlier_close.v1"
 SEALED_HISTORICAL_DATASET_SCHEMA = "sealed_historical_dataset.v1"
+HISTORICAL_RESEARCH_WINDOW_SCHEMA = "historical_research_window.v1"
 RECOMMENDATION_POINT_SELECTOR = "official_scheduled_sell_put.v1"
 RESEARCH_REQUIRED_DAYS = 20
 VALIDATION_REQUIRED_DAYS = 10
@@ -310,7 +311,9 @@ def _validate_research_source(value: object) -> None:
         ),
         "research_source",
     )
-    _fixed(item["mode"], "sealed_historical_dataset", "research_source.mode")
+    mode = _text(item["mode"], "research_source.mode")
+    if mode not in {"sealed_historical_dataset", "historical_research_window"}:
+        _fail("research_source.mode is unsupported")
     _ = _relative_posix_path(item["dataset_ref"], "research_source.dataset_ref")
     _ = _sha256(item["dataset_sha256"], "research_source.dataset_sha256")
     _ = _utc_timestamp(item["research_cutoff_at"], "research_source.research_cutoff_at")

--- a/src/application/strategy_lab/top1/research.py
+++ b/src/application/strategy_lab/top1/research.py
@@ -8,9 +8,11 @@ from datetime import date, datetime, timezone
 from typing import Any, NoReturn, cast
 
 from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.engine import rank_candidate_rows
 from domain.domain.fee_calc import FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
 from src.application.shadow_replay.common import render_json_text
 from src.application.strategy_lab.top1.contracts import (
+    HISTORICAL_RESEARCH_WINDOW_SCHEMA,
     RECOMMENDATION_POINT_SELECTOR,
     RESEARCH_REQUIRED_DAYS,
     SEALED_HISTORICAL_DATASET_SCHEMA,
@@ -46,6 +48,48 @@ _INPUT_KEYS = frozenset(
         "dataset_ref",
         "sealed_dataset",
         "ranking_projections",
+    }
+)
+_HISTORICAL_INPUT_KEYS = frozenset(
+    {
+        "schema_version",
+        "experiment_spec",
+        "dataset_ref",
+        "research_window",
+        "observed_points",
+    }
+)
+_OBSERVED_POINT_KEYS = frozenset(
+    {"trading_date", "recommendation_point_id", "candidates"}
+)
+_HISTORICAL_CANDIDATE_KEYS = frozenset(
+    {
+        "candidate_id",
+        "symbol",
+        "contract_symbol",
+        "option_type",
+        "currency",
+        "expiration",
+        "spot",
+        "dte",
+        "sell_limit",
+        "multiplier",
+        "open_interest",
+        "volume",
+        "spread_ratio",
+        "period_net_return_on_cash_basis",
+        "annualized_net_return_on_cash_basis",
+        "net_assignment_discount_pct",
+        "net_cash_basis",
+        "net_income",
+        "net_income_cny",
+        "net_premium",
+        "stock_owner",
+        "strike",
+        "symbol_concentration_after",
+        "fee_schedule_version",
+        "fee_basis",
+        "fee_schedule_url",
     }
 )
 _DATASET_KEYS = frozenset(
@@ -557,9 +601,11 @@ def _validated_research_input(
     dict[str, object],
     list[dict[str, str]],
     dict[str, dict[str, Any]],
+    bool,
 ]:
     envelope = _mapping(dataset, "dataset")
-    _exact_keys(envelope, _INPUT_KEYS, "dataset")
+    if set(envelope) not in {_INPUT_KEYS, _HISTORICAL_INPUT_KEYS}:
+        _fail("research_input_invalid", "dataset keys are incomplete or unexpected")
     if envelope["schema_version"] != RESEARCH_EVALUATION_INPUT_SCHEMA:
         _fail("research_input_invalid", "research evaluation input schema is unsupported")
     try:
@@ -569,6 +615,134 @@ def _validated_research_input(
     if "validation_evaluation" in spec:
         _fail("experiment_spec_invalid", "research evaluator requires a research-only spec")
     dataset_ref = _relative_ref(envelope["dataset_ref"], "dataset.dataset_ref")
+    if set(envelope) == _HISTORICAL_INPUT_KEYS:
+        window = _mapping(envelope["research_window"], "research_window")
+        source = _mapping(spec["research_source"], "experiment_spec.research_source")
+        economics = _mapping(
+            spec["economics_contracts"], "experiment_spec.economics_contracts"
+        )
+        if (
+            source.get("mode") != "historical_research_window"
+            or window.get("schema_version") != HISTORICAL_RESEARCH_WINDOW_SCHEMA
+            or window.get("market") != spec["market"]
+            or window.get("account") != spec["account"]
+            or window.get("required_days") != RESEARCH_REQUIRED_DAYS
+            or window.get("cutoff_at_utc") != source["research_cutoff_at"]
+            or window.get("market_calendar_version")
+            != economics["market_calendar_version"]
+            or dataset_ref != source["dataset_ref"]
+            or _canonical_file_sha256(window) != source["dataset_sha256"]
+            or window.get("content_sha256")
+            != canonical_sha256(
+                {key: value for key, value in window.items() if key != "content_sha256"}
+            )
+        ):
+            _fail("research_corpus_conflict", "historical window does not match spec")
+        selected_dates = window.get("selected_trading_dates")
+        raw_window_days = window.get("days")
+        raw_points = envelope["observed_points"]
+        if (
+            not isinstance(selected_dates, list)
+            or len(selected_dates) != RESEARCH_REQUIRED_DAYS
+            or not isinstance(raw_window_days, list)
+            or len(raw_window_days) != RESEARCH_REQUIRED_DAYS
+            or not isinstance(raw_points, list)
+        ):
+            _fail("research_corpus_conflict", "historical window coverage is invalid")
+        if (
+            source.get("start_trading_date") != selected_dates[0]
+            or source.get("end_trading_date") != selected_dates[-1]
+        ):
+            _fail(
+                "research_corpus_conflict", "historical window dates do not match spec"
+            )
+        expected_points: dict[str, tuple[str, str]] = {}
+        for day_index, raw_day in enumerate(cast(list[object], raw_window_days)):
+            day = _mapping(raw_day, f"research_window.days[{day_index}]")
+            trading_date = _iso_date(
+                day.get("trading_date"),
+                f"research_window.days[{day_index}].trading_date",
+            )
+            day_points = day.get("points")
+            if (
+                trading_date != selected_dates[day_index]
+                or not isinstance(day_points, list)
+                or not day_points
+            ):
+                _fail("research_corpus_conflict", "historical window day is invalid")
+            for point_index, raw_point in enumerate(cast(list[object], day_points)):
+                point = _mapping(
+                    raw_point,
+                    f"research_window.days[{day_index}].points[{point_index}]",
+                )
+                point_id = _hash(
+                    point.get("recommendation_point_id"),
+                    "recommendation_point_id",
+                    reason_code="research_corpus_conflict",
+                )
+                candidate_hash = _hash(
+                    point.get("candidate_facts_sha256"),
+                    "candidate_facts_sha256",
+                    reason_code="research_corpus_conflict",
+                )
+                if point_id in expected_points:
+                    _fail(
+                        "research_corpus_conflict",
+                        "historical window point is duplicated",
+                    )
+                expected_points[point_id] = (trading_date, candidate_hash)
+        point_rows: list[dict[str, str]] = []
+        projections: dict[str, dict[str, Any]] = {}
+        for index, raw_point in enumerate(cast(list[object], raw_points)):
+            point = _mapping(raw_point, f"observed_points[{index}]")
+            _exact_keys(point, _OBSERVED_POINT_KEYS, f"observed_points[{index}]")
+            trading_date = _iso_date(
+                point["trading_date"], f"observed_points[{index}].trading_date"
+            )
+            point_id = _hash(
+                point["recommendation_point_id"],
+                f"observed_points[{index}].recommendation_point_id",
+                reason_code="research_corpus_conflict",
+            )
+            candidates = point["candidates"]
+            if (
+                not isinstance(candidates, list)
+                or expected_points.get(point_id)
+                != (trading_date, canonical_sha256(candidates))
+                or any(not isinstance(candidate, Mapping) for candidate in candidates)
+                or point_id in projections
+            ):
+                _fail("research_corpus_conflict", "historical point is invalid")
+            candidate_ids = [
+                candidate.get("candidate_id")
+                for candidate in cast(list[Mapping[str, object]], candidates)
+            ]
+            if (
+                any(not isinstance(value, str) or not value for value in candidate_ids)
+                or len(candidate_ids) != len(set(candidate_ids))
+                or any(
+                    set(candidate) != _HISTORICAL_CANDIDATE_KEYS
+                    for candidate in cast(list[Mapping[str, object]], candidates)
+                )
+            ):
+                _fail("research_corpus_conflict", "historical candidate is incomplete")
+            point_rows.append(
+                {
+                    "trading_date": trading_date,
+                    "recommendation_point_id": point_id,
+                    "projection_ref": point_id,
+                }
+            )
+            projections[point_id] = {
+                "candidates": [dict(candidate) for candidate in candidates]
+            }
+        if set(projections) != set(expected_points):
+            _fail("research_corpus_conflict", "historical points do not match window")
+        return spec, dataset_ref, dict(window), point_rows, projections, True
+
+    source = _mapping(spec["research_source"], "experiment_spec.research_source")
+    if source.get("mode") != "sealed_historical_dataset":
+        _fail("research_corpus_conflict", "sealed dataset source mode does not match")
     sealed_dataset, point_rows = _validate_dataset(
         envelope["sealed_dataset"], dataset_ref=dataset_ref, spec=spec
     )
@@ -578,7 +752,7 @@ def _validated_research_input(
         market=str(spec["market"]),
         account=str(spec["account"]),
     )
-    return spec, dataset_ref, sealed_dataset, point_rows, projections
+    return spec, dataset_ref, sealed_dataset, point_rows, projections, False
 
 
 def _research_selections(
@@ -586,6 +760,7 @@ def _research_selections(
     spec: Mapping[str, object],
     point_rows: list[dict[str, str]],
     projections: Mapping[str, Mapping[str, Any]],
+    observed_points: bool,
 ) -> tuple[
     list[tuple[str, str]],
     dict[str, list[dict[str, object]]],
@@ -606,22 +781,30 @@ def _research_selections(
     currency_mismatch = False
     for point in point_rows:
         projection = projections[point["projection_ref"]]
-        try:
-            baseline_rank = rerank_recommendation_point(
-                projection, ranking_profile="current_tie_break"
-            )
-        except Top1RankingError as exc:
-            _fail(exc.reason_code, str(exc))
-        baseline_id = cast(str | None, baseline_rank["top1_candidate_id"])
-        baseline_candidate = _candidate(projection, baseline_id)
-        for variant_id, profile in variants:
+
+        def top1_candidate_id(profile: str) -> str | None:
+            if observed_points:
+                try:
+                    ranked = rank_candidate_rows(
+                        [dict(row) for row in projection["candidates"]],
+                        mode="put",
+                        sell_put_ranking_profile=profile,
+                    )
+                except (KeyError, TypeError, ValueError) as exc:
+                    _fail("ranking_projection_incomplete", str(exc))
+                return str(ranked[0]["candidate_id"]) if ranked else None
             try:
-                challenger_rank = rerank_recommendation_point(
+                ranking = rerank_recommendation_point(
                     projection, ranking_profile=profile
                 )
             except Top1RankingError as exc:
                 _fail(exc.reason_code, str(exc))
-            challenger_id = cast(str | None, challenger_rank["top1_candidate_id"])
+            return cast(str | None, ranking["top1_candidate_id"])
+
+        baseline_id = top1_candidate_id("current_tie_break")
+        baseline_candidate = _candidate(projection, baseline_id)
+        for variant_id, profile in variants:
+            challenger_id = top1_candidate_id(profile)
             challenger_candidate = _candidate(projection, challenger_id)
             if (baseline_candidate is None) != (challenger_candidate is None):
                 _fail(
@@ -654,7 +837,7 @@ def required_research_close_keys(
     dataset: object,
     fee_contract: object,
 ) -> list[tuple[str, str]]:
-    spec, _dataset_ref, _sealed_dataset, point_rows, projections = (
+    spec, _dataset_ref, _sealed_dataset, point_rows, projections, observed_points = (
         _validated_research_input(dataset)
     )
     _ = _validate_fee_contract(fee_contract, spec=spec)
@@ -663,6 +846,7 @@ def required_research_close_keys(
             spec=spec,
             point_rows=point_rows,
             projections=projections,
+            observed_points=observed_points,
         )
     )
     return [] if currency_mismatch else sorted(required_close_keys)
@@ -673,7 +857,7 @@ def evaluate_research(
     close_receipts: object,
     fee_contract: object,
 ) -> dict[str, object]:
-    spec, dataset_ref, sealed_dataset, point_rows, projections = (
+    spec, dataset_ref, sealed_dataset, point_rows, projections, observed_points = (
         _validated_research_input(dataset)
     )
     receipts = _validate_close_receipts(
@@ -685,6 +869,7 @@ def evaluate_research(
             spec=spec,
             point_rows=point_rows,
             projections=projections,
+            observed_points=observed_points,
         )
     )
     if currency_mismatch:
@@ -989,7 +1174,7 @@ def validate_internal_research_revision(
     dataset: object,
     value: object,
 ) -> dict[str, object]:
-    spec, _dataset_ref, _sealed_dataset, _point_rows, _projections = (
+    spec, _dataset_ref, _sealed_dataset, _point_rows, _projections, _observed = (
         _validated_research_input(dataset)
     )
     revision = _mapping(value, "research_revision")
@@ -1070,7 +1255,7 @@ def build_internal_research_revision(
     quota_decision: object,
     observed_at_utc: str,
 ) -> dict[str, object]:
-    spec, _dataset_ref, _sealed_dataset, _point_rows, _projections = (
+    spec, _dataset_ref, _sealed_dataset, _point_rows, _projections, _observed = (
         _validated_research_input(dataset)
     )
     normalized_fee = _normalized_fee_contract(fee_contract, spec=spec)

--- a/src/application/strategy_lab/top1/research_artifacts.py
+++ b/src/application/strategy_lab/top1/research_artifacts.py
@@ -8,8 +8,15 @@ from pathlib import Path
 from typing import Any, NoReturn, cast
 
 from src.application.shadow_replay.common import render_json_text
+from src.application.strategy_lab.top1.contracts import (
+    HISTORICAL_RESEARCH_WINDOW_SCHEMA,
+)
 from src.application.strategy_lab.top1.research import (
     RESEARCH_EVALUATION_INPUT_SCHEMA,
+)
+from src.application.strategy_lab.top1.research_window import (
+    ResearchWindowError,
+    load_research_window,
 )
 from src.infrastructure.private_storage import open_private_text, private_path
 
@@ -78,12 +85,35 @@ def load_materialized_research_input(
     source = spec.get("research_source")
     if not isinstance(source, Mapping):
         _fail("research_artifact_invalid", "research source is invalid")
-    sealed_dataset = _read_canonical_json(
+    research_source = _read_canonical_json(
         artifact_root,
         ref=source.get("dataset_ref"),
         expected_file_sha256=source.get("dataset_sha256"),
-        label="sealed_dataset",
+        label="research_source",
     )
+    if research_source.get("schema_version") == HISTORICAL_RESEARCH_WINDOW_SCHEMA:
+        if source.get("mode") != "historical_research_window":
+            _fail(
+                "research_artifact_invalid",
+                "research source mode does not match window",
+            )
+        try:
+            observed_points = load_research_window(artifact_root, research_source)
+        except ResearchWindowError as exc:
+            raise ResearchArtifactError(exc.reason_code, str(exc)) from exc
+        return {
+            "schema_version": RESEARCH_EVALUATION_INPUT_SCHEMA,
+            "experiment_spec": dict(spec),
+            "dataset_ref": source.get("dataset_ref"),
+            "research_window": research_source,
+            "observed_points": observed_points,
+        }
+
+    sealed_dataset = research_source
+    if source.get("mode") != "sealed_historical_dataset":
+        _fail(
+            "research_artifact_invalid", "research source mode does not match dataset"
+        )
     raw_days = sealed_dataset.get("days")
     if not isinstance(raw_days, list):
         _fail("research_artifact_invalid", "sealed dataset days must be a list")

--- a/src/application/strategy_lab/top1/research_window.py
+++ b/src/application/strategy_lab/top1/research_window.py
@@ -1,0 +1,692 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, NoReturn
+from zoneinfo import ZoneInfo
+
+from domain.domain.decision_state_fingerprint import canonical_sha256
+from domain.domain.fee_calc import estimate_futu_option_sell_fee
+from domain.domain.short_vol_assessment import portfolio_concentration_fields
+from domain.domain.symbol_identity import resolve_symbol_identity
+from src.application.prepared_option_positions_context import (
+    exchange_rate_scalars_from_option_context,
+)
+from src.application.short_vol_risk_context import build_portfolio_risk_context
+from src.application.strategy_lab.evidence import load_strategy_lab_dataset
+from src.application.strategy_lab.top1.contracts import (
+    HISTORICAL_RESEARCH_WINDOW_SCHEMA,
+    RESEARCH_REQUIRED_DAYS,
+)
+from src.application.strategy_lab.top1.corpus import (
+    CorpusError,
+    read_bound_market_calendar_snapshot,
+)
+from src.infrastructure.exchange_rates import CurrencyConverter, ExchangeRates
+from src.infrastructure.private_storage import private_path
+
+
+_RUN_ID = re.compile(r"(?P<stamp>\d{8}T\d{6}Z)-[A-Za-z0-9._-]+\Z")
+_DATASET_STAMP = re.compile(r"(?P<stamp>\d{8}[Tt]\d{6}[Zz])")
+_HASH_64 = re.compile(r"[0-9a-f]{64}\Z")
+_ACCOUNT = re.compile(r"[a-z0-9][a-z0-9._-]{0,127}\Z")
+_CANDIDATE_UNIVERSE = "same_point_accepted_sell_put_candidates"
+_POINT_COMPLETENESS = "all_verified_observed_dataset_points"
+_WINDOW_KEYS = frozenset(
+    {
+        "schema_version",
+        "market",
+        "account",
+        "cutoff_at_utc",
+        "required_days",
+        "market_calendar_version",
+        "market_calendar_ref",
+        "market_calendar_content_sha256",
+        "market_calendar_file_sha256",
+        "latest_mature_trading_date",
+        "selected_trading_dates",
+        "candidate_universe",
+        "point_completeness",
+        "days",
+        "content_sha256",
+    }
+)
+_DAY_KEYS = frozenset({"trading_date", "points"})
+_POINT_KEYS = frozenset(
+    {
+        "recommendation_point_id",
+        "run_id",
+        "observed_at_utc",
+        "source_kind",
+        "dataset_ref",
+        "source_files",
+        "candidate_facts_sha256",
+    }
+)
+
+
+class ResearchWindowError(ValueError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _select_complete_days(
+    trading_dates: Sequence[object],
+    latest_mature_trading_date: object,
+    required_days: object,
+) -> list[str]:
+    if isinstance(required_days, bool) or not isinstance(required_days, int) or required_days != RESEARCH_REQUIRED_DAYS:
+        raise ResearchWindowError(
+            "research_window_invalid",
+            f"required_days must equal {RESEARCH_REQUIRED_DAYS}",
+        )
+    dates: list[str] = []
+    try:
+        for raw in trading_dates:
+            value = str(raw)
+            if date.fromisoformat(value).isoformat() != value:
+                raise ValueError
+            dates.append(value)
+        latest = str(latest_mature_trading_date)
+        if date.fromisoformat(latest).isoformat() != latest:
+            raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise ResearchWindowError("research_window_invalid", "trading dates must be canonical ISO dates") from exc
+    if not dates or dates != sorted(set(dates)):
+        raise ResearchWindowError(
+            "research_window_invalid",
+            "calendar dates must be ordered and unique",
+        )
+    if latest not in dates:
+        raise ResearchWindowError(
+            "research_window_coverage_missing",
+            "market calendar does not cover the mature trading date",
+        )
+    end = dates.index(latest) + 1
+    if end < required_days:
+        raise ResearchWindowError(
+            "research_window_coverage_missing",
+            f"fewer than {required_days} mature trading days are available",
+        )
+    return dates[end - required_days : end]
+
+
+def _normalize_point(
+    artifact_root: str | Path,
+    dataset_ref: object,
+    *,
+    market: str,
+    account: str,
+    cutoff_at_utc: str,
+    runs_root_ref: str | None = None,
+    expected_source_files: object = None,
+) -> dict[str, Any]:
+    def fail(reason_code: str, message: str) -> NoReturn:
+        raise ResearchWindowError(reason_code, message)
+
+    research_root = private_path(artifact_root).parent.resolve()
+
+    def safe_ref(raw: object, label: str) -> tuple[str, Path]:
+        if not isinstance(raw, str) or not raw or raw != raw.strip():
+            fail("research_window_invalid", f"{label} must be canonical text")
+        parts = raw.split("/")
+        if raw.startswith("/") or "\\" in raw or any(part in {"", ".", ".."} for part in parts):
+            fail("research_window_invalid", f"{label} must be a safe relative ref")
+        path = research_root.joinpath(*parts).resolve()
+        if not path.is_relative_to(research_root):
+            fail("research_window_invalid", f"{label} escapes the research root")
+        return raw, path
+
+    def source_file(kind: str, ref: str, path: Path) -> dict[str, str]:
+        try:
+            if not path.is_file():
+                raise OSError
+            with path.open("rb") as handle:
+                digest = hashlib.file_digest(handle, "sha256").hexdigest()
+        except OSError as exc:
+            raise ResearchWindowError("research_window_coverage_missing", f"{kind} source file is unavailable") from exc
+        return {"kind": kind, "ref": ref, "sha256": digest}
+
+    def number(raw: object, label: str, *, positive: bool = False) -> float:
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            fail("research_window_coverage_missing", f"{label} is missing")
+        value = float(raw)
+        if not math.isfinite(value) or (positive and value <= 0):
+            fail("research_window_coverage_missing", f"{label} is invalid")
+        return value
+
+    ref, dataset_dir = safe_ref(dataset_ref, "dataset_ref")
+    if not dataset_dir.is_dir() or dataset_dir.is_symlink():
+        fail("research_window_coverage_missing", "Shadow Replay dataset is unavailable")
+    manifest_ref = f"{ref}/manifest.json"
+    candidates_ref = f"{ref}/candidate_snapshots.jsonl"
+    files = [
+        source_file("manifest", manifest_ref, dataset_dir / "manifest.json"),
+        source_file(
+            "candidate_snapshots",
+            candidates_ref,
+            dataset_dir / "candidate_snapshots.jsonl",
+        ),
+    ]
+    try:
+        evidence = load_strategy_lab_dataset(dataset_dir)
+    except (OSError, TypeError, ValueError) as exc:
+        raise ResearchWindowError("research_window_conflict", "Shadow Replay dataset cannot be verified") from exc
+    integrity = evidence.get("integrity") or {}
+    if integrity.get("status") == "verified":
+        source_kind = "shadow_replay_verified_point"
+    elif integrity == {
+        "status": "legacy_unverified",
+        "reason": "integrity_receipt_missing",
+    }:
+        source_kind = "shadow_replay_legacy_hash_bound_point"
+    else:
+        fail("research_window_coverage_missing", "dataset integrity is not usable")
+    manifest = evidence.get("manifest")
+    if not isinstance(manifest, Mapping):
+        fail("research_window_conflict", "dataset manifest is invalid")
+    source = manifest.get("source")
+    source = source if isinstance(source, Mapping) else {}
+    coverage = source.get("candidate_evidence_coverage")
+    matching_coverage: list[Mapping[str, Any]] = []
+    modern_empty_scope = False
+    if isinstance(coverage, Mapping):
+        raw_accounts = coverage.get("accounts")
+        if not isinstance(raw_accounts, list):
+            fail("research_window_conflict", "dataset candidate evidence coverage is invalid")
+        for raw_account in raw_accounts:
+            if not isinstance(raw_account, Mapping):
+                fail("research_window_conflict", "dataset candidate evidence account is invalid")
+            raw_markets = raw_account.get("markets") or []
+            owners = raw_account.get("owner_snapshots") or []
+            if not isinstance(raw_markets, list) or not isinstance(owners, list):
+                fail("research_window_conflict", "dataset candidate evidence scope is invalid")
+            markets = {str(value).lower() for value in raw_markets if isinstance(value, str) and value}
+            if str(raw_account.get("account") or "").lower() == account and (not markets or market.lower() in markets):
+                matching_coverage.append(raw_account)
+        if matching_coverage and not all(
+            item.get("status") == "supported"
+            and item.get("strict_replay_authority") is True
+            and item.get("contributes_snapshot_facts") is True
+            for item in matching_coverage
+        ):
+            fail("research_window_coverage_missing", "dataset candidate evidence is not usable")
+        modern_empty_scope = any("opening" in item["owner_snapshots"] for item in matching_coverage)
+    dataset_id = manifest.get("dataset_id")
+    if dataset_id != dataset_dir.name:
+        fail("research_window_conflict", "dataset ref and manifest identity differ")
+    run_id = source.get("run_id") or dataset_id
+    run_match = _RUN_ID.fullmatch(run_id) if isinstance(run_id, str) else None
+    if run_match is None:
+        fail("research_window_conflict", "dataset run identity is invalid")
+    dataset_stamp = _DATASET_STAMP.search(dataset_dir.name)
+    if dataset_stamp is None or dataset_stamp.group("stamp").upper() != run_match.group("stamp"):
+        fail("research_window_conflict", "dataset ref and run timestamp differ")
+    if integrity.get("status") == "verified":
+        integrity_files = integrity.get("files")
+        candidate_receipt = (
+            integrity_files.get("candidate_snapshots.jsonl") if isinstance(integrity_files, Mapping) else None
+        )
+        if not isinstance(candidate_receipt, Mapping) or candidate_receipt.get("sha256") != files[1]["sha256"]:
+            fail("research_window_conflict", "candidate file receipt changed")
+
+    observed = datetime.strptime(run_match.group("stamp"), "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+    try:
+        if not cutoff_at_utc.endswith("Z"):
+            raise ValueError
+        cutoff = datetime.fromisoformat(f"{cutoff_at_utc[:-1]}+00:00")
+    except (AttributeError, ValueError) as exc:
+        raise ResearchWindowError("research_window_invalid", "cutoff_at_utc is invalid") from exc
+    if cutoff.utcoffset() != timezone.utc.utcoffset(cutoff) or observed > cutoff:
+        fail("research_window_coverage_missing", "dataset was observed after cutoff")
+
+    raw_rows = evidence.get("candidate_snapshots")
+    if not isinstance(raw_rows, list):
+        fail("research_window_conflict", "candidate snapshots are invalid")
+    scoped: list[dict[str, Any]] = []
+    for raw in raw_rows:
+        if not isinstance(raw, Mapping):
+            fail("research_window_conflict", "candidate row is invalid")
+        row = dict(raw)
+        identity = resolve_symbol_identity(row.get("symbol"))
+        row_mode = str(row.get("mode") or row.get("option_type") or "").lower()
+        family = str(row.get("strategy_family") or row.get("strategy") or "").lower()
+        source_path = str(row.get("source_path") or "").lower()
+        if (
+            str(row.get("account") or "").lower() == account
+            and identity is not None
+            and identity.market == market
+            and row_mode == "put"
+            and family == "sell_put"
+            and not source_path.endswith("_labeled.csv")
+        ):
+            scoped.append(row)
+    if any(str(row.get("status") or "").lower() in {"partial_data", "data_unavailable"} for row in scoped):
+        fail("research_window_coverage_missing", "candidate point is incomplete")
+    if scoped and isinstance(coverage, Mapping) and not matching_coverage:
+        fail("research_window_conflict", "candidate rows are outside the manifest account scope")
+    if not scoped:
+        account_path = f"/accounts/{account}/"
+        candidate_paths = source.get("candidate_paths")
+        legacy_scope = isinstance(candidate_paths, list) and any(
+            isinstance(path, str) and account_path in path and "_sell_put_candidates" in path and ".hk_" in path.lower()
+            for path in candidate_paths
+        )
+        if not modern_empty_scope and not legacy_scope:
+            fail("research_window_not_applicable", "dataset is outside the requested candidate universe")
+    accepted = [row for row in scoped if str(row.get("status") or "").lower() == "accepted"]
+
+    need_context = any(
+        row.get("symbol_concentration_after") is None or row.get("net_income_cny") is None for row in accepted
+    )
+    risk_context = None
+    converter = None
+    if need_context:
+        expected_by_kind = {
+            str(item.get("kind")): item for item in expected_source_files or [] if isinstance(item, Mapping)
+        }
+        if expected_by_kind:
+            context_refs = {
+                kind: str(expected_by_kind.get(kind, {}).get("ref") or "")
+                for kind in ("portfolio_context", "option_positions_context")
+            }
+        else:
+            if runs_root_ref is None:
+                fail(
+                    "research_window_coverage_missing",
+                    "historical concentration context is missing",
+                )
+            runs_ref, _runs_path = safe_ref(runs_root_ref, "runs_root_ref")
+            state_ref = f"{runs_ref}/{run_id}/accounts/{account}/state"
+            context_refs = {
+                "portfolio_context": f"{state_ref}/portfolio_context.json",
+                "option_positions_context": (f"{state_ref}/option_positions_context.json"),
+            }
+        contexts: dict[str, dict[str, Any]] = {}
+        for kind, context_ref in context_refs.items():
+            context_ref, context_path = safe_ref(context_ref, f"{kind}.ref")
+            entry = source_file(kind, context_ref, context_path)
+            files.append(entry)
+            try:
+                payload = json.loads(context_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ResearchWindowError(
+                    "research_window_coverage_missing",
+                    f"{kind} cannot be read",
+                ) from exc
+            if not isinstance(payload, dict):
+                fail("research_window_coverage_missing", f"{kind} is invalid")
+            contexts[kind] = payload
+        usd_per_cny, cny_per_hkd = exchange_rate_scalars_from_option_context(contexts["option_positions_context"])
+        converter = CurrencyConverter(
+            ExchangeRates(
+                usd_per_cny=usd_per_cny,
+                cny_per_hkd=cny_per_hkd,
+            )
+        )
+        portfolio = dict(contexts["portfolio_context"])
+        portfolio["_global_option_ctx"] = contexts["option_positions_context"]
+        risk_context = build_portfolio_risk_context(
+            portfolio_ctx=portfolio,
+            exchange_rate_converter=converter,
+        )
+
+    normalized: dict[str, dict[str, Any]] = {}
+    cutoff_date = cutoff.astimezone(ZoneInfo("Asia/Hong_Kong")).date()
+    for row in accepted:
+        identity = resolve_symbol_identity(row.get("symbol"))
+        if identity is None:
+            fail("research_window_coverage_missing", "candidate symbol is invalid")
+        contract = str(row.get("contract_symbol") or "").strip().upper()
+        if not contract:
+            fail("research_window_coverage_missing", "contract symbol is missing")
+        try:
+            expiration = date.fromisoformat(str(row.get("expiration") or ""))
+        except ValueError as exc:
+            raise ResearchWindowError("research_window_coverage_missing", "candidate expiration is invalid") from exc
+        if expiration > cutoff_date:
+            fail("research_window_coverage_missing", "candidate outcome is not mature")
+        strike = number(row.get("strike"), "strike", positive=True)
+        multiplier_value = number(row.get("multiplier"), "multiplier", positive=True)
+        if not multiplier_value.is_integer():
+            fail("research_window_coverage_missing", "multiplier is invalid")
+        multiplier = int(multiplier_value)
+        spot = number(row.get("spot"), "spot", positive=True)
+        net_premium = number(
+            row.get("net_premium") if row.get("net_premium") is not None else row.get("net_income"),
+            "net_premium",
+            positive=True,
+        )
+        net_cash_basis = number(
+            row.get("net_cash_basis") if row.get("net_cash_basis") is not None else strike * multiplier - net_premium,
+            "net_cash_basis",
+            positive=True,
+        )
+        concentration = row.get("symbol_concentration_after")
+        if concentration is None:
+            assert converter is not None and risk_context is not None
+            assignment_cny = converter.native_to_cny(strike * multiplier, native_ccy=identity.currency)
+            concentration = portfolio_concentration_fields(
+                {**row, "assignment_notional_cny": assignment_cny},
+                mode="put",
+                risk_ctx=risk_context,
+            )["symbol_concentration_after"]
+        concentration_value = number(concentration, "symbol_concentration_after")
+        if concentration_value < 0:
+            fail("research_window_coverage_missing", "concentration is invalid")
+        raw_sell_limit = row.get("sell_limit")
+        if raw_sell_limit is None:
+            mid = number(row.get("mid"), "mid", positive=True)
+            try:
+                fee_estimate = estimate_futu_option_sell_fee(
+                    identity.currency,
+                    mid,
+                    contracts=1,
+                    multiplier=int(multiplier),
+                )
+                sell_limit = (net_premium + fee_estimate.amount) / multiplier
+                fee_estimate = estimate_futu_option_sell_fee(
+                    identity.currency,
+                    sell_limit,
+                    contracts=1,
+                    multiplier=int(multiplier),
+                )
+                sell_limit = (net_premium + fee_estimate.amount) / multiplier
+            except ValueError as exc:
+                raise ResearchWindowError(
+                    "research_window_coverage_missing",
+                    "historical sell limit cannot be reconstructed",
+                ) from exc
+        else:
+            sell_limit = number(raw_sell_limit, "sell_limit", positive=True)
+            try:
+                fee_estimate = estimate_futu_option_sell_fee(
+                    identity.currency,
+                    sell_limit,
+                    contracts=1,
+                    multiplier=int(multiplier),
+                )
+            except ValueError as exc:
+                raise ResearchWindowError(
+                    "research_window_coverage_missing",
+                    "historical fee contract is unsupported",
+                ) from exc
+        period_return = net_premium / net_cash_basis
+        discount = (spot - (strike - net_premium / multiplier)) / spot
+        net_income_cny = row.get("net_income_cny")
+        if net_income_cny is None and converter is not None:
+            net_income_cny = converter.native_to_cny(net_premium, native_ccy=identity.currency)
+        net_income_cny = number(net_income_cny, "net_income_cny", positive=True)
+        dte = number(row.get("dte"), "dte", positive=True)
+        candidate = {
+            "candidate_id": contract,
+            "symbol": identity.canonical,
+            "contract_symbol": contract,
+            "expiration": expiration.isoformat(),
+            "option_type": "put",
+            "stock_owner": identity.futu_code,
+            "strike": strike,
+            "spot": spot,
+            "dte": dte,
+            "sell_limit": sell_limit,
+            "multiplier": multiplier,
+            "currency": identity.currency,
+            "open_interest": row.get("open_interest"),
+            "volume": row.get("volume"),
+            "spread_ratio": row.get("spread_ratio"),
+            "period_net_return_on_cash_basis": period_return,
+            "annualized_net_return_on_cash_basis": (period_return * 365.0 / dte),
+            "net_assignment_discount_pct": discount,
+            "symbol_concentration_after": concentration_value,
+            "net_income": net_premium,
+            "net_premium": net_premium,
+            "net_cash_basis": net_cash_basis,
+            "net_income_cny": net_income_cny,
+            "fee_schedule_version": fee_estimate.fee_schedule_version,
+            "fee_basis": fee_estimate.fee_basis,
+            "fee_schedule_url": fee_estimate.fee_schedule_url,
+        }
+        previous = normalized.get(contract)
+        if previous is not None:
+            fail("research_window_conflict", "candidate is duplicated")
+        normalized[contract] = candidate
+
+    files = sorted(files, key=lambda item: (item["kind"], item["ref"]))
+    if expected_source_files is not None:
+        if not isinstance(expected_source_files, list) or files != expected_source_files:
+            fail("research_window_conflict", "historical source file binding changed")
+    candidates = [normalized[key] for key in sorted(normalized)]
+    point_id = canonical_sha256(
+        {
+            "market": market,
+            "account": account,
+            "run_id": run_id,
+            "candidate_file_sha256": files[
+                next(index for index, item in enumerate(files) if item["kind"] == "candidate_snapshots")
+            ]["sha256"],
+        }
+    )
+    return {
+        "recommendation_point_id": point_id,
+        "run_id": run_id,
+        "observed_at_utc": observed.isoformat().replace("+00:00", "Z"),
+        "source_kind": source_kind,
+        "dataset_ref": ref,
+        "source_files": files,
+        "candidate_facts_sha256": canonical_sha256(candidates),
+        "trading_date": observed.astimezone(ZoneInfo("Asia/Hong_Kong")).date().isoformat(),
+        "candidates": candidates,
+    }
+
+
+def build_research_window(
+    artifact_root: str | Path,
+    *,
+    market: str,
+    account: str,
+    cutoff_at_utc: str,
+    latest_mature_trading_date: str,
+    market_calendar: Mapping[str, Any],
+    datasets_root_ref: str,
+    runs_root_ref: str,
+    required_days: int = RESEARCH_REQUIRED_DAYS,
+) -> dict[str, Any]:
+    """Build, but do not publish, one deterministic historical research window."""
+
+    if market != "HK" or not isinstance(account, str) or _ACCOUNT.fullmatch(account) is None:
+        raise ResearchWindowError("research_window_invalid", "historical research requires HK/lowercase account")
+    if not isinstance(market_calendar, Mapping):
+        raise ResearchWindowError("research_window_invalid", "market_calendar must be a verified binding")
+    try:
+        calendar = read_bound_market_calendar_snapshot(
+            artifact_root,
+            market=market,
+            snapshot_ref=market_calendar["snapshot_ref"],
+            snapshot_content_sha256=market_calendar["snapshot_content_sha256"],
+            snapshot_file_sha256=market_calendar["snapshot_file_sha256"],
+        )
+    except (CorpusError, KeyError) as exc:
+        raise ResearchWindowError("research_window_invalid", "market calendar binding is invalid") from exc
+    if calendar["market_calendar_version"] != market_calendar.get("market_calendar_version"):
+        raise ResearchWindowError("research_window_conflict", "market calendar version changed")
+    selected_dates = _select_complete_days(calendar["trading_dates"], latest_mature_trading_date, required_days)
+    try:
+        parsed_cutoff = datetime.fromisoformat(cutoff_at_utc.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise ResearchWindowError("research_window_invalid", "cutoff_at_utc must be an ISO timestamp") from exc
+    if not cutoff_at_utc.endswith("Z") or parsed_cutoff.utcoffset() != timezone.utc.utcoffset(parsed_cutoff):
+        raise ResearchWindowError("research_window_invalid", "cutoff_at_utc must be UTC")
+
+    research_root = private_path(artifact_root).parent.resolve()
+    parts = datasets_root_ref.split("/") if isinstance(datasets_root_ref, str) else []
+    if not parts or "\\" in datasets_root_ref or any(part in {"", ".", ".."} for part in parts):
+        raise ResearchWindowError("research_window_invalid", "datasets_root_ref is invalid")
+    datasets_root = research_root.joinpath(*parts).resolve()
+    if not datasets_root.is_relative_to(research_root) or not datasets_root.is_dir():
+        raise ResearchWindowError("research_window_coverage_missing", "datasets root is unavailable")
+    selected_set = set(selected_dates)
+    points_by_day: dict[str, list[dict[str, Any]]] = {trading_date: [] for trading_date in selected_dates}
+    seen_runs: set[str] = set()
+    for dataset_dir in sorted(datasets_root.iterdir(), key=lambda path: path.name):
+        matched = _DATASET_STAMP.search(dataset_dir.name)
+        if matched is None or not dataset_dir.is_dir():
+            continue
+        observed = datetime.strptime(matched.group("stamp").upper(), "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+        trading_date = observed.astimezone(ZoneInfo("Asia/Hong_Kong")).date().isoformat()
+        if trading_date not in selected_set:
+            continue
+        dataset_ref = dataset_dir.relative_to(research_root).as_posix()
+        try:
+            point = _normalize_point(
+                artifact_root,
+                dataset_ref,
+                market=market,
+                account=account,
+                cutoff_at_utc=cutoff_at_utc,
+                runs_root_ref=runs_root_ref,
+            )
+        except ResearchWindowError as exc:
+            if exc.reason_code == "research_window_not_applicable":
+                continue
+            raise
+        point_date = point["trading_date"]
+        if point_date not in selected_set:
+            continue
+        if point["run_id"] in seen_runs:
+            raise ResearchWindowError("research_window_conflict", "historical run is duplicated")
+        seen_runs.add(point["run_id"])
+        points_by_day[point_date].append(point)
+
+    days: list[dict[str, Any]] = []
+    for trading_date in selected_dates:
+        points = sorted(
+            points_by_day[trading_date],
+            key=lambda item: (item["observed_at_utc"], item["recommendation_point_id"]),
+        )
+        if not points:
+            raise ResearchWindowError(
+                "research_window_coverage_missing",
+                f"no verified observed point for {trading_date}",
+            )
+        days.append(
+            {
+                "trading_date": trading_date,
+                "points": [{key: point[key] for key in _POINT_KEYS} for point in points],
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "schema_version": HISTORICAL_RESEARCH_WINDOW_SCHEMA,
+        "market": market,
+        "account": account,
+        "cutoff_at_utc": cutoff_at_utc,
+        "required_days": required_days,
+        "market_calendar_version": calendar["market_calendar_version"],
+        "market_calendar_ref": calendar["snapshot_ref"],
+        "market_calendar_content_sha256": calendar["snapshot_content_sha256"],
+        "market_calendar_file_sha256": calendar["snapshot_file_sha256"],
+        "latest_mature_trading_date": latest_mature_trading_date,
+        "selected_trading_dates": selected_dates,
+        "candidate_universe": _CANDIDATE_UNIVERSE,
+        "point_completeness": _POINT_COMPLETENESS,
+        "days": days,
+    }
+    payload["content_sha256"] = canonical_sha256(payload)
+    return payload
+
+
+def load_research_window(
+    artifact_root: str | Path,
+    window: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Verify source hashes and materialize candidates in memory for evaluation."""
+
+    if not isinstance(window, Mapping) or set(window) != _WINDOW_KEYS:
+        raise ResearchWindowError("research_window_conflict", "historical research window keys are invalid")
+    item = dict(window)
+    if item["schema_version"] != HISTORICAL_RESEARCH_WINDOW_SCHEMA:
+        raise ResearchWindowError("research_window_conflict", "historical research window schema changed")
+    content_hash = item.get("content_sha256")
+    if (
+        not isinstance(content_hash, str)
+        or _HASH_64.fullmatch(content_hash) is None
+        or canonical_sha256({key: value for key, value in item.items() if key != "content_sha256"}) != content_hash
+    ):
+        raise ResearchWindowError("research_window_conflict", "historical research window hash changed")
+    try:
+        calendar = read_bound_market_calendar_snapshot(
+            artifact_root,
+            market=item["market"],
+            snapshot_ref=item["market_calendar_ref"],
+            snapshot_content_sha256=item["market_calendar_content_sha256"],
+            snapshot_file_sha256=item["market_calendar_file_sha256"],
+        )
+    except (CorpusError, KeyError) as exc:
+        raise ResearchWindowError("research_window_conflict", "bound market calendar changed") from exc
+    selected_dates = _select_complete_days(
+        calendar["trading_dates"],
+        item["latest_mature_trading_date"],
+        item["required_days"],
+    )
+    if (
+        item["market"] != "HK"
+        or not isinstance(item["account"], str)
+        or item["account"] != item["account"].lower()
+        or calendar["market_calendar_version"] != item["market_calendar_version"]
+        or item["selected_trading_dates"] != selected_dates
+        or item["candidate_universe"] != _CANDIDATE_UNIVERSE
+        or item["point_completeness"] != _POINT_COMPLETENESS
+    ):
+        raise ResearchWindowError("research_window_conflict", "historical research window binding changed")
+    raw_days = item["days"]
+    if not isinstance(raw_days, list) or len(raw_days) != RESEARCH_REQUIRED_DAYS:
+        raise ResearchWindowError("research_window_coverage_missing", "historical day coverage is incomplete")
+    materialized: list[dict[str, Any]] = []
+    seen_points: set[str] = set()
+    for index, raw_day in enumerate(raw_days):
+        if not isinstance(raw_day, Mapping) or set(raw_day) != _DAY_KEYS:
+            raise ResearchWindowError("research_window_conflict", "historical day is invalid")
+        trading_date = raw_day["trading_date"]
+        points = raw_day["points"]
+        if trading_date != selected_dates[index] or not isinstance(points, list) or not points:
+            raise ResearchWindowError("research_window_coverage_missing", "historical point coverage is incomplete")
+        for raw_point in points:
+            if not isinstance(raw_point, Mapping) or set(raw_point) != _POINT_KEYS:
+                raise ResearchWindowError("research_window_conflict", "historical point is invalid")
+            point = dict(raw_point)
+            normalized = _normalize_point(
+                artifact_root,
+                point["dataset_ref"],
+                market=item["market"],
+                account=item["account"],
+                cutoff_at_utc=item["cutoff_at_utc"],
+                expected_source_files=point["source_files"],
+            )
+            binding = {key: normalized[key] for key in _POINT_KEYS}
+            if binding != point or normalized["trading_date"] != trading_date:
+                raise ResearchWindowError("research_window_conflict", "historical point binding changed")
+            point_id = str(point["recommendation_point_id"])
+            if point_id in seen_points:
+                raise ResearchWindowError("research_window_conflict", "historical point is duplicated")
+            seen_points.add(point_id)
+            materialized.append(
+                {
+                    "trading_date": trading_date,
+                    "recommendation_point_id": point_id,
+                    "candidates": normalized["candidates"],
+                }
+            )
+    return materialized
+
+
+__all__ = [
+    "ResearchWindowError",
+    "build_research_window",
+    "load_research_window",
+]

--- a/tests/test_strategy_lab_top1_architecture.py
+++ b/tests/test_strategy_lab_top1_architecture.py
@@ -115,6 +115,7 @@ def test_top1_core_imports_only_approved_pure_owners() -> None:
         "datetime",
         "typing",
         "domain.domain.decision_state_fingerprint",
+        "domain.domain.engine",
         "domain.domain.fee_calc",
         "src.application.shadow_replay.common",
         "src.application.strategy_lab.top1.contracts",
@@ -270,7 +271,9 @@ def test_top1_lifecycle_and_terminal_projection_keep_dependency_direction() -> N
         "pathlib",
         "typing",
         "src.application.shadow_replay.common",
+        "src.application.strategy_lab.top1.contracts",
         "src.application.strategy_lab.top1.research",
+        "src.application.strategy_lab.top1.research_window",
         "src.infrastructure.private_storage",
     }
 

--- a/tests/test_strategy_lab_top1_research_window.py
+++ b/tests/test_strategy_lab_top1_research_window.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from src.application.shadow_replay.common import (
+    DATASET_FILES,
+    refresh_dataset_manifest,
+    render_json_text,
+    write_json,
+    write_jsonl,
+)
+from src.application.strategy_lab.top1.research_artifacts import (
+    load_materialized_research_input,
+)
+from src.application.strategy_lab.top1.research import (
+    RESEARCH_CLOSE_RECEIPT_SCHEMA,
+    ResearchEvaluationError,
+    evaluate_research,
+    required_research_close_keys,
+)
+from src.application.strategy_lab.top1.research_window import (
+    ResearchWindowError,
+    build_research_window,
+    load_research_window,
+)
+from src.infrastructure.private_storage import atomic_write_private_text
+from tests.candidate_evidence_helpers import seal_market_calendar_fixture
+from tests.test_strategy_lab_top1_research import _fee_contract, _spec
+
+
+def _trading_days(start: str, count: int) -> list[str]:
+    current = date.fromisoformat(start)
+    values: list[str] = []
+    while len(values) < count:
+        if current.weekday() < 5:
+            values.append(current.isoformat())
+        current += timedelta(days=1)
+    return values
+
+
+def _candidate(
+    symbol: str,
+    contract: str,
+    *,
+    expiration: str,
+    strike: float,
+    spot: float,
+    net_income: float,
+) -> dict[str, object]:
+    return {
+        "schema_version": "shadow_replay_candidate_snapshot.v1",
+        "account": "lx",
+        "status": "accepted",
+        "strategy": "sell_put",
+        "strategy_family": "sell_put",
+        "mode": "put",
+        "option_type": "put",
+        "symbol": symbol,
+        "contract_symbol": contract,
+        "expiration": expiration,
+        "strike": strike,
+        "spot": spot,
+        "dte": 25,
+        "mid": 10.0,
+        "multiplier": 100.0,
+        "currency": "HKD",
+        "net_income": net_income,
+        "open_interest": 500.0,
+        "volume": 50.0,
+        "spread_ratio": 0.10,
+        "symbol_concentration_after": None,
+        "source_kind": "candidate_csv",
+    }
+
+
+def _seal_dataset(
+    research_root: Path,
+    *,
+    run_id: str,
+    trading_date: str,
+    dataset_id: str | None = None,
+    legacy_unverified: bool = False,
+    account: str = "lx",
+    expiration: str = "2026-01-30",
+    include_candidates: bool = True,
+) -> None:
+    dataset = (
+        research_root / "remote_archive/prod/output_shared/research/shadow_replay/datasets" / (dataset_id or run_id)
+    )
+    dataset.mkdir(parents=True)
+    candidates = (
+        [
+            _candidate(
+                "0700.HK",
+                "HK.TCH260130P300000",
+                expiration=expiration,
+                strike=300.0,
+                spot=450.0,
+                net_income=1_500.0,
+            ),
+            _candidate(
+                "3690.HK",
+                "HK.MET260130P400000",
+                expiration=expiration,
+                strike=400.0,
+                spot=650.0,
+                net_income=980.0,
+            ),
+        ]
+        if include_candidates
+        else []
+    )
+    for candidate in candidates:
+        candidate["account"] = account
+        candidate["source_path"] = f"/archive/output_runs/{run_id}/accounts/{account}/0700.hk_sell_put_candidates.csv"
+    if candidates:
+        labeled_duplicate = dict(candidates[0])
+        labeled_duplicate["source_path"] = labeled_duplicate["source_path"].replace(".csv", "_labeled.csv")
+        candidates.append(labeled_duplicate)
+    for name in DATASET_FILES:
+        write_jsonl(dataset / name, candidates if name == "candidate_snapshots.jsonl" else [])
+    manifest = refresh_dataset_manifest(dataset)
+    manifest["source"] = {
+        "run_id": run_id,
+        "candidate_paths": (
+            [f"/archive/output_runs/{run_id}/accounts/{account}/0700.hk_sell_put_candidates.csv"]
+            if include_candidates
+            else []
+        ),
+        "candidate_evidence_coverage": {
+            "accounts": [
+                {
+                    "account": account,
+                    "markets": ["hk"],
+                    "status": "supported",
+                    "strict_replay_authority": True,
+                    "contributes_snapshot_facts": True,
+                    "owner_snapshots": ["opening"],
+                }
+            ]
+        },
+    }
+    write_json(dataset / "manifest.json", manifest)
+    refresh_dataset_manifest(dataset)
+    if legacy_unverified:
+        manifest = json.loads((dataset / "manifest.json").read_text(encoding="utf-8"))
+        manifest.pop("generation", None)
+        manifest.pop("integrity", None)
+        write_json(dataset / "manifest.json", manifest)
+
+    state = research_root / "remote_archive/prod/output_runs" / run_id / f"accounts/{account}/state"
+    write_json(
+        state / "portfolio_context.json",
+        {
+            "as_of_utc": f"{trading_date}T02:00:00Z",
+            "cash_by_currency": {"HKD": 1_000_000.0},
+            "stocks_by_symbol": {
+                "0700.HK": {
+                    "symbol": "0700.HK",
+                    "shares": 1_000.0,
+                    "currency": "HKD",
+                    "market_value": 450_000.0,
+                }
+            },
+        },
+    )
+    write_json(
+        state / "option_positions_context.json",
+        {
+            "cash_secured_by_symbol_by_ccy": {},
+            "cash_secured_total_by_ccy": {},
+            "cash_secured_unavailable_by_symbol": {},
+            "cash_secured_total_cny": 0.0,
+            "exchange_rates": {"rates": {"USDCNY": 7.0, "HKDCNY": 0.9}},
+        },
+    )
+
+
+def _window_fixture(
+    tmp_path: Path,
+    *,
+    cutoff_at_utc: str = "2026-02-02T08:00:00Z",
+    expiration: str = "2026-01-30",
+    last_account: str = "lx",
+    last_run_time: str = "020000",
+    omit_last: bool = False,
+) -> tuple[Path, Path, list[str], dict[str, object]]:
+    artifact_root = tmp_path / "output_shared/research/strategy_lab"
+    research_root = artifact_root.parent
+    days = _trading_days("2025-12-01", 20)
+    calendar = seal_market_calendar_fixture(
+        artifact_root,
+        days,
+        coverage_start=days[0],
+        coverage_end=days[-1],
+    )
+    for index, trading_date in enumerate(days):
+        if omit_last and index == len(days) - 1:
+            continue
+        run_time = last_run_time if index == len(days) - 1 else "020000"
+        run_id = f"{trading_date.replace('-', '')}T{run_time}Z-{index:06d}"
+        _seal_dataset(
+            research_root,
+            run_id=run_id,
+            trading_date=trading_date,
+            dataset_id=(f"prod-hk-{run_id.lower()}" if index == 0 else None),
+            legacy_unverified=index == 0,
+            account=last_account if index == len(days) - 1 else "lx",
+            expiration=expiration,
+        )
+    return (
+        artifact_root,
+        research_root,
+        days,
+        {
+            "market": "HK",
+            "account": "lx",
+            "cutoff_at_utc": cutoff_at_utc,
+            "latest_mature_trading_date": days[-1],
+            "market_calendar": calendar,
+            "datasets_root_ref": ("remote_archive/prod/output_shared/research/shadow_replay/datasets"),
+            "runs_root_ref": "remote_archive/prod/output_runs",
+        },
+    )
+
+
+def _close_receipt(stock_owner: str, close: float) -> dict[str, object]:
+    return {
+        "schema_version": RESEARCH_CLOSE_RECEIPT_SCHEMA,
+        "market": "HK",
+        "account": "lx",
+        "stock_owner": stock_owner,
+        "expiration": "2026-01-30",
+        "spot_source": "opend_history_kline",
+        "ktype": "K_DAY",
+        "autype": "NONE",
+        "price_field": "close",
+        "status": "available",
+        "underlier_close": close,
+        "reason_detail": None,
+    }
+
+
+def test_historical_window_reuses_shadow_replay_without_copying_candidates(
+    tmp_path: Path,
+) -> None:
+    artifact_root, research_root, days, kwargs = _window_fixture(tmp_path)
+    _seal_dataset(
+        research_root,
+        run_id=f"{days[-1].replace('-', '')}T030000Z-unrelated",
+        trading_date=days[-1],
+        account="sy",
+    )
+    _seal_dataset(
+        research_root,
+        run_id=f"{days[-1].replace('-', '')}T040000Z-empty",
+        trading_date=days[-1],
+        include_candidates=False,
+    )
+    window = build_research_window(artifact_root, **kwargs)
+    assert build_research_window(artifact_root, **kwargs) == window
+    assert len(window["days"]) == 20
+    assert '"candidates"' not in render_json_text(window)
+    assert window["days"][0]["points"][0]["source_kind"] == "shadow_replay_legacy_hash_bound_point"
+
+    points = load_research_window(artifact_root, window)
+    assert len(points) == 21
+    assert points[-1]["candidates"] == []
+    assert all(
+        candidate["symbol_concentration_after"] is not None for point in points for candidate in point["candidates"]
+    )
+
+    window_ref = "top1/windows/fixture.json"
+    window_text = render_json_text(window)
+    atomic_write_private_text(artifact_root / window_ref, window_text)
+    spec = _spec(
+        window,
+        variants=(
+            ("without", "without_concentration"),
+            ("concentration", "concentration_first"),
+        ),
+    )
+    spec["research_source"]["mode"] = "historical_research_window"
+    spec["research_source"]["dataset_ref"] = window_ref
+    loaded = load_materialized_research_input(
+        artifact_root,
+        spec,
+    )
+    assert loaded["research_window"] == window
+    assert loaded["observed_points"] == points
+    assert required_research_close_keys(loaded, _fee_contract()) == [
+        ("HK.00700", "2026-01-30"),
+        ("HK.03690", "2026-01-30"),
+    ]
+    receipts = [
+        _close_receipt("HK.00700", 250.0),
+        _close_receipt("HK.03690", 500.0),
+    ]
+    evaluation = evaluate_research(loaded, receipts, _fee_contract())
+    assert evaluate_research(loaded, list(reversed(receipts)), _fee_contract()) == evaluation
+    assert evaluation["selection"] == "research_leader"
+    assert evaluation["leader_variant_id"] == "concentration"
+    assert [item["variant_id"] for item in evaluation["variant_results"]] == [
+        "without",
+        "concentration",
+    ]
+
+    tampered = deepcopy(loaded)
+    tampered["observed_points"][0]["candidates"][0]["net_premium"] = 1.0
+    with pytest.raises(ResearchEvaluationError, match="historical point is invalid"):
+        required_research_close_keys(tampered, _fee_contract())
+
+    candidate_file = research_root / window["days"][0]["points"][0]["dataset_ref"] / "candidate_snapshots.jsonl"
+    write_jsonl(candidate_file, [])
+    with pytest.raises(ResearchWindowError, match="binding changed"):
+        load_research_window(artifact_root, window)
+
+
+@pytest.mark.parametrize(
+    ("omit_last", "last_account"),
+    ((True, "lx"), (False, "sy")),
+    ids=("missing-day", "account-mismatch"),
+)
+def test_historical_window_requires_every_scoped_day(
+    tmp_path: Path,
+    omit_last: bool,
+    last_account: str,
+) -> None:
+    artifact_root, _research_root, _days, kwargs = _window_fixture(
+        tmp_path,
+        omit_last=omit_last,
+        last_account=last_account,
+    )
+
+    with pytest.raises(ResearchWindowError) as exc_info:
+        build_research_window(artifact_root, **kwargs)
+
+    assert exc_info.value.reason_code == "research_window_coverage_missing"
+
+
+def test_historical_window_requires_calendar_coverage(tmp_path: Path) -> None:
+    artifact_root, _research_root, days, kwargs = _window_fixture(tmp_path)
+    kwargs["latest_mature_trading_date"] = (date.fromisoformat(days[0]) - timedelta(days=1)).isoformat()
+
+    with pytest.raises(ResearchWindowError, match="does not cover") as exc_info:
+        build_research_window(artifact_root, **kwargs)
+
+    assert exc_info.value.reason_code == "research_window_coverage_missing"
+
+
+@pytest.mark.parametrize(
+    ("cutoff_at_utc", "expiration", "last_run_time", "message"),
+    (
+        (
+            "2025-12-26T01:00:00Z",
+            "2025-12-26",
+            "020000",
+            "after cutoff",
+        ),
+        (
+            "2026-02-02T08:00:00Z",
+            "2026-03-27",
+            "020000",
+            "not mature",
+        ),
+    ),
+    ids=("after-cutoff", "immature-candidate"),
+)
+def test_historical_window_rejects_unavailable_outcomes(
+    tmp_path: Path,
+    cutoff_at_utc: str,
+    expiration: str,
+    last_run_time: str,
+    message: str,
+) -> None:
+    artifact_root, _research_root, _days, kwargs = _window_fixture(
+        tmp_path,
+        cutoff_at_utc=cutoff_at_utc,
+        expiration=expiration,
+        last_run_time=last_run_time,
+    )
+
+    with pytest.raises(ResearchWindowError, match=message) as exc_info:
+        build_research_window(artifact_root, **kwargs)
+
+    assert exc_info.value.reason_code == "research_window_coverage_missing"
+
+
+def test_historical_window_rejects_duplicate_run(tmp_path: Path) -> None:
+    artifact_root, research_root, days, kwargs = _window_fixture(tmp_path)
+    run_id = f"{days[-1].replace('-', '')}T020000Z-{len(days) - 1:06d}"
+    _seal_dataset(
+        research_root,
+        run_id=run_id,
+        trading_date=days[-1],
+        dataset_id=f"duplicate-{run_id}",
+    )
+
+    with pytest.raises(ResearchWindowError, match="run is duplicated") as exc_info:
+        build_research_window(artifact_root, **kwargs)
+
+    assert exc_info.value.reason_code == "research_window_conflict"


### PR DESCRIPTION
## Summary

- build deterministic 20-trading-day historical research windows from existing Shadow Replay datasets
- bind calendar, dataset, candidate, and context hashes without copying candidate bodies or creating a new store
- materialize observed candidates in memory and reuse the canonical Sell Put ranker for baseline and multiple challengers
- preserve the existing sealed historical dataset path; no runner, OpenD, config, or runtime-write changes

## Validation

- 112 Strategy Lab Top1 tests passed
- 32 general research tests passed
- Ruff and git diff checks passed
- read-only production evidence check: current HK calendar starts at 2026-08-17, so a 2026-08-14 mature date returns research_window_coverage_missing
- read-only archive compatibility check: 2026-06-10 through 2026-07-09 also returns research_window_coverage_missing because a required portfolio_context source file is absent

## Scope

W2 source delivery only. No merge, release, deployment, configuration change, or runtime artifact write.