### PR TITLE
perf(required-data): fast-path canonical CSV validation

### DIFF
--- a/src/application/opend_symbol_outputs.py
+++ b/src/application/opend_symbol_outputs.py
@@ -1154,6 +1154,8 @@ def _validate_consumer_csv_projection(
         raise SourceReceiptError(
             "required-data JSON and CSV row counts differ"
         )
+    if frame.equals(expected):
+        return
     multiplier_enriched = False
     for row_index in range(len(expected.index)):
         for column in REQUIRED_DATA_COLUMNS:

--- a/tests/test_config_yaml.py
+++ b/tests/test_config_yaml.py
@@ -1292,6 +1292,7 @@ def test_config_init_writes_starter_yaml_and_runtime_configs(tmp_path: Path) -> 
     assert "assistant" not in us_cfg
     assert "inbound" not in us_cfg
     assert hk_cfg[GENERATED_KEY]["market"] == "hk"
+    assert us_cfg["runtime"] == hk_cfg["runtime"]
     assert assistant_cfg["assistant"]["enabled"] is True
     assert assistant_cfg["assistant"]["copilot"]["enabled"] is True
     assert assistant_cfg["assistant"]["copilot"]["toolsets"]["portfolio"] is False

--- a/tests/test_required_data_snapshot.py
+++ b/tests/test_required_data_snapshot.py
@@ -9,8 +9,9 @@ from pathlib import Path
 import pytest
 
 from domain.domain.decision_state_fingerprint import canonical_sha256
-from src.application import opend_symbol_outputs
 from src.application.opend_symbol_outputs import (
+    _csv_roundtrip_frame,
+    _validate_consumer_csv_projection,
     publish_required_data_quote_snapshot,
     save_outputs,
 )
@@ -42,14 +43,13 @@ def test_consumer_csv_projection_equal_frame_skips_cell_fallback(
     monkeypatch,
 ) -> None:
     rows = [{"symbol": "NVDA"}]
-    frame = opend_symbol_outputs._csv_roundtrip_frame(rows)
+    frame = _csv_roundtrip_frame(rows)
     monkeypatch.setattr(
-        opend_symbol_outputs,
-        "_canonical_csv_value",
+        "src.application.opend_symbol_outputs._canonical_csv_value",
         lambda _value: pytest.fail("equal frame entered cell fallback"),
     )
 
-    opend_symbol_outputs._validate_consumer_csv_projection(
+    _validate_consumer_csv_projection(
         rows=rows,
         frame=frame,
         csv=None,

--- a/tests/test_required_data_snapshot.py
+++ b/tests/test_required_data_snapshot.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from domain.domain.decision_state_fingerprint import canonical_sha256
+from src.application import opend_symbol_outputs
 from src.application.opend_symbol_outputs import (
     publish_required_data_quote_snapshot,
     save_outputs,
@@ -35,6 +36,26 @@ from src.application.source_receipts import (
 
 
 _OBSERVED_AT = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def test_consumer_csv_projection_equal_frame_skips_cell_fallback(
+    monkeypatch,
+) -> None:
+    rows = [{"symbol": "NVDA"}]
+    frame = opend_symbol_outputs._csv_roundtrip_frame(rows)
+    monkeypatch.setattr(
+        opend_symbol_outputs,
+        "_canonical_csv_value",
+        lambda _value: pytest.fail("equal frame entered cell fallback"),
+    )
+
+    opend_symbol_outputs._validate_consumer_csv_projection(
+        rows=rows,
+        frame=frame,
+        csv=None,
+        symbol="NVDA",
+        raw_meta={},
+    )
 
 
 def _workspace(tmp_path: Path, run_id: str = "run-1") -> tuple[Path, Path]:

--- a/tests/unit/test_service_deploy_unit.py
+++ b/tests/unit/test_service_deploy_unit.py
@@ -119,6 +119,7 @@ def test_render_systemd_bundle_service_hardening() -> None:
     )
     files = {item["relative_path"]: item for item in bundle["files"]}
     tick = files["systemd/options-monitor-tick-us.service"]["content"]
+    tick_hk = files["systemd/options-monitor-tick-hk.service"]["content"]
     runtime_status = files["systemd/options-monitor-runtime-status.service"]["content"]
     verify = files["systemd/options-monitor-projection-verify.service"]["content"]
     verify_timer = files["systemd/options-monitor-projection-verify.timer"]["content"]
@@ -130,6 +131,8 @@ def test_render_systemd_bundle_service_hardening() -> None:
     assert "TimeoutStartSec=" not in runtime_status
     assert "TimeoutStartSec=" not in verify
     assert "TimeoutStartSec=" not in intake
+    assert "--timeout 600" in tick
+    assert "--timeout 600" in tick_hk
     assert "RuntimeMaxSec=" not in "\n".join(item["content"] for item in files.values())
     assert "[Install]\nWantedBy=multi-user.target" in intake
     assert "[Install]\nWantedBy=multi-user.target" not in tick


### PR DESCRIPTION
## Summary

- Fast-path exact required-data JSON/CSV projections with `DataFrame.equals()` before the existing cell-by-cell fallback.
- Preserve fail-closed drift detection, multiplier enrichment, metadata binding, and Close Advice TOCTOU validation when frames are not exactly equal.
- Add regression assertions that generated US/HK runtime settings match and both rendered tick services use `--timeout 600`.

## Performance evidence

- Deterministic 9-symbol batch, 254 rows per symbol, 60 columns, 10 repetitions.
- Fast path: median `0.0443s`, p90 `0.0445s`, max `0.0447s`.
- Same-data forced fallback: median `9.7051s`, p90 `9.7849s`, max `9.7947s`.
- Median reduction: `99.54%` at the owning validation boundary.

## Verification

- 462 focused and integration tests passed.
- Ruff passed for all touched Python files.
- Repository wording, runtime-config tracking, and sensitive-artifact guardrails passed.
- DeepReview found no material findings and no unresolved medium/high issues.

## Scope boundaries

- No production configuration or runtime artifact changes.
- No gateway lifecycle, batching, concurrency, notification, release, or deployment changes.
- Gitignored plan and review artifacts are intentionally excluded.
