### PR TITLE
refactor(combo): retire staggered-expiry compat paths

### DIFF
--- a/domain/domain/combo_yield_lifecycle.py
+++ b/domain/domain/combo_yield_lifecycle.py
@@ -31,10 +31,8 @@ def _expiry_structure(row: dict[str, Any]) -> str:
     if value:
         return _text(value).lower()
     structure_mode = _text(snapshot_fields.get("structure_mode") or row.get("structure_mode")).lower()
-    if structure_mode == "staggered_expiry_pair":
-        return "diagonal"
-    if structure_mode == "same_expiry_pair":
-        return "same_expiry"
+    if structure_mode and structure_mode != "same_expiry_pair":
+        return "unknown"
     return "same_expiry"
 
 

--- a/domain/domain/engine/combo_yield.py
+++ b/domain/domain/engine/combo_yield.py
@@ -502,8 +502,9 @@ def combo_yield_proposed_gate_reasons(
         if _safe_float(row.get(field)) is None:
             reasons.append(field)
 
-    gap = _expiry_gap_days(row)
-    if gap is None or gap != 0:
+    put_expiration = str(row.get("put_expiration") or "")[:10]
+    call_expiration = str(row.get("call_expiration") or "")[:10]
+    if not put_expiration or not call_expiration or put_expiration != call_expiration:
         reasons.append("same_expiry")
     if spot is None or call_strike is None or call_strike < spot:
         reasons.append("call_strike_below_spot")
@@ -597,20 +598,6 @@ def _positive_int(value: Any) -> int | None:
     except (TypeError, ValueError):
         return None
     return parsed if parsed >= 1 else None
-
-
-def _expiry_gap_days(row: dict[str, Any]) -> int | None:
-    direct = _safe_float(row.get("expiry_gap_days"))
-    if direct is not None:
-        return int(direct)
-    try:
-        from datetime import date
-
-        put_expiry = date.fromisoformat(str(row.get("put_expiration") or "")[:10])
-        call_expiry = date.fromisoformat(str(row.get("call_expiration") or "")[:10])
-    except (TypeError, ValueError):
-        return None
-    return (call_expiry - put_expiry).days
 
 
 def _typed_rank_key(values: tuple[Any, ...]) -> list[dict[str, Any]]:

--- a/domain/domain/performance/attribution.py
+++ b/domain/domain/performance/attribution.py
@@ -109,9 +109,10 @@ def resolve_expiry_structure_from_fields(
 ) -> str | None:
     """Resolve Combo expiry structure with the same fallback as the lifecycle layer.
 
-    Explicit ``expiry_structure`` wins; otherwise ``structure_mode`` maps legacy
-    ``staggered_expiry_pair`` to ``diagonal`` and ``same_expiry_pair`` to
-    ``same_expiry``. Missing structure metadata stays ``None`` so production
+    Explicit ``expiry_structure`` wins; otherwise ``structure_mode`` maps
+    ``same_expiry_pair`` to ``same_expiry`` and any other explicit value to
+    ``unknown`` (fail-closed: unsupported structures must not be treated as
+    same-expiry). Missing structure metadata stays ``None`` so production
     same-expiry rows keep their serialized shape.
     """
     snapshot = snapshot if isinstance(snapshot, Mapping) else {}
@@ -122,10 +123,10 @@ def resolve_expiry_structure_from_fields(
     structure_mode = (
         _text(snapshot.get("structure_mode")) or _text(payload.get("structure_mode"))
     ).lower()
-    if structure_mode == "staggered_expiry_pair":
-        return "diagonal"
     if structure_mode == "same_expiry_pair":
         return "same_expiry"
+    if structure_mode:
+        return "unknown"
     return None
 
 

--- a/src/application/config_validator.py
+++ b/src/application/config_validator.py
@@ -665,16 +665,6 @@ def _validate_optional_dte_window(cfg: dict, path: str):
 def _validate_combo_yield_cfg(cfg: dict, path: str):
     if not isinstance(cfg, dict):
         die(f'{path} must be an object')
-    removed_gap_keys = [
-        key
-        for key in ('min_expiry_gap_days', 'max_expiry_gap_days')
-        if key in cfg
-    ]
-    if removed_gap_keys:
-        die(
-            f"{path} has removed staggered-expiry gap fields: {', '.join(removed_gap_keys)}; "
-            "Combo Yield supports same_expiry_pair only"
-        )
     _reject_unknown_keys(cfg, COMBO_YIELD_ALLOWED_FIELDS, path)
     _validate_optional_bool(cfg, 'enabled', path)
     removed_funding_keys = [

--- a/src/application/shadow_replay/combo_variants.py
+++ b/src/application/shadow_replay/combo_variants.py
@@ -96,17 +96,31 @@ def normalize_combo_variant_spec(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_COMBO_VARIANT_ALLOWED_FIELDS = frozenset(
+    {
+        "variant_id",
+        "structure_mode",
+        "min_net_credit_retention",
+        "max_call_cost_to_put_credit",
+        "min_abs_call_delta",
+        "target_abs_call_delta",
+        "max_abs_call_delta",
+    }
+)
+
+
+def _reject_unknown_variant_keys(raw: dict[str, Any]) -> None:
+    unknown = sorted(str(key) for key in raw if str(key) not in _COMBO_VARIANT_ALLOWED_FIELDS)
+    if not unknown:
+        return
+    raise ValueError(
+        "Combo variant contains unsupported keys: "
+        f"{', '.join(unknown)}; Combo Yield supports same_expiry_pair only"
+    )
+
+
 def combo_research_policy_from_dict(raw: dict[str, Any]) -> ComboYieldResearchPolicy:
-    removed_gap_keys = [
-        key
-        for key in ("min_expiry_gap_days", "target_expiry_gap_days", "max_expiry_gap_days")
-        if key in raw
-    ]
-    if removed_gap_keys:
-        raise ValueError(
-            "Combo variant has removed staggered-expiry gap fields: "
-            f"{', '.join(removed_gap_keys)}; Combo Yield supports same_expiry_pair only"
-        )
+    _reject_unknown_variant_keys(raw)
     mode = text(raw.get("structure_mode")).lower()
     return ComboYieldResearchPolicy(
         variant_id=text(raw.get("variant_id")),

--- a/tests/test_combo_yield_lifecycle.py
+++ b/tests/test_combo_yield_lifecycle.py
@@ -5,7 +5,12 @@ import src.application.ledger.repository as ledger_repository
 from domain.domain.combo_yield_lifecycle import build_full_group_lifecycle, build_option_group_inventory
 
 
-def _lot(record_id: str, *, option_type: str, side: str, opened: int, open_count: int, expiration: str, group_id: str | None, structure: str = "same_expiry") -> dict:
+def _lot(record_id: str, *, option_type: str, side: str, opened: int, open_count: int, expiration: str, group_id: str | None, structure: str | None = "same_expiry", structure_mode: str | None = None) -> dict:
+    snapshot: dict = {}
+    if structure is not None:
+        snapshot["expiry_structure"] = structure
+    if structure_mode is not None:
+        snapshot["structure_mode"] = structure_mode
     return {
         "record_id": record_id,
         "account": "lx",
@@ -19,7 +24,7 @@ def _lot(record_id: str, *, option_type: str, side: str, opened: int, open_count
         "strategy": "combo_yield",
         "leg_role": "sell_put" if option_type == "put" else "enhancement_call",
         "strategy_group_id": group_id,
-        "strategy_snapshot": {"expiry_structure": structure},
+        "strategy_snapshot": snapshot,
     }
 
 
@@ -113,6 +118,20 @@ def test_option_group_inventory_fails_closed_on_legacy_staggered_structure() -> 
     assert group["summary_classification"] == "review_required"
     assert "unsupported_expiry_structure" in group["inventory_issues"]
     assert "same_expiry_mismatch" not in group["inventory_issues"]
+
+
+def test_option_group_inventory_fails_closed_on_staggered_structure_mode_same_expiry() -> None:
+    group_id = "combo_yield:lx:pair-legacy-mode"
+    rows = [
+        _lot("put-1", option_type="put", side="short", opened=1, open_count=1, expiration="2026-08-21", group_id=group_id, structure=None, structure_mode="staggered_expiry_pair"),
+        _lot("call-1", option_type="call", side="long", opened=1, open_count=1, expiration="2026-08-21", group_id=group_id, structure=None, structure_mode="staggered_expiry_pair"),
+    ]
+
+    group = build_option_group_inventory(rows)[0]
+
+    assert group["expiry_structure"] == "unknown"
+    assert group["summary_classification"] == "review_required"
+    assert "unsupported_expiry_structure" in group["inventory_issues"]
 
 
 def test_manual_open_preview_projection_restart_reconstructs_same_expiry_group(tmp_path: Path) -> None:

--- a/tests/test_combo_yield_research.py
+++ b/tests/test_combo_yield_research.py
@@ -231,7 +231,17 @@ def test_proposed_dual_funding_gates_are_independent_and_equality_passes() -> No
     assert "max_call_cost_to_put_credit" in reasons
 
 
-def test_combo_research_policy_rejects_removed_expiry_gap_fields() -> None:
+def test_proposed_gate_rejects_expiry_gap_field_without_expirations() -> None:
+    policy = _policy()
+    row = dict(_pair())
+    row.pop("put_expiration", None)
+    row.pop("call_expiration", None)
+    # 仅带 expiry_gap_days=0 字段、缺真实到期日：必须拒绝，不得靠字段侥幸通过
+    reasons = combo_yield_proposed_gate_reasons(row, policy)
+    assert "same_expiry" in reasons
+
+
+def test_combo_research_policy_rejects_unknown_variant_keys() -> None:
     base = {
         "variant_id": "same-d20",
         "structure_mode": "same_expiry_pair",
@@ -240,9 +250,10 @@ def test_combo_research_policy_rejects_removed_expiry_gap_fields() -> None:
         "target_abs_call_delta": 0.20,
         "max_abs_call_delta": 0.30,
     }
-    for field in ("min_expiry_gap_days", "target_expiry_gap_days", "max_expiry_gap_days"):
-        with pytest.raises(ValueError):
+    for field in ("min_expiry_gap_days", "target_expiry_gap_days", "max_expiry_gap_days", "bogus_field"):
+        with pytest.raises(ValueError) as excinfo:
             combo_research_policy_from_dict({**base, field: 28})
+        assert "unsupported keys" in str(excinfo.value)
 
 
 def test_rank_provenance_keeps_original_put_rank_after_pair_filtering() -> None:

--- a/tests/test_combo_yield_validate_config.py
+++ b/tests/test_combo_yield_validate_config.py
@@ -290,7 +290,7 @@ def test_validate_config_rejects_invalid_template_combo_yield_call_bounds() -> N
     assert "templates.put_base.combo_yield.call.min_strike" in str(exc)
 
 
-def test_validate_config_rejects_removed_staggered_expiry_gap_fields() -> None:
+def test_validate_config_rejects_staggered_expiry_gap_fields_as_unknown_keys() -> None:
     from src.application.config_validator import validate_config
 
     cfg = {
@@ -301,7 +301,7 @@ def test_validate_config_rejects_removed_staggered_expiry_gap_fields() -> None:
                 "sell_put": {"enabled": True, "min_dte": 20, "max_dte": 60},
                 "combo_yield": {
                     "enabled": True,
-                    "structure_mode": "staggered_expiry_pair",
+                    "structure_mode": "same_expiry_pair",
                     "min_expiry_gap_days": 30,
                     "max_expiry_gap_days": 90,
                 },
@@ -313,7 +313,8 @@ def test_validate_config_rejects_removed_staggered_expiry_gap_fields() -> None:
     with pytest.raises(SystemExit) as _caught:
         validate_config(cfg)
     exc = _caught.value
-    assert "has removed staggered-expiry gap fields" in str(exc)
+    assert "contains unsupported keys" in str(exc)
+    assert "min_expiry_gap_days" in str(exc)
 
 
 def test_validate_config_rejects_absolute_call_dte_for_combo_yield() -> None:

--- a/tests/test_performance_attribution.py
+++ b/tests/test_performance_attribution.py
@@ -67,17 +67,7 @@ def test_production_form_without_expiry_structure_keeps_none() -> None:
     assert resolved.attribution.expiry_structure is None
 
 
-def test_legacy_structure_mode_maps_to_expiry_structure() -> None:
-    staggered = _open_event(
-        raw_payload={
-            "strategy_snapshot": {
-                "strategy": "combo_yield",
-                "leg_role": "funding_put",
-                "strategy_group_id": "combo_yield:lx:pair-1",
-                "structure_mode": "staggered_expiry_pair",
-            }
-        }
-    )
+def test_structure_mode_maps_to_expiry_structure() -> None:
     same_expiry = _open_event(
         raw_payload={
             "strategy_snapshot": {
@@ -89,16 +79,11 @@ def test_legacy_structure_mode_maps_to_expiry_structure() -> None:
         }
     )
 
-    staggered_resolved = resolve_event_attribution(
-        staggered, lifecycle_source_id=lot_id_for_open_event(staggered)
-    )
     same_expiry_resolved = resolve_event_attribution(
         same_expiry, lifecycle_source_id=lot_id_for_open_event(same_expiry)
     )
 
-    assert staggered_resolved.issues == ()
-    assert staggered_resolved.attribution is not None
-    assert staggered_resolved.attribution.expiry_structure == "diagonal"
+    assert same_expiry_resolved.issues == ()
     assert same_expiry_resolved.attribution is not None
     assert same_expiry_resolved.attribution.expiry_structure == "same_expiry"
 


### PR DESCRIPTION
## Summary
Remove the remaining staggered/diagonal compatibility logic from the Combo Yield surface while keeping fail-closed semantics.

## Changes
- lifecycle/attribution: non-`same_expiry_pair` `structure_mode` maps to `unknown` (replaces legacy `diagonal`), so unsupported structures are still rejected (`review_required` / `partial`) even when legs share expiry
- combo_yield gate: same-expiry check compares put/call expirations directly instead of trusting `expiry_gap_days`
- config_validator: removed staggered gap-key special-case rejection; unknown-keys guard still rejects them
- shadow replay: combo research policy rejects unknown variant keys symmetrically with config validation
- tests: regression coverage for staggered+same-expiry fail-closed, missing-expiration rejection, unknown variant keys

## Verification
- 324 related tests pass
- Runtime data verified: no staggered/diagonal records exist
- Deepreview (2 rounds): no high/medium findings remaining