### PR TITLE
fix(strategy-lab): resolve release source identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+- Resolved stable release symlinks before verifying source identity, allowing deployed Strategy Lab previews to bind the audited release commit.
+
 ## 3.1.0 - 2026-09-01
 
 ### New Features

--- a/src/application/source_identity.py
+++ b/src/application/source_identity.py
@@ -17,7 +17,7 @@ def source_commit_sha(
 ) -> str | None:
     """Resolve the clean production source commit for a worktree or release."""
 
-    root = root or Path(__file__).resolve().parents[2]
+    root = (root or Path(__file__).resolve().parents[2]).resolve()
     runner = run_cmd or subprocess.run
     git_prefix = ["git"]
     git_env: dict[str, str] | None = None

--- a/tests/test_source_identity.py
+++ b/tests/test_source_identity.py
@@ -49,6 +49,9 @@ def test_release_identity_compares_with_its_tag_not_cache_head(tmp_path: Path) -
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
+    stable_release = apps / "options-monitor"
+    stable_release.symlink_to(release, target_is_directory=True)
     assert source_commit_sha(release) == release_commit
+    assert source_commit_sha(stable_release) == release_commit
     (release / "src/value.py").write_text("VALUE = 3\n", encoding="utf-8")
     assert source_commit_sha(release) is None


### PR DESCRIPTION
## Summary
- resolve stable release symlinks before verifying source identity
- cover deployed release symlink behavior with a regression test
- document the fix under Unreleased

## Verification
- 18 focused tests passed
- Ruff passed
- git diff --check passed
- repository guardrails passed

No release or deployment.