### PR TITLE
perf(required-data): optimize projection validation

### DIFF
--- a/docs/REQUIRED_DATA_STORAGE_DESIGN.md
+++ b/docs/REQUIRED_DATA_STORAGE_DESIGN.md
@@ -1,7 +1,8 @@
 # Required Data Storage Design
 
-> Status: source contract implemented. Commit, release, deployment, and any
-> production history cleanup remain separate operator actions.
+> Status: source contract and shared projection-validation optimization
+> implemented. Commit, release, deployment, and any production history cleanup
+> remain separate operator actions.
 
 ## Goal
 
@@ -286,6 +287,118 @@ the relevant tick/research integration tests, and the full project test suite.
 No production tick is required for source validation. A later natural scheduled
 run may verify storage and read-source evidence only after separate release and
 upgrade authorization.
+
+## Shared projection-validation performance
+
+### Goal, success signals, and non-goals
+
+Reduce the CPU cost of the shared JSON-to-CSV projection validator without
+changing its evidence or failure contract. The deterministic 254-row, 60-column
+fixture must produce the same canonical comparison result while removing the
+per-cell pandas row indexing hotspot. On the same host and fixture, the fallback
+loop should be at least 80% faster than the recorded baseline, and the canonical
+benchmark must retain zero violations and the existing exact cleanup and
+blob-only-resolution evidence.
+
+This optimization does not remove or cache validation across receipt
+publication, manifest sealing, recovery, or blob-only resolution. It does not
+change CSV columns, numeric equivalence, null and boolean handling, multiplier
+enrichment or attestation, schemas, public commands, persisted state, or
+production behavior.
+
+### Current facts and chosen design
+
+`_validate_consumer_csv_projection()` is the shared owner used by quote-receipt
+validation, the unplanned/finalization path, and canonical blob-byte resolution
+through `validate_required_data_quote_bytes()`. It first validates column order
+and row count, constructs the round-tripped expected frame, and returns early
+when `DataFrame.equals()` succeeds. Before the optimization, the fallback
+performed two `DataFrame.iloc` row lookups per cell and repeated both lookups for
+an allowed multiplier enrichment.
+
+The canonical benchmark profile reaches this fallback at multiple trust
+boundaries. A read-only profile attributed 94.2% of its cumulative time to the
+shared validator and recorded 152,847 `iloc` calls. On the same deterministic
+fixture, caching each expected and actual row Series produced identical
+canonical value pairs while reducing median loop time from about 1.11 seconds to
+about 0.026 seconds, a 97.6% reduction. These timings are host-specific
+diagnostic evidence, not a cross-host acceptance threshold.
+
+Keep the existing fast path, row-major validation order, and mixed-dtype row
+coercion. For each row, construct the expected and actual Series once with
+`iloc`, then iterate their scalar values positionally with
+`REQUIRED_DATA_COLUMNS` in a strict zip for the existing canonical comparison
+and multiplier-enrichment check. This removes per-cell Series construction and
+label indexing, creates no new abstraction, and preserves the existing error
+and metadata-binding paths.
+
+```text
+JSON rows -> CSV round-trip frame -> column/row checks -> frame.equals fast path
+  -> row-cached fallback -> canonical scalar comparison
+  -> optional multiplier metadata binding -> return or SourceReceiptError
+```
+
+The function remains stateless: success returns without mutation, and any
+invalid projection or unattested enrichment raises before receipt publication.
+No manifest, cleanup, notification, ledger, broker, or runtime state transition
+changes.
+
+| Owner | Contract |
+|---|---|
+| `src/application/opend_symbol_outputs.py` | Owns the shared fallback loop and preserves fail-closed projection semantics |
+| `tests/test_required_data_snapshot.py` | Covers the unchanged fast path and mixed-dtype row canonicalization |
+| `tests/test_required_data_output_integrity.py` | Covers value drift rejection and multiplier attestation |
+| `scripts/benchmark_required_data_scan_blobs.py` | Provides deterministic end-to-end correctness, storage, allocation, and corroborating host-local timing evidence |
+
+### Rejected alternatives
+
+- `itertuples()` or whole-frame coercion avoids every Series construction but
+  changes mixed-dtype boolean scalar classification on the supported pandas
+  runtime. The faster option is rejected because this work unit does not change
+  canonical projection semantics.
+- Caching or removing repeated validation across lifecycle stages would weaken
+  independent trust boundaries and expand the change beyond the hotspot.
+- Adding a helper, configuration switch, dependency, or timing gate would add
+  ownership and maintenance without improving the loop.
+
+### Implementation slice
+
+Replace only the fallback indexing loop in
+`_validate_consumer_csv_projection()` by caching its two row Series per row and
+iterating their values positionally, then add one focused mixed-dtype regression
+covering the existing boolean canonicalization. Keep the fast path, canonical
+helpers, enrichment rule, metadata binding, and errors unchanged.
+
+### Validation plan
+
+- In one process on the deterministic fixture, use `perf_counter_ns()` to run
+  one warmup and at least five paired repetitions of the repeated-index and
+  row-cached fallback loops. Require identical canonical value pairs and at
+  least 80% reduction in median elapsed time. Record the command, Python and
+  pandas versions, samples, medians, and ratio in the implementation Deepreview
+  artifact; do not add a checked-in helper or timing gate.
+- Run the focused projection and integrity tests and Ruff on the changed Python
+  files.
+- Run the canonical benchmark smoke profile as corroborating end-to-end timing
+  evidence, then the formal canonical profile for deterministic fixture,
+  storage, allocation, cleanup, and blob-only-resolution acceptance. Its timing
+  is not the fallback performance gate.
+- Run the project-required broader tests and guardrails. Regenerate the
+  dependency graph only if imports change.
+
+The implementation is acceptable only if existing drift and unattested-
+multiplier failures remain fail-closed, canonical benchmark violations remain
+empty, and the host-local fallback improves by at least 80%. Timing remains
+reported evidence rather than a portable CI gate.
+
+### Risks and open questions
+
+The fallback still constructs two Series per row, so its remaining ceiling is
+linear in row count. The measured reduction exceeds the target while retaining
+mixed-dtype row coercion; remove the Series only if a separately approved
+canonical-type contract change makes that safe. The integrity tests remain the
+authority for fail-closed behavior. No open product, schema, architecture,
+permission, or production question remains.
 
 ## Risks and deferred work
 

--- a/src/application/opend_symbol_outputs.py
+++ b/src/application/opend_symbol_outputs.py
@@ -1158,14 +1158,22 @@ def _validate_consumer_csv_projection(
         return
     multiplier_enriched = False
     for row_index in range(len(expected.index)):
-        for column in REQUIRED_DATA_COLUMNS:
-            expected_value = _canonical_csv_value(expected.iloc[row_index][column])
-            actual_value = _canonical_csv_value(frame.iloc[row_index][column])
+        # Preserve mixed-dtype row coercion while constructing each Series once.
+        expected_row = expected.iloc[row_index]
+        actual_row = frame.iloc[row_index]
+        for column, raw_value, csv_value in zip(
+            REQUIRED_DATA_COLUMNS,
+            expected_row,
+            actual_row,
+            strict=True,
+        ):
+            expected_value = _canonical_csv_value(raw_value)
+            actual_value = _canonical_csv_value(csv_value)
             if expected_value == actual_value:
                 continue
             if column == "multiplier" and _is_valid_multiplier_enrichment(
-                raw_value=expected.iloc[row_index][column],
-                csv_value=frame.iloc[row_index][column],
+                raw_value=raw_value,
+                csv_value=csv_value,
             ):
                 multiplier_enriched = True
                 continue

--- a/tests/test_required_data_snapshot.py
+++ b/tests/test_required_data_snapshot.py
@@ -62,6 +62,20 @@ def test_consumer_csv_projection_equal_frame_skips_cell_fallback(
     )
 
 
+def test_consumer_csv_projection_preserves_mixed_dtype_row_canonicalization() -> None:
+    rows = [{"symbol": "NVDA", "in_the_money": True}]
+    frame = _csv_roundtrip_frame(rows)
+    frame["in_the_money"] = frame["in_the_money"].astype("string")
+
+    _validate_consumer_csv_projection(
+        rows=rows,
+        frame=frame,
+        csv=None,
+        symbol="NVDA",
+        raw_meta={},
+    )
+
+
 def _workspace(tmp_path: Path, run_id: str = "run-1") -> tuple[Path, Path]:
     run_dir = tmp_path / "output_runs" / run_id
     root = run_dir / "required_data"


### PR DESCRIPTION
## Summary

- construct each expected and actual pandas row once during required-data CSV projection validation
- zip canonical columns with row values to remove repeated label-based Series indexing
- preserve mixed-dtype row coercion, fail-closed validation, and multiplier enrichment semantics

## Performance

- paired median: 1.105 s to 0.026 s
- reduction: 97.633 percent
- speedup: 42.25x
- formal canonical wall p95: 0.322 s with no threshold violations

## Verification

- focused required-data tests: 119 passed
- adjacent consumer tests: 125 passed
- full suite: 5769 passed
- Ruff, repository guardrails, and git diff check passed
- two Deepreview rounds completed; final result pass-with-risks with no high or medium findings

## Scope

Source-only delivery. VERSION and CHANGELOG.md are unchanged; no release, deployment, production mutation, or runtime cleanup is included.