### PR TITLE
feat: auto-group exact Combo Yield fills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### New Features
+- Added account-scoped automatic Combo Yield adoption for uniquely matched, delivery-confirmed Funding Put and Participation Call fills, with successful grouping shown in the trade receipt.
+
 ### Bug Fixes
 - Stopped runtime quality refreshes from scanning complete historical trade-intake audit logs while preserving explicit reconciliation access to that evidence.
 

--- a/docs/FUTU_TRADE_HOLDINGS_SYNC.md
+++ b/docs/FUTU_TRADE_HOLDINGS_SYNC.md
@@ -152,6 +152,30 @@ payload hash。任一来源不完整、日历 hash 变化、零价锚点无法�
 
 ## 通知 Outbox 与批量回执
 
+### Combo Yield 自动归组
+
+自动归组按账户显式开启；默认仍关闭：
+
+```yaml
+trade_intake:
+  combo_reconciliation:
+    default_mode: off
+    accounts:
+      sy: auto
+```
+
+`auto` 只自动采用 `exact_delivered_candidate`、没有候选替代项且属于唯一最优解的
+Put + Call 配对；缺证据或多解继续停在待确认状态。第二腿归组成功后，成交回执显示
+`组合｜✅ 已自动归入 Combo Yield（Funding Put + Participation Call）`。
+
+`observe` 只记录提案，`confirm` 生成提案并要求人工执行 `confirm-combo`；`auto` 下仍可
+手工确认未被自动采用的提案。
+
+成交先持久化，再执行每组独立事务的 adoption，最后渲染回执。单组 adoption 失败不会回滚已记录
+成交，也不会把失败提案标成成功；错误保留在 reconciliation 结果中，提案继续等待后续自动重试或
+人工确认。把账户改回 `confirm` 或 `off` 只影响后续自动采用，不拆除既有组合；既有误归组使用
+`supersede-combo` 的 append-only 回滚路径。
+
 普通开仓成交保留逐 broker deal 的 intake 回执；已处理的 deal 在
 history backfill 中会于 pipeline 之前跳过，不会因回执未确认而重放交易。
 provider 命令已成功但缺少 delivery confirmation 时记为

--- a/src/application/trades/account_mapping.py
+++ b/src/application/trades/account_mapping.py
@@ -139,9 +139,9 @@ def resolve_combo_reconciliation_config(
             raise ValueError(
                 f"trade_intake.combo_reconciliation.accounts.{account} is not a configured account"
             )
-        if mode not in {"off", "observe", "confirm"}:
+        if mode not in {"off", "observe", "confirm", "auto"}:
             raise ValueError(
-                f"trade_intake.combo_reconciliation.accounts.{account} must be off, observe, or confirm"
+                f"trade_intake.combo_reconciliation.accounts.{account} must be off, observe, confirm, or auto"
             )
         account_modes[account] = mode
     return {

--- a/src/application/trades/auto_intake.py
+++ b/src/application/trades/auto_intake.py
@@ -272,6 +272,7 @@ def _process_payload(
     config: dict[str, Any] | None = None,
     config_path: Path | None = None,
     runtime_root: Path | None = None,
+    before_receipt_fn: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
     on_result_fn: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
     retry_failed_deal: bool = False,
     source: str = "push",
@@ -355,6 +356,7 @@ def _process_payload(
         enrich_trade_payload_fn=_enrich_payload if allow_external_lookup else None,
         normalize_trade_deal_fn=normalize_fn,
         resolve_trade_deal_fn=_resolve_with_wheel_intent,
+        before_receipt_fn=before_receipt_fn,
         on_result_fn=on_result_fn,
         portfolio_management_enabled=is_portfolio_management_enabled(config),
         retry_failed_deal=retry_failed_deal,
@@ -747,6 +749,9 @@ def main(argv: list[str] | None = None) -> int:
                 receipt_config=intake_cfg["receipt"],
                 repo=repo,
             )
+            combo_mode = str(
+                manual_source.get("combo_reconciliation_mode") or "off"
+            ).strip().lower()
             result = _process_payload(
                 payload,
                 repo=repo,
@@ -760,32 +765,29 @@ def main(argv: list[str] | None = None) -> int:
                 config=cfg,
                 config_path=cfg_path,
                 runtime_root=runtime_root,
+                before_receipt_fn=lambda current: _attach_combo_reconciliation_after_open(
+                    current,
+                    apply_changes=apply_changes,
+                    mode=combo_mode,
+                    reconcile_fn=lambda: reconcile_account_post_trade_combos(
+                        repo=repo,
+                        runtime_root=runtime_root,
+                        account=str(
+                            current.get("account")
+                            or manual_source.get("account")
+                            or ""
+                        ),
+                        runtime_environment=trade_combo_runtime_environment(
+                            host=manual_host,
+                            port=manual_port,
+                        ),
+                        mode=combo_mode,
+                    ),
+                ),
                 on_result_fn=receipt_callback,
                 retry_failed_deal=bool(args.retry_failed),
                 source="manual",
                 allow_external_lookup=bool(apply_changes),
-            )
-            combo_mode = str(
-                manual_source.get("combo_reconciliation_mode") or "off"
-            ).strip().lower()
-            _attach_combo_reconciliation_after_open(
-                result,
-                apply_changes=apply_changes,
-                mode=combo_mode,
-                reconcile_fn=lambda: reconcile_account_post_trade_combos(
-                    repo=repo,
-                    runtime_root=runtime_root,
-                    account=str(
-                        result.get("account")
-                        or manual_source.get("account")
-                        or ""
-                    ),
-                    runtime_environment=trade_combo_runtime_environment(
-                        host=manual_host,
-                        port=manual_port,
-                    ),
-                    mode=combo_mode,
-                ),
             )
         if apply_changes:
             _write_listener_status(
@@ -1550,16 +1552,18 @@ def _run_listener_source_loop(
     ) -> dict[str, Any]:
         if apply_changes:
             _ensure_settlement_gateways()
-        result = _process_payload(payload, **kwargs)
-        if not apply_changes:
-            return result
-        if str(kwargs.get("source") or "").strip().lower() != "backfill":
-            _attach_combo_reconciliation_after_open(
-                result,
+        result = _process_payload(
+            payload,
+            before_receipt_fn=lambda current: _attach_combo_reconciliation_after_open(
+                current,
                 apply_changes=apply_changes,
                 mode=combo_mode,
                 reconcile_fn=_run_combo_reconciliation,
-            )
+            ),
+            **kwargs,
+        )
+        if not apply_changes:
+            return result
         try:
             timing = ensure_lifecycle_timing_after_intake(
                 repo,

--- a/src/application/trades/combo_reconciliation.py
+++ b/src/application/trades/combo_reconciliation.py
@@ -7,11 +7,12 @@ from src.application.daily_decision_brief_repository import (
     read_combo_candidate_exposures,
 )
 from src.application.ledger.api import (
+    adopt_post_trade_combo_pair,
     reconcile_combo_pair_inferences,
 )
 
 
-_ENABLED_MODES = {"observe", "confirm"}
+_ENABLED_MODES = {"observe", "confirm", "auto"}
 
 
 def trade_combo_runtime_environment(*, host: str, port: int) -> str:
@@ -33,12 +34,12 @@ def reconcile_account_post_trade_combos(
     mode: str,
     effective_now_ms: int | None = None,
 ) -> dict[str, Any]:
-    """Reconcile one account after trade commit without changing Combo membership."""
+    """Reconcile one account after trade commit and adopt only strict auto matches."""
 
     account_value = str(account or "").strip().lower()
     mode_value = str(mode or "off").strip().lower()
     if mode_value not in {"off", *_ENABLED_MODES}:
-        raise ValueError("combo reconciliation mode must be off, observe, or confirm")
+        raise ValueError("combo reconciliation mode must be off, observe, confirm, or auto")
     if not account_value:
         raise ValueError("combo reconciliation requires account")
     if mode_value == "off":
@@ -100,11 +101,44 @@ def reconcile_account_post_trade_combos(
         persist=True,
         effective_now_ms=effective_now_ms,
     )
+    auto_adoptions = []
+    auto_adoption_errors = []
+    if mode_value == "auto":
+        for inference in reconciled.get("inferences") or []:
+            if not (
+                inference.get("status") == "proposal_ready"
+                and inference.get("evidence_grade") == "exact_delivered_candidate"
+                and not inference.get("alternative_inference_ids")
+                and inference.get("selected_in_one_optimum") is True
+            ):
+                continue
+            try:
+                adopted = adopt_post_trade_combo_pair(
+                    repo=repo,
+                    inference_id=str(inference["inference_id"]),
+                    expected_input_hash=str(inference["input_snapshot_hash"]),
+                    actor="trade_intake:auto_combo_reconciliation",
+                    apply_changes=True,
+                    effective_now_ms=effective_now_ms,
+                )
+            except Exception as exc:
+                auto_adoption_errors.append(
+                    {
+                        "inference_id": inference["inference_id"],
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
+            else:
+                auto_adoptions.append(adopted)
     return {
         **reconciled,
         "status": "reconciled",
         "mode": mode_value,
         "evidence_reads": evidence_reads,
+        "auto_adoption_count": len(auto_adoptions),
+        "auto_adoptions": auto_adoptions,
+        "auto_adoption_error_count": len(auto_adoption_errors),
+        "auto_adoption_errors": auto_adoption_errors,
     }
 
 

--- a/src/application/trades/intake.py
+++ b/src/application/trades/intake.py
@@ -489,6 +489,7 @@ def process_trade_payload(
     enrich_trade_payload_fn: Callable[[dict[str, Any]], TradePayloadEnrichmentReturn] | None,
     normalize_trade_deal_fn: Callable[..., Any],
     resolve_trade_deal_fn: Callable[..., Any],
+    before_receipt_fn: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
     on_result_fn: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
     portfolio_management_enabled: bool = False,
     retry_failed_deal: bool = False,
@@ -721,6 +722,10 @@ def process_trade_payload(
                 payload=payload,
             )
             write_trade_intake_state_fn(state_path, state)
+    if before_receipt_fn is not None:
+        enriched_result = before_receipt_fn(result_dict)
+        if isinstance(enriched_result, dict):
+            result_dict = enriched_result
     return _finalize_trade_payload_result(
         result_dict=result_dict,
         state=state,

--- a/src/application/trades/receipt.py
+++ b/src/application/trades/receipt.py
@@ -751,7 +751,9 @@ def build_trade_intake_receipt_message(
         )
     if ledger_store:
         fields.append(("账本", ledger_store.get("sqlite_path") or "-"))
-    if _combo_yield_relation_pending(diagnostics):
+    if _matching_auto_combo_adoption(result):
+        fields.append(("组合", "✅ 已自动归入 Combo Yield（Funding Put + Participation Call）"))
+    elif _combo_yield_relation_pending(diagnostics):
         fields.append(("组合", "关系待确认；未提供 pair_intent_id，当前按单腿记录，未自动归入 Combo Yield 组。"))
     fields.append(("诊断", reason))
     sections: list[tuple[str, list[str]]] = []
@@ -778,6 +780,30 @@ def _combo_yield_relation_pending(diagnostics: dict[str, Any]) -> bool:
     for key in ("combo_yield_enrichment", "position_effect_inference"):
         item = diagnostics.get(key)
         if isinstance(item, dict) and bool(item.get("combination_relation_pending")):
+            return True
+    return False
+
+
+def _matching_auto_combo_adoption(result: dict[str, Any]) -> bool:
+    event_ids = {
+        str(item.get("event_id") or "").strip()
+        for item in result.get("operations") or []
+        if isinstance(item, dict)
+    }
+    reconciliation = result.get("combo_reconciliation")
+    if not event_ids or not isinstance(reconciliation, dict):
+        return False
+    for adoption in reconciliation.get("auto_adoptions") or []:
+        if not isinstance(adoption, dict) or adoption.get("status") not in {
+            "adopted",
+            "already_confirmed",
+        }:
+            continue
+        inference = adoption.get("inference")
+        if isinstance(inference, dict) and event_ids & {
+            str(inference.get("put_open_event_id") or "").strip(),
+            str(inference.get("call_open_event_id") or "").strip(),
+        }:
             return True
     return False
 

--- a/src/interfaces/cli/option_positions.py
+++ b/src/interfaces/cli/option_positions.py
@@ -331,12 +331,12 @@ def _require_combo_confirmation_mode(
         )
     if not config_path.exists():
         raise SystemExit(
-            f"confirm-combo apply requires a runtime config with account mode=confirm: {config_path}"
+            f"confirm-combo apply requires a runtime config with account mode=confirm or auto: {config_path}"
         )
     config = _load_json_object(config_path)
     account = normalize_account(inference.get("account"))
     mode = combo_reconciliation_mode_for_account(config, account=account)
-    if mode != "confirm":
+    if mode not in {"confirm", "auto"}:
         raise SystemExit(
             f"confirm-combo apply is disabled for account {account}: effective mode={mode}"
         )

--- a/tests/test_config_yaml.py
+++ b/tests/test_config_yaml.py
@@ -1668,7 +1668,7 @@ trade_intake:
   combo_reconciliation:
     default_mode: off
     accounts:
-      lx: observe
+      lx: auto
 markets:
   us:
     accounts: [lx]
@@ -1684,7 +1684,7 @@ markets:
 
     assert cfg["trade_intake"]["combo_reconciliation"] == {
         "default_mode": "off",
-        "accounts": {"lx": "observe"},
+        "accounts": {"lx": "auto"},
     }
 
 

--- a/tests/test_option_positions_cli.py
+++ b/tests/test_option_positions_cli.py
@@ -303,6 +303,15 @@ def test_combo_confirmation_mode_is_account_scoped_and_fail_closed(
         inference=inference,
     )["mode"] == "confirm"
 
+    config = json.loads(confirm_path.read_text(encoding="utf-8"))
+    config["trade_intake"]["combo_reconciliation"]["accounts"]["lx"] = "auto"
+    confirm_path.write_text(json.dumps(config), encoding="utf-8")
+    assert cli_mod._require_combo_confirmation_mode(
+        base=tmp_path,
+        args=args,
+        inference=inference,
+    )["mode"] == "auto"
+
 
 def _write_data_config(path: Path, *, sqlite_path: Path) -> Path:
     payload = {

--- a/tests/test_trades_auto_intake_audit.py
+++ b/tests/test_trades_auto_intake_audit.py
@@ -1141,6 +1141,7 @@ def test_process_payload_records_receipt_state_after_applied(tmp_path: Path) -> 
 
     writes: list[dict] = []
     events: list[dict] = []
+    receipt_results: list[dict] = []
 
     out = process_trade_payload(
         {"deal_id": "deal-receipt-1"},
@@ -1156,10 +1157,16 @@ def test_process_payload_records_receipt_state_after_applied(tmp_path: Path) -> 
         enrich_trade_payload_fn=None,
         normalize_trade_deal_fn=lambda payload, futu_account_mapping=None: deal,
         resolve_trade_deal_fn=lambda *_args, **_kwargs: _Result(),
-        on_result_fn=lambda _context: {"status": "sent", "delivery_confirmed": True, "message_id": "msg-1"},
+        before_receipt_fn=lambda result: {
+            **result,
+            "combo_reconciliation": {"status": "reconciled"},
+        },
+        on_result_fn=lambda context: receipt_results.append(context["result"])
+        or {"status": "sent", "delivery_confirmed": True, "message_id": "msg-1"},
     )
 
     assert out["receipt"]["status"] == "sent"
+    assert receipt_results[0]["combo_reconciliation"]["status"] == "reconciled"
     receipt = writes[-1]["processed_deal_ids"][
         "futu:lx:REAL_1:deal-receipt-1"
     ]["receipt"]

--- a/tests/test_trades_combo_reconciliation.py
+++ b/tests/test_trades_combo_reconciliation.py
@@ -58,7 +58,7 @@ def _event(
     )
 
 
-def test_account_reconciler_reads_frozen_exposure_and_persists_only_inference(
+def test_account_reconciler_reads_frozen_exposure_and_auto_adopts_strict_match(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -137,6 +137,30 @@ def test_account_reconciler_reads_frozen_exposure_and_persists_only_inference(
         not item["fields"].get("strategy_group_id")
         for item in repo.list_position_lots()
     )
+
+    adoptions: list[dict] = []
+
+    def _adopt(**kwargs):
+        adoptions.append(kwargs)
+        return {
+            "status": "adopted",
+            "inference": result["inferences"][0],
+        }
+
+    monkeypatch.setattr(module, "adopt_post_trade_combo_pair", _adopt)
+    auto_result = reconcile_account_post_trade_combos(
+        repo=repo,
+        runtime_root=tmp_path,
+        account="lx",
+        runtime_environment="opend:127.0.0.1:11111",
+        mode="auto",
+        effective_now_ms=BASE_TIME_MS + 4_000,
+    )
+
+    assert auto_result["auto_adoption_count"] == 1
+    assert adoptions[0]["inference_id"] == result["inferences"][0]["inference_id"]
+    assert adoptions[0]["actor"] == "trade_intake:auto_combo_reconciliation"
+    assert adoptions[0]["apply_changes"] is True
 
 
 def test_off_mode_does_not_touch_the_repository(tmp_path) -> None:

--- a/tests/test_trades_receipt.py
+++ b/tests/test_trades_receipt.py
@@ -745,6 +745,40 @@ def test_build_trade_intake_receipt_message_marks_same_expiry_combo_relation_pen
     assert "未自动归入 Combo Yield 组" in msg
 
 
+def test_build_trade_intake_receipt_message_reports_auto_combo_adoption() -> None:
+    msg = build_trade_intake_receipt_message(
+        deal=None,
+        result={
+            "status": "applied",
+            "reason": "applied_open",
+            "deal_id": "call-open",
+            "account": "sy",
+            "action": "open",
+            "operations": [{"event_id": "call-open"}],
+            "diagnostics": {
+                "combo_yield_enrichment": {
+                    "combination_relation_pending": True,
+                }
+            },
+            "combo_reconciliation": {
+                "auto_adoptions": [
+                    {
+                        "status": "adopted",
+                        "inference": {
+                            "put_open_event_id": "put-open",
+                            "call_open_event_id": "call-open",
+                        },
+                    }
+                ]
+            },
+        },
+        payload={"symbol": "0700.HK"},
+    )
+
+    assert "组合｜✅ 已自动归入 Combo Yield" in msg
+    assert "关系待确认" not in msg
+
+
 def test_trade_receipt_preserves_normalized_feishu_size_error(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("OM_FEISHU_BOT_USER_OPEN_ID", "ou_bot")
     out = send_trade_intake_receipt(


### PR DESCRIPTION
## Summary
- add account-scoped `auto` post-trade Combo reconciliation
- adopt only delivery-confirmed, unique optimal Funding Put + Participation Call pairs
- reconcile before receipt rendering and report successful automatic grouping
- keep ambiguous or failed proposals available for manual confirmation

## Safety and rollback
- reuse the existing atomic adoption transaction and compare-and-set inference hash
- an adoption failure does not roll back the durable broker fill or claim success
- changing an account back to `confirm` or `off` stops future automatic adoption
- existing incorrect groups use the append-only `supersede-combo` rollback path

## Verification
- 5856 full-suite tests passed
- 508 trade/position/Combo tests passed
- 576 config/control/agent tests passed
- Ruff, dependency graph, guardrails, US/HK config validate and build dry-runs passed