### PR TITLE
feat(strategy-lab): add two-day engineering canary

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1016 (`src`: 543, `domain`: 76, `scripts`: 12, `tests`: 385)
-- Internal import edges: 6788 total, 2947 production/script edges excluding tests
+- Internal import edges: 6791 total, 2947 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,11 +46,11 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2829| application
+  tests -->|2831| application
   tests -->|453| domain
   tests -->|2| domain_services
   tests -->|233| infrastructure
-  tests -->|237| interfaces
+  tests -->|238| interfaces
   tests -->|23| scripts
   tests -->|18| storage
 ```
@@ -79,9 +79,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2829 |
+| tests | application | 2831 |
 | tests | domain | 453 |
-| tests | interfaces | 237 |
+| tests | interfaces | 238 |
 | tests | infrastructure | 233 |
 | tests | scripts | 23 |
 | tests | storage | 18 |

--- a/docs/STRATEGY_LAB_DESIGN.md
+++ b/docs/STRATEGY_LAB_DESIGN.md
@@ -1,7 +1,8 @@
 # Strategy Lab 当前实现清单
 
 - **状态**：Phase 3 本地实现完成；远端自然 Tick 隔离门槛已通过；待真实 20 日 / 10 日验收
-- **更新时间**：2026-08-31
+- **工程验通**：只读两日 Canary 已实现，待两个完整自然交易日线上验收
+- **更新时间**：2026-09-01
 - **产品合同**：[Strategy Lab PRD](STRATEGY_LAB_EXPERIMENT_PLATFORM_PRD.md)
 - **技术设计**：[Strategy Lab 系统设计](STRATEGY_LAB_EXPERIMENT_PLATFORM_SYSTEM_DESIGN.md)
 
@@ -14,6 +15,7 @@ Strategy Lab 当前有以下根级入口：
 
 ```text
 ./om strategy-lab recipes
+./om strategy-lab canary
 ./om strategy-lab preview
 ./om strategy-lab confirm-research
 ./om strategy-lab preview-validation
@@ -25,7 +27,7 @@ Strategy Lab 当前有以下根级入口：
 ./om strategy-lab readiness refresh-history-k
 ```
 
-`recipes` 和 `preview` 只读，不创建实验、写 Store 或调用 OpenD。readiness 入口预览或在
+`recipes`、`canary` 和 `preview` 只读，不创建实验、写 Store 或调用 OpenD。readiness 入口预览或在
 显式 hash、actor 和 `--write` 确认后发布 targeted history-K readiness receipt。
 `confirm-research` 和 `confirm-validation` 分别只接受当次重建后仍可用且 hash 相同的 preview；
 `research execute` 与 `advance` 每次最多执行一个 provider 逻辑证据单元。`status` 和 `receipt` 只读，只依赖
@@ -56,8 +58,78 @@ dataset、mark、outcome 和 candidate-impact 继续使用 `./om research shadow
 三表 Store 仅包含 `experiments`、`experiment_events` 和 `experiment_observations`。全局
 最多一个非终态实验，确认、revision、observation 和 receipt 绑定必须幂等并 fail closed。
 
+## 两日工程验通
+
+两日工程验通用于尽快确认新链路能够消费真实正式点并执行集中度 Recipe。它是工程 canary，不能替代
+20 日研究或 10 日隐藏验证，也不能产生实验结论。
+
+公开只读入口为：
+
+```bash
+./om strategy-lab canary --profile-path <runtime>/service.profile.json
+```
+
+CLI 在一次调用内冻结当前 UTC 时间，并调用 `preview_engineering_canary()`。该服务只选择截至该时间的
+最近两个市场交易日；不会因为最近一天缺点、冲突或尚未结束而回退到更早的完整日。每个选中日期必须：
+
+1. 存在唯一且有效的 expectation；
+2. 所有预期正式推荐点均已封存且早于调用时间；
+3. 每个正式点都能复用 `build_concentration_arms()` 生成一个 baseline 和三个固定 challenger；
+4. 不要求合约已经到期，不读取 terminal FX、费用计划或收益 outcome。
+
+输出保持为一个小型只读摘要：
+
+```json
+{
+  "authoritative": false,
+  "status": "available",
+  "observed_at_utc": "<UTC>",
+  "selected_trading_dates": ["<day-1>", "<day-2>"],
+  "blockers": [],
+  "projection": {
+    "recipe_id": "sell_put_option_position_concentration",
+    "trading_day_count": 2,
+    "recommendation_point_count": 24,
+    "variant_ids": [
+      "baseline",
+      "challenger_0.002",
+      "challenger_0.004",
+      "challenger_0.006"
+    ]
+  },
+  "unlocks": []
+}
+```
+
+实际点数由两日 expectation 决定，示例中的 `24` 不是固定门槛。缺日、冲突、点未到时或 Recipe
+证据不完整时返回 `blocked`、原 owner 的 reason code 和 `projection: null`；不得增加 Canary 专用的
+reason-code 映射层。任何结果的 `authoritative` 都为 `false`，`unlocks` 都为空，也不包含 leader、
+comparison、Research Receipt 或 Final Receipt 字段。`available` 只表示两日 Corpus 和 Recipe 投影可用，
+不是实验通过或收益结论。
+
+实现边界：
+
+| 文件 | 当前实现 |
+|---|---|
+| `src/application/strategy_lab/recipe.py` | 给现有 `_load_window_day()` 增加一个默认开启的内部 maturity 开关，并新增固定两日的 `select_engineering_canary_window()`；正式 20 日选择保持原行为，Canary 不要求到期且不回退 |
+| `src/application/strategy_lab/service.py` | 新增只读 `preview_engineering_canary()`，校验轻量 runtime context 并汇总覆盖和 Recipe 投影 |
+| `src/interfaces/cli/strategy_lab_ops.py` | 新增 `canary` 子命令；只调用 `resolve_strategy_lab_runtime_context(profile, market="hk")` 并要求 profile 包含 `lx`，不解析 ledger、费用或 OpenD binding，不打开或创建 Experiment Store |
+| `tests/test_strategy_lab_recipe.py`、`tests/test_strategy_lab_cli.py` | 增加一个未到期两日成功测试、一个最新日异常且不回退测试、一个 CLI 单次时钟及零文件/Store/OpenD 副作用测试；缺失和冲突的底层矩阵继续由现有 Formal Corpus 测试拥有 |
+
+不修改 `RESEARCH_SESSIONS = 20`、`VALIDATION_SESSIONS = 10`、正式 preview、Research Receipt、
+leader、隐藏验证或 Final Receipt。Canary 不增加表、状态、timer、配置项、可变 `--days` 参数或迁移。
+
+history-K provider PoC 仍由现有 `strategy-lab readiness refresh-history-k` 显式执行。该入口按合同只接受
+已到期合约；两日新候选通常尚未到期，因此 Canary 不生成伪装成可立即执行的 probe，也不把 provider
+调用藏进只读命令。工程验通时另选一个已到期真实合约执行 PoC，并独立核对自然 Tick 的延迟和超时。
+
+两日工程验通的完成信号是：Canary 对两个连续自然交易日返回 `available`、显式 history-K PoC 成功、
+同一窗口内 Tick 没有新增 Strategy Lab 导致的超时。它仍不能证明收益、成交、Research Receipt、
+research leader 或 Final Receipt。
+
 ## 尚未完成
 
+- 两日工程 Canary 的真实线上验通；
 - 真实 20 日研究、未来 10 日隐藏验证、合约到期等待和 Final Receipt 审计；
 - MCP、Skill、飞书、并行实验、自动采用与生产配置写入。
 

--- a/src/application/strategy_lab/recipe.py
+++ b/src/application/strategy_lab/recipe.py
@@ -503,6 +503,8 @@ def _load_window_day(
     cutoff: datetime,
     cutoff_ms: int,
     calendar: Mapping[str, Any],
+    *,
+    require_mature_outcomes: bool = True,
 ) -> tuple[dict[str, Any] | None, str | None]:
     runtime_root = context["runtime_root"]
     try:
@@ -576,7 +578,9 @@ def _load_window_day(
             )
         except StrategyLabRecipeError as exc:
             return None, exc.reason_code
-        if any(not _expiration_is_mature(arm["candidate"].get("expiration"), cutoff_ms) for arm in arms["arms"]):
+        if require_mature_outcomes and any(
+            not _expiration_is_mature(arm["candidate"].get("expiration"), cutoff_ms) for arm in arms["arms"]
+        ):
             return None, "research_outcome_immature"
         points.append(arms)
     return (
@@ -664,6 +668,53 @@ def select_research_window(
         "no mature 20-session research window is available",
         sessions=[],
     )
+
+
+def select_engineering_canary_window(
+    context: Mapping[str, Any],
+    observed_at_utc: str,
+) -> dict[str, Any]:
+    try:
+        cutoff = datetime.fromisoformat(observed_at_utc.replace("Z", "+00:00")).astimezone(timezone.utc)
+        calendar = read_market_calendar_binding(context["artifact_root"], market="HK")
+    except Exception as exc:
+        return _blocked("market_calendar_binding_unavailable", str(exc), sessions=[])
+    cutoff_ms = int(cutoff.timestamp() * 1000)
+    cutoff_date = cutoff.astimezone(_HK_TZ).date().isoformat()
+    if not calendar["coverage_start"] <= cutoff_date <= calendar["coverage_end"]:
+        return _blocked(
+            "market_calendar_binding_unavailable",
+            "HK observation date is outside calendar coverage",
+            sessions=[],
+        )
+    dates = [value for value in calendar["trading_dates"] if value <= cutoff_date]
+    if len(dates) < 2:
+        return _blocked("research_corpus_warming", "fewer than 2 trading sessions", sessions=[])
+    selected_dates = dates[-2:]
+    sessions: list[dict[str, Any]] = []
+    for trading_date in selected_dates:
+        day, reason = _load_window_day(
+            context,
+            trading_date,
+            cutoff,
+            cutoff_ms,
+            calendar,
+            require_mature_outcomes=False,
+        )
+        if day is None:
+            return _blocked(
+                reason or "research_window_coverage_missing",
+                f"engineering canary session is incomplete: {trading_date}",
+                sessions=sessions,
+                selected_trading_dates=selected_dates,
+            )
+        sessions.append(day)
+    return {
+        "status": "available",
+        "blockers": [],
+        "selected_trading_dates": selected_dates,
+        "sessions": sessions,
+    }
 
 
 def _all_arms(window: Mapping[str, Any]) -> list[dict[str, Any]]:
@@ -872,5 +923,6 @@ __all__ = [
     "describe_recipe",
     "project_validation_arms",
     "resolve_terminal_fx_binding",
+    "select_engineering_canary_window",
     "select_research_window",
 ]

--- a/src/application/strategy_lab/service.py
+++ b/src/application/strategy_lab/service.py
@@ -68,6 +68,7 @@ from src.application.strategy_lab.recipe import (
     check_recipe_readiness,
     describe_recipe,
     resolve_terminal_fx_binding,
+    select_engineering_canary_window,
 )
 from src.application.strategy_lab.readiness import HISTORY_K_POC_NOT_BEFORE_HK
 from src.application.strategy_lab.receipts import (
@@ -273,6 +274,47 @@ def list_recipes(
                 },
             }
         ]
+    }
+
+
+def preview_engineering_canary(
+    context: Mapping[str, Any],
+    *,
+    occurred_at_utc: str,
+) -> dict[str, Any]:
+    profile = context.get("profile") if isinstance(context, Mapping) else None
+    accounts = profile.get("accounts") if isinstance(profile, Mapping) else None
+    if context.get("market") != MARKET or not isinstance(accounts, list) or ACCOUNT not in accounts:
+        _fail("Strategy Lab engineering canary requires hk/lx in the service profile")
+    observed = _occurred_at(occurred_at_utc)
+    window = select_engineering_canary_window(context, observed)
+    selected_dates = list(window.get("selected_trading_dates", []))
+    if window.get("status") != "available":
+        return {
+            "authoritative": False,
+            "status": "blocked",
+            "observed_at_utc": observed,
+            "selected_trading_dates": selected_dates,
+            "blockers": list(window.get("blockers", [])),
+            "projection": None,
+            "unlocks": [],
+        }
+    sessions = list(window["sessions"])
+    points = [point for session in sessions for point in session["points"]]
+    variant_ids = [str(arm["arm_id"]) for arm in points[0]["arms"]]
+    return {
+        "authoritative": False,
+        "status": "available",
+        "observed_at_utc": observed,
+        "selected_trading_dates": selected_dates,
+        "blockers": [],
+        "projection": {
+            "recipe_id": RECIPE_ID,
+            "trading_day_count": len(sessions),
+            "recommendation_point_count": len(points),
+            "variant_ids": variant_ids,
+        },
+        "unlocks": [],
     }
 
 
@@ -2281,6 +2323,7 @@ __all__ = [
     "execute_research",
     "get_experiment_status",
     "list_recipes",
+    "preview_engineering_canary",
     "preview_experiment",
     "preview_validation",
     "read_receipt",

--- a/src/interfaces/cli/strategy_lab_ops.py
+++ b/src/interfaces/cli/strategy_lab_ops.py
@@ -27,6 +27,7 @@ from src.application.strategy_lab.service import (
     execute_research,
     get_experiment_status,
     list_recipes,
+    preview_engineering_canary,
     preview_experiment,
     preview_validation,
     read_receipt,
@@ -55,6 +56,9 @@ def add_strategy_lab_commands(subparsers: Any) -> argparse.ArgumentParser:
     refresh.add_argument("--confirmed-probe-sha256", default=None)
     refresh.add_argument("--actor", default=None)
     refresh.add_argument("--write", action="store_true")
+
+    canary = commands.add_parser("canary", help="preview two days of engineering-only Recipe projection")
+    canary.add_argument("--profile-path", required=True)
 
     recipes = commands.add_parser("recipes", help="list currently supported experiment recipes")
     recipes.add_argument("--profile-path", required=True)
@@ -154,6 +158,7 @@ def _experiment_request(args: argparse.Namespace) -> dict[str, str]:
 def handle_strategy_lab_command(args: argparse.Namespace) -> dict[str, Any]:
     if args.strategy_lab_command in {
         "recipes",
+        "canary",
         "preview",
         "confirm-research",
         "preview-validation",
@@ -167,10 +172,15 @@ def handle_strategy_lab_command(args: argparse.Namespace) -> dict[str, Any]:
             profile = load_service_profile(Path(args.profile_path).expanduser())
             context = (
                 resolve_strategy_lab_runtime_context(profile, market="hk")
-                if args.strategy_lab_command in {"status", "receipt"}
+                if args.strategy_lab_command in {"canary", "status", "receipt"}
                 else resolve_strategy_lab_context(profile)
             )
-            if args.strategy_lab_command == "recipes":
+            if args.strategy_lab_command == "canary":
+                data = preview_engineering_canary(
+                    context,
+                    occurred_at_utc=_now_utc(),
+                )
+            elif args.strategy_lab_command == "recipes":
                 data = list_recipes(
                     context,
                     fee_plan_receipt_path=args.fee_plan_receipt_path,

--- a/tests/test_strategy_lab_cli.py
+++ b/tests/test_strategy_lab_cli.py
@@ -45,7 +45,7 @@ def test_strategy_lab_help_exposes_phase3_confirmation_commands(
     assert raised.value.code == 0
     help_text = capsys.readouterr().out
     assert (
-            "{readiness,recipes,preview,confirm-research,preview-validation,"
+            "{readiness,canary,recipes,preview,confirm-research,preview-validation,"
             "confirm-validation,advance,status,research,receipt}" in help_text
     )
 
@@ -53,6 +53,46 @@ def test_strategy_lab_help_exposes_phase3_confirmation_commands(
         parse_args(["strategy-lab", "research", "--help"])
     assert research_help.value.code == 0
     assert "{execute}" in capsys.readouterr().out
+
+
+def test_canary_uses_light_context_one_clock_and_no_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.interfaces.cli.strategy_lab_ops as cli
+
+    profile_path, _fee_plan_path, context = _patch_read_only_context(monkeypatch, tmp_path)
+    clock_values = iter([NOW])
+    monkeypatch.setattr(cli, "_now_utc", lambda: next(clock_values))
+    monkeypatch.setattr(
+        cli,
+        "resolve_strategy_lab_context",
+        lambda _profile: pytest.fail("canary must not resolve ledger or OpenD context"),
+    )
+    runtime_calls: list[tuple[object, str]] = []
+
+    def resolve_runtime(profile: object, *, market: str) -> dict[str, object]:
+        runtime_calls.append((profile, market))
+        return context
+
+    monkeypatch.setattr(cli, "resolve_strategy_lab_runtime_context", resolve_runtime)
+    received: dict[str, object] = {}
+
+    def preview(fake_context: object, **kwargs: object) -> dict[str, object]:
+        received.update(context=fake_context, **kwargs)
+        return {"authoritative": False, "status": "blocked"}
+
+    monkeypatch.setattr(cli, "preview_engineering_canary", preview)
+
+    response = handle_strategy_lab_command(parse_args(["strategy-lab", "canary", "--profile-path", str(profile_path)]))
+
+    assert response["tool_name"] == "strategy-lab.canary"
+    assert response["data"] == {"authoritative": False, "status": "blocked"}
+    assert received == {"context": context, "occurred_at_utc": NOW}
+    assert runtime_calls == [({"path": str(profile_path)}, "hk")]
+    with pytest.raises(StopIteration):
+        next(clock_values)
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_recipes_freezes_one_clock_and_calls_only_service(

--- a/tests/test_strategy_lab_recipe.py
+++ b/tests/test_strategy_lab_recipe.py
@@ -21,9 +21,10 @@ from src.application.strategy_lab.recipe import (
     build_concentration_arms,
     build_validation_plan,
     project_validation_arms,
+    select_engineering_canary_window,
     select_research_window,
 )
-from src.application.strategy_lab.service import preview_experiment
+from src.application.strategy_lab.service import preview_engineering_canary, preview_experiment
 from tests.candidate_evidence_helpers import seal_opening_candidate_fixture
 
 
@@ -445,6 +446,191 @@ def test_window_uses_newest_mature_20_and_never_skips_a_hole(
     assert hole in interior["selected_trading_dates"]
 
 
+def test_engineering_canary_uses_exact_latest_two_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.application.strategy_lab.recipe as recipe
+
+    dates = _trading_dates(3)
+    monkeypatch.setattr(
+        recipe,
+        "read_market_calendar_binding",
+        lambda *_args, **_kwargs: {
+            "coverage_start": dates[0],
+            "coverage_end": "2026-07-05",
+            "trading_dates": dates,
+        },
+    )
+    calls: list[str] = []
+
+    def load_day(
+        _context: object,
+        trading_date: str,
+        _cutoff: datetime,
+        _cutoff_ms: int,
+        _calendar: object,
+        *,
+        require_mature_outcomes: bool = True,
+    ):
+        assert require_mature_outcomes is False
+        calls.append(trading_date)
+        return {
+            "trading_date": trading_date,
+            "points": [
+                {
+                    "arms": [
+                        {"arm_id": "baseline"},
+                        {"arm_id": "challenger_0.002"},
+                        {"arm_id": "challenger_0.004"},
+                        {"arm_id": "challenger_0.006"},
+                    ]
+                }
+            ],
+        }, None
+
+    monkeypatch.setattr(recipe, "_load_window_day", load_day)
+    context = {"artifact_root": Path("/does/not/read"), "runtime_root": Path("/does/not/read")}
+
+    available = select_engineering_canary_window(context, "2026-07-05T08:00:00Z")
+
+    assert available["status"] == "available"
+    assert available["selected_trading_dates"] == dates[-2:]
+    assert calls == dates[-2:]
+
+    calls.clear()
+
+    def load_with_latest_gap(*args: object, **kwargs: object):
+        day, reason = load_day(*args, **kwargs)
+        if args[1] == dates[-1]:
+            return None, "formal_point_evidence_missing"
+        return day, reason
+
+    monkeypatch.setattr(recipe, "_load_window_day", load_with_latest_gap)
+    blocked = select_engineering_canary_window(context, "2026-07-05T08:00:00Z")
+
+    assert blocked["status"] == "blocked"
+    assert blocked["selected_trading_dates"] == dates[-2:]
+    assert blocked["blockers"][0]["reason_code"] == "formal_point_evidence_missing"
+    assert calls == dates[-2:]
+
+    calls.clear()
+    monkeypatch.setattr(
+        recipe,
+        "read_market_calendar_binding",
+        lambda *_args, **_kwargs: {
+            "coverage_start": dates[0],
+            "coverage_end": dates[-1],
+            "trading_dates": dates,
+        },
+    )
+    stale = select_engineering_canary_window(context, "2026-07-05T08:00:00Z")
+
+    assert stale["status"] == "blocked"
+    assert stale["blockers"][0]["reason_code"] == "market_calendar_binding_unavailable"
+    assert calls == []
+
+
+def test_engineering_canary_returns_read_only_non_authoritative_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.application.strategy_lab.service as service
+
+    sessions = [
+        {
+            "trading_date": trading_date,
+            "points": [
+                {
+                    "arms": [
+                        {"arm_id": "baseline"},
+                        {"arm_id": "challenger_0.002"},
+                        {"arm_id": "challenger_0.004"},
+                        {"arm_id": "challenger_0.006"},
+                    ]
+                }
+            ],
+        }
+        for trading_date in ("2026-08-27", "2026-08-28")
+    ]
+    monkeypatch.setattr(
+        service,
+        "select_engineering_canary_window",
+        lambda *_args, **_kwargs: {
+            "status": "available",
+            "blockers": [],
+            "selected_trading_dates": [item["trading_date"] for item in sessions],
+            "sessions": sessions,
+        },
+    )
+    monkeypatch.setattr(service, "_store", lambda *_args: pytest.fail("canary must not open Store"))
+    monkeypatch.setattr(
+        service,
+        "build_futu_gateway",
+        lambda **_kwargs: pytest.fail("canary must not build an OpenD gateway"),
+    )
+    before = list(tmp_path.iterdir())
+
+    result = preview_engineering_canary(
+        {
+            "market": "hk",
+            "profile": {"accounts": ["lx"]},
+            "artifact_root": tmp_path,
+            "runtime_root": tmp_path,
+        },
+        occurred_at_utc="2026-08-28T08:00:00Z",
+    )
+
+    assert result == {
+        "authoritative": False,
+        "status": "available",
+        "observed_at_utc": "2026-08-28T08:00:00Z",
+        "selected_trading_dates": ["2026-08-27", "2026-08-28"],
+        "blockers": [],
+        "projection": {
+            "recipe_id": RECIPE_ID,
+            "trading_day_count": 2,
+            "recommendation_point_count": 2,
+            "variant_ids": [
+                "baseline",
+                "challenger_0.002",
+                "challenger_0.004",
+                "challenger_0.006",
+            ],
+        },
+        "unlocks": [],
+    }
+    assert not {"leader", "comparison", "research_receipt", "final_receipt"} & result.keys()
+
+    monkeypatch.setattr(
+        service,
+        "select_engineering_canary_window",
+        lambda *_args, **_kwargs: {
+            "status": "blocked",
+            "blockers": [
+                {
+                    "reason_code": "formal_corpus_conflict",
+                    "message": "fixture conflict",
+                }
+            ],
+            "selected_trading_dates": ["2026-08-27", "2026-08-28"],
+            "sessions": [],
+        },
+    )
+    blocked = preview_engineering_canary(
+        {
+            "market": "hk",
+            "profile": {"accounts": ["lx"]},
+            "artifact_root": tmp_path,
+            "runtime_root": tmp_path,
+        },
+        occurred_at_utc="2026-08-28T08:00:00Z",
+    )
+    assert blocked["status"] == "blocked"
+    assert blocked["projection"] is None
+    assert blocked["blockers"][0]["reason_code"] == "formal_corpus_conflict"
+    assert list(tmp_path.iterdir()) == before
+
+
 def _window_day_artifacts(timestamp: str) -> tuple[dict[str, object], dict[str, object]]:
     expectation = {
         "status": "available",
@@ -694,6 +880,32 @@ def test_window_day_uses_expectation_calendar_and_compares_only_session_semantic
     assert reason is None
     assert day is not None
     assert day["market_calendar_binding"]["market_calendar_version"] == "old.v1"
+
+    monkeypatch.setattr(
+        recipe,
+        "build_concentration_arms",
+        lambda *_args, **_kwargs: {"arms": [{"candidate": {"expiration": "2026-09-30"}}]},
+    )
+    immature, immature_reason = recipe._load_window_day(
+        context,
+        "2026-08-26",
+        cutoff,
+        int(cutoff.timestamp() * 1000),
+        current,
+    )
+    assert immature is None
+    assert immature_reason == "research_outcome_immature"
+
+    canary_day, canary_reason = recipe._load_window_day(
+        context,
+        "2026-08-26",
+        cutoff,
+        int(cutoff.timestamp() * 1000),
+        current,
+        require_mature_outcomes=False,
+    )
+    assert canary_reason is None
+    assert canary_day is not None
 
     current["trading_sessions"][0]["trade_date_type"] = "MORNING"
     changed, changed_reason = recipe._load_window_day(


### PR DESCRIPTION
Adds a read-only two-day Strategy Lab engineering canary with exact latest-session selection, stale-calendar fail-closed behavior, lightweight runtime context, CLI coverage, and updated design documentation. Formal 20-day research and 10-day hidden-validation contracts remain unchanged. Verified with focused tests (34 passed), full Strategy Lab and Formal Corpus tests (182 passed), documentation tests (5 passed), Ruff, repository guardrails, and git diff checks.