### PR TITLE
fix(strategy-lab): derive health from formal corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Improvements
+- Made Strategy Lab Top1 readiness compute a bounded 20-day corpus-health view directly from formal corpus facts, removing the stale duplicate health-artifact dependency while retaining fail-closed calendar and storage-capacity checks.
+
 ## 2.2.2 - 2026-08-29
 
 ### Improvements

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1047 (`src`: 570, `domain`: 76, `scripts`: 12, `tests`: 389)
-- Internal import edges: 7063 total, 3071 production/script edges excluding tests
+- Internal import edges: 7064 total, 3071 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -39,14 +39,14 @@ flowchart LR
   domain_services -->|2| storage
   infrastructure -->|9| application
   infrastructure -->|3| domain
-  interfaces -->|165| application
+  interfaces -->|166| application
   interfaces -->|3| domain
   interfaces -->|7| infrastructure
   scripts -->|41| application
   scripts -->|2| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2946| application
+  tests -->|2947| application
   tests -->|464| domain
   tests -->|2| domain_services
   tests -->|230| infrastructure
@@ -60,7 +60,7 @@ flowchart LR
 | from | to | imports |
 |---|---|---|
 | application | domain | 453 |
-| interfaces | application | 165 |
+| interfaces | application | 166 |
 | application | infrastructure | 154 |
 | application | storage | 41 |
 | scripts | application | 41 |
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2946 |
+| tests | application | 2947 |
 | tests | domain | 464 |
 | tests | interfaces | 252 |
 | tests | infrastructure | 230 |
@@ -94,7 +94,7 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 | from | to | imports |
 |---|---|---|
 | src.application | domain.domain | 237 |
-| src.interfaces | src.application | 129 |
+| src.interfaces | src.application | 130 |
 | src.application | src.infrastructure | 113 |
 | src.application.ledger | domain.domain | 64 |
 | src.application.ledger | domain.domain.ledger | 42 |

--- a/docs/STRATEGY_LAB_EXPERIMENT_PLATFORM_SYSTEM_DESIGN.md
+++ b/docs/STRATEGY_LAB_EXPERIMENT_PLATFORM_SYSTEM_DESIGN.md
@@ -1,7 +1,7 @@
 # Strategy Lab 统一策略实验平台系统设计
 
-- **状态**：MVP 实验内核与基础事实归档已落地；真实 20 日 / 10 日窗口待验收
-- **日期**：2026-08-26
+- **状态**：MVP 实验内核与基础事实归档已落地；健康回执来源收敛待实施，真实 20 日 / 10 日窗口待验收
+- **日期**：2026-08-29
 - **产品依据**：`docs/STRATEGY_LAB_EXPERIMENT_PLATFORM_PRD.md`
 - **当前实现参考**：`docs/STRATEGY_LAB_DESIGN.md`
 - **首个 recipe**：HK / lx / Sell Put Top1
@@ -19,8 +19,8 @@ MVP 不新建通用实验框架。已有 Sell Put Top1 状态机、ExperimentSto
 2. opening snapshot 继续封存 accepted + rejected decisions；每个正式 run / account 另采集一次共享的
    全部未平仓期权行情快照。候选扫描和账户快照共同绑定到同一 run，recipe 不再请求 provider；
 3. 经 recommendation point 绑定后，将紧凑基础事实以透明 gzip 长期保存到 Research Archive；
-4. Corpus Health Receipt 是对 expectation、archive 和现有 storage baseline 的确定性只读视图，
-   不新增状态库；
+4. Corpus Health Receipt 是对 expectation、archive 和当前文件系统容量的确定性只读视图；它不扫描
+   与 Formal Corpus 无关的 runtime 历史，也不新增状态库；
 5. Top1 corpus 改为可重建的 recipe 索引和派生投影，不再以 `output_runs` 或自己的
    accepted-candidate 副本作为基础事实；
 6. readiness、研究、验证和 outcome 只读消费 archive ref / hash 与已冻结实验合同。
@@ -42,7 +42,7 @@ MVP 不新建通用实验框架。已有 Sell Put Top1 状态机、ExperimentSto
 | 运行事实 | HK / US、`lx` 的正式 run 绑定 opening decision、同 run 持仓行情、mark 和 FX；取证失败只降级 Strategy Lab | 需要真实运行持续证明两市场均按本次 collector 结果归档 |
 | 正式点绑定 | `recommendation_point.v3` 校验 run / account / config / policy、三类 owner ref / hash 和时间一致性 | 需要抽查真实点 readback；任一缺失或冲突继续 fail closed |
 | Research Archive | `formal_corpus.py` 已提供 expectation、正式点紧凑 gzip 写入、透明读取与冲突检测 | 需要随真实正式点验证长期容量和连续性 |
-| 积累健康 | Corpus Health Receipt 对比 HK / US expectation、archive 和 storage baseline | 回执不替代 canonical corpus，不能自动补点或启动研究 |
+| 积累健康 | `./om research corpus-health` 已从 Formal Corpus 计算 HK / US expectation 和 archive，但同步调用全 runtime storage baseline；Top1 advance 还会生成旧 Store-backed 重复回执 | 删除旧回执读写；Formal health 改为 Formal Corpus + 当前磁盘快照，readiness 每次只构建一次且不扫描全 runtime manifest |
 | Recipe Projection | projection v3 从 formal archive 派生，不复制基础行情 | 需要用真实点确认与原 Top1 行为一致 |
 | 历史事实 | 无价值的历史 migration preview 已删除 | 不增加 apply；缺失历史不回填，只重新积累 |
 
@@ -57,6 +57,7 @@ flowchart LR
     M --> B
     B --> A["4 Research Archive\nresearch/formal_corpus.py\ncanonical JSON + transparent gzip"]
     A --> H["5 Corpus Health Receipt\nexpectation vs archived attempts"]
+    D["当前文件系统容量\n一次 disk_usage"] --> H
     A --> P["6 Top1 Recipe Projection\ntop1/corpus.py + ranking.py"]
     H --> R["7 Capability / Readiness\nreadiness.py + workspace.py"]
     P --> R
@@ -193,20 +194,120 @@ health 或 retention 计算。进程退出时 `flock` 由操作系统释放，�
 
 ### 3.4 Corpus 健康回执
 
-`sell_put_top1_corpus_health_receipt.v1` 同时用于当前投影和每日首次观察：
+`corpus_health_receipt.v2` 是唯一产品健康回执，由
+`src/application/research/formal_corpus.py::build_corpus_health_receipt()` 在查询时构建：
 
-- 当前路径为 `strategy_lab/top1/corpus/hk/lx/health/current.json`，每次 advance 原子替换；
-- 每日路径为 `strategy_lab/top1/corpus/hk/lx/health/days/<date>.json`，只覆盖最近 20 个成熟交易日，
-  首次写入后不覆盖；
-- `day` 只保存 expected、captured、pending、overdue、missing、not-evaluable、conflicting、unexpected
-  的计数、状态和原因码，不复制 point payload 或 point ID 列表；
-- `accumulation` 只出现在当前回执，保存最近连续完整日数、剩余日数、窗口边界和首个阻塞日；
-- 当前回执绑定 advance 周期，`fresh_until_utc = observed_at_utc + 2 * interval`；`fresh` 只在读取时计算；
-- 两类回执都校验固定 schema、identity、规范 JSON、大小、content hash、日历与 corpus evidence hash；
-  读取时另返回 file hash。
+- 唯一事实来源是 Formal Corpus 的 immutable expectation 和 point artifact；
+  `ExperimentStore` 不参与 expected、captured、missing、conflict、not-evaluable 或连续完整日的计算；
+- HK / US 共用同一函数和 `./om research corpus-health --market <hk|us> --account lx`
+  查询入口，CLI 不自行统计；
+- builder 只接受两种显式 scope：默认 `full` 供手工 CLI 审计全历史；
+  `latest_mature_window` 供 scheduled readiness 只校验日历中最近
+  `RESEARCH_REQUIRED_DAYS` 个已结束交易日和当前交易日。基础 builder 不反向依赖
+  Top1 常量，由 readiness caller 传入 `mature_day_limit=RESEARCH_REQUIRED_DAYS`。`full`
+  只允许 limit 为 `None`，window scope 只允许正整数；不增加用户可配置的 CLI scope 开关；
+- `latest_mature_window` 必须先读受控 calendar binding，再直接打开选中日期目录；
+  calendar 不可用，或同一 `observed_at_utc` 换算的市场本地日期不在
+  `[coverage_start, coverage_end]` 内时，复用 `market_calendar_binding_unavailable` fail closed，
+  且不读取任何 expectation / point artifact，也不回退成全历史扫描。该 scope 的 `days`、totals、
+  连续成熟日、freshness、最早 / 最晚日期和 `formal_corpus_bytes` 都只统计选中日期；
+  scope 外的早期缺口或冲突不阻止定时推进，但仍由 `full` 视图完整报告；
+- scope 选择、成熟日判定和 freshness 共用 builder 的同一 `observed_at_utc`。
+  standalone readiness 在入口只捕获一次当前时间；scheduled advance 透传它在调用开始时
+  已冻结的 `occurred_at_utc`。builder 在 caller 已给时间时不得重新读墙钟，保证跨市场日界时
+  同一 scheduled invocation 仍选择同一日期窗口；
+- expectation / point coverage、canonical hash 和已结束交易日完整性是 immutable artifact 的确定性派生结果；
+  freshness、archive 占用、可用磁盘和当前容量风险是查询时的运行快照，不伪装成不可变审计事实；
+- 容量快照只对 `runtime_root` 调用一次标准库 `shutil.disk_usage()`。当前可用空间低于
+  `max(filesystem_capacity * 5%, 10 GiB)` 时为 `critical`；否则为
+  `insufficient_history`，明确表示本回执没有做增长预测。两者分别阻止和允许 readiness；
+- `collect_storage_runtime_baseline()` 继续服务显式的全 runtime 存储审计、manifest 引用校验和
+  90 日预测，但不得从 health、readiness 或 scheduled advance 同步调用。两份输出职责不同，
+  不缓存、持久化或复制 storage baseline；
+- `continuous_complete_trading_days` 只统计成熟交易日，即 `trading_date < 当前市场本地日期`。
+  当前交易日仍显示在 `days` 诊断明细中，但尚未结束或尚未完整时不得把成熟日连续后缀清零；
+- 顶层 `status` 保持表达查询时的完整采集健康，因此当前交易日未完整时仍可为 `unhealthy`；Top1
+  readiness 不以该状态替代成熟日门槛，只消费连续成熟日、容量和其他独立 blocker；
+- Top1 readiness 在一次调用中只构建一次该回执，同一对象同时用于 corpus
+  门禁和返回事实；即使 `ExperimentStore` 未 ready、为空或不可打开，也必须先返回该独立事实，
+  Store 状态只单独阻止实验推进；
+- 回执是只读派生视图，可以导出，但不再持久化 `current` 或每日重复状态文件。
 
-每日文件表示该日成熟后的首次观察，允许晚于交易日生成；它不锁定 canonical corpus。后续事实恢复只会
-改善重新计算的 `current`，不会改写每日文件。研究 preview 仍重新验证正式 corpus，不能凭健康回执启动。
+公开 JSON 合同按事实 owner 收敛：
+
+- `./om research corpus-health` 升级为 `corpus_health_receipt.v2`；删除旧
+  `storage.baseline_status`，保留 `formal_corpus_bytes`，并返回当前 filesystem 容量、可用空间、
+  critical floor、`critical_reasons` 和 `status`；不返回 manifest、冷数据或增长预测；
+- Top1 readiness 升级为 `sell_put_top1_readiness.v2`；只保留 canonical
+  `facts.corpus`，删除重复的 `facts.corpus_health_receipt`；
+- scheduled advance 升级为 `sell_put_top1_advance_result.v2`；删除顶层
+  `corpus_health`，唯一健康事实位于 `readiness.facts.corpus`。
+
+已完成的有界 consumer inventory 表明：仓库 production code 只构造和返回上述
+readiness / advance 字段，没有解析它们的下游调用方；已部署 systemd unit 只执行
+`./om research strategy-lab top1-loop advance ... --write`，不解析 JSON；当前只有测试直接断言旧字段。
+不可发现的外部 consumer 不能证明兼容需求；显式升级 schema 比在 v1 中偷换嵌套形状更可审计，
+因此不增加 legacy adapter、双 schema 或过渡字段。
+
+v2 的容量字段固定为最小查询快照：
+
+```json
+{
+  "scope": {
+    "mode": "latest_mature_window",
+    "mature_day_limit": 20,
+    "include_current_trading_day": true
+  },
+  "storage": {
+    "formal_corpus_bytes": 200704,
+    "capacity": {
+      "status": "insufficient_history",
+      "filesystem_capacity_bytes": 107374182400,
+      "current_free_bytes": 21474836480,
+      "critical_floor_bytes": 10737418240,
+      "critical_reasons": []
+    }
+  }
+}
+```
+
+`status` 只允许 `insufficient_history`、`critical` 或 `unavailable`。`disk_usage` 失败时仍返回结构有效的
+health v2，capacity 为 `unavailable`、顶层 `status=unhealthy`，readiness 使用现有
+`research_storage_capacity_unavailable` 阻止推进；不得吞掉已算出的 corpus coverage。
+
+健康查询失败与查询成功但尚未就绪必须分开：
+
+- Formal Corpus builder 失败或不可用时，readiness 返回 `facts.corpus=null`，通过现有
+  `top1_status_unavailable` fact error 说明原因，且 `validation_runtime_ready=false`；
+- scheduled advance 无法加载 readiness，或加载成功但 `readiness.facts.corpus=null`时，
+  终态必须为 `partial`；
+- Formal Corpus 返回结构有效的 `unhealthy`、连续完整日不足或容量 blocker 时，
+  advance 仍可为 `ok`，但 `validation_runtime_ready=false` 且不推进实验；这是有效事实，不是读取失败。
+
+现有 `strategy_lab/top1/corpus/*/health/current.json` 和 `health/days/*.json` 是旧
+`sell_put_top1_corpus_health_receipt.v1` 产物；切换后不再更新、不再被 readiness 读取，也不作为删除或
+改写 Formal Corpus 的授权。研究 preview 仍逐日验证被选窗口，不能凭健康回执自动启动研究。
+
+### 3.5 Advance 300 秒性能边界
+
+对发布版本 2.2.1 的只读分阶段诊断已经定位首个可复现慢边界：完整 Formal Corpus health 超过
+60 秒，其中 `collect_storage_runtime_baseline()` 超过 60 秒；去掉该 baseline 后，2 日 / 24 点的
+Formal artifact 校验为 14.87 秒。相同环境中 36 个 service 的 72 次 systemd 状态查询合计 0.81 秒，
+因此本工作单不优化 systemd polling，也不把 US 自动平仓的独立失败混入本链路。
+
+根修复是 3.4 的 owner 收敛：scheduled advance 不再同步扫描约 87,261 条 runtime 研究文件和
+1,580 个 manifest，也不再校验无界的全历史 Formal artifact。scheduled readiness 只直读
+最近 20 个成熟交易日和当前交易日的 expectation / point，再读取一次当前磁盘容量。
+实现不得提高 300 秒限制，
+不得改 tick、formal point、opening snapshot、required-data、prepared context、recommendation point
+或任何采集路径，也不得新增 cache、service、timer、持久化表或 profiler。
+
+实现后以相同只读输入复核 `build_corpus_health_receipt()`、`_readiness()` 和完整 scheduled advance
+的墙钟时间；不增加依赖机器负载的单元性能断言。自动化改为断言 scoped 调用的
+point loader 与 artifact `stat` 数量上界为选中的 20 个成熟日加当日各 expectation
+声明的 point 总数，不随 scope 外历史增长。手工 `full` 审计仍为
+O(全历史)；它不在 5 分钟 advance 热路径上，MVP 不为它增加摘要或缓存。
+阶段计时和回执中的 scope 日期必须绑定同一 scheduled `occurred_at_utc`，不用各阶段的墙钟时间重算。
 
 ## 4. 核心执行流程
 
@@ -554,13 +655,18 @@ MVP seed 的排序 profile 和 0.002 / 0.004 / 0.006 阈值目前没有 canonica
 | 2. 运行事实封存 | `opening_candidate_snapshot.py`、`required_data_blobs.py`、`prepared_option_positions_context.py` | **复用 + 修改条件** | opening snapshot 和 required-data blob 原样复用；prepared v2 保留现有 mark collector / payload，HK / US 正式 run 都为 `lx` 采集一次并直接使用本次返回的 facts；不新增 artifact 或 per-recipe 调用 |
 | 3. 正式点绑定与校验 | `recommendation_point.py` | **复用 + 修改** | 保留 point ID、write-once 及 validator；升级 v3 绑定 opening、required-data 和 prepared 三个 owner |
 | 4. Research Archive | `research/archive.py` 只有远端 pull / inventory / verify | **复用传输 + 确实新增** | 新增 `research/formal_corpus.py`、canonical JSON + deterministic gzip 读写；不加 DB、repository 抽象或对象存储 |
-| 5. Corpus Health Receipt | Top1 `read_corpus_status()` 仅覆盖 HK recipe index；`research/storage_baseline.py` 已提供磁盘与保留风险 | **复用 + 确实新增** | 同一 `formal_corpus.py` 对比 expectation 和 archived attempts，并复用 storage baseline；通过现有 `./om research` 返回 canonical receipt，不建 receipt 表 |
+| 5. Corpus Health Receipt | `research/formal_corpus.py` 已提供 canonical health，但错误地同步调用全 runtime storage baseline；Top1 `corpus.py` 仍保留 Store-backed 重复回执 | **修改 + 删除重复路径** | 只由 `formal_corpus.py` 对比 expectation 和 archived attempts，并读取一次当前磁盘容量；手工 CLI 使用全历史 scope，scheduled readiness 使用最近 20 个成熟日加当日 scope；不建 receipt 表、摘要文件或缓存 |
 | 6. Recipe Projection | `top1/corpus.py`、`top1/ranking.py`、Candidate Engine | **复用 + 修改 + 删除重复字段** | corpus 只存 archive ref 和 recipe 派生 metric；v3 projection 不复制基础 candidate 字段，运行时在内存合并 |
 | 7. Capability / Readiness | `top1/capability_receipts.py`、`top1/readiness.py`、`top1/workspace.py` | **复用 + 修改** | 保留四态和现有 capability；source readiness 改为消费 Corpus Health Receipt + recipe projection |
 | 8. ExperimentStore 与验证观察 | `experiment_store.py`、`validation.py`、`fill_observation.py`、`advance.py` | **原样复用为主** | 保留冻结 spec、授权、commitment、selected-arm Bid / Ask 和幂等提交；只更换 source ref，不加 schema / table |
 | 9. Outcome 与确定性评价 | `research_runner.py`、`economics.py`、`statistics.py`、`outcome.py`、`terminal_projection.py` | **原样复用** | 继续使用已冻结真实合约、FX、费用、年化收益率 + CNY PnL 和现有回执链；不动公式 |
 
 ### 6.2 原样复用
+
+第 6.1 节记录整个 MVP 的代码映射；本轮工作单只允许修改健康回执与 advance 调用链。
+允许的生产文件限定为 `research/formal_corpus.py` 的健康计算、`top1/advance.py`、
+`interfaces/cli/strategy_lab_top1.py`、`top1/readiness.py` 及对应聚焦测试。tick、正式点采集、
+recommendation point、required-data、prepared context、service / timer / config 和 US 自动平仓均不在本轮范围。
 
 | 文件 | 函数 / 合同 | 复用理由 |
 |---|---|---|
@@ -573,7 +679,8 @@ MVP seed 的排序 profile 和 0.002 / 0.004 / 0.006 阈值目前没有 canonica
 | `domain/domain/short_vol_assessment.py` | `calculate_option_market_concentration_after()` | 首个 recipe 的唯一集中度计算 owner |
 | `domain/domain/performance/models.py` | `select_fx_rate()` 等 FX value object / selector | 研究与 outcome 继续 fail closed 选择汇率 |
 | `src/application/research/archive.py` | `archive_pull()`、`archive_inventory()`、`archive_verify()` | 新 formal corpus 位于已同步的 `output_shared/research`，无需第二个远端传输工具 |
-| `src/application/research/storage_baseline.py` | `collect_storage_runtime_baseline()` | Health Receipt 复用现有 archive 占用、磁盘余量、90 日预测和 warning / critical 阈值，不重算容量规则 |
+| `src/application/research/formal_corpus.py` | expectation / point writer、loader 与 artifact 合同 | 原样复用；本轮只修改同文件 health 的成熟交易日后缀计算，不改任何采集或 artifact 合同 |
+| `src/application/research/storage_baseline.py` | `collect_storage_runtime_baseline()` | 原样保留为显式全 runtime 存储审计；health / readiness / advance 不再调用，也不修改其 collector、manifest 校验、增长预测或输出合同 |
 | `src/infrastructure/private_storage.py` | `exclusive_private_file_lock()`、`atomic_write_private_text()`、`atomic_write_private_bytes()` | 复用私有权限、同机互斥和原子发布；相同 identity 的不同 hash 仍由 formal corpus 判 conflict |
 | `src/application/strategy_lab/top1/lifecycle.py` | commitment、authorization、leader、receipt 及恢复函数 | 基础事实收敛不改实验生命周期 |
 | `src/infrastructure/strategy_lab/experiment_store.py` | 现有 experiment / generation / event / receipt API、`commit_validation_observation_batch()`、`commit_outcome_batch()` | 仍是唯一实验状态和原子提交 owner；本轮不迁移 schema |
@@ -581,20 +688,21 @@ MVP seed 的排序 profile 和 0.002 / 0.004 / 0.006 阈值目前没有 canonica
 
 ### 6.3 需要修改
 
+本节是当前工作单唯一的 production changed-files 清单。第 6.1 节其余模块是整体 MVP owner 映射，
+均已落地或仅供架构参考，不得据此重新修改采集、projection 或 CLI。
+
 | 文件 | 函数 | 最小修改 |
 |---|---|---|
-| `src/application/tick_cron.py` | `run_tick_cron()` | 在现有 market lock 内、生产 tick 前预封当前市场 expectation；只对显式 runtime root 写入，失败不阻断 tick |
-| `src/application/tick_account_execution.py` | `prepare_option_positions_contexts()` 调用条件 | 将 HK-only、Top1-available 的 mark scope 改为 HK / US canonical scheduled run 的 `lx`；每个 run / account 仍只调用一次，手工 run 不调用 |
-| `src/application/prepared_option_positions_context.py` | `prepare_option_positions_contexts()`、`_persist_current_option_marks()`、`build_option_market_evidence_payload()` / validator | 任何 provider 读前复用完整 ready / unavailable artifact；payload-only 时从已嵌入 authority 重建 manifest，其他部分状态 fail closed，均不重拉；collector 返回本次 mark facts 供 builder 直接使用并沿用 repository 持久化；formal run 覆盖全部 open option exact instruments，禁止从 repository 重选旧 mark |
-| `src/application/recommendation_point.py` | `build_recommendation_point()`、`validate_recommendation_point()`、`capture_scheduled_recommendation_point()`、`point_binding_from_recommendation_point()` | 增加 v3 三 owner 绑定和 `formal_point_time_coherence.v1`；point ID 保持不随 envelope 版本变化 |
-| `src/application/tick_notification_flow.py` | `_observe_recommendation_points()` | 去掉 HK-only 和 Top1 availability 对基础归档的限制；只处理 scheduled HK / US、`lx`，归档仍 best effort |
-| `src/application/strategy_lab/top1/advance.py`、`src/interfaces/cli/strategy_lab_top1.py` | `advance_scheduled()`、`handle_top1_command()`、`_profile_context()` | 保留 profile expectation 的幂等复核和 HK Top1 推进，但首封时间由各市场 tick 拥有；archive / calendar 操作可选 US，不被 HK recipe scope 拒绝 |
-| `src/application/strategy_lab/top1/ranking.py` | `build_ranking_projection()`、`validate_ranking_projection()`、`rerank_recommendation_point()` | 升级 v3 只保留 archive binding 和 recipe metric；重排仍调用 Candidate Engine |
-| `src/application/strategy_lab/top1/corpus.py` | `capture_recommendation_point()`、`read_validation_point_source()`、`preview_research_dataset()`、`freeze_research_dataset()` | 改读 formal corpus，以基础 expectation 构造 HK recipe index；不扫描 `output_runs`、不打开当前账本 / mark / FX |
-| `src/application/strategy_lab/top1/readiness.py`、`workspace.py` | `build_top1_readiness()`、`preview_sell_put_top1_research()` | 注入 Corpus Health Receipt 与 v3 projection；20 个连续完整日缺一即 blocked |
-| `src/interfaces/cli/research.py` | research parser / handler | 增加只读 `corpus-health --market hk|us --account lx`；返回应用函数的 canonical response，CLI 不自行统计 |
+| `src/application/research/formal_corpus.py` | `build_corpus_health_receipt()` | 升级为 `corpus_health_receipt.v2`，新增经校验的 `scope` 参数，只允许 `full` / `latest_mature_window`，以及仅 window 使用的 `mature_day_limit`；后者先要求同一 observation time 的市场本地日期位于 calendar coverage，再只直读最近成熟日加当日；calendar 不可用或过期时复用现有 reason code fail closed，不读取 artifact、不回退全扫；删除同步 storage baseline，改为一次 `shutil.disk_usage()` 和当前 critical floor；不改 writer、loader 或采集器 |
+| `src/application/strategy_lab/top1/advance.py` | `advance_scheduled()` | 升级为 `sell_put_top1_advance_result.v2`；停止调用旧 `publish_corpus_health_receipt()` 并删除顶层 `corpus_health`；readiness 加载失败或 canonical corpus 缺失时记录 failure 并返回 `partial`，有效但未就绪的 corpus 仅阻止实验推进 |
+| `src/interfaces/cli/strategy_lab_top1.py` | `_readiness(context, store, *, observed_at_utc=None)` | 入口只冻结一次 observation time；standalone 用该次当前时间，scheduled advance 的 `load_readiness` closure 传已有 `occurred_at_utc`。无条件且只调用一次 Formal Corpus `build_corpus_health_receipt(scope="latest_mature_window", mature_day_limit=RESEARCH_REQUIRED_DAYS, observed_at_utc=observed_at_utc)`，直接传 `runtime_root`，不经旧 `read_corpus_status()` / Store 分支；不受 `ExperimentStore.schema_state()` 是否 ready 影响，不得另调 storage baseline；结果只传给 canonical corpus，Store 仍独立形成推进 blocker |
+| `src/application/strategy_lab/top1/readiness.py` | `build_top1_readiness()` | 升级为 `sell_put_top1_readiness.v2`，删除 `corpus_health_receipt` 入参和 `facts.corpus_health_receipt`；20 个成熟连续完整日缺一即 blocked |
 
 ### 6.4 确实需要新增
+
+下表是 MVP 基础事实链原需新增且当前已落地的 owner。本轮健康来源收敛和超时诊断不新增生产函数、
+存储 schema、状态、服务、timer 或依赖；只升级 health、readiness 和 advance 三个已有返回 schema，复用 6.2 中的
+health owner 并停止重复生产路径。
 
 | 文件 | 函数 | 职责 |
 |---|---|---|
@@ -602,7 +710,6 @@ MVP seed 的排序 profile 和 0.002 / 0.004 / 0.006 阈值目前没有 canonica
 | 同上 | `seal_profile_formal_expectations()` | 按调用方给出的 market / config scope 和各自 timezone 预封 `lx`；只读已绑定 calendar，不请求 provider |
 | 同上 | `capture_formal_point_attempt()` | 从 recommendation point v3 绑定的三个 owner 构造紧凑 ready / not-evaluable record；复用同一文件锁按 point identity 串行 compare-and-publish，source binding 相同时采用首份 artifact，处理时间不产生新版本；只读本次共享快照，不再读 provider、repository 或当前状态 |
 | 同上 | `load_formal_point()` | 透明解压、校验 canonical bytes / hash；只有唯一 ready attempt 时返回 available |
-| 同上 | `build_corpus_health_receipt()` | 按 market / account / trading day 统计 expected / captured / missing / conflict / not-evaluable、freshness 和连续完整日；复用 storage baseline 输出容量 / 保留风险，并按当前实验 requirement 显示 fill / outcome 或 `not_required`；零事实也返回 unhealthy |
 | 同上 | `read_bound_market_calendar_snapshot()`、`read_market_calendar_binding()`、`refresh_market_calendar_binding()` | 将 Top1 `corpus.py` 中已有的 filesystem-backed calendar binding 校验 / 读写实现移入基础 owner；它们不使用 ExperimentStore，provider refresh 仍只由现有受控命令调用；Top1 改为 import |
 | `src/application/strategy_lab/top1/ranking.py` | `materialize_top1_recipe_input()` | 只在内存中合并 formal point 基础事实和 v3 recipe metric，校验 accepted universe 不变 |
 | `tests/test_formal_corpus.py` | 一个聚合测试文件 | 覆盖 expectation、gzip readback、幂等 / conflict、完全未采集的健康回执和不阻断 production flow |
@@ -619,10 +726,12 @@ MVP seed 的排序 profile 和 0.002 / 0.004 / 0.006 阈值目前没有 canonica
 | `src/application/strategy_lab/top1/corpus.py` | `_build_point_ranking_projection()` 及直接加载 `output_runs` opening / prepared artifact 的路径 | v3 projection 全部从 formal corpus 构建 |
 | 同上 | store-backed `_persist_expectation()` / `seal_day_expectation()` 及 calendar binding 实现 | calendar binding 实现移到 `research/formal_corpus.py`；新 file-only writer 保留 `_expectation_denominator()` 和首份 seal 采用语义后再删旧 caller，不删 schema v4 表或历史行 |
 | 同上 | `discover_recommendation_points()` | 新 archive 完成连续 readback，且已确认旧历史无 ready 迁移价值；不增加 apply |
+| 同上 | `sell_put_top1_corpus_health_receipt.v1` 的 build / publish / read / validate、current / daily ref 和仅服务该合同的 helper | **后续独立 work unit**：本轮 source switch 已发布并证明无内部 caller 后再单独确认；不删除历史 artifact、schema v4 表或其他 corpus projection 逻辑 |
 | `src/application/strategy_lab/top1/ranking.py` | projection v2 写入的 Bid / Ask、Greeks、合约和其他基础 candidate 副本 | v3 写入及读取全部通过；已有 v1/v2 artifact 仅在没有 active experiment 引用后停止支持 |
 
-删除项不得和新 writer 同时一步到位。先双读验证“新 archive 可读且内容与 run owner 一致”，
-再切 Top1 reader，最后删除旧读写路径；整个过程不改写历史 artifact 或回执。
+删除项不得和 source switch 合并。本轮只切 health caller、将 readiness / advance 明确升级为 v2 并修改成熟日计算；旧 health
+实现与专属测试的机械删除属于独立后续 work unit，必须重新确认文件范围和 caller inventory。整个过程不改写
+历史 artifact 或回执。其余旧 archive reader 仍按其原切换门槛处理，不纳入本工作单。
 
 ### 6.6 明确不删除
 
@@ -642,9 +751,10 @@ MVP seed 的排序 profile 和 0.002 / 0.004 / 0.006 阈值目前没有 canonica
 ### 7.1 ExperimentStore 保持不变
 
 `ExperimentStore` 当前已经是 schema v4。本轮不做 schema migration，也不增加 archive、health、preview、
-capability 或 metric 表。新 expectation、formal point 和 Corpus Health Receipt 只读写 7.2 的文件布局，
-必须在 `ExperimentStore` 为空或不可打开时仍可封存 / 查询，不调用 `corpus_day()`、
-`record_corpus_day()` 或其他 store API。
+capability 或 metric 表。Expectation 和 formal point 只读写 7.2 的文件布局；Corpus Health Receipt
+只读这些 artifact 并按需计算，不再持久化重复状态。`ExperimentStore` 为 ready、empty、unsupported
+或不可打开时，Formal Corpus health 都必须独立计算并返回，不调用 `corpus_day()`、
+`record_corpus_day()` 或其他 store API；Store 非 ready 只形成实验推进 blocker，不能吞掉健康事实。
 
 现有 `strategy_lab_corpus_days` 及其索引行只是旧 HK Top1 recipe projection 状态。切换期仅供旧 reader
 对比；Top1 reader 切到 formal corpus 后删除该路径的 caller，但不为清理闲置表引入 schema migration，
@@ -677,12 +787,17 @@ output_shared/research/formal_corpus/v1/
 - 写入使用现有 `private_storage` 的私有目录、原子发布和权限约束；
 - loader 只枚举 `expectations/**/*.json` 和 `points/**/*.json.gz`；`.locks/` 不是 artifact，
   不进入 corpus 校验、health 或 retention；
-- Corpus Health Receipt 每次从 immutable expectation / point 事实确定性计算，可以导出，但不再持久化
-  一张重复状态表；
-- 回执的全历史 `status` 继续显示早期缺口；recipe readiness 只消费最新连续
-  20 个 complete 交易日和容量状态，再由 dataset reader 逐日校验被选窗口；
-- 已结束交易日的 point coverage 是不可变派生结果；查询时另附当前 freshness、archive 占用、可用磁盘、
-  最早保留日期和保留风险。容量规则直接复用 `collect_storage_runtime_baseline()`；
+- Corpus Health Receipt 每次从 immutable expectation / point 事实计算，可以导出，但不再持久化
+  一张重复状态表；coverage 是确定性派生值，freshness 和容量是查询时运行快照；
+- `full` 视图继续显示早期缺口和冲突；`latest_mature_window` 只返回 calendar 选中的最新
+  20 个已结束交易日和当前交易日，不解压、load 或 `stat` scope 外的 point artifact。
+  readiness 消费该有界视图的连续成熟日和容量状态，再由 dataset reader 逐日校验已冻结的
+  正好 20 日窗口；scope 外冲突不阻止 readiness，但在 `full` 手工审计中仍可见。当前市场本地日期
+  保留在 `days` 诊断中，但排除在 `continuous_complete_trading_days` 后缀之外；当前日不完整仍可使顶层
+  `status=unhealthy`，用于表达查询时的采集完整性，不得因此单独阻断已满足成熟窗口的 readiness；
+- 已结束交易日的 point coverage 是不可变派生结果；查询时另附当前 freshness、Formal Corpus 占用、
+  可用磁盘、最早保留日期和当前 critical 容量风险。容量快照只调用一次 `shutil.disk_usage()`；
+  不同步扫描全 runtime manifest，不做增长预测；
 - MVP 不做 prune。数据规模经实测需要治理且已定义 retention 合同时，再增加保留策略。
 
 该布局只保存研究所需的最小规范字段和来源 binding，不复制 provider 原始响应、完整 output run 或 recipe
@@ -710,6 +825,7 @@ mark、当天最后报价、开仓权利金、Shadow Replay 或 performance-evid
 | 请求未实现的 recipe、指标或评价合同 | `unsupported` | `unsupported_recipe` / `unsupported_metric_contract` |
 | 维护方安全开关关闭 | `disabled` | `strategy_lab_service_disabled` |
 | 正式日 expectation 缺失或迟到 | 普通扫描 / 通知继续；当日 health 不健康 | `formal_expectation_missing` / `formal_expectation_late` |
+| 当前交易日 expectation / point 尚未完整 | 保留在 `days` 明细且顶层 health 可为 `unhealthy`；不降低成熟日连续后缀，也不单独阻断已满足窗口的 readiness | 无新增 reason code |
 | 同一日 timer 重试，denominator 不变 | 采用首份 expectation 及其 seal time；返回 `idempotent`，不产生新 hash | 无新增 reason code |
 | point 首次写入后内容相同 | `idempotent` | `formal_point_already_recorded` |
 | 同一 expectation / point 出现不同内容 hash | 当日 conflict；Top1 不得消费 | `formal_corpus_conflict` |
@@ -723,7 +839,9 @@ mark、当天最后报价、开仓权利金、Shadow Replay 或 performance-evid
 | 20 日任一日无完整正式来源 | `blocked` | `research_window_coverage_missing` |
 | Top1 recipe projection 缺失但 archive 完整 | 内存重建后继续 | `recipe_projection_rebuilt` |
 | Top1 archive binding 缺失或冲突 | `blocked` | `formal_point_evidence_missing` / `formal_corpus_conflict` |
-| archive 容量或保留风险为 warning / critical | `blocked` | 复用 storage baseline 的 warning / critical reason |
+| 当前磁盘容量低于 critical floor | `blocked` | `research_storage_capacity_risk`；详细原因来自 health v2 `storage.capacity.critical_reasons` |
+| 当前磁盘容量无法读取 | `blocked`，但保留已计算的 corpus coverage | `research_storage_capacity_unavailable` |
+| `ExperimentStore` 未 ready、为空、unsupported 或不可打开 | `facts.corpus` 仍返回；实验推进独立 `blocked` | 复用 Store schema / runtime blocker |
 | 研究所需 expiration boundary 无 terminal FX | `blocked` | `terminal_fx_evidence_missing` / `terminal_fx_evidence_conflict` |
 | OpenD quota、费用或到期 close 能力不足 | `blocked` | 复用现有 capability reason code |
 | 确认 hash 与重建结果不一致 | 拒绝写入 | `preview_hash_changed` |
@@ -734,6 +852,8 @@ mark、当天最后报价、开仓权利金、Shadow Replay 或 performance-evid
 | expiry close 已成熟但 terminal FX 暂未可用 | deadline 前保持 pending；deadline 后 `outcome_unavailable` | `terminal_fx_evidence_retryable` / `terminal_fx_evidence_missing` |
 | 任一硬风控违规 | `keep_baseline` | `hard_risk_violation` |
 | 维护方在验证中停机 | 暂停推进，不终止实验 | `strategy_lab_service_disabled` |
+| advance 被 300 秒终止 | 结果视为未知；先只读核对 Store、artifact 和 journal，再决定恢复，不直接重跑 write | 现有 systemd timeout 与 readback 证据，不新增 reason code |
+| US 自动平仓 service 独立失败 | 单独诊断其业务 owner；不据此判定 Formal Corpus 正式点缺失 | 复用该 service 自身失败证据 |
 
 ## 9. 测试与验收
 
@@ -759,7 +879,8 @@ mark、当天最后报价、开仓权利金、Shadow Replay 或 performance-evid
 - `test_strategy_lab_top1.py`：recipe projection v3 不复制基础行情；从 archive binding 内存 materialize 后，
   accepted set、DTE、Mid、市场集中度和指标证据与原 recipe 一致。
 - `test_strategy_lab_top1_corpus.py`：只从 formal corpus 建立 HK Top1 recipe index，不扫描 `output_runs`；
-  archive 缺失 / 冲突 fail closed，projection 缺失可重建；健康回执区分缺失、冲突和连续完整窗口。
+  archive 缺失 / 冲突 fail closed，projection 缺失可重建。旧 Store-backed health 专属测试只在后续
+  独立删除 work unit 证明零生产 caller 后随实现机械删除。
 - `test_strategy_lab_top1_workspace.py`：正式 20 日 v3 corpus 的 preview 零写入且确定；缺任一 expected point
   即 blocked；确认 hash 不匹配零写入，匹配后发布同一 dataset 并幂等完成研究。
 - `test_strategy_lab_top1_w1b.py`：opening / terminal 使用不同汇率的 CNY 经济结果，三个原币
@@ -770,10 +891,21 @@ mark、当天最后报价、开仓权利金、Shadow Replay 或 performance-evid
   crossing 原子绑定 opening FX 至 observation / job，缺失时仍保留报价和 `crossing=true`，
   但 `not_evaluable` 且不建 job；崩溃重试不重选汇率。
 - `test_strategy_lab_top1_store.py`：保持 schema v4、receipt、Proposal 和 4096-byte FX binding 回归，不新增
-  formal corpus 表；新 expectation / health 在空 store 及 store 打开失败时仍工作，且未调用 corpus store API。
+  formal corpus 表；health 在 Store ready、empty、unsupported 和打开失败时仍工作，且未调用 corpus store API。
 - `test_tick_cron.py`：HK / US tick 只预封当前市场且严格先于生产 tick；缺 calendar /
-  coverage 只记录降级，不阻止生产 tick。`test_strategy_lab_top1_readiness.py`、
-  `test_strategy_lab_top1_advance.py` 保留 advance 的幂等复核与 Top1 service disabled 时只暂停 recipe 推进。
+  coverage 只记录降级，不阻止生产 tick；本轮不改该文件或采集行为。
+- `test_strategy_lab_top1_readiness.py`：升级为 `sell_put_top1_readiness.v2`，精确断言
+  健康事实只有 `facts.corpus` 且不存在 `facts.corpus_health_receipt`；Store 非 ready 时仍只调用一次
+  Formal Corpus builder，且参数固定为 `latest_mature_window` + `RESEARCH_REQUIRED_DAYS`；不读旧持久化回执且
+  不调用 `collect_storage_runtime_baseline()`；standalone 只捕获一次 observation time，调度入口则将已冻结的
+  `occurred_at_utc` 透传到 builder；
+  builder 失败时 `facts.corpus=null`、保留 fact error 且 runtime 不 ready；20 个成熟日完整、
+  当前日不完整、其余 facts ready 时，顶层 corpus 可为 `unhealthy`，但
+  `validation_runtime_ready=true`。
+- `test_strategy_lab_top1_advance.py`：升级为 `sell_put_top1_advance_result.v2` 并保留 service disabled 语义；
+  精确断言不存在顶层 `corpus_health`，advance 不再调用 legacy health publisher 且 readiness 只加载一次；
+  readiness 失败或 canonical corpus 缺失时为 `partial`，结构有效但 `unhealthy` / warming 时可为
+  `ok` 且 `validation_runtime_ready=false`。
 - `test_strategy_lab_top1_research_runner.py`：移除 feature mock，保留幂等恢复和 OpenD 失败路径；
   只消费 confirmed preview 绑定的 terminal FX，缺失时 fail closed；revision 已持久化后重试
   不打开 repository 或重新拉 close。
@@ -794,15 +926,27 @@ mark、当天最后报价、开仓权利金、Shadow Replay 或 performance-evid
 3. deterministic gzip 可透明读取，canonical hash 不受压缩影响，损坏文件 fail closed；
 4. ready point 含 accepted / rejected、同 run 持仓、本次共享采集的 exact marks 和 FX binding，不含 provider 原始响应；
 5. 缺任一必需 binding 时写 not-evaluable attempt，不伪造 ready；
-6. health receipt 对完全未采集、缺点、冲突和连续完整窗口返回稳定状态与计数；
-7. health receipt 复用 storage baseline 输出 archive 占用、free bytes、最早日期和保留风险；无实验时
-   fill / outcome 显示 `not_required`；
-8. writer readback 失败只产生 diagnostic，不影响调用方扫描 / 通知；
-9. loader、expectation 和 health 不依赖数据库、缓存或手工解压，且不调用
+6. health receipt 对完全未采集、缺点、冲突和连续完整窗口返回稳定状态与计数；20 个成熟交易日完整、
+   当前交易日未完整时，`days` 显示当前日、顶层 `status=unhealthy`，且
+   `continuous_complete_trading_days` 仍为 20；
+7. health v2 输出 Formal Corpus 占用、一次 `disk_usage` 的 capacity / free / critical floor、最早日期
+   和当前容量风险；可用空间低于 critical floor 时 blocked，其他情况为 `insufficient_history`；
+   `collect_storage_runtime_baseline()` 不被调用；无实验时 fill / outcome 显示 `not_required`；
+8. 构造超过 20 个成熟日和当前日的 corpus；spy 断言 `latest_mature_window` 只对选中日期
+   调用 point loader 和 artifact `stat`，`days`、totals、freshness、日期边界和 bytes 也只反映该 scope；
+   scope 外冲突只使 `full` 失败，scope 内缺口必须阻止 readiness；calendar 不可用时不得退化为全扫；
+   calendar 的 `coverage_end` 早于 observation date 或 `coverage_start` 晚于 observation date 时，
+   必须返回 `market_calendar_binding_unavailable`，且 spy 证明 point loader 和 artifact `stat` 零调用；
+   额外以香港本地 00:00 为边界，断言显式 `observed_at_utc` 决定成熟日和当前日，
+   不受 builder 真实执行时的墙钟影响；
+9. writer readback 失败只产生 diagnostic，不影响调用方扫描 / 通知；
+10. loader、expectation 和 health 不依赖数据库、缓存或手工解压，且不调用
    `ExperimentStore` corpus API；持久存在的 lock 文件不被 loader 视为 artifact；
-10. 300 秒时间跨度边界可 ready，超过或缺必需时间时稳定 not-evaluable。
+11. 300 秒时间跨度边界可 ready，超过或缺必需时间时稳定 not-evaluable。
 
 不为 9 个逻辑模块分别建类或测试文件；其余合同继续由现有 owner 测试。
+超时定位不新增易抖动的墙钟性能测试；自动化只断言公开链调用次数、schema 和 fail-closed 结果，
+生产输入规模与阶段耗时保留为一次性诊断证据。
 
 ### 9.3 MVP 真实验收
 
@@ -822,17 +966,28 @@ mark、当天最后报价、开仓权利金、Shadow Replay 或 performance-evid
 
 ## 10. 当前运行与验收顺序
 
-MVP 代码切片已完成，当前按以下顺序运行验收：
+基础事实代码切片已完成，advance 超时 owner 也已通过只读诊断定位。继续计算连续完整日前按以下顺序收敛：
 
-1. 通过现有受控入口刷新并校验 HK / US calendar coverage；各市场现有 `tick-cron` 在启动生产 tick 前
+1. 将 Formal Corpus health 升级为 v2：移除全 runtime storage baseline，改为当前磁盘容量快照，
+   同时实现手工 `full` 和 readiness `latest_mature_window` 两个 scope，后者严格限定最近
+   20 个成熟交易日加当日；不改 collector、不提高超时；
+2. 将 Top1 advance / readiness 健康来源收敛到该 health v2，删除旧 Store-backed 回执的运行时读写，
+   scheduled readiness 透传 advance 已冻结的 `occurred_at_utc`；将两个返回合同明确升级为 v2，
+   不建兼容 adapter，并完成聚焦回归；
+3. 只有用户另行授权发布 / 升级后，才在目标运行环境以相同只读输入重复阶段计时，证明 health、readiness
+   和 scheduled advance 既不进入全 runtime storage baseline，也不 load / `stat` 最近 20 个成熟日加当日以外的
+   Formal artifact；
+4. 旧 Store-backed health 实现只在 source switch 已发布且全仓证明无内部 caller 后，
+   作为独立 work unit 另行确认删除；不删除历史 artifact；
+5. 通过现有受控入口刷新并校验 HK / US calendar coverage；各市场现有 `tick-cron` 在启动生产 tick 前
    预封本市场 `lx` expectation；
-2. ordinary scheduled tick 为 HK / US `lx` 采集一次共享持仓行情，写 recommendation point v3，
+6. ordinary scheduled tick 为 HK / US `lx` 采集一次共享持仓行情，写 recommendation point v3，
    归档后 readback；
-3. 先观察至少一个 HK 和一个 US 正式点，确认 hash、字段、压缩和健康回执；
-4. 每日检查 Corpus Health Receipt，重新积累连续 20 个完整 HK 交易日；缺点只修复事实产出，不回填；
-5. 20 日完整后生成 research preview，用户确认后执行研究；没有可信 `research_leader` 时停止；
-6. 有 leader 时由用户第二次确认未来 10 日隐藏验证，现有 timer 推进 fill、outcome 和 Final Receipt；
-7. 只有 `candidate_for_adoption` 才在回执中出现 `adoption_proposal`，且仍需独立配置、发布和部署授权。
+7. 先观察至少一个 HK 和一个 US 正式点，确认 hash、字段、压缩和健康回执；
+8. 每日检查 Corpus Health Receipt，重新积累连续 20 个完整 HK 交易日；缺点只修复事实产出，不回填；
+9. 20 日完整后生成 research preview，用户确认后执行研究；没有可信 `research_leader` 时停止；
+10. 有 leader 时由用户第二次确认未来 10 日隐藏验证，现有 timer 推进 fill、outcome 和 Final Receipt；
+11. 只有 `candidate_for_adoption` 才在回执中出现 `adoption_proposal`，且仍需独立配置、发布和部署授权。
 
 本轮不新增 MCP、Agent Skill、飞书控制面、数据库表、定时器或历史 apply 命令。任何持仓、真实合约行情
 或 FX 缺口都必须让 point / preview fail closed；不得用当前值补历史，也不得降低评价标准。

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,6 +1,6 @@
 flowchart LR
   src_application["src.application"] -->|237| domain_domain["domain.domain"]
-  src_interfaces["src.interfaces"] -->|129| src_application["src.application"]
+  src_interfaces["src.interfaces"] -->|130| src_application["src.application"]
   src_application["src.application"] -->|113| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|64| domain_domain["domain.domain"]
   src_application_ledger["src.application.ledger"] -->|42| domain_domain_ledger["domain.domain.ledger"]

--- a/src/application/research/formal_corpus.py
+++ b/src/application/research/formal_corpus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gzip
 import json
 import re
+import shutil
 from collections.abc import Mapping
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -51,7 +52,7 @@ from src.infrastructure.private_storage import (
 FORMAL_CORPUS_VERSION = "v1"
 FORMAL_EXPECTATION_SCHEMA = "formal_day_expectation.v1"
 FORMAL_POINT_SCHEMA = "formal_point_attempt.v1"
-CORPUS_HEALTH_SCHEMA = "corpus_health_receipt.v1"
+CORPUS_HEALTH_SCHEMA = "corpus_health_receipt.v2"
 FORMAL_POINT_TIME_COHERENCE_SCHEMA = "formal_point_time_coherence.v1"
 FORMAL_POINT_MAX_SKEW_MS = 300_000
 MARKET_CALENDAR_POINTER_SCHEMA = "sell_put_top1_market_calendar_pointer.v1"
@@ -1419,158 +1420,203 @@ def build_corpus_health_receipt(
     account: str,
     repo_root: str | Path | None = None,
     observed_at_utc: str | None = None,
+    scope: str = "full",
+    mature_day_limit: int | None = None,
 ) -> dict[str, Any]:
     market, account = _identity(market, account)
+    scope = _text(scope, "scope")
+    if scope not in {"full", "latest_mature_window"}:
+        _fail("formal_corpus_input_invalid", "scope is invalid")
+    if scope == "full":
+        if mature_day_limit is not None:
+            _fail(
+                "formal_corpus_input_invalid",
+                "full scope does not accept mature_day_limit",
+            )
+    elif type(mature_day_limit) is not int or mature_day_limit <= 0:
+        _fail(
+            "formal_corpus_input_invalid",
+            "latest_mature_window requires a positive mature_day_limit",
+        )
     normalized_runtime_root = _runtime_root(runtime_root)
     observed_at = _timestamp(
         observed_at_utc
         or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "observed_at_utc",
     )
+    local_date = (
+        datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+        .astimezone(ZoneInfo(_MARKET_TIMEZONES[market]))
+        .date()
+        .isoformat()
+    )
+    calendar_root = (
+        normalized_runtime_root / "output_shared" / "research" / "strategy_lab"
+    )
+    try:
+        calendar = read_market_calendar_binding(calendar_root, market=market)
+    except FormalCorpusError:
+        if scope == "latest_mature_window":
+            raise
+        calendar = None
+    selected_dates: list[str] | None = None
+    if scope == "latest_mature_window":
+        assert calendar is not None and mature_day_limit is not None
+        if not calendar["coverage_start"] <= local_date <= calendar["coverage_end"]:
+            _fail(
+                "market_calendar_binding_unavailable",
+                f"{market} observation date is outside calendar coverage",
+            )
+        trading_dates = list(calendar["trading_dates"])
+        selected_dates = [
+            value for value in trading_dates if value < local_date
+        ][-mature_day_limit:]
+        if local_date in trading_dates:
+            selected_dates.append(local_date)
+
     identity_root = _corpus_root(runtime_root) / market.lower() / account
     expectation_root = identity_root / "expectations"
     point_root = identity_root / "points"
-    try:
-        calendar = read_market_calendar_binding(
-            _runtime_root(runtime_root) / "output_shared" / "research" / "strategy_lab",
-            market=market,
-        )
-    except FormalCorpusError:
-        calendar = None
     days: list[dict[str, Any]] = []
     layout_conflicts = 0
     expectation_dates: set[str] = set()
-    if expectation_root.is_dir() and not expectation_root.is_symlink():
-        for directory in sorted(expectation_root.iterdir()):
-            if directory.is_symlink() or not directory.is_dir():
-                layout_conflicts += 1
-                continue
-            try:
-                trading_date = _day(directory.name)
-            except FormalCorpusError:
-                layout_conflicts += 1
-                continue
-            expectation_dates.add(trading_date)
-            try:
-                expectations = _expectation_artifacts(runtime_root, market, account, trading_date)
-            except FormalCorpusError:
-                expectations = []
-                conflict = True
-            else:
-                conflict = len(expectations) != 1
-            if not expectations:
-                days.append(
-                    {
-                        "trading_date": trading_date,
-                        "status": "conflict" if conflict else "missing",
-                        "reason_code": (
-                            "formal_corpus_conflict"
-                            if conflict
-                            else "formal_expectation_missing"
-                        ),
-                        "market_calendar_version": None,
-                        "market_calendar_sha256": None,
-                        "schedule_config_sha256": None,
-                        "expected_point_count": 0,
-                        "captured_point_count": 0,
-                        "not_evaluable_point_count": 0,
-                        "missing_point_count": 0,
-                        "points": [],
-                    }
-                )
-                continue
-            expectation = expectations[0][0]
-            expected = list(expectation["expected_recommendation_point_ids"])
-            conflict |= _point_day_layout_conflicts(
-                runtime_root, market, account, trading_date, expected
-            )
-            captured = not_evaluable = missing = 0
-            points: list[dict[str, Any]] = []
-            for point_id in expected:
+    candidate_dates: list[str] = []
+    if selected_dates is None:
+        if expectation_root.is_dir() and not expectation_root.is_symlink():
+            for directory in sorted(expectation_root.iterdir()):
+                if directory.is_symlink() or not directory.is_dir():
+                    layout_conflicts += 1
+                    continue
                 try:
-                    loaded = load_formal_point(
-                        runtime_root,
-                        market=market,
-                        account=account,
-                        trading_date=trading_date,
-                        recommendation_point_id=point_id,
-                    )
-                except FormalCorpusError as exc:
-                    loaded = {
-                        "status": "conflict",
-                        "reason_code": exc.reason_code,
-                        "point": None,
-                    }
-                point = loaded.get("point")
-                recommendation_point = (
-                    point.get("recommendation_point")
-                    if isinstance(point, Mapping)
-                    else None
-                )
-                coherence = (
-                    recommendation_point.get("formal_point_time_coherence")
-                    if isinstance(recommendation_point, Mapping)
-                    else None
-                )
-                points.append(
-                    {
-                        "recommendation_point_id": point_id,
-                        "status": loaded["status"],
-                        "reason_code": loaded.get("reason_code"),
-                        "captured_at_utc": (
-                            point.get("captured_at_utc")
-                            if isinstance(point, Mapping)
-                            else None
-                        ),
-                        "source_observed_at_utc": (
-                            coherence.get("maximum_observed_at_utc")
-                            if isinstance(coherence, Mapping)
-                            else None
-                        ),
-                        "time_coherence": (
-                            dict(coherence) if isinstance(coherence, Mapping) else None
-                        ),
-                    }
-                )
-                if loaded["status"] == "available":
-                    captured += 1
-                elif loaded["status"] == "not_evaluable":
-                    not_evaluable += 1
-                elif loaded["status"] == "missing":
-                    missing += 1
-                else:
-                    conflict = True
-            day_status = "conflict" if conflict else "complete" if (
-                expectation["sealed_before_first_target"]
-                and expected
-                and captured == len(expected)
-            ) else "incomplete"
+                    candidate_dates.append(_day(directory.name))
+                except FormalCorpusError:
+                    layout_conflicts += 1
+    else:
+        for trading_date in selected_dates:
+            directory = expectation_root / trading_date
+            if directory.is_symlink() or not directory.is_dir():
+                if directory.exists() or directory.is_symlink():
+                    layout_conflicts += 1
+                continue
+            candidate_dates.append(trading_date)
+    for trading_date in candidate_dates:
+        expectation_dates.add(trading_date)
+        try:
+            expectations = _expectation_artifacts(
+                runtime_root, market, account, trading_date
+            )
+        except FormalCorpusError:
+            expectations = []
+            conflict = True
+        else:
+            conflict = len(expectations) != 1
+        if not expectations:
             days.append(
                 {
                     "trading_date": trading_date,
-                    "status": day_status,
+                    "status": "conflict" if conflict else "missing",
                     "reason_code": (
                         "formal_corpus_conflict"
                         if conflict
-                        else None if day_status == "complete" else "formal_day_incomplete"
+                        else "formal_expectation_missing"
                     ),
-                    "market_calendar_version": expectation[
-                        "market_calendar_version"
-                    ],
-                    "market_calendar_sha256": expectation[
-                        "market_calendar_sha256"
-                    ],
-                    "schedule_config_sha256": expectation[
-                        "schedule_config_sha256"
-                    ],
-                    "expected_point_count": len(expected),
-                    "captured_point_count": captured,
-                    "not_evaluable_point_count": not_evaluable,
-                    "missing_point_count": missing,
-                    "points": points,
+                    "market_calendar_version": None,
+                    "market_calendar_sha256": None,
+                    "schedule_config_sha256": None,
+                    "expected_point_count": 0,
+                    "captured_point_count": 0,
+                    "not_evaluable_point_count": 0,
+                    "missing_point_count": 0,
+                    "points": [],
                 }
             )
-    if point_root.is_dir() and not point_root.is_symlink():
+            continue
+        expectation = expectations[0][0]
+        expected = list(expectation["expected_recommendation_point_ids"])
+        conflict |= _point_day_layout_conflicts(
+            runtime_root, market, account, trading_date, expected
+        )
+        captured = not_evaluable = missing = 0
+        points: list[dict[str, Any]] = []
+        for point_id in expected:
+            try:
+                loaded = load_formal_point(
+                    runtime_root,
+                    market=market,
+                    account=account,
+                    trading_date=trading_date,
+                    recommendation_point_id=point_id,
+                )
+            except FormalCorpusError as exc:
+                loaded = {
+                    "status": "conflict",
+                    "reason_code": exc.reason_code,
+                    "point": None,
+                }
+            point = loaded.get("point")
+            recommendation_point = (
+                point.get("recommendation_point")
+                if isinstance(point, Mapping)
+                else None
+            )
+            coherence = (
+                recommendation_point.get("formal_point_time_coherence")
+                if isinstance(recommendation_point, Mapping)
+                else None
+            )
+            points.append(
+                {
+                    "recommendation_point_id": point_id,
+                    "status": loaded["status"],
+                    "reason_code": loaded.get("reason_code"),
+                    "captured_at_utc": (
+                        point.get("captured_at_utc")
+                        if isinstance(point, Mapping)
+                        else None
+                    ),
+                    "source_observed_at_utc": (
+                        coherence.get("maximum_observed_at_utc")
+                        if isinstance(coherence, Mapping)
+                        else None
+                    ),
+                    "time_coherence": (
+                        dict(coherence) if isinstance(coherence, Mapping) else None
+                    ),
+                }
+            )
+            if loaded["status"] == "available":
+                captured += 1
+            elif loaded["status"] == "not_evaluable":
+                not_evaluable += 1
+            elif loaded["status"] == "missing":
+                missing += 1
+            else:
+                conflict = True
+        day_status = "conflict" if conflict else "complete" if (
+            expectation["sealed_before_first_target"]
+            and expected
+            and captured == len(expected)
+        ) else "incomplete"
+        days.append(
+            {
+                "trading_date": trading_date,
+                "status": day_status,
+                "reason_code": (
+                    "formal_corpus_conflict"
+                    if conflict
+                    else None if day_status == "complete" else "formal_day_incomplete"
+                ),
+                "market_calendar_version": expectation["market_calendar_version"],
+                "market_calendar_sha256": expectation["market_calendar_sha256"],
+                "schedule_config_sha256": expectation["schedule_config_sha256"],
+                "expected_point_count": len(expected),
+                "captured_point_count": captured,
+                "not_evaluable_point_count": not_evaluable,
+                "missing_point_count": missing,
+                "points": points,
+            }
+        )
+    if selected_dates is None and point_root.is_dir() and not point_root.is_symlink():
         for directory in point_root.iterdir():
             if (
                 directory.is_symlink()
@@ -1578,25 +1624,38 @@ def build_corpus_health_receipt(
                 or directory.name not in expectation_dates
             ):
                 layout_conflicts += 1
+    elif selected_dates is not None:
+        for trading_date in selected_dates:
+            if trading_date in expectation_dates:
+                continue
+            directory = point_root / trading_date
+            if directory.exists() or directory.is_symlink():
+                layout_conflicts += 1
     if calendar is not None:
         rows_by_date = {item["trading_date"]: item for item in days}
         trading_dates = list(calendar["trading_dates"])
-        local_date = (
-            datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
-            .astimezone(ZoneInfo(_MARKET_TIMEZONES[market]))
-            .date()
-            .isoformat()
-        )
         existing_dates = sorted(rows_by_date)
-        if existing_dates:
-            start = existing_dates[0]
-            end = max(existing_dates[-1], local_date if local_date in trading_dates else existing_dates[-1])
-        elif local_date in trading_dates:
-            start = end = local_date
+        if selected_dates is not None:
+            denominator = selected_dates
         else:
-            start = end = None
-        if start is not None and end is not None:
-            denominator = [value for value in trading_dates if start <= value <= end]
+            if existing_dates:
+                start = existing_dates[0]
+                end = max(
+                    existing_dates[-1],
+                    local_date
+                    if local_date in trading_dates
+                    else existing_dates[-1],
+                )
+            elif local_date in trading_dates:
+                start = end = local_date
+            else:
+                start = end = None
+            denominator = (
+                [value for value in trading_dates if start <= value <= end]
+                if start is not None and end is not None
+                else []
+            )
+        if denominator:
             if any(value not in trading_dates for value in existing_dates):
                 layout_conflicts += 1
             for value in denominator:
@@ -1620,7 +1679,9 @@ def build_corpus_health_receipt(
                     }
             days = [rows_by_date[value] for value in sorted(rows_by_date)]
             suffix = 0
-            for value in reversed(denominator):
+            for value in reversed(
+                [item for item in denominator if item < local_date]
+            ):
                 if rows_by_date[value]["status"] != "complete":
                     break
                 suffix += 1
@@ -1628,34 +1689,59 @@ def build_corpus_health_receipt(
             suffix = 0
     else:
         suffix = 0
-    artifact_files = [
-        path
-        for root in (expectation_root, point_root)
-        if root.is_dir() and not root.is_symlink()
-        for pattern in ("**/*.json", "**/*.json.gz")
-        for path in root.glob(pattern)
-        if path.is_file() and not path.is_symlink()
-    ]
-    storage: dict[str, Any] = {
-        "formal_corpus_bytes": sum(path.stat().st_size for path in set(artifact_files)),
-        "baseline_status": "unavailable",
-        "capacity": None,
+    artifact_files: set[Path] = set()
+    if selected_dates is None:
+        for root in (expectation_root, point_root):
+            if root.is_dir() and not root.is_symlink():
+                for pattern in ("**/*.json", "**/*.json.gz"):
+                    artifact_files.update(
+                        path
+                        for path in root.glob(pattern)
+                        if path.is_file() and not path.is_symlink()
+                    )
+    else:
+        for trading_date in selected_dates:
+            artifact_files.update(
+                path
+                for path in (expectation_root / trading_date).glob("*.json")
+                if path.is_file() and not path.is_symlink()
+            )
+            artifact_files.update(
+                path
+                for path in (point_root / trading_date).glob("*/*.json.gz")
+                if path.is_file() and not path.is_symlink()
+            )
+    capacity: dict[str, Any] = {
+        "status": "unavailable",
+        "filesystem_capacity_bytes": None,
+        "current_free_bytes": None,
+        "critical_floor_bytes": None,
+        "critical_reasons": [],
     }
     try:
-        from src.application.research.storage_baseline import collect_storage_runtime_baseline
-
-        baseline = collect_storage_runtime_baseline(
-            repo_root=repo_root or normalized_runtime_root,
-            runtime_root=normalized_runtime_root,
-        )
-        storage.update(
-            {
-                "baseline_status": baseline.get("status"),
-                "capacity": baseline.get("thresholds"),
-            }
-        )
-    except Exception:
+        disk = shutil.disk_usage(normalized_runtime_root)
+    except OSError:
         pass
+    else:
+        total_bytes = int(disk.total)
+        free_bytes = int(disk.free)
+        critical_floor = max((total_bytes + 19) // 20, 10 * 1024**3)
+        critical_reasons = (
+            ["current_free_space_below_critical_floor"]
+            if free_bytes < critical_floor
+            else []
+        )
+        capacity = {
+            "status": "critical" if critical_reasons else "insufficient_history",
+            "filesystem_capacity_bytes": total_bytes,
+            "current_free_bytes": free_bytes,
+            "critical_floor_bytes": critical_floor,
+            "critical_reasons": critical_reasons,
+        }
+    storage: dict[str, Any] = {
+        "formal_corpus_bytes": sum(path.stat().st_size for path in artifact_files),
+        "capacity": capacity,
+    }
     totals = {
         "days_total": len(days),
         "days_complete": sum(item["status"] == "complete" for item in days),
@@ -1698,17 +1784,13 @@ def build_corpus_health_receipt(
     complete_dates = [
         item["trading_date"] for item in days if item["status"] == "complete"
     ]
-    capacity_status = (
-        storage["capacity"].get("status")
-        if isinstance(storage.get("capacity"), Mapping)
-        else None
-    )
+    capacity_status = capacity["status"]
     healthy = bool(
         calendar is not None
         and days
         and all(item["status"] == "complete" for item in days)
         and layout_conflicts == 0
-        and capacity_status in {"ok", "insufficient_history"}
+        and capacity_status == "insufficient_history"
     )
     return {
         "schema_version": CORPUS_HEALTH_SCHEMA,
@@ -1716,6 +1798,11 @@ def build_corpus_health_receipt(
         "market": market,
         "account": account,
         "observed_at_utc": observed_at,
+        "scope": {
+            "mode": scope,
+            "mature_day_limit": mature_day_limit,
+            "include_current_trading_day": True,
+        },
         **totals,
         "continuous_complete_trading_days": suffix,
         "earliest_complete_trading_date": complete_dates[0] if complete_dates else None,

--- a/src/application/strategy_lab/top1/advance.py
+++ b/src/application/strategy_lab/top1/advance.py
@@ -12,7 +12,6 @@ from src.application.strategy_lab.top1.corpus import (
     CorpusError,
     capture_recommendation_point,
     discover_recommendation_points,
-    publish_corpus_health_receipt,
     read_market_calendar_binding,
     read_validation_day_source,
     read_validation_point_source,
@@ -38,7 +37,7 @@ from src.application.strategy_lab.top1.validation import (
 from src.infrastructure.strategy_lab.experiment_store import ExperimentStore
 
 
-ADVANCE_RESULT_SCHEMA = "sell_put_top1_advance_result.v1"
+ADVANCE_RESULT_SCHEMA = "sell_put_top1_advance_result.v2"
 ADVANCE_REVISION = "top1-advance.v1"
 
 
@@ -87,7 +86,6 @@ def advance_scheduled(
         "occurred_at_utc": occurred_at_utc,
         "service_available": service_available,
         "corpus": [],
-        "corpus_health": None,
         "readiness": None,
         "experiments": [],
         "recovered_experiment_ids": [],
@@ -304,22 +302,6 @@ def advance_scheduled(
             )
             had_failure = True
 
-    try:
-        health = publish_corpus_health_receipt(
-            store,
-            artifact_root,
-            market=market,
-            account=account,
-            observed_at_utc=occurred_at_utc,
-            advance_interval_seconds=advance_interval_seconds,
-        )
-        result["corpus_health"] = health
-        if health.get("daily_receipt_errors"):
-            had_failure = True
-    except Exception as exc:
-        result["corpus_health"] = _error(exc)
-        had_failure = True
-
     runtime_ready = False
     try:
         readiness = load_readiness()
@@ -327,6 +309,9 @@ def advance_scheduled(
             raise ValueError("readiness loader must return an object")
         result["readiness"] = dict(readiness)
         runtime_ready = readiness.get("validation_runtime_ready") is True
+        facts = readiness.get("facts")
+        if not isinstance(facts, Mapping) or facts.get("corpus") is None:
+            had_failure = True
     except Exception as exc:
         result["readiness"] = {"validation_runtime_ready": False, **_error(exc)}
         had_failure = True

--- a/src/application/strategy_lab/top1/readiness.py
+++ b/src/application/strategy_lab/top1/readiness.py
@@ -9,7 +9,7 @@ from src.application.research.formal_corpus import CORPUS_HEALTH_SCHEMA
 from src.application.strategy_lab.top1.contracts import RESEARCH_REQUIRED_DAYS
 
 
-READINESS_SCHEMA = "sell_put_top1_readiness.v1"
+READINESS_SCHEMA = "sell_put_top1_readiness.v2"
 ADVANCE_SERVICE = "options-monitor-strategy-lab-top1-advance.service"
 ADVANCE_TIMER = "options-monitor-strategy-lab-top1-advance.timer"
 CAPABILITY_FACTS = (
@@ -155,7 +155,6 @@ def build_top1_readiness(
     corpus_status: Mapping[str, Any] | None,
     calendar_binding: Mapping[str, Any] | None,
     capability_facts: Mapping[str, bool] | None = None,
-    corpus_health_receipt: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Combine existing read-only facts; never probe providers or mutate services."""
 
@@ -227,9 +226,9 @@ def build_top1_readiness(
         storage = _object(corpus_status.get("storage"))
         capacity = _object(storage.get("capacity"))
         capacity_status = capacity.get("status")
-        if capacity_status in {"warning", "critical"}:
+        if capacity_status == "critical":
             runtime_blockers.append("research_storage_capacity_risk")
-        elif capacity_status not in {"ok", "insufficient_history"}:
+        elif capacity_status != "insufficient_history":
             runtime_blockers.append("research_storage_capacity_unavailable")
     if not _calendar_ready(calendar_binding):
         runtime_blockers.append("market_calendar_binding_unavailable")
@@ -258,11 +257,6 @@ def build_top1_readiness(
             ),
             "store_schema": dict(schema_state),
             "corpus": dict(corpus_status) if corpus_status is not None else None,
-            "corpus_health_receipt": (
-                dict(corpus_health_receipt)
-                if corpus_health_receipt is not None
-                else None
-            ),
             "market_calendar": (
                 {
                     key: calendar_binding.get(key)

--- a/src/interfaces/cli/strategy_lab_top1.py
+++ b/src/interfaces/cli/strategy_lab_top1.py
@@ -21,9 +21,9 @@ from src.application.strategy_lab.top1.capability_receipts import (
     read_top1_capability_receipt,
     refresh_top1_capability_receipt,
 )
+from src.application.strategy_lab.top1.contracts import RESEARCH_REQUIRED_DAYS
 from src.application.strategy_lab.top1.corpus import (
     CorpusError,
-    read_corpus_health_receipt,
     read_corpus_status,
     read_market_calendar_binding,
     refresh_market_calendar_binding,
@@ -43,7 +43,10 @@ from src.application.strategy_lab.top1.workspace import (
     start_confirmed_research,
     start_confirmed_validation,
 )
-from src.application.research.formal_corpus import seal_profile_formal_expectations
+from src.application.research.formal_corpus import (
+    build_corpus_health_receipt,
+    seal_profile_formal_expectations,
+)
 from domain.domain.fee_calc import FUTU_HK_TERMINAL_FEE_SCHEDULE_VERSION
 from src.infrastructure.futu_gateway import (
     FutuGatewayError,
@@ -244,7 +247,15 @@ def _profile_context(
     }
 
 
-def _readiness(context: Mapping[str, Any], store: ExperimentStore) -> dict[str, Any]:
+def _readiness(
+    context: Mapping[str, Any],
+    store: ExperimentStore,
+    *,
+    observed_at_utc: str | None = None,
+) -> dict[str, Any]:
+    observed_at_utc = observed_at_utc or datetime.now(timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
     profile = context["profile"]
     errors: list[dict[str, str]] = []
     try:
@@ -268,17 +279,17 @@ def _readiness(context: Mapping[str, Any], store: ExperimentStore) -> dict[str, 
 
     schema = store.schema_state()
     corpus: dict[str, Any] | None = None
-    if schema.get("status") == "ready":
-        try:
-            corpus = read_corpus_status(
-                store,
-                market="HK",
-                account="lx",
-                artifact_root=context["artifact_root"],
-                repo_root=context["repo_root"],
-            )
-        except Exception as exc:
-            errors.append({"reason_code": "top1_status_unavailable", "message": str(exc)})
+    try:
+        corpus = build_corpus_health_receipt(
+            context["runtime_root"],
+            market="HK",
+            account="lx",
+            observed_at_utc=observed_at_utc,
+            scope="latest_mature_window",
+            mature_day_limit=RESEARCH_REQUIRED_DAYS,
+        )
+    except Exception as exc:
+        errors.append({"reason_code": "top1_status_unavailable", "message": str(exc)})
     try:
         calendar = read_market_calendar_binding(context["artifact_root"], market="HK")
     except Exception as exc:
@@ -286,24 +297,6 @@ def _readiness(context: Mapping[str, Any], store: ExperimentStore) -> dict[str, 
         errors.append(
             {"reason_code": "market_calendar_binding_unavailable", "message": str(exc)}
         )
-    health_receipt: dict[str, Any] | None = None
-    read_at_utc = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    try:
-        health_receipt = read_corpus_health_receipt(
-            context["artifact_root"],
-            market="HK",
-            account="lx",
-            now_utc=read_at_utc,
-        )
-        if health_receipt["fresh"] is not True:
-            errors.append(
-                {
-                    "reason_code": "corpus_health_receipt_stale",
-                    "message": "Strategy Lab Top1 corpus health receipt is stale",
-                }
-            )
-    except CorpusError as exc:
-        errors.append({"reason_code": exc.reason_code, "message": str(exc)})
     capability_receipt: dict[str, object] | None = None
     binding = context["top1"].get("opend_binding")
     if isinstance(binding, Mapping):
@@ -328,7 +321,6 @@ def _readiness(context: Mapping[str, Any], store: ExperimentStore) -> dict[str, 
             if capability_receipt is not None
             else None
         ),
-        corpus_health_receipt=health_receipt,
     )
     result["facts"]["capability_receipt"] = (
         {
@@ -805,7 +797,9 @@ def handle_top1_command(args: argparse.Namespace) -> dict[str, Any]:
             market="HK",
             account="lx",
             load_schedule=load_schedule,
-            load_readiness=lambda: _readiness(context, store),
+            load_readiness=lambda: _readiness(
+                context, store, observed_at_utc=occurred_at_utc
+            ),
             load_gateway=load_gateway,
             advance_revision=ADVANCE_REVISION,
             advance_interval_seconds=int(top1["advance_interval"]),

--- a/tests/test_close_advice_required_data.py
+++ b/tests/test_close_advice_required_data.py
@@ -356,6 +356,10 @@ def test_position_only_requirement_creates_one_exact_prefetch_plan(
         lambda *_args, **_kwargs: 110.0,
     )
     monkeypatch.setattr(
+        "src.application.opend_utils.get_trading_date",
+        lambda _market: date(2026, 7, 29),
+    )
+    monkeypatch.setattr(
         planning,
         "list_option_expirations",
         lambda *_args, **_kwargs: [],

--- a/tests/test_copilot_phase1.py
+++ b/tests/test_copilot_phase1.py
@@ -1155,6 +1155,11 @@ def test_local_harness_routes_every_surface_to_the_same_pi_boundary(monkeypatch,
     from src.application.copilot import local_harness
 
     captured: list[dict] = []
+    monkeypatch.setattr(
+        local_harness,
+        "load_assistant_copilot_settings",
+        lambda **_kwargs: (frozenset(), "eager", None),
+    )
 
     def process(start_payload, *, on_proposed, on_tool_call, environ, **_kwargs):
         captured.append({"start": start_payload, "environ": dict(environ or {})})
@@ -1316,6 +1321,11 @@ def test_local_harness_passes_model_secret_only_in_allowlisted_child_environment
 
     captured: dict[str, object] = {}
     secret = "s5-model-secret"
+    monkeypatch.setattr(
+        local_harness,
+        "load_assistant_copilot_settings",
+        lambda **_kwargs: (frozenset(), "eager", None),
+    )
 
     def process(start_payload, *, on_proposed, on_tool_call, environ, **_kwargs):
         captured["start"] = start_payload

--- a/tests/test_formal_corpus.py
+++ b/tests/test_formal_corpus.py
@@ -4,6 +4,7 @@ import gzip
 import hashlib
 import json
 from concurrent.futures import ThreadPoolExecutor
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
@@ -332,7 +333,7 @@ def test_health_uses_calendar_denominator_and_exposes_point_diagnostics(
         "missing",
         "complete",
     ]
-    assert health["continuous_complete_trading_days"] == 1
+    assert health["continuous_complete_trading_days"] == 0
     assert health["status"] == "unhealthy"
     assert health["days"][-1]["points"][0] == {
         "recommendation_point_id": health["days"][-1]["points"][0][
@@ -357,8 +358,6 @@ def test_health_normalizes_storage_root_and_fails_closed_without_capacity(
     monkeypatch,
 ) -> None:
     from src.application.research import formal_corpus as mod
-    from src.application.research import storage_baseline
-
     _seal(tmp_path)
     monkeypatch.setattr(
         mod,
@@ -385,16 +384,13 @@ def test_health_normalizes_storage_root_and_fails_closed_without_capacity(
             },
         },
     )
-    calls: list[dict[str, object]] = []
+    calls: list[Path] = []
 
-    def baseline(**kwargs):
-        calls.append(kwargs)
-        return {
-            "status": "complete",
-            "thresholds": {"status": "insufficient_history"},
-        }
+    def disk_usage(path: Path):
+        calls.append(path)
+        return type("Usage", (), {"total": 100 * 1024**3, "free": 20 * 1024**3})()
 
-    monkeypatch.setattr(storage_baseline, "collect_storage_runtime_baseline", baseline)
+    monkeypatch.setattr(mod.shutil, "disk_usage", disk_usage)
     repo_root = tmp_path / "repo"
     artifact_root = tmp_path / "output_shared/research/strategy_lab"
     healthy = build_corpus_health_receipt(
@@ -405,12 +401,30 @@ def test_health_normalizes_storage_root_and_fails_closed_without_capacity(
         observed_at_utc="2026-08-26T03:00:00Z",
     )
     assert healthy["status"] == "healthy"
-    assert calls == [{"repo_root": repo_root, "runtime_root": tmp_path}]
+    assert healthy["storage"]["capacity"]["status"] == "insufficient_history"
+    assert calls == [tmp_path]
 
     monkeypatch.setattr(
-        storage_baseline,
-        "collect_storage_runtime_baseline",
-        lambda **_kwargs: (_ for _ in ()).throw(OSError("unavailable")),
+        mod.shutil,
+        "disk_usage",
+        lambda _path: type(
+            "Usage", (), {"total": 100 * 1024**3, "free": 9 * 1024**3}
+        )(),
+    )
+    critical = build_corpus_health_receipt(
+        artifact_root,
+        market="HK",
+        account="lx",
+        observed_at_utc="2026-08-26T03:00:00Z",
+    )
+    assert critical["status"] == "unhealthy"
+    assert critical["storage"]["capacity"]["status"] == "critical"
+    assert critical["storage"]["capacity"]["critical_floor_bytes"] == 10 * 1024**3
+
+    monkeypatch.setattr(
+        mod.shutil,
+        "disk_usage",
+        lambda _path: (_ for _ in ()).throw(OSError("unavailable")),
     )
     unavailable = build_corpus_health_receipt(
         artifact_root,
@@ -420,7 +434,170 @@ def test_health_normalizes_storage_root_and_fails_closed_without_capacity(
         observed_at_utc="2026-08-26T03:00:00Z",
     )
     assert unavailable["status"] == "unhealthy"
-    assert unavailable["storage"]["capacity"] is None
+    assert unavailable["storage"]["capacity"]["status"] == "unavailable"
+
+
+def test_health_window_reads_only_twenty_mature_days_and_current(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from src.application.research import formal_corpus as mod
+
+    cursor = date(2026, 7, 20)
+    mature_dates: list[str] = []
+    while len(mature_dates) < 22:
+        if cursor.weekday() < 5:
+            mature_dates.append(cursor.isoformat())
+        cursor += timedelta(days=1)
+    while cursor.weekday() >= 5:
+        cursor += timedelta(days=1)
+    current_date = cursor.isoformat()
+    for trading_date in mature_dates:
+        seal_formal_day_expectation(
+            tmp_path,
+            market="HK",
+            account="lx",
+            schedule=_schedule(),
+            trading_date=trading_date,
+            market_calendar_version="fixture.v1",
+            market_calendar_sha256="a" * 64,
+            sealed_at_utc=f"{trading_date}T01:00:00Z",
+        )
+    unexpected = (
+        tmp_path
+        / "output_shared/research/formal_corpus/v1/hk/lx/points"
+        / mature_dates[0]
+        / ("f" * 64)
+    )
+    unexpected.mkdir(parents=True)
+    monkeypatch.setattr(
+        mod,
+        "read_market_calendar_binding",
+        lambda *_args, **_kwargs: {
+            "market_calendar_version": "fixture.v1",
+            "snapshot_content_sha256": "a" * 64,
+            "coverage_start": mature_dates[0],
+            "coverage_end": current_date,
+            "trading_dates": [*mature_dates, current_date],
+        },
+    )
+    loaded_dates: list[str] = []
+
+    def load_point(*_args, trading_date, **_kwargs):
+        loaded_dates.append(trading_date)
+        return {
+            "status": "available",
+            "reason_code": None,
+            "point": {
+                "captured_at_utc": f"{trading_date}T02:00:02Z",
+                "recommendation_point": {
+                    "formal_point_time_coherence": {
+                        "maximum_observed_at_utc": f"{trading_date}T02:00:00Z"
+                    }
+                },
+            },
+        }
+
+    monkeypatch.setattr(mod, "load_formal_point", load_point)
+    monkeypatch.setattr(
+        mod.shutil,
+        "disk_usage",
+        lambda _path: type(
+            "Usage", (), {"total": 100 * 1024**3, "free": 20 * 1024**3}
+        )(),
+    )
+    window = build_corpus_health_receipt(
+        tmp_path,
+        market="HK",
+        account="lx",
+        observed_at_utc=f"{(cursor - timedelta(days=1)).isoformat()}T16:00:00Z",
+        scope="latest_mature_window",
+        mature_day_limit=20,
+    )
+
+    assert loaded_dates == mature_dates[-20:]
+    assert window["schema_version"] == "corpus_health_receipt.v2"
+    assert window["days_total"] == 21
+    assert window["days"][-1]["trading_date"] == current_date
+    assert window["days"][-1]["status"] == "missing"
+    assert window["continuous_complete_trading_days"] == 20
+    assert window["days_conflicting"] == 0
+    assert window["earliest_trading_date"] == mature_dates[-20]
+
+    loaded_dates.clear()
+    full = build_corpus_health_receipt(
+        tmp_path,
+        market="HK",
+        account="lx",
+        observed_at_utc=f"{(cursor - timedelta(days=1)).isoformat()}T16:00:00Z",
+    )
+    assert loaded_dates == mature_dates
+    assert full["days_conflicting"] == 1
+    assert full["earliest_trading_date"] == mature_dates[0]
+
+
+@pytest.mark.parametrize(
+    "observed_at_utc",
+    ["2026-07-31T15:59:59Z", "2026-08-23T16:00:00Z"],
+)
+def test_health_window_rejects_out_of_coverage_before_artifact_reads(
+    tmp_path: Path,
+    monkeypatch,
+    observed_at_utc: str,
+) -> None:
+    from src.application.research import formal_corpus as mod
+
+    monkeypatch.setattr(
+        mod,
+        "read_market_calendar_binding",
+        lambda *_args, **_kwargs: {
+            "market_calendar_version": "fixture.v1",
+            "snapshot_content_sha256": "a" * 64,
+            "coverage_start": "2026-08-01",
+            "coverage_end": "2026-08-23",
+            "trading_dates": ["2026-08-01", "2026-08-23"],
+        },
+    )
+    def unexpected_read(*_args, **_kwargs):
+        raise AssertionError("artifacts must not be read outside calendar coverage")
+
+    monkeypatch.setattr(mod, "_expectation_artifacts", unexpected_read)
+    monkeypatch.setattr(mod, "load_formal_point", unexpected_read)
+
+    with pytest.raises(FormalCorpusError) as raised:
+        build_corpus_health_receipt(
+            tmp_path,
+            market="HK",
+            account="lx",
+            observed_at_utc=observed_at_utc,
+            scope="latest_mature_window",
+            mature_day_limit=20,
+        )
+    assert raised.value.reason_code == "market_calendar_binding_unavailable"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"scope": "unknown"},
+        {"scope": "full", "mature_day_limit": 20},
+        {"scope": "latest_mature_window"},
+        {"scope": "latest_mature_window", "mature_day_limit": 0},
+        {"scope": "latest_mature_window", "mature_day_limit": True},
+    ],
+)
+def test_health_scope_contract_rejects_invalid_combinations(
+    tmp_path: Path,
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(FormalCorpusError) as raised:
+        build_corpus_health_receipt(
+            tmp_path,
+            market="HK",
+            account="lx",
+            **kwargs,
+        )
+    assert raised.value.reason_code == "formal_corpus_input_invalid"
 
 
 def test_ready_point_reloads_and_materializes_recipe_projection(

--- a/tests/test_strategy_lab_top1_advance.py
+++ b/tests/test_strategy_lab_top1_advance.py
@@ -12,18 +12,6 @@ from src.application.strategy_lab.top1.advance import advance_scheduled
 AVAILABLE = {"OM_STRATEGY_LAB_TOP1_AVAILABLE": "1"}
 
 
-@pytest.fixture(autouse=True)
-def _publish_health_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        advance_module,
-        "publish_corpus_health_receipt",
-        lambda *_args, **_kwargs: {
-            "receipt": {"schema_version": "sell_put_top1_corpus_health_receipt.v1"},
-            "daily_receipts_published": [],
-        },
-    )
-
-
 def _explode() -> Any:  # pragma: no cover - asserted unreachable
     raise AssertionError("lazy dependency must not be loaded")
 
@@ -38,6 +26,13 @@ def _calendar() -> dict[str, object]:
         ],
         "market_calendar_version": "hk-calendar.v1",
         "snapshot_content_sha256": "a" * 64,
+    }
+
+
+def _readiness(ready: bool) -> dict[str, object]:
+    return {
+        "validation_runtime_ready": ready,
+        "facts": {"corpus": {"schema_version": "corpus_health_receipt.v2"}},
     }
 
 
@@ -64,6 +59,7 @@ def test_disabled_gate_loads_no_schedule_source_readiness_or_gateway(
     )
 
     assert result["status"] == "disabled"
+    assert result["schema_version"] == "sell_put_top1_advance_result.v2"
     assert result["service_available"] is False
 
 
@@ -162,7 +158,7 @@ def test_collecting_order_due_conclusion_and_peer_failure_isolation(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": False},
+        load_readiness=lambda: _readiness(False),
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -228,7 +224,7 @@ def test_behavior_drift_terminates_without_loading_gateway(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": True},
+        load_readiness=lambda: _readiness(True),
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -320,7 +316,7 @@ def test_hidden_window_overlap_blocks_sealing_and_collection(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": True},
+        load_readiness=lambda: _readiness(True),
         load_gateway=lambda: expected_gateway,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -381,7 +377,7 @@ def test_out_of_coverage_calendar_blocks_sealing_without_fallback(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": False},
+        load_readiness=lambda: _readiness(False),
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -423,7 +419,7 @@ def test_active_experiment_read_failure_blocks_schedule_sealing(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": False},
+        load_readiness=lambda: _readiness(False),
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -476,7 +472,7 @@ def test_idle_advance_only_fails_when_readiness_cannot_be_loaded(
         account="lx",
         load_schedule=lambda: {},
         load_readiness=(
-            (lambda: {"validation_runtime_ready": readiness_result})
+            (lambda: _readiness(readiness_result))
             if readiness_result is not None
             else _explode
         ),
@@ -556,7 +552,7 @@ def test_validation_provider_need_makes_unready_advance_partial(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": False},
+        load_readiness=lambda: _readiness(False),
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -618,7 +614,7 @@ def test_timer_binding_mismatch_is_partial_without_gateway(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": True},
+        load_readiness=lambda: _readiness(True),
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -692,7 +688,7 @@ def test_corpus_conflicts_make_advance_partial(
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": False},
+        load_readiness=lambda: _readiness(False),
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=60,
@@ -707,10 +703,10 @@ def test_corpus_conflicts_make_advance_partial(
     assert any(item.get("status") == "conflict" for item in result["corpus"])
 
 
-def test_corpus_health_publishes_before_readiness_and_failure_is_partial(
+def test_advance_uses_readiness_as_the_only_health_fact(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    calls: list[str] = []
+    readiness_calls = 0
     monkeypatch.setattr(
         advance_module,
         "read_active_experiment_ids",
@@ -728,16 +724,11 @@ def test_corpus_health_publishes_before_readiness_and_failure_is_partial(
         lambda *_args, **_kwargs: [],
     )
 
-    def publish(*_args: object, **_kwargs: object) -> dict[str, object]:
-        calls.append("health")
-        return {"receipt": {"fresh": True}, "daily_receipts_published": []}
-
     def readiness() -> dict[str, object]:
-        assert calls == ["health"]
-        calls.append("readiness")
-        return {"validation_runtime_ready": False}
+        nonlocal readiness_calls
+        readiness_calls += 1
+        return _readiness(False)
 
-    monkeypatch.setattr(advance_module, "publish_corpus_health_receipt", publish)
     result = advance_scheduled(
         object(),
         tmp_path / "source",
@@ -751,62 +742,33 @@ def test_corpus_health_publishes_before_readiness_and_failure_is_partial(
         advance_interval_seconds=300,
         actor="timer",
         occurred_at_utc="2026-08-16T01:00:00Z",
-        idempotency_key="health-before-readiness",
+        idempotency_key="single-health-fact",
         environ=AVAILABLE,
     )
     assert result["status"] == "ok"
-    assert result["corpus_health"]["receipt"] == {"fresh": True}
-    assert calls == ["health", "readiness"]
+    assert result["schema_version"] == "sell_put_top1_advance_result.v2"
+    assert "corpus_health" not in result
+    assert result["readiness"]["facts"]["corpus"] is not None
+    assert readiness_calls == 1
 
-    monkeypatch.setattr(
-        advance_module,
-        "publish_corpus_health_receipt",
-        lambda *_args, **_kwargs: {
-            "receipt": {"fresh": True},
-            "daily_receipts_published": [],
-            "daily_receipt_errors": [{"reason_code": "daily_conflict"}],
-        },
-    )
-    daily_conflict = advance_scheduled(
+    unavailable = advance_scheduled(
         object(),
         tmp_path / "source",
         tmp_path / "artifacts",
         market="HK",
         account="lx",
         load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": False},
+        load_readiness=lambda: {
+            "validation_runtime_ready": False,
+            "facts": {"corpus": None},
+        },
         load_gateway=_explode,
         advance_revision="top1-advance.v1",
         advance_interval_seconds=300,
         actor="timer",
         occurred_at_utc="2026-08-16T01:05:00Z",
-        idempotency_key="daily-health-conflict",
+        idempotency_key="health-unavailable",
         environ=AVAILABLE,
     )
-    assert daily_conflict["status"] == "partial"
-
-    def fail_health(*_args: object, **_kwargs: object) -> dict[str, object]:
-        raise ValueError("health failed")
-
-    monkeypatch.setattr(advance_module, "publish_corpus_health_receipt", fail_health)
-    failed = advance_scheduled(
-        object(),
-        tmp_path / "source",
-        tmp_path / "artifacts",
-        market="HK",
-        account="lx",
-        load_schedule=lambda: {},
-        load_readiness=lambda: {"validation_runtime_ready": False},
-        load_gateway=_explode,
-        advance_revision="top1-advance.v1",
-        advance_interval_seconds=300,
-        actor="timer",
-        occurred_at_utc="2026-08-16T01:10:00Z",
-        idempotency_key="health-failure",
-        environ=AVAILABLE,
-    )
-    assert failed["status"] == "partial"
-    assert failed["corpus_health"] == {
-        "reason_code": "advance_failed",
-        "message": "health failed",
-    }
+    assert unavailable["status"] == "partial"
+    assert "corpus_health" not in unavailable

--- a/tests/test_strategy_lab_top1_readiness.py
+++ b/tests/test_strategy_lab_top1_readiness.py
@@ -56,10 +56,10 @@ def _source_facts() -> tuple[dict[str, object], dict[str, object]]:
 
 def _healthy_corpus(*, complete_days: int = 20) -> dict[str, object]:
     return {
-        "schema_version": "corpus_health_receipt.v1",
+        "schema_version": "corpus_health_receipt.v2",
         "status": "healthy",
         "continuous_complete_trading_days": complete_days,
-        "storage": {"capacity": {"status": "ok"}},
+        "storage": {"capacity": {"status": "insufficient_history"}},
     }
 
 
@@ -98,12 +98,12 @@ def test_readiness_requires_every_live_capability_fact(tmp_path: Path) -> None:
     ready = build_top1_readiness(
         **common,
         capability_facts={name: True for name in CAPABILITY_FACTS},
-        corpus_health_receipt={"fresh": True, "receipt_ref": "health/current.json"},
     )
     assert ready["source_delivery_ready"] is True
+    assert ready["schema_version"] == "sell_put_top1_readiness.v2"
     assert ready["validation_runtime_ready"] is True
     assert ready["validation_runtime_blockers"] == []
-    assert ready["facts"]["corpus_health_receipt"]["fresh"] is True
+    assert "corpus_health_receipt" not in ready["facts"]
 
     warming = build_top1_readiness(
         **{**common, "corpus_status": _healthy_corpus(complete_days=19)},
@@ -259,8 +259,6 @@ def test_readiness_cli_is_read_only_and_reports_uninitialized_store(
 ) -> None:
     import src.interfaces.cli.strategy_lab_top1 as cli
     from src.interfaces.cli.main import parse_args
-    from src.application.strategy_lab.top1.corpus import CorpusError
-
     profile = _profile(tmp_path)
     profile_path = tmp_path / "service.profile.json"
     profile_path.write_text(json.dumps(profile), encoding="utf-8")
@@ -274,10 +272,16 @@ def test_readiness_cli_is_read_only_and_reports_uninitialized_store(
         "read_market_calendar_binding",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("missing")),
     )
+    health_calls: list[tuple[object, dict[str, object]]] = []
+
+    def health(root: object, **kwargs: object) -> dict[str, object]:
+        health_calls.append((root, kwargs))
+        return _healthy_corpus(complete_days=19)
+
     monkeypatch.setattr(
         cli,
-        "read_corpus_health_receipt",
-        lambda *_args, **_kwargs: {"fresh": False, "receipt_ref": "health/current.json"},
+        "build_corpus_health_receipt",
+        health,
     )
     args = parse_args(
         [
@@ -307,24 +311,30 @@ def test_readiness_cli_is_read_only_and_reports_uninitialized_store(
     assert response["ok"] is True
     assert response["data"]["validation_runtime_ready"] is False
     assert response["data"]["facts"]["store_schema"]["status"] == "not_initialized"
-    assert response["data"]["facts"]["corpus_health_receipt"]["fresh"] is False
-    assert any(
-        item["reason_code"] == "corpus_health_receipt_stale"
-        for item in response["data"]["fact_errors"]
+    assert response["data"]["facts"]["corpus"]["schema_version"] == (
+        "corpus_health_receipt.v2"
     )
+    assert "research_corpus_warming" in response["data"][
+        "validation_runtime_blockers"
+    ]
+    assert len(health_calls) == 1
+    assert health_calls[0][0] == tmp_path / "runtime"
+    assert health_calls[0][1]["market"] == "HK"
+    assert health_calls[0][1]["account"] == "lx"
+    assert health_calls[0][1]["scope"] == "latest_mature_window"
+    assert health_calls[0][1]["mature_day_limit"] == 20
+    assert str(health_calls[0][1]["observed_at_utc"]).endswith("Z")
     assert not store_path.exists()
 
     monkeypatch.setattr(
         cli,
-        "read_corpus_health_receipt",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            CorpusError("corpus_health_receipt_unavailable", "missing")
-        ),
+        "build_corpus_health_receipt",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("missing")),
     )
     missing = cli.handle_top1_command(args)
-    assert missing["data"]["facts"]["corpus_health_receipt"] is None
+    assert missing["data"]["facts"]["corpus"] is None
     assert any(
-        item["reason_code"] == "corpus_health_receipt_unavailable"
+        item["reason_code"] == "top1_status_unavailable"
         for item in missing["data"]["fact_errors"]
     )
     assert not store_path.exists()

--- a/tests/test_strategy_lab_top1_workspace.py
+++ b/tests/test_strategy_lab_top1_workspace.py
@@ -274,10 +274,10 @@ def _preview_args(
         "fee_contract": _fee_contract(),
         "capability_facts": {name: True for name in CAPABILITY_FACTS},
         "corpus_status": {
-            "schema_version": "corpus_health_receipt.v1",
+            "schema_version": "corpus_health_receipt.v2",
             "status": "healthy",
             "continuous_complete_trading_days": 20,
-            "storage": {"capacity": {"status": "ok"}},
+            "storage": {"capacity": {"status": "insufficient_history"}},
         },
         "evidence_bundle": bundle,
         "environ": AVAILABLE,


### PR DESCRIPTION
Summary: derive the bounded 20-day Strategy Lab corpus-health view directly from formal corpus facts; remove the duplicate stale health-artifact dependency; preserve fail-closed calendar and storage-capacity checks; update the system design and regressions. Verification: 365 focused tests passed; Ruff passed; Guardrails passed; dependency graph current; git diff check passed. Delivery scope: source merge only, with no VERSION change, release, deployment, or production mutation.