### PR TITLE
fix(release): accept protected-main merge topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 - Reduced each portfolio fetch to one CNH OpenD funds refresh and isolated accounts with unavailable prepared portfolio context before shared prefetch, while preserving healthy peer scans and scheduled failure alerts.
 - Let Copilot recover once from both plain and rejected answer attempts, preserve real cancellation and budget failures, and remove stale unrequested MTD cutoffs before option-performance reads.
+- Allowed the release gate to validate the unchanged GitHub merge commit that wraps an audited release-metadata commit on protected `main`.
 
 ## 3.0.2 - 2026-08-31
 

--- a/release/coverage/v3.1.0.json
+++ b/release/coverage/v3.1.0.json
@@ -5,7 +5,7 @@
     "tag": "v3.0.2",
     "commit": "af7129e61c8c5900e8c5d48673e2d168b63df93b"
   },
-  "reviewed_head": "4e27387d5af065c4f4274e3e6c4bfbf9e648355b",
+  "reviewed_head": "008531405e899cdee6cae222ba21e7f79c56c113",
   "commits": [
     {
       "sha": "3d107f0709443721f4b1099770645b0e340d0d1e",
@@ -58,6 +58,18 @@
     {
       "sha": "4e27387d5af065c4f4274e3e6c4bfbf9e648355b",
       "subject": "Merge pull request #196 from liuxie066/fix/copilot-answer-repair-mtd-cutoff"
+    },
+    {
+      "sha": "18f35d2ec2aa51c2aceebce82ca03eb573b88d26",
+      "subject": "chore: release 3.1.0"
+    },
+    {
+      "sha": "f8960fd8d7472d8499f322996d8f1e210544de83",
+      "subject": "Merge pull request #197 from liuxie066/codex/release-v3.1.0"
+    },
+    {
+      "sha": "008531405e899cdee6cae222ba21e7f79c56c113",
+      "subject": "fix(release): accept protected-main merge topology"
     }
   ],
   "release_notes": [
@@ -83,6 +95,13 @@
       "text": "Let Copilot recover once from both plain and rejected answer attempts, preserve real cancellation and budget failures, and remove stale unrequested MTD cutoffs before option-performance reads.",
       "commits": [
         "bbc98a635005d825e2c791c3979eff005a85f8f3"
+      ]
+    },
+    {
+      "category": "Bug Fixes",
+      "text": "Allowed the release gate to validate the unchanged GitHub merge commit that wraps an audited release-metadata commit on protected `main`.",
+      "commits": [
+        "008531405e899cdee6cae222ba21e7f79c56c113"
       ]
     }
   ],
@@ -114,6 +133,14 @@
     {
       "commit": "4e27387d5af065c4f4274e3e6c4bfbf9e648355b",
       "reason": "Merge-only integration commit; the Copilot fix is mapped to its source commit."
+    },
+    {
+      "commit": "18f35d2ec2aa51c2aceebce82ca03eb573b88d26",
+      "reason": "Superseded release-metadata commit from the failed initial publication attempt; no independent user-visible behavior."
+    },
+    {
+      "commit": "f8960fd8d7472d8499f322996d8f1e210544de83",
+      "reason": "Merge-only integration commit for the failed initial publication attempt; no independent user-visible behavior."
     }
   ],
   "design_evidence": [
@@ -193,6 +220,24 @@
       "commit": "4e27387d5af065c4f4274e3e6c4bfbf9e648355b",
       "references": [
         "https://github.com/liuxie066/options-monitor/pull/196"
+      ]
+    },
+    {
+      "commit": "18f35d2ec2aa51c2aceebce82ca03eb573b88d26",
+      "references": [
+        "https://github.com/liuxie066/options-monitor/pull/197"
+      ]
+    },
+    {
+      "commit": "f8960fd8d7472d8499f322996d8f1e210544de83",
+      "references": [
+        "https://github.com/liuxie066/options-monitor/pull/197"
+      ]
+    },
+    {
+      "commit": "008531405e899cdee6cae222ba21e7f79c56c113",
+      "references": [
+        "https://github.com/liuxie066/options-monitor/pull/198"
       ]
     }
   ]

--- a/src/application/release_delta_coverage.py
+++ b/src/application/release_delta_coverage.py
@@ -597,27 +597,54 @@ def _validate_reviewed_head_boundary(
         ["rev-list", "--count", f"{reviewed_head}..{current_head}"],
         run_cmd=run_cmd,
     )
-    if count_text != "1":
+    release_commit = current_head
+    if count_text == "2":
+        parents = _git_stdout(
+            base,
+            ["show", "-s", "--format=%P", current_head],
+            run_cmd=run_cmd,
+        ).lower().split()
+        if len(parents) != 2 or parents[0] != reviewed_head:
+            _fail(
+                "RELEASE_DELTA_POST_REVIEW_COMMITS",
+                "only a protected-main merge of the release-metadata commit may follow reviewed_head",
+            )
+        release_commit = parents[1]
+        if _git_stdout(
+            base,
+            ["rev-parse", f"{current_head}^{{tree}}"],
+            run_cmd=run_cmd,
+        ) != _git_stdout(
+            base,
+            ["rev-parse", f"{release_commit}^{{tree}}"],
+            run_cmd=run_cmd,
+        ):
+            _fail(
+                "RELEASE_DELTA_RELEASE_COMMIT_SCOPE",
+                "protected-main merge must not change the release commit tree",
+            )
+    elif count_text != "1":
         _fail(
             "RELEASE_DELTA_POST_REVIEW_COMMITS",
-            "more than the single release-metadata commit exists after reviewed_head",
+            "more than the release-metadata commit and its protected-main merge exist after reviewed_head",
         )
-    parent = _git_stdout(base, ["rev-parse", f"{current_head}^"], run_cmd=run_cmd).lower()
+
+    parent = _git_stdout(base, ["rev-parse", f"{release_commit}^"], run_cmd=run_cmd).lower()
     subject = _git_stdout(
         base,
-        ["show", "-s", "--format=%s", current_head],
+        ["show", "-s", "--format=%s", release_commit],
         run_cmd=run_cmd,
     )
     if parent != reviewed_head or subject != f"chore: release {version}":
         _fail(
             "RELEASE_DELTA_INVALID_RELEASE_COMMIT",
-            f"the only commit after reviewed_head must be 'chore: release {version}' with reviewed_head as its parent",
+            f"the release commit must be 'chore: release {version}' with reviewed_head as its parent",
         )
 
     changed = set(
         _git_lines(
             base,
-            ["diff-tree", "--no-commit-id", "--name-only", "-r", current_head],
+            ["diff-tree", "--no-commit-id", "--name-only", "-r", release_commit],
             run_cmd=run_cmd,
         )
     )

--- a/tests/test_release_delta_coverage.py
+++ b/tests/test_release_delta_coverage.py
@@ -168,6 +168,22 @@ def test_delta_coverage_accepts_complete_review_before_and_after_release_commit(
     assert post_commit == summary
 
 
+def test_delta_coverage_accepts_protected_main_merge_of_release_commit(tmp_path: Path) -> None:
+    repo, _manifest = _prepared_repo(tmp_path)
+    main_branch = _git(repo, "branch", "--show-current")
+    _git(repo, "switch", "-c", "release")
+    _git(repo, "add", "VERSION", "CHANGELOG.md", "release/coverage/v1.1.0.json")
+    _git(repo, "commit", "-m", "chore: release 1.1.0")
+    _git(repo, "switch", main_branch)
+    _git(repo, "merge", "--no-ff", "release", "-m", "Merge pull request #123 from release")
+
+    validate_release_delta_coverage(
+        base_dir=repo,
+        version="1.1.0",
+        release_evidence=_release_evidence(repo),
+    )
+
+
 def test_release_check_cli_enforces_delta_coverage(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- accept the protected-main merge commit that wraps the single release metadata commit
- require the merge tree to exactly match the reviewed release commit
- add a real git-topology regression test
- refresh the failed v3.1.0 release evidence before merge

## Verification
- release delta coverage tests: 23 passed
- strict v3.1.0 release metadata validation: passed

This PR only repairs the release gate and release evidence; it does not deploy or mutate production.