### PR TITLE
docs(worktree): define release closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@
 - Prefer root-cause fixes at the owning boundary. If a tactical patch is unavoidable, state the tradeoff and follow-up.
 - Follow parsimony at repo boundaries: do not add entities, layers, states, tools, config keys, or workflows unless they are necessary.
 - Preserve user changes in a dirty worktree. Never reset or revert unrelated files unless explicitly asked.
+- Worktrees are conditional isolation, not a per-phase default. Reuse the same task worktree through implementation,
+  validation, review, and PR; create another only for a protected/shared branch, unrelated dirty changes, or parallel conflict.
+- Close a task worktree only after its PR and required checks are terminal; for a release, wait until the tag, GitHub
+  Release, target commit, and assets are verified. Require a clean status, proof that the branch is contained in
+  `origin/main`, and no active owner before removing the exact worktree and local branch. Preserve dirty, unmerged,
+  patch-equivalent-only, stashed, or owner-unknown work unless separately approved.
 - Do not invoke Gateflow, planreview, or deepreview unless the user explicitly requests the named workflow or skill in the current task.
 
 ## DeepReview Profile

--- a/docs/AGENT_WIKI.md
+++ b/docs/AGENT_WIKI.md
@@ -842,9 +842,12 @@ When the user explicitly asks to publish a release, execute the full publication
    `--require-delta-coverage`.
 7. Commit only `VERSION`, `CHANGELOG.md`, and the coverage manifest as
    `chore: release <version>`.
-8. Push `main`.
-9. Watch the `Guardrails` workflow and its downstream `release` job.
-10. Verify the GitHub Release, remote tag, target commit, and assets.
+8. Push the release branch, open a Pull Request to protected `main`, and wait for required checks; do not attempt a direct `main` push.
+9. Merge the release Pull Request.
+10. Watch the `main` push `Guardrails` workflow and its downstream `release` job.
+11. Verify the GitHub Release, remote tag, target commit, and assets.
+12. Close the exact release worktree and local branch only after the release verification and ownership checks in
+    [Release Process](RELEASE_PROCESS.md#发布工作区收口) pass.
 
 The coverage gate uses the previous stable tag as the baseline. It requires every commit in the
 delta to map to an exact Changelog item or an explicit `no_release_note` reason, and rejects code

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -103,8 +103,9 @@ Changelog、commit、push、创建 tag、发布 GitHub Release 或升级生产�
 5. 将 `Unreleased` 移入日期化的目标版本段落，并更新 `VERSION`；
 6. 渲染最终 Release Notes，确认只包含目标版本且分类顺序正确；
 7. 运行发布前检查；
-8. 把 `VERSION`、`CHANGELOG.md` 和 coverage manifest 作为唯一的
-   `chore: release <version>` 提交推送到 `main`。
+8. 在基于最新 `origin/main` 的 release 分支上，把 `VERSION`、`CHANGELOG.md` 和 coverage
+   manifest 作为唯一的 `chore: release <version>` 提交；
+9. 推送 release 分支，通过 Pull Request 合入受保护的 `main`，并等待必需检查通过。
 
 Delta coverage manifest 不是从 commit message 猜 Release Notes。它先确定上一稳定 tag 和
 当前 `HEAD`，生成完整 commit inventory，并复制已经人工维护的 `Unreleased` 条目。维护者必须：
@@ -273,7 +274,7 @@ VERSION="$(cat VERSION)"
 - 重新校验 release metadata / coverage，并验证最终 source archive 中的 Pi runtime
 - 发布对应 GitHub Release
 
-因此常规发布只需要把版本元数据改好并推到 `main`；不需要再手动补打上同名 tag。
+因此常规发布只需要把版本元数据改好，通过 Pull Request 合入 `main`；不需要再手动补打上同名 tag。
 自动 release job 复用同一次 `Guardrails` 已通过的回归结果，不重复运行同一批 Python / Pi
 测试。普通开发提交因为不修改 `VERSION`，不会进入 release job。
 
@@ -281,6 +282,29 @@ VERSION="$(cat VERSION)"
 审阅与发布前检查，再从 GitHub Actions 手动运行 `Release from VERSION`。手动入口使用当前
 `main` 的 `VERSION` 和提交 SHA，并以完整模式重新执行 metadata、coverage、测试、归档和发布步骤；
 不得用它跳过失败门禁或从未审阅的提交补发 tag。
+
+### 发布工作区收口
+
+Release worktree 只用于本地隔离；GitHub Actions 使用临时 checkout，不需要保留本地发布工作区。
+只有在 tag、GitHub Release、target commit 和产物全部验证后，才可收口 release worktree。
+
+收口前必须同时确认：
+
+- worktree 没有已修改或未跟踪文件；
+- `git merge-base --is-ancestor <branch> origin/main` 成功；
+- 没有活跃任务继续占用该 worktree。
+
+然后只按准确路径和分支名收口：
+
+```bash
+git worktree remove <exact-worktree-path>
+git branch -d <exact-local-branch>
+```
+
+仓库启用 GitHub 合并后自动删除 head branch；这不会删除本地 worktree 或本地分支。
+如果分支只能通过 `git cherry origin/main <branch>` 证明 patch-equivalent，而不是 `origin/main`
+的祖先，不得自动使用 `git branch -D`；应单独审阅并确认。不得清理脏 worktree、
+未合并分支、stash、所有权不明的任务，也不得用通配符批量删除临时目录。
 
 ---
 


### PR DESCRIPTION
Summary:
- reuse one task worktree through implementation, validation, review, and PR
- close worktrees only after terminal checks and confirmed containment in origin/main
- route releases through a release branch and protected-main PR

Checks:
- git diff --check
- ./.venv/bin/python scripts/guardrails_check.py --check-doc-wording --check-runtime-config-tracking --check-sensitive-artifacts

Scope:
- documentation only
- no VERSION, tag, GitHub Release, deployment, or production change