### PR TITLE
fix(release): validate diverged protected-main merge

### DIFF
--- a/release/coverage/v3.1.0.json
+++ b/release/coverage/v3.1.0.json
@@ -5,7 +5,7 @@
     "tag": "v3.0.2",
     "commit": "af7129e61c8c5900e8c5d48673e2d168b63df93b"
   },
-  "reviewed_head": "008531405e899cdee6cae222ba21e7f79c56c113",
+  "reviewed_head": "d47d5fc16197834debaa64e64357b71dd60b56cf",
   "commits": [
     {
       "sha": "3d107f0709443721f4b1099770645b0e340d0d1e",
@@ -70,6 +70,18 @@
     {
       "sha": "008531405e899cdee6cae222ba21e7f79c56c113",
       "subject": "fix(release): accept protected-main merge topology"
+    },
+    {
+      "sha": "969679dbc9e8d20d6a744e2816ae89f1d102c883",
+      "subject": "chore: release 3.1.0"
+    },
+    {
+      "sha": "9548d2f5cb08594d913281e652e5cacbb02c33ea",
+      "subject": "Merge pull request #198 from liuxie066/codex/fix-release-merge-boundary"
+    },
+    {
+      "sha": "d47d5fc16197834debaa64e64357b71dd60b56cf",
+      "subject": "fix(release): validate diverged protected-main merge"
     }
   ],
   "release_notes": [
@@ -101,7 +113,8 @@
       "category": "Bug Fixes",
       "text": "Allowed the release gate to validate the unchanged GitHub merge commit that wraps an audited release-metadata commit on protected `main`.",
       "commits": [
-        "008531405e899cdee6cae222ba21e7f79c56c113"
+        "008531405e899cdee6cae222ba21e7f79c56c113",
+        "d47d5fc16197834debaa64e64357b71dd60b56cf"
       ]
     }
   ],
@@ -141,6 +154,14 @@
     {
       "commit": "f8960fd8d7472d8499f322996d8f1e210544de83",
       "reason": "Merge-only integration commit for the failed initial publication attempt; no independent user-visible behavior."
+    },
+    {
+      "commit": "969679dbc9e8d20d6a744e2816ae89f1d102c883",
+      "reason": "Superseded release-metadata commit from the second failed publication attempt; no independent user-visible behavior."
+    },
+    {
+      "commit": "9548d2f5cb08594d913281e652e5cacbb02c33ea",
+      "reason": "Merge-only integration commit for the second failed publication attempt; no independent user-visible behavior."
     }
   ],
   "design_evidence": [
@@ -238,6 +259,24 @@
       "commit": "008531405e899cdee6cae222ba21e7f79c56c113",
       "references": [
         "https://github.com/liuxie066/options-monitor/pull/198"
+      ]
+    },
+    {
+      "commit": "969679dbc9e8d20d6a744e2816ae89f1d102c883",
+      "references": [
+        "https://github.com/liuxie066/options-monitor/pull/198"
+      ]
+    },
+    {
+      "commit": "9548d2f5cb08594d913281e652e5cacbb02c33ea",
+      "references": [
+        "https://github.com/liuxie066/options-monitor/pull/198"
+      ]
+    },
+    {
+      "commit": "d47d5fc16197834debaa64e64357b71dd60b56cf",
+      "references": [
+        "https://github.com/liuxie066/options-monitor/pull/199"
       ]
     }
   ]

--- a/src/application/release_delta_coverage.py
+++ b/src/application/release_delta_coverage.py
@@ -604,10 +604,14 @@ def _validate_reviewed_head_boundary(
             ["show", "-s", "--format=%P", current_head],
             run_cmd=run_cmd,
         ).lower().split()
-        if len(parents) != 2 or parents[0] != reviewed_head:
+        if len(parents) != 2 or _git_result(
+            base,
+            ["merge-base", "--is-ancestor", parents[0], reviewed_head],
+            run_cmd=run_cmd,
+        ).returncode != 0:
             _fail(
                 "RELEASE_DELTA_POST_REVIEW_COMMITS",
-                "only a protected-main merge of the release-metadata commit may follow reviewed_head",
+                "protected-main merge first parent must be an ancestor of reviewed_head",
             )
         release_commit = parents[1]
         if _git_stdout(

--- a/tests/test_release_delta_coverage.py
+++ b/tests/test_release_delta_coverage.py
@@ -169,12 +169,12 @@ def test_delta_coverage_accepts_complete_review_before_and_after_release_commit(
 
 
 def test_delta_coverage_accepts_protected_main_merge_of_release_commit(tmp_path: Path) -> None:
-    repo, _manifest = _prepared_repo(tmp_path)
-    main_branch = _git(repo, "branch", "--show-current")
+    repo, manifest = _prepared_repo(tmp_path)
+    _git(repo, "branch", "protected-main", f"{manifest['reviewed_head']}^")
     _git(repo, "switch", "-c", "release")
     _git(repo, "add", "VERSION", "CHANGELOG.md", "release/coverage/v1.1.0.json")
     _git(repo, "commit", "-m", "chore: release 1.1.0")
-    _git(repo, "switch", main_branch)
+    _git(repo, "switch", "protected-main")
     _git(repo, "merge", "--no-ff", "release", "-m", "Merge pull request #123 from release")
 
     validate_release_delta_coverage(


### PR DESCRIPTION
## Summary
- model the actual protected-main PR topology where reviewed code and release metadata live on the second-parent branch
- require the merge first parent to be an ancestor of reviewed_head
- keep the existing exact release-parent and tree-equality checks
- refresh the failed v3.1.0 release evidence before merge

## Verification
- release delta coverage tests: 23 passed
- strict v3.1.0 metadata validation on the real main topology: passed

No production mutation is performed by this PR.