### PR TITLE
fix(tick): fail closed on unavailable portfolio context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+- Reduced each portfolio fetch to one CNH OpenD funds refresh and isolated accounts with unavailable prepared portfolio context before shared prefetch, while preserving healthy peer scans and scheduled failure alerts.
+
 ## 3.0.2 - 2026-08-31
 
 ### Improvements

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1036 (`src`: 558, `domain`: 76, `scripts`: 12, `tests`: 390)
-- Internal import edges: 6938 total, 3038 production/script edges excluding tests
+- Internal import edges: 6941 total, 3038 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,10 +46,10 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2861| application
+  tests -->|2863| application
   tests -->|457| domain
   tests -->|2| domain_services
-  tests -->|231| infrastructure
+  tests -->|232| infrastructure
   tests -->|250| interfaces
   tests -->|23| scripts
   tests -->|18| storage
@@ -79,10 +79,10 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2861 |
+| tests | application | 2863 |
 | tests | domain | 457 |
 | tests | interfaces | 250 |
-| tests | infrastructure | 231 |
+| tests | infrastructure | 232 |
 | tests | scripts | 23 |
 | tests | storage | 18 |
 | tests | domain_services | 2 |

--- a/src/application/futu_portfolio_context.py
+++ b/src/application/futu_portfolio_context.py
@@ -45,7 +45,6 @@ _FUTU_NET_CASH_POWER_FIELDS_BY_CCY = {
     "MYR": ("myr_net_cash_power",),
 }
 _FUTU_FUND_ASSET_FIELDS = ("fund_assets", "mmf_assets", "money_fund_assets")
-_OPEND_FX_DISPLAY_CURRENCIES = ("CNH", "USD", "HKD")
 
 
 def _resolve_trd_env(value: Any) -> str:
@@ -430,23 +429,19 @@ def _query_opend_exchange_rate_observation(
     account_ids: set[str],
     trd_env: str,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    rows_by_currency = {
-        currency: _filter_rows_for_account_ids(
+    return (
+        _filter_rows_for_account_ids(
             _query_rows_for_account_ids(
                 gateway,
                 "get_account_balance",
                 account_ids,
                 trd_env=trd_env,
-                currency=currency,
+                currency="CNH",
                 refresh_cache=True,
             ),
             account_ids,
             trd_env=trd_env,
-        )
-        for currency in _OPEND_FX_DISPLAY_CURRENCIES
-    }
-    return (
-        rows_by_currency["CNH"],
+        ),
         _fetch_market_exchange_rate_observation(),
     )
 

--- a/src/application/tick_account_execution.py
+++ b/src/application/tick_account_execution.py
@@ -494,7 +494,7 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
         str, list[dict[str, Any]]
     ] = {}
     prepared_option_unavailable_by_account: dict[str, str] = {}
-    prepared_contexts: dict[str, dict[str, Any] | None] = {}
+    prepared_contexts: dict[str, dict[str, Any]] = {}
     snapshot_status: str | None = None
     barrier_reason: str | None = None
     prefetch_done = bool(request.prefetch_done)
@@ -630,7 +630,7 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
                 invalid_prepared_accounts.add(account)
                 continue
             try:
-                prepared_contexts[account] = load_prepared_portfolio_context(
+                prepared_context = load_prepared_portfolio_context(
                     manifest_path=manifest_path,
                     expected_base=request.base,
                     expected_run_id=request.run_id,
@@ -652,6 +652,17 @@ def run_tick_account_execution(request: TickAccountExecutionRequest) -> TickAcco
                 )
                 invalid_prepared_accounts.add(account)
                 continue
+            if not isinstance(prepared_context, dict):
+                account_config_errors[account] = AccountRunConfigError(
+                    "ACCOUNT_CONFIG_PREPARED_CONTEXT_INVALID",
+                    str(
+                        manifest.get("reason")
+                        or "prepared portfolio context is unavailable"
+                    ),
+                )
+                invalid_prepared_accounts.add(account)
+                continue
+            prepared_contexts[account] = prepared_context
             prepared_manifest_paths[account] = manifest_path
             prepared_manifest_sha256_by_account[account] = str(
                 manifest.get("manifest_sha256") or ""

--- a/tests/test_futu_portfolio_context.py
+++ b/tests/test_futu_portfolio_context.py
@@ -427,7 +427,7 @@ def test_fetch_futu_portfolio_context_filters_rows_by_mapped_account_ids() -> No
 
     assert out["cash_by_currency"] == {"CNY": 120000.0}
     assert sorted(out["stocks_by_symbol"].keys()) == ["NVDA"]
-    assert fake_gateway.balance_calls == [int(FAKE_FUTU_ACC_ID_LX_PRIMARY)] * 3
+    assert fake_gateway.balance_calls == [int(FAKE_FUTU_ACC_ID_LX_PRIMARY)]
     assert fake_gateway.position_calls == [int(FAKE_FUTU_ACC_ID_LX_PRIMARY)]
 
 
@@ -499,12 +499,11 @@ def test_fetch_futu_portfolio_context_uses_account_settings_account_id_without_t
 
     assert captured["balance"] == [
         {
-            "currency": currency,
+            "currency": "CNH",
             "acc_id": int(FAKE_FUTU_ACC_ID_LX_PRIMARY),
             "trd_env": "REAL",
             "refresh_cache": True,
         }
-        for currency in ("CNH", "USD", "HKD")
     ]
     assert captured["positions"] == [{"acc_id": int(FAKE_FUTU_ACC_ID_LX_PRIMARY), "trd_env": "REAL"}]
     assert out["cash_by_currency"] == {"USD": 2500.0}

--- a/tests/test_tick_account_execution_barrier.py
+++ b/tests/test_tick_account_execution_barrier.py
@@ -1513,6 +1513,131 @@ def test_config_failure_projection_does_not_follow_output_runs_symlink(
     assert list(outside.iterdir()) == []
 
 
+@pytest.mark.parametrize(
+    ("accounts", "expected_healthy"),
+    [(["lx"], []), (["lx", "sy"], ["sy"])],
+)
+def test_unavailable_prepared_context_fails_closed_before_shared_prefetch(
+    monkeypatch,
+    tmp_path: Path,
+    accounts: list[str],
+    expected_healthy: list[str],
+) -> None:
+    from src.application import tick_account_execution as mod
+    from src.infrastructure.io_utils import atomic_write_json
+
+    request = _request(
+        tmp_path,
+        accounts=accounts,
+        workers=len(accounts),
+        force=False,
+    )
+    build_prefetch_config = Mock(wraps=mod.build_cross_account_prefetch_config)
+    prepare_options = Mock(wraps=_fake_prepare_options)
+    prefetch = Mock(
+        return_value={
+            "global_required_data_plan": {
+                "plan_id": "a" * 64,
+                "symbols": [],
+            },
+            "symbols": [],
+            "results": {},
+        }
+    )
+    account_children: list[str] = []
+
+    def _prepare(**kwargs):
+        prepared = _fake_prepare(**kwargs)
+        authority = kwargs["account_config_authorities"]["lx"]
+        manifest_path = Path(prepared["lx"]["manifest_path"])
+        manifest = {
+            "schema_version": "prepared_portfolio_context.v1",
+            "run_id": kwargs["run_id"],
+            "account": "lx",
+            "status": "unavailable",
+            "account_config_sha256": authority.account_config_sha256,
+            "reason": "portfolio_context_unavailable",
+        }
+        atomic_write_json(manifest_path, manifest)
+        prepared["lx"] = {
+            **manifest,
+            "manifest_path": str(manifest_path),
+            "manifest_sha256": hashlib.sha256(
+                manifest_path.read_bytes()
+            ).hexdigest(),
+        }
+        return prepared
+
+    def _seal(**kwargs):
+        payload = {
+            "schema_version": "required_data_snapshot_manifest.v1",
+            "run_id": kwargs["run_id"],
+            "status": "complete",
+            "plan_id": "a" * 64,
+            "symbols": {},
+            "summary": {},
+        }
+        atomic_write_json(kwargs["manifest_path"], payload)
+        return payload
+
+    def _run_one_account(*, request, **_kwargs):
+        account_children.append(request.acct)
+        return mod.AccountRunOutcome(
+            result=AccountResult(request.acct, True, False, "ok", ""),
+            acct_metrics={"account": request.acct},
+            prefetch_done=True,
+            ran_pipeline=True,
+        )
+
+    monkeypatch.setattr(mod, "_account_pipeline_is_required", lambda **_kwargs: True)
+    monkeypatch.setattr(mod, "prepare_portfolio_contexts", _prepare)
+    monkeypatch.setattr(mod, "prepare_option_positions_contexts", prepare_options)
+    monkeypatch.setattr(
+        mod,
+        "build_cross_account_prefetch_config",
+        build_prefetch_config,
+    )
+    monkeypatch.setattr(
+        mod,
+        "_build_close_advice_barrier_plan",
+        lambda **kwargs: (kwargs["candidate_config"], None),
+    )
+    monkeypatch.setattr(mod, "prefetch_required_data", prefetch)
+    monkeypatch.setattr(mod, "seal_required_data_snapshot", _seal)
+    monkeypatch.setattr(mod, "run_one_account", _run_one_account)
+
+    outcome = mod.run_tick_account_execution(request)
+
+    expected_scope = set(expected_healthy)
+    assert build_prefetch_config.call_count == 1
+    planner_kwargs = build_prefetch_config.call_args.kwargs
+    assert set(planner_kwargs["account_configs"]) == expected_scope
+    assert set(planner_kwargs["prepared_portfolio_contexts"]) == expected_scope
+    assert prepare_options.call_count == 1
+    assert (
+        set(prepare_options.call_args.kwargs["account_config_authorities"])
+        == expected_scope
+    )
+    assert prefetch.call_count == (1 if expected_healthy else 0)
+    assert account_children == expected_healthy
+    assert outcome.ran_pipeline_accounts == expected_healthy
+    results_by_account = {result.account: result for result in outcome.results}
+    metrics_by_account = {
+        str(metrics["account"]): metrics for metrics in outcome.account_metrics
+    }
+    assert results_by_account["lx"].decision_reason == (
+        "account_config_prepared_context_invalid"
+    )
+    assert results_by_account["lx"].should_notify is False
+    assert metrics_by_account["lx"]["error_code"] == (
+        "ACCOUNT_CONFIG_PREPARED_CONTEXT_INVALID"
+    )
+    assert metrics_by_account["lx"]["error"] == "portfolio_context_unavailable"
+    assert metrics_by_account["lx"]["ran_scan"] is False
+    assert metrics_by_account["lx"]["ran_pipeline"] is False
+    assert metrics_by_account["lx"]["should_notify"] is False
+
+
 def test_config_drift_isolated_to_one_account_before_shared_prefetch(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- reduce each Futu portfolio fetch from three forced account-funds refreshes to one CNH display-currency request
- reject unavailable prepared portfolio contexts before option preparation, shared prefetch, and account child execution
- preserve healthy peer-account scans and scheduled fixed-failure alerts

## Validation
- 26 provider tests passed
- 34 account-execution barrier tests passed
- 73 notification and tick tests passed
- Ruff passed for the four changed Python files
- repository guardrails and git diff checks passed

## Boundaries
- source merge only; no version bump, release, deployment, OpenD upgrade, service restart, notification send, or production rerun