### PR TITLE
fix(strategy-lab): scope position evidence by market

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1009 (`src`: 541, `domain`: 78, `scripts`: 12, `tests`: 378)
-- Internal import edges: 6729 total, 2930 production/script edges excluding tests
+- Internal import edges: 6731 total, 2931 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,7 +31,7 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|442| domain
+  application -->|443| domain
   application -->|4| domain_services
   application -->|147| infrastructure
   application -->|41| storage
@@ -47,7 +47,7 @@ flowchart LR
   scripts -->|2| infrastructure
   storage -->|1| domain
   tests -->|2813| application
-  tests -->|426| domain
+  tests -->|427| domain
   tests -->|2| domain_services
   tests -->|233| infrastructure
   tests -->|238| interfaces
@@ -59,7 +59,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 442 |
+| application | domain | 443 |
 | interfaces | application | 164 |
 | application | infrastructure | 147 |
 | scripts | application | 45 |
@@ -80,7 +80,7 @@ flowchart LR
 | from | to | imports |
 |---|---|---|
 | tests | application | 2813 |
-| tests | domain | 426 |
+| tests | domain | 427 |
 | tests | interfaces | 238 |
 | tests | infrastructure | 233 |
 | tests | scripts | 23 |
@@ -93,7 +93,7 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 
 | from | to | imports |
 |---|---|---|
-| src.application | domain.domain | 226 |
+| src.application | domain.domain | 227 |
 | src.interfaces | src.application | 129 |
 | src.application | src.infrastructure | 105 |
 | src.application.ledger | domain.domain | 64 |
@@ -180,7 +180,7 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | module | incoming imports |
 |---|---|
 | src.application.agent_tool_contracts | 96 |
-| domain.domain.symbol_identity | 70 |
+| domain.domain.symbol_identity | 71 |
 | src.application.agent_tool_config | 62 |
 | src.application.ledger.api | 58 |
 | domain.domain.ledger.position_fields | 50 |

--- a/docs/STRATEGY_LAB_EXPERIMENT_PLATFORM_PRD.md
+++ b/docs/STRATEGY_LAB_EXPERIMENT_PLATFORM_PRD.md
@@ -3,7 +3,7 @@
 - **产品名称**：Strategy Lab
 - **产品范围**：用真实证据完成策略假设的历史研究、未来隐藏验证和可审计回执
 - **MVP Recipe**：Cash-Secured Put (CSP) 期权持仓市值集中度
-- **产品状态**：Phase 3 本地实现完成；远端自然 Tick 隔离门槛已通过；待 Phase 4 真实 20 日 / 10 日验收
+- **产品状态**：Phase 3 本地实现完成；远端自然 Tick 隔离门槛已通过；Phase 4 正式点持仓证据范围待修复后重新积累
 
 本文是 Strategy Lab 的产品权威。技术架构、代码复用和删除范围见
 [系统设计](STRATEGY_LAB_EXPERIMENT_PLATFORM_SYSTEM_DESIGN.md)；当前遗留实现与重建差距见
@@ -438,7 +438,10 @@ option_position_concentration_after
   / (全部已有期权绝对市值 + candidate_option_market_value_cny)
 ```
 
-计算包含同一账户全部未平仓期权，多空使用绝对市值、不相互抵消，按 underlying 分组并统一换算 CNY。
+计算包含同一账户、同一正式点市场的全部当前持有期权仓位，多空使用绝对市值、不相互抵消，按
+underlying 分组并统一换算 CNY。其他市场仓位不进入该正式点的分子、分母、mark 覆盖或因这些仓位
+额外产生的 FX 要求；正式点市场自身的候选换算 FX 仍是必需证据。prepared context 的账户身份、完整性
+和 `decision_snapshot_actionable` 仍按账户整体校验；任何当前持仓若无法识别市场，不能被静默忽略。
 不包含股票持仓、潜在接货金额或全部 Short Put 名义敞口。
 
 ### 12.4 安全边界
@@ -573,14 +576,17 @@ Research Archive 保存可供多种实验复用且事后不能可靠重建的事
 - accepted / rejected 候选及理由；
 - 合约、Bid、Ask、Bid/Ask Volume、Last、Volume、OI、IV、Greeks；
 - Strike、到期日、Multiplier、DTE、标的价格和 quote time；
-- 同账户全部未平仓期权 identity / 数量、推荐时点可用的 mark 和 FX；
+- 同账户、同正式点市场的全部当前持有期权 identity / 数量、推荐时点可用的 mark，以及这些持仓和正式点
+  候选换算所需的 FX；
 - 来源、接收时间、内容 hash 和数据状态。
 
 DTE、Mid、Spread、收益率和集中度等可重算值不重复保存。Tick 内的切换顺序固定为：扫描前 prepared
 context 只冻结持仓 identity / 数量和 FX；生产扫描及 required-data / opening artifact 持久化后，
-recommendation-point 路径按同一 run、account、formal point time 从这些既有 artifact 绑定每个持仓合约的
-exact mark ref/hash；Formal Corpus 必须从同一 prepared context 和冻结 required-data artifacts 重新构造
-binding 并与 point 中的值精确比较，通过后才封存。它不调用 provider，也不从其他 repository 补值。
+recommendation-point 路径按同一 run、account、market、formal point time 从这些既有 artifact 绑定当前
+正式点市场的每个持仓合约 exact mark ref/hash；Formal Corpus 必须从同一 prepared context 和冻结
+required-data artifacts 重新构造 binding 并与 point 中的值精确比较，通过后才封存。它不调用 provider，
+也不从其他市场、其他 run 或其他 repository 补值。进入 binding 的持仓必须同时满足 underlying identity
+市场、持仓 currency 和 mark market code 与正式点市场一致；冲突或未知值一律使该点不可评价。
 
 mark 必须复用现有 performance evidence 的唯一规范化口径：优先按 requested instrument key、其次按持仓
 已有 market code 精确匹配；缺 market code 时才以 option type、到期日、Strike、Multiplier 和非空代码

--- a/docs/STRATEGY_LAB_EXPERIMENT_PLATFORM_SYSTEM_DESIGN.md
+++ b/docs/STRATEGY_LAB_EXPERIMENT_PLATFORM_SYSTEM_DESIGN.md
@@ -1,7 +1,7 @@
 # Strategy Lab 统一策略实验平台系统设计
 
-- **状态**：Phase 3 本地实现完成；远端自然 Tick 隔离门槛已通过；待 Phase 4 真实数据验收
-- **日期**：2026-08-31
+- **状态**：Phase 3 本地实现完成；远端自然 Tick 隔离门槛已通过；Phase 4 正式点持仓证据范围待修复
+- **日期**：2026-09-02
 - **产品依据**：[Strategy Lab PRD](STRATEGY_LAB_EXPERIMENT_PLATFORM_PRD.md)
 - **首个 Recipe**：`sell_put_option_position_concentration`
 
@@ -30,7 +30,8 @@ Recipe preview
 4. 实验状态可在进程重启后恢复，重复命令和调度推进幂等；
 5. 旧实验库、旧命令和旧兼容路径不迁移；
 6. 首次完成前不引入 Strategy Lab 的 schema、Recipe 或合同版本体系；
-7. MVP 全局最多一个未终态实验，且不能增加生产 Tick 的 OpenD 调用数。
+7. MVP 全局最多一个未终态实验，且不能增加生产 Tick 的 OpenD 调用数；
+8. 正式点只绑定同账户、同市场的当前持有期权仓位，不要求取得其他市场的同期行情。
 
 ## 2. 总体架构
 
@@ -198,8 +199,8 @@ security identity 与 quota code 完全相同。已有 receipt、保护窗口和
 1. 从 formal point 读取实际封存的生产 Top1 作为 baseline；
 2. 读取同一点完整 accepted Cash-Secured Put (CSP) 候选，缺任一候选事实则该点不可评价；
 3. 对每个候选调用
-   `calculate_option_market_concentration_after()`，只使用同一 formal point 绑定的全部未平仓期权、mark 和
-   FX；
+   `calculate_option_market_concentration_after()`，只使用同一 formal point 绑定的同账户、同市场全部当前
+   持有期权、mark 和 FX；
 4. 调用 `rank_candidate_rows(mode="put", sell_put_ranking_profile=
    "option_market_concentration", near_return_threshold=...)`；
 5. 排序第一名为 challenger，保留候选、持仓、mark、FX 和排名输入的 ref/hash。
@@ -209,6 +210,35 @@ security identity 与 quota code 完全相同。已有 receipt、保护窗口和
 Recipe 不增加指派后股票集中度、全部 Short Put 名义敞口或其他新安全门槛。baseline 和 challenger
 都必须来自生产 accepted 集合。不得从 performance-evidence repository、其他 run 或后来的 quote
 回退补推荐时刻集中度输入。
+
+#### 5.2.1 持仓证据的市场范围
+
+正式点和冻结 required-data batch 都以 `market` 为边界。唯一 owner
+`build_option_position_evidence_binding()` 按以下顺序处理：
+
+1. 先校验 prepared receipt、账户 identity 和 `decision_snapshot_actionable`；所有 open position 仍通过现有
+   `_prepared_position()` 校验，不能因为属于其他市场而跳过坏行；
+2. 每条 open position 只调用一次现有 `resolve_symbol_identity()`；无法解析市场，或 identity currency 与
+   instrument currency 不一致时返回 `option_position_evidence_missing`。原始持仓存在 `market_code` 时，也必须
+   先解析并确认其 market 与 identity market 一致，不能先把冲突行当作其他市场过滤；
+3. 完成上述逐行一致性校验后，只把 identity market 等于正式点 market 的仓位放入一个
+   `selected_positions` 集合；最终匹配到的 mark `market_code` 也必须解析为该市场；
+4. required-data mark 查找、`open_option_positions`、mark coverage 和持仓产生的 FX currencies 全部只消费
+   `selected_positions`。正式点市场 currency 仍必须存在，供同市场候选换算使用；其他市场仓位不能额外引入
+   mark 或 FX 要求；
+5. `validate_option_position_evidence_binding(..., expected_market=...)` 对已生成 artifact 重复检查 position
+   identity market、currency 和 mark `market_code` 的同市场不变量，不能只依赖 content hash。
+
+同市场持仓缺少 required-data symbol、唯一合约行、有效 mark、时间一致性或 FX 时，正式点继续 fail closed。
+point producer 与 Formal Corpus verifier 都调用该 builder；`formal_corpus.py` 不增加第二套筛选。该修复不改变
+artifact schema、不新增 provider 调用，也不回填已经封存的失败正式点。没有同市场当前持仓是合法输入；此时
+binding 的持仓和 mark 列表为空，但仍保留正式点市场候选所需的 FX，集中度在加入 candidate 后计算。
+
+不采用以下方案：把其他市场持仓加入当前 Tick 批次会增加 provider 调用并破坏生产优先级；使用其他 run
+或上一交易窗口的 mark 会破坏同点时间一致性。若未来需要跨市场账户级集中度，应作为独立 Recipe 定义
+异步估值时点和证据合同，不扩展本次修复。现有 symbol alias fallback 可能把显式市场代码解析成另一市场；
+本修复以现有 identity 结果和 currency 一致性 fail closed，不在本 work unit 改写全局 alias 规则。修复后由
+自然正式点和 Corpus Health 回执验证同市场持仓的原批次覆盖率。
 
 ### 5.3 标准结果
 
@@ -246,7 +276,7 @@ CNY PnL 改善，从通过变体中选择唯一 leader；隐藏验证只评价�
 |---|---|---|---|
 | 推荐时刻 | 正式点、accepted/rejected 候选、生产 Top1 | Research Archive | 只读现有 artifact |
 | 推荐时刻 | 合约报价、Greeks、OI、DTE、标的价 | Research Archive | 只读 required-data / opening snapshot |
-| 推荐时刻 | 全部未平仓期权 identity / 数量、mark、FX | Formal Point artifact | 只读同 point 绑定事实；不跨 repository 回退 |
+| 推荐时刻 | 同账户、同市场全部当前持有期权 identity / 数量、mark、FX | Formal Point artifact | 只读同 point 绑定事实；不跨市场或 repository 回退 |
 | 20 日研究 | 入选 arm 的期权 1 分钟 K | OpenD | 闭市后按需请求 |
 | 10 日验证 | 锁定 arm 的 Bid / Bid Volume | OpenD | 盘中每分钟一个批次 |
 | 到期 | 标的未复权日收盘、FX、费用 | OpenD / performance evidence / fee-plan | 成熟后按需补全 |
@@ -257,14 +287,14 @@ Evidence cutover 只走一条路径：
    Strategy Lab mark；
 2. 原生产扫描完成并持久化 required-data / opening artifact；
 3. `tick_notification_flow.py` 在这些 artifact 可读后调用 `recommendation_point.py`；后者按同一
-   run/account/point time 从允许的 artifact 解析每个持仓合约的 exact mark，复用
+   run/account/market/point time 从允许的 artifact 解析当前正式点市场每个持仓合约的 exact mark，复用
    `performance/evidence_collection.py` 的合约行匹配、mark 选择和 `ValuationMarkFact` 规范化，生成
    `option_position_evidence_binding`；
 4. `formal_corpus.py` 重新读取 point 所引用的 prepared context 和冻结 required-data batch，用同一确定性
    builder 重建 position / mark / FX binding，并与 point 中的 binding 精确比较后封存；不调用 provider，
    不跨 run/repository 回退；
-5. 任一持仓合约未被原批次覆盖、source time 超出冻结 coherence 窗口、identity 或 hash 不一致时，point
-   `not_evaluable`，且不得新增 provider 请求。
+5. 任一同市场持仓合约未被原批次覆盖、source time 超出冻结 coherence 窗口、identity 或 hash 不一致时，
+   point `not_evaluable`；其他市场持仓不参与该点，且不得新增 provider 请求。
 
 现有 private helper 在原文件内提升为一个可复用
 `build_option_valuation_mark_fact(position, snapshot_rows, source_binding, formal_time_bounds)`，不另建 mark
@@ -596,7 +626,7 @@ MVP 保持 `blocked`；不在本设计中预建第二个 OpenD endpoint。
 | `src/application/tick_account_execution.py` | 取消 Strategy Lab 专用 `mark_evidence_accounts` 整仓刷新；不增加 Tick provider 调用 |
 | `src/application/prepared_option_positions_context.py` | 删除 Strategy Lab 触发的 `refresh_quotes=True` mark 路径和 prepared mark ready 要求；继续封存 position / FX 通用事实 |
 | `src/application/performance/evidence_collection.py` | 提升 `build_option_valuation_mark_fact()`，复用现有行匹配、mark 选择和 fact 构造；现有 performance 调用方改用同一实现 |
-| `src/application/recommendation_point.py` | 在原扫描 artifact 可读后组装唯一 `option_position_evidence_binding`；不请求 provider |
+| `src/application/recommendation_point.py` | 在共同 builder 内构造一次 `selected_positions`，据此组装并验证唯一 `option_position_evidence_binding`；不请求 provider |
 | `src/application/tick_notification_flow.py` | 固定“扫描 artifact durable -> recommendation point -> formal corpus”的调用顺序 |
 | `src/application/research/formal_corpus.py` | 从绑定的 prepared context 与冻结 required-data batch 重建 position / mark / FX binding，精确比较后封存；不调用 provider 或跨源回退 |
 
@@ -665,8 +695,15 @@ hash 与观测日期寻址，不写 ExperimentStore；过期只影响后续 prev
 
 1. `comparison.py`：完整配对、同合约 delta 零、缺点、`no_fill` 和两条判断；
 2. `recipe.py`：三个收益带、完整 accepted 集合、同 formal point 绑定、成熟 20 日窗口和缺失 fail closed；
-3. mark binding：midpoint、Last fallback、无价、crossed、重复匹配、缺 market code、多 lots、越界 source
-   time / 后续批次、deterministic fact/hash 和 provider 调用数为 0；
+3. mark binding 保留现有基础覆盖，并只新增五个回归断言：
+   - mixed HK/US prepared rows + HK required-data batch 时，positions、marks 和由持仓产生的 FX 只含 HK；
+   - 未知 market，或任一 position 的 identity / currency / 原始 market code 冲突时在筛选前 fail closed；同市场
+     mark market code 冲突也 fail closed，且 fixture 包含一条本会被误归为其他市场的冲突行；
+   - 同市场 required-data symbol 缺失时仍 fail closed；
+   - 对 binding 重新计算 hash 后混入跨市场 position，validator 仍拒绝；
+   - 一个 producer -> Formal Corpus 混合市场 fixture 能由共同 builder 精确重建并封存；
+   midpoint、Last fallback、无价、crossed、重复匹配、多 lots、时间边界、deterministic hash 和 provider 调用数
+   继续由现有测试证明，不为本修复重复建测试矩阵；
 4. `evidence.py`：分钟 K 多页 / 顺序 / 重复 / receipt readiness、Bid crossing、正 / 零 / 非法 raw Bid
    Volume、request / receive tolerance；分别断言 call/envelope 无效不写 artifact、requested code 行缺陷写 invalid
    artifact、完整行写 available artifact，且 observed/fill time 使用 received time；到期查询必须绑定实际
@@ -772,6 +809,9 @@ Strategy Lab focused suite；后续切片不得负责修复上一切片留下的
 
 ### Phase 4：真实数据验收
 
+- 只在共同 `build_option_position_evidence_binding()` 及其 validator 修复正式点市场范围；使用一个
+  `selected_positions` 驱动 position / mark / FX 输出，并用最小混合市场、冲突、缺失和 Formal Corpus 集成
+  回归证明 producer / verifier 合同一致；
 - 先确认 Research Archive readiness，再人工启动 20 日真实研究；
 - 只有可信 leader 才确认未来 10 日；
 - 到期后审计 Final Receipt 和生产 Tick 性能。

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  src_application["src.application"] -->|226| domain_domain["domain.domain"]
+  src_application["src.application"] -->|227| domain_domain["domain.domain"]
   src_interfaces["src.interfaces"] -->|129| src_application["src.application"]
   src_application["src.application"] -->|105| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|64| domain_domain["domain.domain"]

--- a/src/application/recommendation_point.py
+++ b/src/application/recommendation_point.py
@@ -18,6 +18,7 @@ from domain.domain.performance.models import (
     ValuationMarkFact,
     canonical_decimal_text,
 )
+from domain.domain.symbol_identity import resolve_symbol_identity
 from src.application.candidate_snapshot_contract import (
     CandidateSnapshotContractError,
     utc_timestamp,
@@ -706,13 +707,28 @@ def build_option_position_evidence_binding(
     ):
         _fail("option_position_evidence_missing", "prepared position facts are unavailable")
 
-    positions: list[OptionValuationPosition] = []
+    selected_positions: list[OptionValuationPosition] = []
     for row in position_rows:
         if not isinstance(row, Mapping):
             _fail("option_position_evidence_missing", "prepared option lot is invalid")
         if str(row.get("status") or "").strip().lower() != "open":
             continue
-        positions.append(_prepared_position(row, account=account))
+        position = _prepared_position(row, account=account)
+        identity = resolve_symbol_identity(position.instrument.symbol)
+        if identity is None or identity.currency != position.instrument.currency:
+            _fail(
+                "option_position_evidence_missing",
+                f"{position.instrument.symbol} market identity conflicts with its currency",
+            )
+        if position.market_code:
+            code_identity = resolve_symbol_identity(position.market_code)
+            if code_identity is None or code_identity.market != identity.market:
+                _fail(
+                    "option_position_evidence_missing",
+                    f"{position.instrument.symbol} market code conflicts with its identity",
+                )
+        if identity.market == market:
+            selected_positions.append(position)
     rows_by_symbol: dict[str, tuple[list[dict[str, Any]], dict[str, Any]]] = {}
     for symbol, raw_entry in required_data_entries.items():
         entry, csv_bytes = raw_entry
@@ -729,7 +745,7 @@ def build_option_position_evidence_binding(
 
     marks_by_instrument: dict[str, dict[str, Any]] = {}
     market_code_by_instrument: dict[str, str] = {}
-    for position in positions:
+    for position in selected_positions:
         source = rows_by_symbol.get(position.instrument.symbol)
         if source is None:
             _fail(
@@ -751,14 +767,21 @@ def build_option_position_evidence_binding(
         if existing is not None and existing != mark:
             _fail("option_position_evidence_conflict", "one instrument has conflicting marks")
         marks_by_instrument[fact.instrument_key] = mark
-        market_code_by_instrument[fact.instrument_key] = _text(
+        market_code = _text(
             fact.raw.get("market_code"),
             "option mark market_code",
         )
+        code_identity = resolve_symbol_identity(market_code)
+        if code_identity is None or code_identity.market != market:
+            _fail(
+                "option_position_evidence_missing",
+                f"{position.instrument.symbol} option mark market code conflicts with the formal point",
+            )
+        market_code_by_instrument[fact.instrument_key] = market_code
 
     rates = cny_per_currency_rates_from_option_context(payload)
     required_currencies = {
-        position.instrument.currency for position in positions
+        position.instrument.currency for position in selected_positions
     } | {"USD" if market == "US" else "HKD"}
     if not required_currencies.issubset(rates):
         _fail("option_position_evidence_missing", "prepared FX facts are incomplete")
@@ -822,7 +845,7 @@ def build_option_position_evidence_binding(
             "contracts_open": position.contracts_open,
             "market_code": market_code_by_instrument[position.instrument.instrument_key],
         }
-        for position in positions
+        for position in selected_positions
     ]
     binding: dict[str, Any] = {
         "schema_version": _OPTION_POSITION_EVIDENCE_SCHEMA,
@@ -870,6 +893,9 @@ def validate_option_position_evidence_binding(
     expected_recommendation_point_id: str,
     expected_market: str | None = None,
 ) -> dict[str, Any]:
+    expected_market_value = (
+        _market(expected_market) if expected_market is not None else None
+    )
     if not isinstance(value, Mapping) or set(value) != _OPTION_POSITION_EVIDENCE_FIELDS:
         _fail("option_position_evidence_invalid", "option position evidence fields are invalid")
     item = dict(value)
@@ -935,6 +961,7 @@ def validate_option_position_evidence_binding(
                 f"option position is invalid: {exc}",
             )
         _text(row.get("broker"), "position broker")
+        identity = resolve_symbol_identity(instrument.symbol)
         if (
             instrument.instrument_key != row.get("instrument_key")
             or row.get("symbol") != instrument.symbol
@@ -949,9 +976,18 @@ def validate_option_position_evidence_binding(
             or row.get("contracts_open") != contracts_open
             or contracts_open <= 0
             or isinstance(row.get("contracts_open"), bool)
+            or identity is None
+            or identity.currency != instrument.currency
+            or (
+                expected_market_value is not None
+                and identity.market != expected_market_value
+            )
         ):
             _fail("option_position_evidence_invalid", "option position fields conflict")
         code = _text(row.get("market_code"), "position market_code")
+        code_identity = resolve_symbol_identity(code)
+        if code_identity is None or code_identity.market != identity.market:
+            _fail("option_position_evidence_invalid", "option market code conflicts")
         existing_code = market_codes.get(instrument.instrument_key)
         if existing_code is not None and existing_code != code:
             _fail("option_position_evidence_invalid", "option market code conflicts")
@@ -1050,7 +1086,7 @@ def validate_option_position_evidence_binding(
     market_currency = {
         "HK": "HKD",
         "US": "USD",
-    }.get(_market(expected_market) if expected_market is not None else None)
+    }.get(expected_market_value)
     if market_currency is not None:
         required_currencies.add(market_currency)
     fx_currencies: set[str] = set()

--- a/tests/candidate_evidence_helpers.py
+++ b/tests/candidate_evidence_helpers.py
@@ -136,6 +136,8 @@ def seal_opening_candidate_fixture(
     market: str = "US",
     accepted_rows: Iterable[Mapping[str, Any]] = (),
     rejected_rows: Iterable[Mapping[str, Any]] = (),
+    sealed_at: str = "2026-06-01T00:00:00Z",
+    manifest_sealed_at: str = "2026-06-01T00:00:01Z",
 ) -> dict[str, Any]:
     """Publish a current manifest-bound opening snapshot for test facts."""
 
@@ -263,7 +265,7 @@ def seal_opening_candidate_fixture(
         scan_statuses=scan_statuses,
         final_candidates=final_candidates,
         candidate_evaluations=evaluations,
-        sealed_at="2026-06-01T00:00:00Z",
+        sealed_at=sealed_at,
     )
     publish_strategy_scan_status_index_v2(
         report_dir=account_dir,
@@ -277,7 +279,7 @@ def seal_opening_candidate_fixture(
         run_id=run_id,
         account=account,
         strategy_policy_sha256=POLICY_HASH,
-        sealed_at="2026-06-01T00:00:01Z",
+        sealed_at=manifest_sealed_at,
     )
 
 

--- a/tests/test_formal_corpus.py
+++ b/tests/test_formal_corpus.py
@@ -51,6 +51,7 @@ def _prepared_receipt(
     opening: Mapping[str, Any],
     *,
     hkd_cny: float = 0.92,
+    open_positions: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     observed_at = str(opening["sealed_at_utc"])
     payload = {
@@ -62,9 +63,9 @@ def _prepared_receipt(
         },
         "exchange_rates": {
             "timestamp": observed_at,
-            "rates": {"HKDCNY": hkd_cny},
+            "rates": {"HKDCNY": hkd_cny, "USDCNY": 7.2},
         },
-        "open_positions_min": [],
+        "open_positions_min": open_positions or [],
         "decision_snapshot_actionable": True,
     }
     payload_bytes = _canonical_bytes(payload)
@@ -84,6 +85,31 @@ def _prepared_receipt(
         "payload": payload,
         "manifest_bytes": _canonical_bytes(manifest),
         "payload_bytes": payload_bytes,
+    }
+
+
+def _open_position(
+    record_id: str,
+    *,
+    symbol: str,
+    currency: str,
+    market_code: str,
+) -> dict[str, Any]:
+    return {
+        "record_id": record_id,
+        "status": "open",
+        "broker": "futu",
+        "symbol": symbol,
+        "option_type": "put",
+        "strike": "100",
+        "expiration_ymd": "2026-08-21",
+        "currency": currency,
+        "multiplier": "100",
+        "side": "short",
+        "contracts_open": 1,
+        "premium": "2",
+        "opened_at": 1_700_000_000_000,
+        "market_code": market_code,
     }
 
 
@@ -747,6 +773,8 @@ def test_ready_point_reloads_and_materializes_recipe_projection(
         tmp_path,
         run_id=run_id,
         market="HK",
+        sealed_at="2026-08-26T02:00:01Z",
+        manifest_sealed_at="2026-08-26T02:00:02Z",
     )
     _publication, point = capture_scheduled_recommendation_point(
         tmp_path,
@@ -766,7 +794,21 @@ def test_ready_point_reloads_and_materializes_recipe_projection(
     )["owners"]["opening"]
     required_bytes = b'{"fixture":true}\n'
     required_hash = hashlib.sha256(required_bytes).hexdigest()
-    receipt = _prepared_receipt(opening)
+    open_positions = [
+        _open_position(
+            "hk-lot",
+            symbol="0700.HK",
+            currency="HKD",
+            market_code="HK.0700260821P100000",
+        ),
+        _open_position(
+            "us-lot",
+            symbol="FUTU",
+            currency="USD",
+            market_code="US.FUTU260821P100000",
+        ),
+    ]
+    receipt = _prepared_receipt(opening, open_positions=open_positions)
     target_ms = int(
         datetime.fromisoformat(target.replace("Z", "+00:00")).timestamp() * 1000
     )
@@ -776,6 +818,22 @@ def test_ready_point_reloads_and_materializes_recipe_projection(
         ).timestamp()
         * 1000
     )
+    required_entries = {
+        "0700.HK": (
+            {
+                "scan_blob_ref": {
+                    "blob_relpath": "required/0700.HK.csv",
+                    "blob_sha256": "e" * 64,
+                }
+            },
+            (
+                "code,bid_price,ask_price,snapshot_requested_at_utc,"
+                "snapshot_received_at_utc\n"
+                f"HK.0700260821P100000,2.0,2.4,{opening['sealed_at_utc']},"
+                f"{opening['sealed_at_utc']}\n"
+            ).encode(),
+        )
+    }
     evidence = build_option_position_evidence_binding(
         run_id=run_id,
         account="lx",
@@ -784,9 +842,10 @@ def test_ready_point_reloads_and_materializes_recipe_projection(
         account_config_sha256=opening["account_config_sha256"],
         evidence_at_utc=opening["sealed_at_utc"],
         prepared_receipt=receipt,
-        required_data_entries={},
+        required_data_entries=required_entries,
         formal_time_bounds=(target_ms - 300000, sealed_ms),
     )
+    assert [row["lot_id"] for row in evidence["open_option_positions"]] == ["hk-lot"]
     required_manifest = {
         "run_id": run_id,
         "symbols": {
@@ -844,10 +903,14 @@ def test_ready_point_reloads_and_materializes_recipe_projection(
     monkeypatch.setattr(
         mod,
         "resolve_frozen_required_data_csv_bytes_batch",
-        lambda **_kwargs: SimpleNamespace(entries={}, unavailable={}),
+        lambda **_kwargs: SimpleNamespace(entries=required_entries, unavailable={}),
     )
 
-    alternate_receipt = _prepared_receipt(opening, hkd_cny=0.93)
+    alternate_receipt = _prepared_receipt(
+        opening,
+        hkd_cny=0.93,
+        open_positions=open_positions,
+    )
     alternate_evidence = build_option_position_evidence_binding(
         run_id=run_id,
         account="lx",
@@ -856,7 +919,7 @@ def test_ready_point_reloads_and_materializes_recipe_projection(
         account_config_sha256=opening["account_config_sha256"],
         evidence_at_utc=opening["sealed_at_utc"],
         prepared_receipt=alternate_receipt,
-        required_data_entries={},
+        required_data_entries=required_entries,
         formal_time_bounds=(target_ms - 300000, sealed_ms),
     )
     alternate_evidence["position_source"] = dict(evidence["position_source"])

--- a/tests/test_recommendation_point.py
+++ b/tests/test_recommendation_point.py
@@ -9,6 +9,7 @@ import pytest
 
 from domain.domain.decision_state_fingerprint import canonical_sha256
 from domain.domain.engine import build_candidate_decision
+from domain.domain.performance.models import OptionInstrumentKey
 from src.application.candidate_snapshot_manifest import (
     CANDIDATE_SNAPSHOT_MANIFEST_FILE,
     load_candidate_snapshot_bundle,
@@ -140,6 +141,33 @@ def _prepared_option_receipt(
     }
 
 
+def _open_option_position(
+    record_id: str,
+    *,
+    symbol: str,
+    currency: str,
+    market_code: str | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "record_id": record_id,
+        "status": "open",
+        "broker": "futu",
+        "symbol": symbol,
+        "option_type": "put",
+        "strike": "100",
+        "expiration_ymd": "2026-08-21",
+        "currency": currency,
+        "multiplier": "100",
+        "side": "short",
+        "contracts_open": 1,
+        "premium": "2",
+        "opened_at": 1_700_000_000_000,
+    }
+    if market_code is not None:
+        row["market_code"] = market_code
+    return row
+
+
 def test_formal_point_time_coherence_canonicalizes_aware_candidate_timestamp() -> None:
     opening = {
         "candidate_decisions": [
@@ -213,26 +241,21 @@ def test_option_position_binding_uses_only_the_frozen_scan_batch() -> None:
         "account": "lx",
         "account_config_sha256": CONFIG_HASH,
     }
-    fields = {
-        "status": "open",
-        "broker": "futu",
-        "symbol": "NVDA",
-        "option_type": "put",
-        "strike": "100",
-        "expiration_ymd": "2026-08-21",
-        "currency": "USD",
-        "multiplier": "100",
-        "side": "short",
-        "contracts_open": 1,
-        "premium": "2",
-        "opened_at": 1_700_000_000_000,
-        "market_code": "US.NVDA260821P100000",
-    }
     receipt = _prepared_option_receipt(
         opening,
         open_positions=[
-            {"record_id": "lot-1", **fields},
-            {"record_id": "lot-2", **fields},
+            _open_option_position(
+                "lot-1",
+                symbol="NVDA",
+                currency="USD",
+                market_code="US.NVDA260821P100000",
+            ),
+            _open_option_position(
+                "lot-2",
+                symbol="NVDA",
+                currency="USD",
+                market_code="US.NVDA260821P100000",
+            ),
         ],
     )
     csv_bytes = (
@@ -287,6 +310,38 @@ def test_option_position_binding_uses_only_the_frozen_scan_batch() -> None:
             expected_recommendation_point_id=point_id,
             expected_market="US",
         )
+    cross_market = json.loads(json.dumps(binding))
+    hk_instrument = OptionInstrumentKey(
+        symbol="0700.HK",
+        option_type="put",
+        strike="100",
+        expiration_ymd="2026-08-21",
+        currency="HKD",
+        multiplier="100",
+    )
+    cross_market["open_option_positions"][0].update(
+        {
+            "instrument_key": hk_instrument.instrument_key,
+            "symbol": hk_instrument.symbol,
+            "currency": hk_instrument.currency,
+            "market_code": "HK.0700260821P100000",
+        }
+    )
+    cross_market["content_sha256"] = canonical_sha256(
+        {
+            key: value
+            for key, value in cross_market.items()
+            if key != "content_sha256"
+        }
+    )
+    with pytest.raises(RecommendationPointError, match="option position fields conflict"):
+        validate_option_position_evidence_binding(
+            cross_market,
+            expected_run_id="formal-binding",
+            expected_account="lx",
+            expected_recommendation_point_id=point_id,
+            expected_market="US",
+        )
     with pytest.raises(
         RecommendationPointError,
         match="absent from the production snapshot batch",
@@ -300,6 +355,161 @@ def test_option_position_binding_uses_only_the_frozen_scan_batch() -> None:
             evidence_at_utc="2026-07-21T14:00:02Z",
             prepared_receipt=receipt,
             required_data_entries={},
+            formal_time_bounds=(1_784_642_340_000, 1_784_642_405_000),
+        )
+
+
+def test_option_position_binding_uses_only_same_market_positions() -> None:
+    opening = {
+        "run_id": "mixed-market-binding",
+        "account": "lx",
+        "account_config_sha256": CONFIG_HASH,
+    }
+    receipt = _prepared_option_receipt(
+        opening,
+        open_positions=[
+            _open_option_position(
+                "hk-lot",
+                symbol="0700.HK",
+                currency="HKD",
+                market_code="HK.0700260821P100000",
+            ),
+            _open_option_position(
+                "us-lot",
+                symbol="FUTU",
+                currency="USD",
+                market_code="US.FUTU260821P100000",
+            ),
+        ],
+    )
+    hk_csv = (
+        "code,bid_price,ask_price,last_price,snapshot_requested_at_utc,"
+        "snapshot_received_at_utc\n"
+        "HK.0700260821P100000,2.0,2.4,9.0,"
+        "2026-07-21T13:59:59Z,2026-07-21T14:00:00Z\n"
+    ).encode()
+    kwargs = {
+        "run_id": "mixed-market-binding",
+        "account": "lx",
+        "market": "HK",
+        "recommendation_point_id": "d" * 64,
+        "account_config_sha256": CONFIG_HASH,
+        "evidence_at_utc": "2026-07-21T14:00:02Z",
+        "prepared_receipt": receipt,
+        "formal_time_bounds": (1_784_642_340_000, 1_784_642_405_000),
+    }
+    binding = build_option_position_evidence_binding(
+        **kwargs,
+        required_data_entries={
+            "0700.HK": (
+                {
+                    "scan_blob_ref": {
+                        "blob_relpath": "required/0700.HK.csv",
+                        "blob_sha256": "b" * 64,
+                    }
+                },
+                hk_csv,
+            )
+        },
+    )
+
+    assert [row["lot_id"] for row in binding["open_option_positions"]] == ["hk-lot"]
+    assert len(binding["valuation_mark_facts"]) == 1
+    assert [row["base_currency"] for row in binding["fx_rate_facts"]] == ["HKD"]
+    with pytest.raises(
+        RecommendationPointError,
+        match="0700.HK is absent from the production snapshot batch",
+    ):
+        build_option_position_evidence_binding(
+            **kwargs,
+            required_data_entries={},
+        )
+
+
+@pytest.mark.parametrize(
+    "symbol,currency,market_code,market",
+    [
+        ("???", "USD", None, "US"),
+        ("US.MET", "USD", None, "US"),
+        ("0700.HK", "HKD", "US.FUTU260821P100000", "US"),
+    ],
+)
+def test_option_position_binding_rejects_invalid_market_identity_before_filtering(
+    symbol: str,
+    currency: str,
+    market_code: str | None,
+    market: str,
+) -> None:
+    opening = {
+        "run_id": "invalid-market-binding",
+        "account": "lx",
+        "account_config_sha256": CONFIG_HASH,
+    }
+    row = _open_option_position(
+        "bad-lot",
+        symbol=symbol,
+        currency=currency,
+        market_code=market_code,
+    )
+    with pytest.raises(RecommendationPointError, match="market"):
+        build_option_position_evidence_binding(
+            run_id="invalid-market-binding",
+            account="lx",
+            market=market,
+            recommendation_point_id="e" * 64,
+            account_config_sha256=CONFIG_HASH,
+            evidence_at_utc="2026-07-21T14:00:02Z",
+            prepared_receipt=_prepared_option_receipt(
+                opening,
+                open_positions=[row],
+            ),
+            required_data_entries={},
+            formal_time_bounds=(1_784_642_340_000, 1_784_642_405_000),
+        )
+
+
+def test_option_position_binding_rejects_cross_market_snapshot_code() -> None:
+    opening = {
+        "run_id": "cross-market-mark",
+        "account": "lx",
+        "account_config_sha256": CONFIG_HASH,
+    }
+    receipt = _prepared_option_receipt(
+        opening,
+        open_positions=[
+            _open_option_position(
+                "hk-lot",
+                symbol="0700.HK",
+                currency="HKD",
+            )
+        ],
+    )
+    csv_bytes = (
+        "code,option_type,expiration_ymd,strike,multiplier,bid_price,ask_price,"
+        "snapshot_requested_at_utc,snapshot_received_at_utc\n"
+        "US.FUTU260821P100000,put,2026-08-21,100,100,2.0,2.4,"
+        "2026-07-21T13:59:59Z,2026-07-21T14:00:00Z\n"
+    ).encode()
+    with pytest.raises(RecommendationPointError, match="formal point"):
+        build_option_position_evidence_binding(
+            run_id="cross-market-mark",
+            account="lx",
+            market="HK",
+            recommendation_point_id="f" * 64,
+            account_config_sha256=CONFIG_HASH,
+            evidence_at_utc="2026-07-21T14:00:02Z",
+            prepared_receipt=receipt,
+            required_data_entries={
+                "0700.HK": (
+                    {
+                        "scan_blob_ref": {
+                            "blob_relpath": "required/0700.HK.csv",
+                            "blob_sha256": "b" * 64,
+                        }
+                    },
+                    csv_bytes,
+                )
+            },
             formal_time_bounds=(1_784_642_340_000, 1_784_642_405_000),
         )
 


### PR DESCRIPTION
## Summary

- bind formal-point option positions, marks, and position-derived FX to the point market
- fail closed on unknown or inconsistent position and mark market identity
- keep producer and Formal Corpus verification on the shared builder contract
- document the corrected Strategy Lab evidence scope

## Validation

- 38 focused tests passed
- Ruff passed
- dependency graph check passed with 631 production modules and 0 cycles
- Guardrails passed
- git diff check passed

No version, release, deployment, runtime configuration, or production-state changes.