### PR TITLE
fix(quality): avoid historical audit scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+- Stopped runtime quality refreshes from scanning complete historical trade-intake audit logs while preserving explicit reconciliation access to that evidence.
+
 ## 3.2.0 - 2026-09-01
 
 ### New Features

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1016 (`src`: 543, `domain`: 76, `scripts`: 12, `tests`: 385)
-- Internal import edges: 6791 total, 2947 production/script edges excluding tests
+- Internal import edges: 6792 total, 2947 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,7 +46,7 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2831| application
+  tests -->|2832| application
   tests -->|453| domain
   tests -->|2| domain_services
   tests -->|233| infrastructure
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2831 |
+| tests | application | 2832 |
 | tests | domain | 453 |
 | tests | interfaces | 238 |
 | tests | infrastructure | 233 |

--- a/src/application/agent_tools/runtime_status_impl.py
+++ b/src/application/agent_tools/runtime_status_impl.py
@@ -181,7 +181,6 @@ def _trade_intake_summary(state_json: dict[str, Any], status_json: dict[str, Any
 def _trade_intake_reconciliation_summary(
     *,
     state_path: Path,
-    audit_path: Path,
     ledger_store: dict[str, Any],
 ) -> dict[str, Any]:
     sqlite_path_raw = ledger_store.get("sqlite_path")
@@ -198,7 +197,6 @@ def _trade_intake_reconciliation_summary(
     try:
         preview = preview_trade_intake_reconciliation_from_sqlite(
             state_path=state_path,
-            audit_path=audit_path,
             sqlite_path=Path(str(sqlite_path_raw)).expanduser(),
         )
     except Exception as exc:
@@ -2209,7 +2207,6 @@ def private_runtime_status_tool(
                 source_summary.update(
                     _trade_intake_reconciliation_summary(
                         state_path=source_state_path,
-                        audit_path=source_audit_path,
                         ledger_store=ledger_store,
                     )
                 )
@@ -2273,15 +2270,9 @@ def private_runtime_status_tool(
                 if payload.get("trade_intake_state_path")
                 else default_intake_state_path
             )
-            resolved_legacy_audit_path = (
-                _path_from_config(payload.get("trade_intake_audit_path"), base=base)
-                if payload.get("trade_intake_audit_path")
-                else default_intake_audit_path
-            )
             trade_intake_summary.update(
                 _trade_intake_reconciliation_summary(
                     state_path=resolved_legacy_state_path,
-                    audit_path=resolved_legacy_audit_path,
                     ledger_store=ledger_store,
                 )
             )

--- a/tests/test_agent_plugin_smoke.py
+++ b/tests/test_agent_plugin_smoke.py
@@ -2391,6 +2391,35 @@ def test_runtime_status_reads_account_trade_intake_sources(tmp_path: Path) -> No
     assert trade["summary"]["last_backfill_applied_count"] == 1
 
 
+def test_runtime_status_reconciliation_preview_skips_historical_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.agent_tools.runtime_status_impl as runtime_status
+
+    calls: list[dict[str, Any]] = []
+
+    def _preview(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"available": True}
+
+    monkeypatch.setattr(
+        runtime_status,
+        "preview_trade_intake_reconciliation_from_sqlite",
+        _preview,
+    )
+    state_path = tmp_path / "state.json"
+    sqlite_path = tmp_path / "ledger.sqlite3"
+
+    summary = runtime_status._trade_intake_reconciliation_summary(
+        state_path=state_path,
+        ledger_store={"sqlite_path": str(sqlite_path)},
+    )
+
+    assert calls == [{"state_path": state_path, "sqlite_path": sqlite_path}]
+    assert summary["reconciliation_preview_available"] is True
+
+
 def test_runtime_status_reports_config_authority(tmp_path: Path) -> None:
 
     cfg_path = tmp_path / "config.us.json"


### PR DESCRIPTION
## Summary
- stop runtime quality refreshes from passing complete trade-intake audit logs into reconciliation previews
- preserve audit metadata and explicit manual reconciliation access
- add a regression test and refresh the generated dependency graph

## Verification
- focused runtime-status, trade-intake, and quality tests passed
- Agent contract, Ruff, guardrails, dependency graph, and sensitive-artifact checks passed
- DeepReview found no medium or high findings

No VERSION change, release, deployment, or production mutation.