### PR TITLE
chore(docs): guard indexed living-document paths

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -117,7 +117,7 @@ Linux / Mac 部署使用 `./om service render` 生成 systemd / launchd 服务�
 ./om run tick-cron --market hk --config /var/lib/options-monitor/config.hk.json --accounts lx sy --timeout 600
 ```
 
-旧的 `scripts/send_if_needed.py` / `scripts/send_if_needed_multi.py` 已删除。传一个账户就是单账户运行，传多个账户就是多账户运行；两者最终进入同一条 `multi_account_tick.run_tick` 链路。共享扫描数据可复用，通知与失败按账户隔离。
+已删除：`scripts/send_if_needed.py`。已删除：`scripts/send_if_needed_multi.py`。传一个账户就是单账户运行，传多个账户就是多账户运行；两者最终进入同一条 `multi_account_tick.run_tick` 链路。共享扫描数据可复用，通知与失败按账户隔离。
 
 ## 值班三步检查（先做这个）
 
@@ -215,4 +215,4 @@ cd "$REPO_ROOT"
   --confirm
 ```
 
-辅助诊断工具位于 `scripts/tools/`。
+辅助诊断优先使用 `./om-agent` 和 `./om` 的只读入口。

--- a/docs/AGENT_WIKI.md
+++ b/docs/AGENT_WIKI.md
@@ -697,7 +697,8 @@ notification token around Close Advice.
 ### Notifications
 
 - Per-account content: `src/application/notify_symbols.py`
-- Multi-account wrapper: `src/application/multi_tick/notify_format.py`
+- Scheduled delivery flow: `src/application/tick_notification_flow.py`
+- Scheduled business renderer: `src/application/daily_decision_brief_renderer.py`
 - Shared System Notice / Receipt presentation shell: `src/application/notification_shells.py`
 - Preview tool: `preview_notification`
 - Perception audit card: `assistant_perception` events written by

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 1047 (`src`: 571, `domain`: 76, `scripts`: 12, `tests`: 388)
-- Internal import edges: 7010 total, 3059 production/script edges excluding tests
+- Python files scanned: 1048 (`src`: 571, `domain`: 76, `scripts`: 12, `tests`: 389)
+- Internal import edges: 7012 total, 3059 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -51,7 +51,7 @@ flowchart LR
   tests -->|2| domain_services
   tests -->|231| infrastructure
   tests -->|252| interfaces
-  tests -->|19| scripts
+  tests -->|21| scripts
   tests -->|18| storage
 ```
 
@@ -83,7 +83,7 @@ flowchart LR
 | tests | domain | 462 |
 | tests | interfaces | 252 |
 | tests | infrastructure | 231 |
-| tests | scripts | 19 |
+| tests | scripts | 21 |
 | tests | storage | 18 |
 | tests | domain_services | 2 |
 

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -14,6 +14,7 @@ Enabled checks:
 - Reject commits if repo path/name matches `options-monitor-prod`
 - Scan staged index content for high-confidence credentials, private data fingerprints, known personal email addresses, personal paths, and tracked runtime configs; findings are redacted
 - Reject a repository-effective Git author email already classified as private; use a GitHub `noreply` identity for public commits
+- Reject a missing living-doc authority/indexed target and deterministic repository paths whose owner is absent from the staged Git index; explicit historical, removed, retired, proposed, and example paths are exempt
 - Require the first commit-message line to match `<type>(<scope>): <subject>`
 - No trailer or co-author line is required by the hooks
 
@@ -21,7 +22,7 @@ Enabled checks:
 
 Workflow: `.github/workflows/guardrails.yml`
 
-- Docs wording check: forbid treating `config.json` / `config.scheduled` / `config.market_*` as OM runtime entry
+- Docs check: forbid treating `config.json` / `config.scheduled` / `config.market_*` as OM runtime entry, require the living-doc authority graph to remain present, and reject deterministic repository paths in indexed living docs when their owner is missing
 - Runtime config tracking check: forbid committing root runtime configs such as `config.us.json` / `config.hk.json`; commit only templates under `configs/examples/`
 - Sensitive artifact check: reject high-confidence provider credentials, private keys, credentialed URLs, known private runtime/financial/email fingerprints, and literal personal home or mounted-volume paths without printing the blocked value
 - Lint: run `python -m ruff check .`
@@ -34,4 +35,4 @@ Trigger: `push` and `pull_request` to `main`
 
 - Any entrypoint that accepts user-entered symbol, broker raw payload, or OpenD/Futu underlying identifier must canonicalize to the shared symbol format before business logic.
 - Canonical market symbols are values like `NVDA`, `0700.HK`, `9992.HK`; aliases such as `POP` must not be persisted as runtime symbol config or position symbols.
-- Shared alias handling lives in `src/application/opend_utils.py:resolve_underlier_alias`; new entrypoints should reuse it instead of adding ad hoc `upper()` or market-specific parsing branches.
+- Shared alias handling lives in `src/application/opend_utils.py::resolve_underlier_alias`; new entrypoints should reuse it instead of adding ad hoc `upper()` or market-specific parsing branches.

--- a/docs/PI_AGENT_CORE_INTEGRATION.md
+++ b/docs/PI_AGENT_CORE_INTEGRATION.md
@@ -4,9 +4,10 @@ Status: S1-S7 were implemented and released in v1.15.0. The Assistant channel
 entry and shared Host call path use Pi Agent Core, the legacy Python Agent
 runtime is removed, and the mixed Python/Node release gates are active. S8
 context-bounded tool loading and evidence admission were released in v1.15.11.
-The repository is currently at v1.16.0. Deployment and configured-provider
-canary status are environment facts and must be checked through the controlled
-runtime surfaces; Git history alone does not prove an environment was upgraded.
+The current repository version is owned by `VERSION`, and published release
+history is owned by `CHANGELOG.md`. Deployment and configured-provider canary
+status are environment facts and must be checked through the controlled runtime
+surfaces; Git history alone does not prove an environment was upgraded.
 
 Last upstream verification: 2026-08-19. The pinned baseline is
 `@earendil-works/pi-agent-core@0.84.2`, `@earendil-works/pi-ai@0.84.2`, and
@@ -720,10 +721,10 @@ ownership pressure justifies it.
 
 ### 9.4 Delete after atomic cutover
 
-- `src/application/copilot/engine.py`
-- `src/application/copilot/model_client.py`
-- `src/application/copilot/conversation_memory.py`
-- `src/application/copilot/agent.py`
+- Removed: `src/application/copilot/engine.py`
+- Removed: `src/application/copilot/model_client.py`
+- Removed: `src/application/copilot/conversation_memory.py`
+- Removed: `src/application/copilot/agent.py`
 
 Deletion happens only after all callers and architecture guards point to Pi and
 the full acceptance gate passes. Database columns are left in place initially;
@@ -1706,9 +1707,9 @@ tests/test_inbound_control.py
 tests/test_inbound_feishu_ws.py
 ```
 
-`src/application/copilot/local_harness.py`,
-`src/application/copilot/model_client.py`, and
-`src/application/copilot/host.py` are deliberately unchanged in S4. The legacy
+Historical S4 record: `src/application/copilot/local_harness.py` and
+`src/application/copilot/host.py` were deliberately unchanged in S4.
+Removed: `src/application/copilot/model_client.py`. The legacy
 `CopilotModelSettings`, `_resolve_model_runner()`, `ModelRunner`, and
 `run_engine()` remain the application path until S5 switches the shared Host
 call site atomically. S4 must not partially implement that S5 cutover merely to
@@ -3903,7 +3904,7 @@ ambiguous, eager remains available.
 | `src/application/copilot/result_admission.py` | validate `submit_answer` claims against Host evidence and append non-removable coverage banners; retain existing final result checks |
 | `src/application/ledger/repository.py`, `queries.py`, and `api.py` | migrate and query the canonical trade-event stream; own `ingest_seq`, normalized market/effect projections, snapshot fencing, keyset SQL, cursor validation/encoding, and the public ledger facade |
 | `src/application/agent_tools/operations_impl.py` and `positions.py` | keep the existing `option_positions_read(action=events)` entry; expose the events-only cursor/count inputs and output contract; call only the public ledger facade and never load all events |
-| `src/application/copilot/pi_agent_process.py` | serialize the revised closed `run.start` and private activation/admission fields without exposing secrets |
+| `src/infrastructure/pi_agent_process.py` | serialize the revised closed `run.start` and private activation/admission fields without exposing secrets |
 | `agent-runtime/main.ts` | render dynamic catalog context, own internal tools, atomically replace schemas, enforce budgets/compaction, terminate approved answers, and normalize Session turns |
 | `src/application/agent_tools/operations_impl.py`, `secret_store/registry.py`, and `service_deploy.py` | derive the cursor child key from the existing inbound HMAC secret; keep the retired cursor env name unset without registering or binding a second credential |
 

--- a/docs/quality-monitoring/om-check-implementation.md
+++ b/docs/quality-monitoring/om-check-implementation.md
@@ -35,7 +35,7 @@
 |---|---|---|
 | 原子 artifact | `src/infrastructure/quality/artifact_repository.py` | schema-valid service 发布测试 |
 | 控制状态 | `src/infrastructure/quality/control_state_repository.py` | transient→persistent、首次 deep reconcile 测试 |
-| OpenD 只读快照 | `src/infrastructure/quality/opend_position_adapter.py` | fake adapter、请求市场隔离与 position/lifecycle 测试 |
+| OpenD 只读快照 | `src/application/quality/opend_position_adapter.py` | fake adapter、请求市场隔离与 position/lifecycle 测试 |
 | CLI | `src/interfaces/quality/cli.py` | 复用同一 service/artifact |
 | HTTP | `src/interfaces/quality/http.py` | bearer auth、ETag、`no-store`、只读 artifact 测试 |
 | Agent tool | `src/application/agent_tools/quality.py` | agent contract/plugin smoke 全量回归 |

--- a/scripts/guardrails_check.py
+++ b/scripts/guardrails_check.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
+from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parents[1]
 TEXT_SUFFIXES = {
@@ -35,6 +36,7 @@ TEXT_SUFFIXES = {
 }
 TEXT_FILENAMES = {"Makefile"}
 LineReader = Callable[[Path], list[str]]
+PathExists = Callable[[Path], bool]
 
 RUNTIME_TERMS = (
     "运行入口",
@@ -64,6 +66,26 @@ FORBIDDEN_CONFIG_MARKERS = (
     "config.market_us",
     "config.market_hk",
 )
+
+LIVING_DOC_HISTORY_HEADING = "## 迁移与历史兼容"
+REPO_PATH_PREFIXES = (
+    "src/",
+    "domain/",
+    "scripts/",
+    "tests/",
+    ".github/",
+    "configs/",
+    "agent-runtime/",
+)
+_MARKDOWN_LINK_RE = re.compile(r"\[[^]]+\]\(([^)]+)\)")
+_INLINE_CODE_RE = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
+_PATH_LIFECYCLE_PREFIX_RE = re.compile(
+    r"(?:\b(?:historical|removed|deleted|retired|deprecated|proposed|planned|example)\b"
+    r"|历史(?:路径|文件)?|已删除|已移除|已退役|已弃用|拟新增|计划新增|待新增|示例)"
+    r"\s*[:：]?\s*$",
+    re.IGNORECASE,
+)
+_NONDETERMINISTIC_PATH_CHARS = frozenset("*?[]{}<>")
 
 ROOT_RUNTIME_CONFIG_EXACT = {
     "config.assistant.json",
@@ -160,20 +182,28 @@ class Violation:
         return f"{self.path}:{self.line_no}: {self.reason}\n  {self.line.strip()}"
 
 
-def tracked_file_paths() -> list[Path]:
+def git_index_paths() -> list[Path]:
     try:
-        out = subprocess.check_output(["git", "ls-files"], cwd=str(ROOT), text=True)
+        out = subprocess.check_output(["git", "ls-files", "-z"], cwd=str(ROOT))
     except Exception as exc:
         raise SystemExit(f"[guardrails] failed to list files: {exc}")
 
+    return [
+        Path(raw.decode("utf-8", errors="surrogateescape"))
+        for raw in out.split(b"\0")
+        if raw
+    ]
+
+
+def tracked_file_paths() -> list[Path]:
+    paths = git_index_paths()
+
     files: list[Path] = []
-    for rel in out.splitlines():
-        if not rel:
-            continue
+    for rel in paths:
         p = ROOT / rel
         if not p.is_file():
             continue
-        files.append(Path(rel))
+        files.append(rel)
     return files
 
 
@@ -233,6 +263,138 @@ def read_staged_lines(path: Path) -> list[str]:
     except Exception as exc:
         raise SystemExit(f"[guardrails] failed to read staged file {rel}: {exc}") from exc
     return out.decode("utf-8", errors="ignore").splitlines()
+
+
+def working_tree_path_exists(path: Path) -> bool:
+    root = ROOT.resolve()
+    candidate = (root / path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return candidate.exists()
+
+
+def index_path_exists(path: Path, index_paths: set[str]) -> bool:
+    key = path.as_posix().rstrip("/")
+    if not key or key == "." or ".." in path.parts:
+        return False
+    return key in index_paths or any(item.startswith(f"{key}/") for item in index_paths)
+
+
+def _local_markdown_targets(
+    document: Path,
+    lines: list[str],
+    *,
+    path_exists: PathExists,
+) -> tuple[list[Path], list[Violation]]:
+    root = ROOT.resolve()
+    targets: list[Path] = []
+    issues: list[Violation] = []
+    for idx, line in enumerate(lines, start=1):
+        for raw_target in _MARKDOWN_LINK_RE.findall(line):
+            parsed = urlsplit(raw_target.strip())
+            if parsed.scheme or parsed.netloc or not parsed.path.lower().endswith(".md"):
+                continue
+            candidate = (document.parent / parsed.path).resolve()
+            try:
+                relative = candidate.relative_to(root)
+            except ValueError:
+                continue
+            if path_exists(relative):
+                targets.append(candidate)
+            else:
+                issues.append(
+                    Violation(
+                        document.relative_to(root),
+                        idx,
+                        "indexed living-doc target does not exist",
+                        line,
+                    )
+                )
+    return targets, issues
+
+
+def living_document_paths(
+    *,
+    line_reader: LineReader = read_lines,
+    path_exists: PathExists = working_tree_path_exists,
+) -> tuple[list[Path], list[Violation]]:
+    root = ROOT.resolve()
+    index = root / "docs" / "INDEX.md"
+    if not path_exists(Path("docs/INDEX.md")):
+        return [], [
+            Violation(
+                Path("docs/INDEX.md"),
+                1,
+                "living-doc authority index does not exist",
+                "<missing docs/INDEX.md>",
+            )
+        ]
+
+    index_lines: list[str] = []
+    for line in line_reader(index):
+        if line.strip() == LIVING_DOC_HISTORY_HEADING:
+            break
+        index_lines.append(line)
+
+    direct, issues = _local_markdown_targets(index, index_lines, path_exists=path_exists)
+    documents = [index, *direct]
+    for document in direct:
+        relative = document.relative_to(root)
+        if document.name != "README.md" or relative.parts[:1] != ("docs",) or len(relative.parts) < 3:
+            continue
+        nested, nested_issues = _local_markdown_targets(
+            document,
+            line_reader(document),
+            path_exists=path_exists,
+        )
+        documents.extend(nested)
+        issues.extend(nested_issues)
+    return list(dict.fromkeys(documents)), issues
+
+
+def _normalized_repo_path(token: str) -> Path | None:
+    value = token.strip()
+    if not value.startswith(REPO_PATH_PREFIXES):
+        return None
+    if (
+        any(character.isspace() for character in value)
+        or any(character in _NONDETERMINISTIC_PATH_CHARS for character in value)
+        or "..." in value
+    ):
+        return None
+    value = value.split("::", 1)[0]
+    value = re.sub(r":\d+(?:-\d+)?$", "", value)
+    return Path(value)
+
+
+def check_living_doc_repo_paths(
+    files: list[Path],
+    *,
+    line_reader: LineReader = read_lines,
+    path_exists: PathExists = working_tree_path_exists,
+) -> list[Violation]:
+    issues: list[Violation] = []
+    for path in files:
+        for idx, line in enumerate(line_reader(path), start=1):
+            for match in _INLINE_CODE_RE.finditer(line):
+                relative = _normalized_repo_path(match.group(1))
+                if relative is None:
+                    continue
+                if _PATH_LIFECYCLE_PREFIX_RE.search(line[: match.start()]):
+                    continue
+                if path_exists(relative):
+                    continue
+                issues.append(
+                    Violation(
+                        path.relative_to(ROOT.resolve()),
+                        idx,
+                        "indexed living-doc repository path does not exist",
+                        line,
+                    )
+                )
+    return issues
 
 
 def check_runtime_entry_wording(
@@ -427,14 +589,29 @@ def main() -> None:
         tracked_paths = staged_file_paths()
         files = text_staged_files(tracked_paths)
         line_reader = read_staged_lines
+        index_paths = {path.as_posix() for path in git_index_paths()}
+        path_exists = lambda path: index_path_exists(path, index_paths)
     else:
         tracked_paths = tracked_file_paths()
         files = text_tracked_files(tracked_paths)
         line_reader = read_lines
+        path_exists = working_tree_path_exists
     issues: list[Violation] = []
 
     if run_doc:
         issues.extend(check_runtime_entry_wording(files, line_reader=line_reader))
+        living_docs, living_doc_issues = living_document_paths(
+            line_reader=line_reader,
+            path_exists=path_exists,
+        )
+        issues.extend(living_doc_issues)
+        issues.extend(
+            check_living_doc_repo_paths(
+                living_docs,
+                line_reader=line_reader,
+                path_exists=path_exists,
+            )
+        )
     if run_tracking:
         issues.extend(check_runtime_config_tracking(tracked_paths))
     if run_sensitive:

--- a/tests/test_guardrails_doc_paths.py
+++ b/tests/test_guardrails_doc_paths.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts import guardrails_check
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_repo_path_check_accepts_current_paths_suffixes_and_nondeterministic_tokens(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(guardrails_check, "ROOT", tmp_path)
+    _write(tmp_path / "src/current.py", "")
+    _write(tmp_path / "src/package/member.py", "")
+    document = _write(
+        tmp_path / "docs/current.md",
+        "\n".join(
+            (
+                "`src/current.py`",
+                "`src/package/`",
+                "`src/current.py::handler`",
+                "`src/current.py:42`",
+                "`tests/*/test_service.py`",
+                "`src/<module>.py`",
+                "`src/[account]/state.py`",
+                "`src/...`",
+                "`scripts/tool.py --check`",
+            )
+        ),
+    )
+
+    assert guardrails_check.check_living_doc_repo_paths([document]) == []
+
+
+def test_repo_path_check_exempts_only_explicit_path_lifecycle_markers(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(guardrails_check, "ROOT", tmp_path)
+    document = _write(
+        tmp_path / "docs/current.md",
+        "\n".join(
+            (
+                "Removed: `src/removed.py`",
+                "Historical: `src/historical.py`",
+                "Proposed: `src/proposed.py`",
+                "示例：`src/example.py`",
+                "Must not import `src/missing.py`.",
+                "不得写入 `src/missing-cn.py`。",
+                "Current owner: `src/missing-current.py`.",
+            )
+        ),
+    )
+
+    issues = guardrails_check.check_living_doc_repo_paths([document])
+
+    assert [issue.line_no for issue in issues] == [5, 6, 7]
+    assert all(issue.reason == "indexed living-doc repository path does not exist" for issue in issues)
+
+
+def test_living_document_resolver_stops_before_history_and_follows_nested_subindex(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(guardrails_check, "ROOT", tmp_path)
+    _write(
+        tmp_path / "docs/INDEX.md",
+        "\n".join(
+            (
+                "# Docs",
+                "- [Current](CURRENT.md)",
+                "- [Quality](quality/README.md)",
+                "## 迁移与历史兼容",
+                "- [Legacy](legacy.md)",
+            )
+        ),
+    )
+    _write(tmp_path / "docs/CURRENT.md", "current\n")
+    _write(tmp_path / "docs/quality/README.md", "- [Implementation](implementation.md)\n")
+    _write(tmp_path / "docs/quality/implementation.md", "implementation\n")
+    _write(tmp_path / "docs/legacy.md", "legacy\n")
+
+    documents, issues = guardrails_check.living_document_paths()
+
+    assert issues == []
+    assert [path.relative_to(tmp_path).as_posix() for path in documents] == [
+        "docs/INDEX.md",
+        "docs/CURRENT.md",
+        "docs/quality/README.md",
+        "docs/quality/implementation.md",
+    ]
+
+
+def test_staged_check_uses_index_bytes_and_path_authority(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(guardrails_check, "ROOT", tmp_path)
+    _write(tmp_path / "docs/INDEX.md", "- [Current](CURRENT.md)\n")
+    _write(
+        tmp_path / "docs/CURRENT.md",
+        "\n".join(
+            (
+                "`src/removed.py`",
+                "`src/staged.py`",
+                "`src/package/`",
+            )
+        ),
+    )
+    removed = _write(tmp_path / "src/removed.py", "")
+    staged = _write(tmp_path / "src/staged.py", "")
+    _write(tmp_path / "src/package/member.py", "")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "update-index", "--force-remove", "src/removed.py"],
+        cwd=tmp_path,
+        check=True,
+    )
+    staged.unlink()
+
+    index_paths = {path.as_posix() for path in guardrails_check.git_index_paths()}
+
+    def staged_path_exists(path: Path) -> bool:
+        return guardrails_check.index_path_exists(path, index_paths)
+
+    documents, target_issues = guardrails_check.living_document_paths(
+        line_reader=guardrails_check.read_staged_lines,
+        path_exists=staged_path_exists,
+    )
+    issues = guardrails_check.check_living_doc_repo_paths(
+        documents,
+        line_reader=guardrails_check.read_staged_lines,
+        path_exists=staged_path_exists,
+    )
+
+    assert removed.exists()
+    assert not staged.exists()
+    assert target_issues == []
+    assert [issue.line_no for issue in issues] == [1]
+
+
+def test_staged_resolver_fails_closed_when_authority_or_target_is_deleted(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(guardrails_check, "ROOT", tmp_path)
+    index = _write(tmp_path / "docs/INDEX.md", "- [Current](CURRENT.md)\n")
+    current = _write(tmp_path / "docs/CURRENT.md", "current\n")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+
+    index_paths = {path.as_posix() for path in guardrails_check.git_index_paths()}
+
+    def staged_path_exists(path: Path) -> bool:
+        return guardrails_check.index_path_exists(path, index_paths)
+
+    subprocess.run(
+        ["git", "update-index", "--force-remove", "docs/CURRENT.md"],
+        cwd=tmp_path,
+        check=True,
+    )
+    index_paths = {path.as_posix() for path in guardrails_check.git_index_paths()}
+    documents, issues = guardrails_check.living_document_paths(
+        line_reader=guardrails_check.read_staged_lines,
+        path_exists=staged_path_exists,
+    )
+
+    assert current.exists()
+    assert documents == [index]
+    assert [(issue.path.as_posix(), issue.line_no, issue.reason) for issue in issues] == [
+        ("docs/INDEX.md", 1, "indexed living-doc target does not exist")
+    ]
+
+    subprocess.run(["git", "add", "docs/CURRENT.md"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "update-index", "--force-remove", "docs/INDEX.md"],
+        cwd=tmp_path,
+        check=True,
+    )
+    index_paths = {path.as_posix() for path in guardrails_check.git_index_paths()}
+    documents, issues = guardrails_check.living_document_paths(
+        line_reader=guardrails_check.read_staged_lines,
+        path_exists=staged_path_exists,
+    )
+
+    assert index.exists()
+    assert documents == []
+    assert [(issue.path.as_posix(), issue.line_no, issue.reason) for issue in issues] == [
+        ("docs/INDEX.md", 1, "living-doc authority index does not exist")
+    ]


### PR DESCRIPTION
## Summary

- correct stale current-owner paths and replace a hard-coded repository version fact with VERSION / CHANGELOG ownership
- extend the existing documentation guard to validate indexed living-doc authority links and deterministic inline repository paths
- use Git-index authority for staged checks and fail closed when the living-doc index or an indexed target is deleted
- add focused regression coverage and regenerate the canonical dependency summary

## Validation

- focused pytest: 20 passed
- Ruff: pass
- working-tree guardrails: OK
- staged Git-index guardrails: OK
- dependency graph check: current; 659 production modules; 0 cycles; no production edge delta
- full pytest: 5901 passed, 4 warnings
- slice DeepReview: one medium finding accepted, fixed, and re-reviewed
- aggregate DeepReview: pass, no new material findings

## Scope boundary

No runtime behavior, public CLI/tool schema, configuration, VERSION, release metadata, deployment, service, notification send, financial data, or production state is changed. W1b historical prose deletion remains separate.