### PR TITLE
docs(worktree): require terminal closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@
 - Preserve user changes in a dirty worktree. Never reset or revert unrelated files unless explicitly asked.
 - Worktrees are conditional isolation, not a per-phase default. Reuse the same task worktree through implementation,
   validation, review, and PR; create another only for a protected/shared branch, unrelated dirty changes, or parallel conflict.
-- Close a task worktree only after its PR and required checks are terminal; for a release, wait until the tag, GitHub
+- After a task PR and required checks are terminal, the same task must close its exact worktree and local branch before
+  declaring completion; for a release, wait until the tag, GitHub
   Release, target commit, and assets are verified. Require a clean status, proof that the branch is contained in
   `origin/main`, and no active owner before removing the exact worktree and local branch. Preserve dirty, unmerged,
   patch-equivalent-only, stashed, or owner-unknown work unless separately approved.


### PR DESCRIPTION
## Summary

- Require the same task to close its exact worktree and local branch after PR checks become terminal.
- Preserve the existing clean-status, origin/main ancestry, ownership, release, and dirty-worktree safety gates.

## Validation

- Repository Guardrails: passed
- git diff --check: passed
- Outgoing scope: AGENTS.md only

## Scope

Source-only documentation contract. No VERSION update, tag, Release, deployment, runtime mutation, or production write.