### PR TITLE
fix(ledger): bind historical Futu order identities

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1009 (`src`: 541, `domain`: 78, `scripts`: 12, `tests`: 378)
-- Internal import edges: 6738 total, 2934 production/script edges excluding tests
+- Internal import edges: 6753 total, 2936 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -31,7 +31,7 @@ flowchart LR
   domain_services["domain.services"]
   domain["domain.domain"]
   storage["domain.storage"]
-  application -->|444| domain
+  application -->|445| domain
   application -->|4| domain_services
   application -->|147| infrastructure
   application -->|41| storage
@@ -46,11 +46,11 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2816| application
-  tests -->|428| domain
+  tests -->|2823| application
+  tests -->|429| domain
   tests -->|2| domain_services
   tests -->|233| infrastructure
-  tests -->|238| interfaces
+  tests -->|243| interfaces
   tests -->|23| scripts
   tests -->|18| storage
 ```
@@ -59,7 +59,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| application | domain | 444 |
+| application | domain | 445 |
 | interfaces | application | 164 |
 | application | infrastructure | 147 |
 | scripts | application | 45 |
@@ -79,9 +79,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2816 |
-| tests | domain | 428 |
-| tests | interfaces | 238 |
+| tests | application | 2823 |
+| tests | domain | 429 |
+| tests | interfaces | 243 |
 | tests | infrastructure | 233 |
 | tests | scripts | 23 |
 | tests | storage | 18 |
@@ -97,7 +97,7 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 | src.interfaces | src.application | 129 |
 | src.application | src.infrastructure | 105 |
 | src.application.ledger | domain.domain | 65 |
-| src.application.ledger | domain.domain.ledger | 46 |
+| src.application.ledger | domain.domain.ledger | 47 |
 | src.application.research | src.application | 35 |
 | scripts | src.application | 34 |
 | src.application | domain.storage | 32 |

--- a/docs/LEDGER_ARCHITECTURE.md
+++ b/docs/LEDGER_ARCHITECTURE.md
@@ -24,7 +24,8 @@ trade_events -> deterministic projection -> position_lots
 
 订单费用是同一成交事件的延迟证据，不另建费用事实账本。受控 fee enrichment 是唯一
 允许更新既有事件费用 provenance 的路径：按完整订单组执行 CAS、审计、读回并在同一
-事务重放受影响投影。其他模块不得直接改 `event_json`。
+事务重放受影响投影。其他模块不得直接改 `event_json`。下文“Futu 订单身份
+补录”定义一条同样受控的 metadata-only 例外。
 
 ## 模块所有权
 
@@ -145,6 +146,144 @@ position-projection migration 的 `_write_connection()` 持有同一 `<db>.write
 `add`、`assign`、`exercise` 的 preview、apply 和响应丢失后的重试必须复用同一个
 `--request-id`。相同 request ID 与相同 intent 返回原结果；同一 ID 绑定不同 intent
 会 fail closed。确认前检查响应中的目标 SQLite、account、lot/event identity、数量和写入合同。
+
+## Futu 订单身份补录
+
+### 目标、边界与成功信号
+
+历史手工 Futu 期权 open 事件可能已保留完整成交经济事实，但缺少 OpenD 费用查询所需的
+`raw_payload.futu_account_id` 和 `raw_payload.order_id`。本变更让操作员在人工核实 OpenD
+历史订单后，用现有 `trade-events repair` 原地绑定这两个身份，然后仍由现有
+`fees-sync` 查询并持久化 actual fee。
+
+成功必须同时满足：
+
+- dry-run 展示唯一目标、绑定前后身份和 `expected_before_sha256`，不写 SQLite；
+- apply 后仍是同一 `event_id` 和 `ingest_seq`，事件数量、合约、金额、数量、时间、
+  cash-conversion fact IDs、lot identity 和下游 close/adjust lineage 不变；
+- 原地更新造成的全局 position source generation 变化在同事务中发布，不留下新的
+  position 或 current-decision dirty state；
+- 带有有效下游 close/adjust 的 open 事件可补身份；经济或 lot-target override 仍走原有
+  void/replacement 路径及 downstream dependency 阻断；
+- 同一绑定重试为零 DML no-op；部分身份、冲突身份、目标已 void 或 CAS 冲突时零写入并失败；
+- 绑定后的同范围 `fees-sync` dry-run 选中该订单，actual fee 写入后再次 dry-run 收敛为 no-op。
+
+本变更不支持 close、expire-close、assignment、exercise 或 assigned-stock sale；不自动匹配 OpenD
+历史订单，不进行批量映射、部分身份补齐、事件时间纠正、经济事实更改、下游链重写、
+schema/config 变更或生产回填。账本与 OpenD 时间相差 12 小时等情况仍需操作员独立确认；
+近似时间、合约、数量或价格不会被代码提升成持久订单身份。
+
+### 当前事实与选定方案
+
+当前 `repair` 已接受 `--futu-account-id` 和 `--order-id`，但总是 void 原事件并追加
+replacement。这会被有效下游 close/adjust 正确拒绝，而强行 replacement 又会改变 event
+identity 并破坏指向原 event ID 的证据。另一个已验证的约束是：任何 `event_json` 更新都会推进
+全局 position source generation，所以只重建 position lots 不足以保持 current-decision 可信。
+
+选定的最小方案保留现有 CLI 和 application facade，在 ledger command 入口优先识别
+identity-only override，不进入 append-repair preflight：
+
+1. 对 `futu_account_id` 和 `order_id` 按原值校验且不静默 trim；前者必须是无前导零的正整数字符串，
+   后者必须非空且不含空白或控制字符。两字段必须同时显式提供。
+2. 有效 override key set 精确等于这两个身份字段时才走 identity-only；与任何经济、合约、
+   时间或 lot-target override 混用时继续原 void/replacement 语义。
+3. 目标必须是 active canonical Futu `open` 期权事件；首次绑定时 fee basis 必须尚非 actual。
+   相同 `(futu_account_id, order_id)` 被其他 active event 使用时首版直接拒绝，不实现多事件订单分配。
+4. 目标两个身份都缺失时允许绑定；两者都与输入相同时即使 fee 后来已为 actual 也返回 no-op；部分存在或
+   任一值冲突时 fail closed。目标已有相同身份但没有本功能 provenance 时仍是 no-op，不为补审计数据改写历史。
+5. identity-only 要求显式、非默认 `reason`引用人工 OpenD 核对证据。绑定自身不连接 provider；
+   REAL 账户范围、终态、币种、成交数量和 actual fee 仍由后续 `fees-sync` 验证。
+
+不新增 `bind-order-identity` 命令，因为它会重复现有参数、写入门禁和 facade。不让
+`fees-sync` 自动匹配缺身份事件，也不增加通用 event mutator 或新审计表。
+
+### 数据流、状态与失败语义
+
+```text
+om trade-events repair --futu-account-id ... --order-id ... --reason ...
+  -> trades.review / ledger.api（现有签名不变）
+  -> ledger.commands 优先选择 identity-only 或原 append-repair
+  -> dry-run: 构造 advisory preview，零写入
+  -> apply: db-path writer lock -> BEGIN IMMEDIATE
+            -> 重读原始 JSON 及有效 void 集，重做全部验证
+            -> capture global current-decision fence
+            -> old-JSON CAS + exact readback
+            -> forced-full position projection，要求 lot diff 为零
+            -> finalize current-decision projection -> commit
+  -> 现有 fees-sync 独立 dry-run/apply
+```
+
+apply 不使用 dry-run 结果作为事实；preview 明确标记为 advisory。事务内验证从原始存储 JSON 做
+copy-on-write，只允许以下路径变化：
+
+```text
+raw_payload.futu_account_id
+raw_payload.order_id
+raw_payload.order_identity_provenance
+```
+
+`order_identity_provenance` 不得覆盖已有同名数据，它记录 schema version、以
+`event_id + normalized futu_account_id + order_id` 确定性生成的 binding ID、来源
+`manual_trade_event_repair`、reason、绑定前两个空身份、`expected_before_sha256` 和首次
+`bound_at_ms`。apply 回执另返回实际 `after_sha256`；避免把时间字段包含在 dry-run 的预期 after hash 中。
+
+原始 SQL 由 trade-event repository 内一个窄 CAS 方法持有：
+`WHERE event_id = ? AND event_json = ?` 必须更新且只更新一行。intervention 持有策略、原始 JSON
+深度 diff、事务编排和读回校验；canonical codec 只用于验证结果，不用来重序列化无关的历史字段。
+CAS、读回、lot 零差异、current-decision finalize、foreign-key 检查或 commit 任一失败都回滚；不 retry。
+
+响应状态为 `dry_run`、`applied` 或 `no_op`。`no_op` 退出码为 0、`write_applied=false`、不推进
+source generation；验证失败或冲突退出码为 2。普通 void/replacement repair 的现有 JSON 响应保持不变，
+identity-only 的文本回执、help 和 rollback hint 必须明确不会生成 void/replacement event。
+
+### Owner 与实现分片
+
+- `src/interfaces/cli/trade_events.py`：保留现有参数和高风险写入门禁，修正 help、文本回执和真实
+  `write_applied` / rollback hint。
+- `src/application/trades/review.py` 和 `src/application/ledger/api.py`：保留现有公开签名与分层，不新增 facade。
+- `src/application/ledger/commands.py`：优先分流 identity-only 与原 append-repair，组装稳定响应。
+- `src/application/ledger/interventions.py`：持有目标状态机、allowlist diff、current-decision fence 和事务编排。
+- `src/application/ledger/repository_trade_events.py`：只新增目标化的 raw event JSON CAS，不提供通用 mutator。
+- `src/application/trades/order_fee_sync.py` 继续持有 provider 验证；
+  `src/application/ledger/order_fee_migration.py` 以原始 JSON 做 CAS 与 fee-only copy-on-write，并维护全局
+  trade-event current-decision fence。
+
+代码、CLI 回执、[Option Positions Repair](OPTION_POSITIONS_REPAIR.md) 和测试作为一个最小纵向分片交付，
+避免 ledger 已分流但 CLI 仍报 `void=None repair=None` 的中间状态。
+
+### 验证计划、风险与开放项
+
+最小回归覆盖：
+
+- 有 downstream close 的 open 事件：dry-run 零写入；apply 后只有三条 allowlist JSON 路径变化，
+  event count/ID/ingest sequence、完整 lot fingerprint、cash-conversion IDs 和 downstream lineage 不变；
+- 两个已初始化账户的 current-decision 在绑定后仍 clean，业务 payload 不变；强制 projection/finalize
+  失败时原 JSON、source generation 和读模型整体回滚；
+- 同一绑定再执行为零 DML no-op；单字段、空白、部分或冲突身份、重复 active identity、
+  已 void 目标、非 open、已有 actual fee 和 CAS 冲突都失败且零写入；
+- 身份参数与 strike 等任一经济 override 混用时，原有 void/replacement 行为和 downstream 阻断不变；
+- 原始 JSON 含 legacy top-level `fee_provenance` 或未知 raw keys 时不会被 codec 顺带规范化；
+- fake OpenD provider 验证绑定后 `fees-sync` 选中订单并写 actual fee，保留无关历史 JSON，且同范围
+  第二次 dry-run 与相同身份重试均为 no-op。
+
+实现验证运行 focused pytest、受影响文件 Ruff、`git diff --check`、文档/敏感产物 guardrails 和
+`./.venv/bin/python scripts/generate_dependency_graph.py --check`。
+
+残余风险：
+
+- identity-only 不加载 runtime config，所以不在绑定阶段证明 Futu account ID 属于账本 account；
+  owner 仍是 `order_fee_sync`，影响是错误但格式合法的身份可以被持久化。本分片用显式人工证据、
+  高风险确认、重复 identity 阻断和后续 `fees-sync` 缩小风险；如要由系统证明合约/方向/价格，
+  应作为 provider admission 的独立 hardening，不塞入本 repair。
+- 首版不允许覆盖或解绑，错误绑定不能用同一命令修正。owner 是后续 ledger repair 设计，影响是
+  提交后只能使用写前备份或另行授权的前向修复；本命令不会自动创建备份。生产使用必须逐笔 preview、
+  另行创建并验证备份、写后读回和
+  `fees-sync` dry-run，任一不一致立即停止。
+- 首版拒绝多事件共用订单身份；如未来出现经证明的合法 split-fill/order 组，owner 是
+  `order_fee_sync` 和 ledger identity contract，需单独设计分配与纠错，不放宽本分片。
+
+开放项：无。当前能力不需要新 schema、public command 或 provider capability。发布/升级和
+生产回填继续是独立授权边界。
 
 ## 读取语义
 

--- a/docs/OPTION_POSITIONS_REPAIR.md
+++ b/docs/OPTION_POSITIONS_REPAIR.md
@@ -113,7 +113,35 @@
 
 ---
 
-### 场景 D：Futu 当前期权条款与账本不同
+### 场景 D：历史 Futu 开仓缺少 OpenD 订单身份
+
+只适用于经济事实已正确、fee 尚非 actual 的 active option open 事件。人工核实
+OpenD 订单后先预览；`reason` 必须写明 OpenD 核对证据：
+
+```bash
+./om trade-events repair <open_event_id> \
+  --futu-account-id <numeric_account_id> \
+  --order-id <order_id> \
+  --reason "OpenD manual evidence: <reference>" \
+  --dry-run --format json
+```
+
+该命令不会自动创建数据库备份。生产执行前先另行创建并验证 SQLite 备份；确认 `event_id`、
+绑定前后身份和 `expected_before_sha256` 后再单独写入：
+
+```bash
+./om trade-events repair <open_event_id> \
+  --futu-account-id <numeric_account_id> \
+  --order-id <order_id> \
+  --reason "OpenD manual evidence: <reference>" \
+  --confirm --format json
+```
+
+该路径原地补录 metadata，不生成 void/replacement event，不能与 strike、price、contracts
+等其他 override 混用。写入后仍要单独 dry-run/apply `trade-events fees-sync`；本命令不连接 OpenD，
+也不自动补 fee。
+
+### 场景 E：Futu 当前期权条款与账本不同
 
 分红、拆并股等公司行动可能调整存量合约的 strike、multiplier 或其他交割条款。
 此时 Futu 的期权代码只用于定位合约；当前经济条款必须以该代码对应的 market
@@ -152,7 +180,7 @@ divergence，不会建议 `adjust-lot`。系统不会做模糊 strike 匹配，�
 
 ---
 
-### 场景 E：你怀疑投影脏了，但账本本身没问题
+### 场景 F：你怀疑投影脏了，但账本本身没问题
 
 默认只预览投影差异：
 

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -3,7 +3,7 @@ flowchart LR
   src_interfaces["src.interfaces"] -->|129| src_application["src.application"]
   src_application["src.application"] -->|105| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|65| domain_domain["domain.domain"]
-  src_application_ledger["src.application.ledger"] -->|46| domain_domain_ledger["domain.domain.ledger"]
+  src_application_ledger["src.application.ledger"] -->|47| domain_domain_ledger["domain.domain.ledger"]
   src_application_research["src.application.research"] -->|35| src_application["src.application"]
   scripts["scripts"] -->|34| src_application["src.application"]
   src_application["src.application"] -->|32| domain_storage["domain.storage"]

--- a/src/application/ledger/commands.py
+++ b/src/application/ledger/commands.py
@@ -21,8 +21,11 @@ from domain.domain.trade_contract_identity import normalize_trade_side
 from src.application.ledger.interventions import (
     build_manual_repair_preview,
     build_manual_void_preview,
+    is_order_identity_repair_request,
+    persist_manual_order_identity_binding,
     persist_manual_repair_event,
     persist_manual_void_event,
+    preview_manual_order_identity_binding,
 )
 from src.application.ledger.lot_resolver import (
     CloseTargetResolution,
@@ -2223,6 +2226,13 @@ def preview_trade_event_repair(
     overrides: dict[str, Any],
     reason: str,
 ) -> dict[str, Any]:
+    if is_order_identity_repair_request(overrides):
+        return preview_manual_order_identity_binding(
+            repo,
+            target_event_id=event_id,
+            overrides=overrides,
+            repair_reason=reason,
+        )
     from src.application.ledger.queries import trade_event_log, trade_event_projection_preview
 
     preview = build_manual_repair_preview(
@@ -2254,6 +2264,13 @@ def record_trade_event_repair(
     overrides: dict[str, Any],
     reason: str,
 ) -> dict[str, Any]:
+    if is_order_identity_repair_request(overrides):
+        return persist_manual_order_identity_binding(
+            repo,
+            target_event_id=event_id,
+            overrides=overrides,
+            repair_reason=reason,
+        )
     ledger_result = persist_manual_repair_event_with_ledger(
         repo,
         target_event_id=event_id,

--- a/src/application/ledger/interventions.py
+++ b/src/application/ledger/interventions.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import hashlib
 import json
 import sqlite3
+import unicodedata
 import uuid
 from typing import Any
 
-from domain.domain.ledger import ContractKey, TradeEvent
+from domain.domain.ledger import ContractKey, TradeEvent, fee_fact_for_event, position_lots_fingerprint
+from domain.domain.ledger.fees import FeeBasis
 from domain.domain.ledger.position_fields import (
     normalize_account,
     normalize_broker,
@@ -22,6 +25,10 @@ from domain.domain.trade_contract_identity import (
     normalize_trade_side,
 )
 from src.application.ledger.event_codec import stored_trade_event_to_ledger_event, valid_void_target_event_id
+from src.application.ledger.current_decision_projection import (
+    capture_trade_event_decision_projection_fence,
+    finalize_current_decision_projection,
+)
 from src.application.ledger.position_projection_runtime import (
     run_position_projection_in_transaction,
 )
@@ -35,6 +42,10 @@ from src.application.ledger.writer import (
     projection_diagnostics_summary,
 )
 from src.infrastructure.feishu_bitable import safe_float
+
+
+_ORDER_IDENTITY_OVERRIDE_KEYS = frozenset({"futu_account_id", "order_id"})
+_ORDER_IDENTITY_PROVENANCE_SCHEMA = "futu_order_identity_binding.v1"
 
 
 def _canonical_trade_symbol(value: Any) -> str:
@@ -368,6 +379,338 @@ def build_manual_void_preview(
 
 def _repair_override_payload(overrides: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in dict(overrides or {}).items() if value not in (None, "")}
+
+
+def is_order_identity_repair_request(overrides: dict[str, Any]) -> bool:
+    raw = dict(overrides or {})
+    keys = set(_repair_override_payload(raw))
+    identity_requested = any(raw.get(key) is not None for key in _ORDER_IDENTITY_OVERRIDE_KEYS)
+    return identity_requested and not (keys - _ORDER_IDENTITY_OVERRIDE_KEYS)
+
+
+def _normalized_order_identity(overrides: dict[str, Any]) -> tuple[str, str]:
+    effective = _repair_override_payload(overrides)
+    if set(effective) != _ORDER_IDENTITY_OVERRIDE_KEYS:
+        raise ValueError("order identity repair requires both --futu-account-id and --order-id")
+    futu_account_id = str(effective["futu_account_id"])
+    order_id = str(effective["order_id"])
+    if (
+        not futu_account_id.isascii()
+        or not futu_account_id.isdigit()
+        or futu_account_id.startswith("0")
+    ):
+        raise ValueError("futu_account_id must be canonical positive integer text")
+    if not order_id or any(
+        char.isspace() or unicodedata.category(char).startswith("C") for char in order_id
+    ):
+        raise ValueError("order_id must not contain whitespace or control characters")
+    return futu_account_id, order_id
+
+
+def _order_identity_reason(repair_reason: str) -> str:
+    reason = str(repair_reason or "").strip()
+    if reason == "manual_repair" or "opend" not in reason.lower():
+        raise ValueError("order identity repair reason must reference the manual OpenD evidence")
+    return reason
+
+
+def _storage_trade_event_rows(repo: Any, *, conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
+    sqlite_repo = require_option_positions_event_write_repo(repo)
+    reader = getattr(sqlite_repo, "list_position_projection_event_rows", None)
+    if not callable(reader):
+        raise TypeError("order identity repair requires raw trade-event storage access")
+    return [dict(item) for item in reader(conn=conn)]
+
+
+def _storage_payload(row: dict[str, Any]) -> dict[str, Any]:
+    try:
+        payload = json.loads(str(row.get("event_json") or ""))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"trade event JSON is invalid: event_id={row.get('event_id')}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"trade event JSON must be an object: event_id={row.get('event_id')}")
+    return payload
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _binding_id(event_id: str, futu_account_id: str, order_id: str) -> str:
+    digest = hashlib.sha256(
+        "\x1f".join((event_id, futu_account_id, order_id)).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"order_identity_binding_{digest}"
+
+
+def _assert_identity_only_payload_change(
+    before: dict[str, Any],
+    after: dict[str, Any],
+) -> None:
+    before_outer = deepcopy(before)
+    after_outer = deepcopy(after)
+    before_raw = before_outer.pop("raw_payload", {})
+    after_raw = after_outer.pop("raw_payload", {})
+    if before_outer != after_outer or not isinstance(before_raw, dict) or not isinstance(after_raw, dict):
+        raise ValueError("order identity repair changed non-identity event data")
+    for key in (*_ORDER_IDENTITY_OVERRIDE_KEYS, "order_identity_provenance"):
+        before_raw.pop(key, None)
+        after_raw.pop(key, None)
+    if before_raw != after_raw:
+        raise ValueError("order identity repair changed non-identity raw payload data")
+
+
+def _order_identity_binding_plan(
+    repo: Any,
+    *,
+    target_event_id: str,
+    overrides: dict[str, Any],
+    repair_reason: str,
+    conn: sqlite3.Connection | None = None,
+    bound_at_ms: int | None = None,
+) -> dict[str, Any]:
+    futu_account_id, order_id = _normalized_order_identity(overrides)
+    reason = _order_identity_reason(repair_reason)
+    rows = _storage_trade_event_rows(repo, conn=conn)
+    target_id = str(target_event_id or "").strip()
+    target_row = next((item for item in rows if str(item.get("event_id") or "") == target_id), None)
+    if target_row is None:
+        raise ValueError(f"trade event not found: {target_event_id}")
+    payloads = [(item, _storage_payload(item)) for item in rows]
+    voided_event_ids = {
+        target
+        for _row, payload in payloads
+        if (target := valid_void_target_event_id(payload))
+    }
+    if target_id in voided_event_ids:
+        raise ValueError(f"trade event already voided: {target_id}")
+
+    before_json = str(target_row["event_json"])
+    before_payload = _storage_payload(target_row)
+    event, diagnostics = stored_trade_event_to_ledger_event(before_payload)
+    errors = [item.code for item in diagnostics if item.severity == "error"]
+    if event is None or errors:
+        raise ValueError(
+            "order identity repair requires a canonical trade event: "
+            f"{target_id}; diagnostics={','.join(errors) or 'event_decode_failed'}"
+        )
+    if event.event_type != "open":
+        raise ValueError("order identity repair only supports option open events")
+    if normalize_broker(event.contract_key.broker) != "富途":
+        raise ValueError("order identity repair only supports Futu events")
+    raw_payload = before_payload.get("raw_payload") or {}
+    if not isinstance(raw_payload, dict):
+        raise ValueError("trade event raw_payload must be an object")
+    existing = (
+        str(raw_payload.get("futu_account_id") or "").strip(),
+        str(raw_payload.get("order_id") or "").strip(),
+    )
+    requested = (futu_account_id, order_id)
+    for row, payload in payloads:
+        other_id = str(row.get("event_id") or "")
+        if other_id == target_id or other_id in voided_event_ids:
+            continue
+        other_raw = payload.get("raw_payload") or {}
+        if not isinstance(other_raw, dict):
+            continue
+        other_identity = (
+            str(other_raw.get("futu_account_id") or "").strip(),
+            str(other_raw.get("order_id") or "").strip(),
+        )
+        if other_identity == requested:
+            raise ValueError(f"order identity is already used by active event: {other_id}")
+
+    expected_before_sha256 = _sha256_text(before_json)
+    common = {
+        "operation": "futu_order_identity_binding",
+        "target_event_id": target_id,
+        "before_identity": {
+            "futu_account_id": existing[0] or None,
+            "order_id": existing[1] or None,
+        },
+        "after_identity": {
+            "futu_account_id": futu_account_id,
+            "order_id": order_id,
+        },
+        "futu_account_id": futu_account_id,
+        "order_id": order_id,
+        "expected_before_sha256": expected_before_sha256,
+        "fee_basis": fee_fact_for_event(event).basis.value,
+    }
+    if existing == requested:
+        return common | {
+            "binding_status": "no_op",
+            "before_json": before_json,
+            "after_json": before_json,
+            "after_sha256": expected_before_sha256,
+        }
+    if fee_fact_for_event(event).basis == FeeBasis.ACTUAL:
+        raise ValueError("order identity repair does not apply to an event with actual fee evidence")
+    if any(existing):
+        raise ValueError("order identity repair cannot fill a partial or conflicting identity")
+    if "order_identity_provenance" in raw_payload:
+        raise ValueError("order identity provenance already exists")
+    if bound_at_ms is None:
+        return common | {"binding_status": "ready", "before_json": before_json}
+
+    after_payload = deepcopy(before_payload)
+    after_raw = dict(raw_payload)
+    after_raw.update(
+        {
+            "futu_account_id": futu_account_id,
+            "order_id": order_id,
+            "order_identity_provenance": {
+                "schema_version": _ORDER_IDENTITY_PROVENANCE_SCHEMA,
+                "binding_id": _binding_id(target_id, futu_account_id, order_id),
+                "source": "manual_trade_event_repair",
+                "reason": reason,
+                "before_identity": {"futu_account_id": None, "order_id": None},
+                "expected_before_sha256": expected_before_sha256,
+                "bound_at_ms": int(bound_at_ms),
+            },
+        }
+    )
+    after_payload["raw_payload"] = after_raw
+    _assert_identity_only_payload_change(before_payload, after_payload)
+    after_event, after_diagnostics = stored_trade_event_to_ledger_event(after_payload)
+    if after_event is None or any(item.severity == "error" for item in after_diagnostics):
+        raise ValueError("order identity repair produced an invalid canonical trade event")
+    after_json = json.dumps(after_payload, ensure_ascii=False, sort_keys=True)
+    return common | {
+        "binding_status": "ready",
+        "before_json": before_json,
+        "after_json": after_json,
+        "after_sha256": _sha256_text(after_json),
+        "bound_at_ms": int(bound_at_ms),
+    }
+
+
+def preview_manual_order_identity_binding(
+    repo: Any,
+    *,
+    target_event_id: str,
+    overrides: dict[str, Any],
+    repair_reason: str,
+) -> dict[str, Any]:
+    plan = _order_identity_binding_plan(
+        repo,
+        target_event_id=target_event_id,
+        overrides=overrides,
+        repair_reason=repair_reason,
+    )
+    return {
+        key: value
+        for key, value in (
+            plan
+            | {
+                "mode": "no_op" if plan["binding_status"] == "no_op" else "dry_run",
+                "advisory": True,
+            }
+        ).items()
+        if key not in {"before_json", "after_json", "binding_status"}
+    }
+
+
+def persist_manual_order_identity_binding(
+    repo: Any,
+    *,
+    target_event_id: str,
+    overrides: dict[str, Any],
+    repair_reason: str,
+) -> dict[str, Any]:
+    def _run(sqlite_repo: Any, conn: sqlite3.Connection | None) -> dict[str, Any]:
+        if conn is None:
+            raise TypeError("order identity repair requires SQLite transaction authority")
+        applied_at_ms = now_ms()
+        plan = _order_identity_binding_plan(
+            sqlite_repo,
+            target_event_id=target_event_id,
+            overrides=overrides,
+            repair_reason=repair_reason,
+            conn=conn,
+            bound_at_ms=applied_at_ms,
+        )
+        if plan["binding_status"] == "no_op":
+            return {
+                key: value
+                for key, value in (plan | {"mode": "no_op", "advisory": False}).items()
+                if key not in {"before_json", "after_json", "binding_status"}
+            }
+
+        before_lots = sqlite_repo.list_position_lots(conn=conn)
+        before_fingerprint = position_lots_fingerprint(before_lots)
+        source_before = int(
+            sqlite_repo.read_position_projection_source_state(conn=conn).get("source_generation") or 0
+        )
+        fence = capture_trade_event_decision_projection_fence(sqlite_repo, conn=conn)
+        updated = sqlite_repo.compare_and_swap_trade_event_order_identity_json(
+            event_id=plan["target_event_id"],
+            expected_event_json=plan["before_json"],
+            replacement_event_json=plan["after_json"],
+            updated_at_ms=applied_at_ms,
+            conn=conn,
+        )
+        if not updated:
+            raise ValueError(f"order identity repair CAS conflict: {plan['target_event_id']}")
+        readback = next(
+            (
+                item
+                for item in _storage_trade_event_rows(sqlite_repo, conn=conn)
+                if str(item.get("event_id") or "") == plan["target_event_id"]
+            ),
+            None,
+        )
+        if readback is None or str(readback.get("event_json") or "") != plan["after_json"]:
+            raise ValueError(f"order identity repair readback failed: {plan['target_event_id']}")
+
+        runtime = run_position_projection_in_transaction(
+            sqlite_repo,
+            (),
+            conn=conn,
+            mode="forced_full",
+        )
+        publication = runtime.publication
+        if publication.added or publication.changed or publication.removed:
+            raise ValueError("order identity repair changed position lots")
+        after_fingerprint = position_lots_fingerprint(sqlite_repo.list_position_lots(conn=conn))
+        if after_fingerprint != before_fingerprint:
+            raise ValueError("order identity repair changed the position lot fingerprint")
+        decision = (
+            finalize_current_decision_projection(
+                sqlite_repo,
+                fence=fence,
+                updated_at_ms=applied_at_ms,
+                conn=conn,
+            )
+            if fence is not None
+            else None
+        )
+        sqlite_repo.assert_foreign_keys_clean(conn=conn)
+        source_after = int(
+            sqlite_repo.read_position_projection_source_state(conn=conn).get("source_generation") or 0
+        )
+        return {
+            key: value
+            for key, value in (
+                plan
+                | {
+                    "mode": "applied",
+                    "advisory": False,
+                    "position_lot_count": int(runtime.position_lot_count),
+                    "position_lots_fingerprint": after_fingerprint,
+                    "projection_source_generation_before": source_before,
+                    "projection_source_generation_after": source_after,
+                    "decision_projection": decision,
+                }
+            ).items()
+            if key not in {"before_json", "after_json", "binding_status"}
+        }
+
+    return with_sqlite_repo_transaction(
+        repo,
+        _run,
+        require_projection_publication=True,
+    )
 
 
 def _normalized_repair_core_event(target: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:

--- a/src/application/ledger/order_fee_migration.py
+++ b/src/application/ledger/order_fee_migration.py
@@ -26,10 +26,11 @@ from domain.domain.performance.cash_conversion import (
 from src.application.cash_conversion import build_cash_conversion
 from src.application.ledger.current_decision_projection import (
     capture_current_decision_projection_fence,
+    capture_trade_event_decision_projection_fence,
     compact_assigned_stock_view,
     finalize_current_decision_projection,
 )
-from src.application.ledger.event_codec import encode_trade_event_for_storage
+from src.application.ledger.event_codec import stored_trade_event_to_ledger_event
 from src.application.ledger.order_fee_semantics import zero_option_fee_lifecycle_reason
 from src.application.ledger.position_projection_runtime import (
     run_position_projection_in_transaction,
@@ -244,15 +245,21 @@ def _build_units(
     tuple[dict[str, Any], ...],
     dict[str, dict[str, int]],
 ]:
-    trade_rows = repo.list_trade_events()
+    trade_rows = repo.list_position_projection_event_rows()
     stock_rows = repo.list_assigned_stock_events()
     trade_events: list[TradeEvent] = []
+    trade_event_json: dict[str, str] = {}
     unresolved: list[dict[str, Any]] = []
     passive_outcomes: list[dict[str, Any]] = []
     for row in trade_rows:
         try:
-            event = TradeEvent.from_dict(row)
-        except (TypeError, ValueError) as exc:
+            payload = json.loads(str(row.get("event_json") or ""))
+            if not isinstance(payload, dict):
+                raise TypeError("trade event JSON must be an object")
+            event, diagnostics = stored_trade_event_to_ledger_event(payload)
+            if event is None or any(item.severity == "error" for item in diagnostics):
+                raise ValueError("stored trade event is not canonical")
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
             unresolved.append(
                 {
                     "event_kind": "option_trade",
@@ -263,6 +270,7 @@ def _build_units(
             )
             continue
         trade_events.append(event)
+        trade_event_json[event.event_id] = str(row["event_json"])
     voided = {
         str(event.target_event_id)
         for event in trade_events
@@ -384,6 +392,7 @@ def _build_units(
                 option_group,
                 observation=observation,
                 applied_at_ms=applied_at_ms,
+                trade_event_json=trade_event_json,
             )
             event_kind = "option_trade"
         else:
@@ -461,6 +470,7 @@ def _build_units(
                     _trade_change(
                         event,
                         updated,
+                        before_json=trade_event_json[event.event_id],
                         before_basis=FeeBasis.MISSING.value,
                         after_basis=FeeBasis.ACTUAL.value,
                     ),
@@ -491,6 +501,7 @@ def _build_units(
         changes, reason = _estimated_option_changes(
             events,
             applied_at_ms=applied_at_ms,
+            trade_event_json=trade_event_json,
         )
         if changes:
             units.append(_Unit(identity=f"formula:option:{identity}", changes=tuple(changes)))
@@ -539,6 +550,7 @@ def _actual_option_changes(
     *,
     observation: ActualOrderFee,
     applied_at_ms: int,
+    trade_event_json: Mapping[str, str],
 ) -> tuple[list[_Change], str | None]:
     ordered = sorted(events, key=lambda item: (item.event_time_ms, item.event_id))
     allocations = _allocate(observation.amount, [event.contracts for event in ordered])
@@ -566,6 +578,7 @@ def _actual_option_changes(
             _trade_change(
                 event,
                 updated,
+                before_json=trade_event_json[event.event_id],
                 before_basis=before.basis.value,
                 after_basis=FeeBasis.ACTUAL.value,
                 observation=observation,
@@ -613,7 +626,10 @@ def _actual_stock_changes(
 
 
 def _estimated_option_changes(
-    events: Sequence[TradeEvent], *, applied_at_ms: int
+    events: Sequence[TradeEvent],
+    *,
+    applied_at_ms: int,
+    trade_event_json: Mapping[str, str],
 ) -> tuple[list[_Change], str | None]:
     ordered = sorted(events, key=lambda item: (item.event_time_ms, item.event_id))
     if any(normalize_broker(item.contract_key.broker) != "富途" for item in ordered):
@@ -669,6 +685,7 @@ def _estimated_option_changes(
             _trade_change(
                 event,
                 updated,
+                before_json=trade_event_json[event.event_id],
                 before_basis=FeeBasis.MISSING.value,
                 after_basis=FeeBasis.ESTIMATED.value,
             )
@@ -884,22 +901,56 @@ def _trade_change(
     before: TradeEvent,
     after: TradeEvent,
     *,
+    before_json: str,
     before_basis: str,
     after_basis: str,
     observation: ActualOrderFee | None = None,
 ) -> _Change:
+    after_json = _option_fee_after_json(before_json, after)
     return _Change(
         event_kind="option_trade",
         event_id=before.event_id,
         account=before.contract_key.account,
-        before_json=encode_trade_event_for_storage(before).event_json,
-        after_json=encode_trade_event_for_storage(after).event_json,
+        before_json=before_json,
+        after_json=after_json,
         before_basis=before_basis,
         after_basis=after_basis,
         provider_batch_id=observation.provider_batch_id if observation else None,
         provider_observed_at_ms=observation.observed_at_ms if observation else None,
         fee_details_sha256=observation.fee_details_sha256 if observation else None,
     )
+
+
+def _option_fee_after_json(before_json: str, after: TradeEvent) -> str:
+    try:
+        payload = json.loads(before_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError("stored trade event JSON is invalid") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("stored trade event JSON must be an object")
+    stored_raw = payload.get("raw_payload")
+    if stored_raw is not None and not isinstance(stored_raw, dict):
+        raise ValueError("stored trade event raw_payload must be an object")
+
+    after_payload = after.to_dict()
+    after_raw = dict(after_payload["raw_payload"])
+    raw_payload = dict(stored_raw or {})
+    for key in ("fee_provenance", "cash_conversions"):
+        if key in after_raw:
+            raw_payload[key] = after_raw[key]
+        else:
+            raw_payload.pop(key, None)
+    payload["fees"] = after_payload["fees"]
+    payload["raw_payload"] = raw_payload
+    result = _json(payload)
+    decoded, diagnostics = stored_trade_event_to_ledger_event(payload)
+    if (
+        decoded is None
+        or any(item.severity == "error" for item in diagnostics)
+        or decoded.to_dict() != after_payload
+    ):
+        raise ValueError("fee enrichment produced an invalid trade event")
+    return result
 
 
 def _stock_change(
@@ -934,7 +985,14 @@ def _apply_unit(
     if conn is None:
         raise TypeError("fee enrichment requires SQLite transaction authority")
     accounts = sorted({change.account for change in unit.changes})
-    fence = capture_current_decision_projection_fence(repo, accounts=accounts, conn=conn)
+    option_changed = any(change.event_kind == "option_trade" for change in unit.changes)
+    fence = (
+        capture_trade_event_decision_projection_fence(repo, conn=conn)
+        if option_changed
+        else capture_current_decision_projection_fence(repo, accounts=accounts, conn=conn)
+    )
+    if fence is None:
+        raise ValueError("fee enrichment projection fence is empty")
     _ensure_audit_table(conn)
     for change in unit.changes:
         table, column = (
@@ -957,7 +1015,6 @@ def _apply_unit(
             raise ValueError(f"fee enrichment update failed: {change.event_id}")
         _insert_audit(conn, unit=unit, change=change, applied_at_ms=applied_at_ms)
 
-    option_changed = any(change.event_kind == "option_trade" for change in unit.changes)
     projection = (
         run_position_projection_in_transaction(
             repo,

--- a/src/application/ledger/repository_trade_events.py
+++ b/src/application/ledger/repository_trade_events.py
@@ -99,6 +99,32 @@ class TradeEventRepositoryMixin:
             )
         return True
 
+    def compare_and_swap_trade_event_order_identity_json(
+        self,
+        *,
+        event_id: str,
+        expected_event_json: str,
+        replacement_event_json: str,
+        updated_at_ms: int,
+        conn: sqlite3.Connection,
+    ) -> bool:
+        if conn is None or not conn.in_transaction:
+            raise ValueError("order identity binding requires an active transaction")
+        updated = conn.execute(
+            """
+            UPDATE trade_events
+            SET event_json = ?, updated_at_ms = ?
+            WHERE event_id = ? AND event_json = ?
+            """,
+            (
+                str(replacement_event_json),
+                int(updated_at_ms),
+                str(event_id),
+                str(expected_event_json),
+            ),
+        )
+        return int(updated.rowcount or 0) == 1
+
     def list_trade_events(self, *, conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
         with self._optional_conn(conn) as active_conn:
             rows = active_conn.execute(

--- a/src/interfaces/cli/trade_events.py
+++ b/src/interfaces/cli/trade_events.py
@@ -88,7 +88,10 @@ def main(argv: list[str] | None = None) -> int:
     p_void.add_argument("--format", choices=["text", "json"], default="text")
     _add_write_flags(p_void, high_risk=True)
 
-    p_repair = sub.add_parser("repair", help="void an event and append a corrected replacement event")
+    p_repair = sub.add_parser(
+        "repair",
+        help="repair an event; identity-only Futu order metadata is bound in place",
+    )
     p_repair.add_argument("--runtime-root", default=None, help="runtime root for active ledger store")
     p_repair.add_argument("event_id")
     p_repair.add_argument("--reason", default="manual_repair")
@@ -257,15 +260,29 @@ def main(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             print(str(exc))
             return 2
+        identity_binding = payload.get("operation") == "futu_order_identity_binding"
+        write_applied = bool(payload.get("mode") == "applied") if identity_binding else should_apply
         payload["ledger_store"] = ledger_store
         payload = attach_write_contract(
             payload,
             dry_run=not should_apply,
-            write_applied=should_apply,
-            rollback_hint="void repair events or restore option_positions SQLite from backup",
+            write_applied=write_applied,
+            rollback_hint=(
+                "identity binding creates no backup or void event; restore a separately verified pre-write SQLite backup"
+                if identity_binding
+                else "void repair events or restore option_positions SQLite from backup"
+            ),
         )
         if args.format == "json":
             _print_json(payload)
+            return 0
+        if identity_binding:
+            state = str(payload.get("mode") or "").upper()
+            verb = "would bind" if payload.get("mode") == "dry_run" else "already bound" if payload.get("mode") == "no_op" else "bound"
+            print(
+                f"[{state}] {verb} Futu order identity event_id={args.event_id} "
+                f"futu_account_id={payload.get('futu_account_id')} order_id={payload.get('order_id')}"
+            )
             return 0
         if should_apply:
             print(

--- a/tests/test_ledger_current_decision_projection.py
+++ b/tests/test_ledger_current_decision_projection.py
@@ -62,6 +62,8 @@ from src.application.ledger.position_projection_runtime import (
     run_position_projection_forced_full,
     run_position_projection_in_transaction,
 )
+from src.application.ledger.interventions import persist_manual_order_identity_binding
+from src.application.ledger.order_fee_migration import enrich_order_fees
 from src.application.ledger.read_only_evidence import (
     open_trade_reconciliation_evidence_repo,
 )
@@ -2338,6 +2340,71 @@ def test_fence_finalizer_skips_unchanged_and_rebuilds_global_fanout_once(
     assert len(projection_dml) == len(accounts)
     assert all(
         read_current_decision_projection(repo, account=account, now_ms=13_000)[
+            "status"
+        ]
+        == "trusted"
+        for account in accounts
+    )
+
+
+def test_order_identity_binding_and_fee_enrichment_rebuild_every_clean_current_decision_account(
+    tmp_path: Path,
+) -> None:
+    accounts = ("lx", "sy")
+    repo = _repo(tmp_path, accounts=accounts)
+    for account in accounts:
+        _bootstrap(repo, account)
+    before_lots = repo.list_position_lots()
+
+    applied = persist_manual_order_identity_binding(
+        repo,
+        target_event_id="open-lx",
+        overrides={"futu_account_id": "123", "order_id": "order-1"},
+        repair_reason="OpenD manual evidence: deal-1",
+    )
+
+    assert applied["decision_projection"]["statuses"] == {
+        "lx": "published",
+        "sy": "published",
+    }
+    assert repo.list_position_lots() == before_lots
+    assert all(
+        read_current_decision_projection(repo, account=account, now_ms=20_000)[
+            "status"
+        ]
+        == "trusted"
+        for account in accounts
+    )
+
+    enriched = enrich_order_fees(
+        repo,
+        account="lx",
+        actual_fees=(
+            {
+                "broker": "富途",
+                "account": "lx",
+                "futu_account_id": "123",
+                "order_id": "order-1",
+                "fee_amount": "1.23",
+                "currency": "USD",
+                "event_kind": "option_trade",
+                "dealt_quantity": "1",
+                "observed_at_ms": 14_000,
+            },
+        ),
+        apply=True,
+        applied_at_ms=15_000,
+        target_identity=("富途", "lx", "123", "order-1"),
+    )
+
+    assert enriched["status_counts"] == {"committed": 1}
+    assert enriched["outcomes"][0]["decision_projection"]["statuses"] == {
+        "lx": "published",
+        "sy": "published",
+    }
+    assert repo.list_position_lots() == before_lots
+    assert all(
+        read_current_decision_projection(repo, account=account, now_ms=20_000)[
             "status"
         ]
         == "trusted"

--- a/tests/test_order_fee_sync.py
+++ b/tests/test_order_fee_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -16,6 +17,8 @@ from domain.domain.performance.cash_conversion import (
 from src.application.cash_conversion import build_cash_conversion
 from src.application.ledger.order_fee_migration import _conversion_for_amount, enrich_order_fees
 from src.application.ledger.order_fee_semantics import zero_option_fee_lifecycle_reason
+from src.application.ledger.interventions import persist_manual_order_identity_binding
+from src.application.ledger.position_projection_runtime import run_position_projection_forced_full
 from src.application.ledger.repository import SQLiteOptionPositionsRepository
 from src.application.ledger.writer import persist_trade_event_object
 from src.application.trades import order_fee_sync as order_fee_sync_module
@@ -25,7 +28,11 @@ from src.application.trades.order_fee_sync import sync_order_fees
 EVENT_MS = 1_780_000_000_000
 
 
-def _repo_with_bare_option_event(tmp_path: Path) -> SQLiteOptionPositionsRepository:
+def _repo_with_bare_option_event(
+    tmp_path: Path,
+    *,
+    with_identity: bool = True,
+) -> SQLiteOptionPositionsRepository:
     repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
     event = TradeEvent(
         event_id="event-1",
@@ -46,7 +53,11 @@ def _repo_with_bare_option_event(tmp_path: Path) -> SQLiteOptionPositionsReposit
         source="broker",
         multiplier=100,
         lot_id="lot-1",
-        raw_payload={"futu_account_id": "123", "order_id": "order-1"},
+        raw_payload=(
+            {"futu_account_id": "123", "order_id": "order-1"}
+            if with_identity
+            else {}
+        ),
     )
     repo.upsert_trade_event(event)
     return repo
@@ -194,6 +205,80 @@ def test_fee_sync_dry_run_is_read_only_and_apply_persists_actual_fee(
     assert event.raw_payload["fee_provenance"]["source"] == "opend.order_fee_query"
     with repo._connect() as conn:  # noqa: SLF001 - audit proof
         assert conn.execute("SELECT COUNT(*) FROM broker_fee_enrichment_audit").fetchone()[0] == 1
+
+
+def test_bound_order_identity_flows_into_existing_fee_sync(tmp_path: Path) -> None:
+    repo = _repo_with_bare_option_event(tmp_path, with_identity=False)
+    legacy_fee = {"basis": "missing", "reason": "legacy top-level evidence"}
+    with repo._connect() as conn:  # noqa: SLF001 - byte-level compatibility fixture
+        row = conn.execute(
+            "SELECT event_json FROM trade_events WHERE event_id = ?",
+            ("event-1",),
+        ).fetchone()
+        payload = json.loads(str(row["event_json"]))
+        payload["legacy_extension"] = {"keep": True}
+        payload["fee_provenance"] = legacy_fee
+        conn.execute(
+            "UPDATE trade_events SET event_json = ? WHERE event_id = ?",
+            (json.dumps(payload, ensure_ascii=False, sort_keys=True), "event-1"),
+        )
+    run_position_projection_forced_full(repo)
+    persist_manual_order_identity_binding(
+        repo,
+        target_event_id="event-1",
+        overrides={"futu_account_id": "123", "order_id": "order-1"},
+        repair_reason="OpenD manual evidence: deal-1",
+    )
+    kwargs = {
+        "account": "lx",
+        "start_ms": EVENT_MS - 1,
+        "end_exclusive_ms": EVENT_MS + 1,
+        "observed_at_ms": EVENT_MS + 10,
+        "allowed_futu_account_ids": ("123",),
+    }
+
+    preview = sync_order_fees(repo, provider=_Provider(), apply=False, **kwargs)
+    applied = sync_order_fees(repo, provider=_Provider(), apply=True, **kwargs)
+    converged_provider = _Provider()
+    converged = sync_order_fees(
+        repo,
+        provider=converged_provider,
+        apply=False,
+        **(kwargs | {"observed_at_ms": EVENT_MS + 20}),
+    )
+    with repo._connect() as conn:  # noqa: SLF001 - byte-level compatibility proof
+        row = conn.execute(
+            "SELECT event_json FROM trade_events WHERE event_id = ?",
+            ("event-1",),
+        ).fetchone()
+        after_sync_json = str(row["event_json"])
+        after_sync = json.loads(after_sync_json)
+    source_generation = repo.read_position_projection_source_state()["source_generation"]
+    retry = persist_manual_order_identity_binding(
+        repo,
+        target_event_id="event-1",
+        overrides={"futu_account_id": "123", "order_id": "order-1"},
+        repair_reason="OpenD manual evidence: deal-1",
+    )
+
+    assert preview["actual_observation_count"] == 1
+    assert applied["migration"]["status_counts"] == {"committed": 1}
+    assert converged["selected_order_count"] == 0
+    assert converged["actual_observation_count"] == 0
+    assert converged_provider.terminal_calls == converged_provider.fee_calls == 0
+    assert after_sync["legacy_extension"] == {"keep": True}
+    assert after_sync["fee_provenance"] == legacy_fee
+    assert after_sync["raw_payload"]["order_identity_provenance"]["source"] == (
+        "manual_trade_event_repair"
+    )
+    assert after_sync["raw_payload"]["fee_provenance"]["basis"] == "actual"
+    assert retry["mode"] == "no_op"
+    with repo._connect() as conn:  # noqa: SLF001 - no-op byte proof
+        assert conn.execute(
+            "SELECT event_json FROM trade_events WHERE event_id = ?",
+            ("event-1",),
+        ).fetchone()["event_json"] == after_sync_json
+    assert repo.read_position_projection_source_state()["source_generation"] == source_generation
 
 
 def test_order_backed_expiry_reaches_actual_fee_provider(tmp_path: Path) -> None:

--- a/tests/test_position_projection_facade_inventory.py
+++ b/tests/test_position_projection_facade_inventory.py
@@ -136,6 +136,11 @@ def test_projection_runtime_facade_modes_are_fully_inventoried() -> None:
                 "'forced_full'",
             ): 1,
             (
+                "src/application/ledger/interventions.py",
+                "persist_manual_order_identity_binding>_run",
+                "'forced_full'",
+            ): 1,
+            (
                 "src/application/ledger/manual_trades.py",
                 "persist_manual_adjust_events>_run",
                 "'fast_if_safe'",

--- a/tests/test_trade_events_cli.py
+++ b/tests/test_trade_events_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+import hashlib
 import json
 import sqlite3
 from pathlib import Path
@@ -364,6 +366,344 @@ def test_trade_events_repair_rejects_open_event_with_downstream_close(monkeypatc
     assert "cannot repair an open event with downstream close/adjust dependencies" in out
     assert "explicit_target" in out
     assert repo.list_position_lots()[0]["fields"]["contracts_open"] == 0
+
+
+def test_trade_events_identity_repair_binds_in_place_with_downstream_and_is_idempotent(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    import src.interfaces.cli.trade_events as cli
+    from src.application.ledger.position_projection_runtime import run_position_projection_forced_full
+
+    repo, event_id = _repo_with_open_event(tmp_path)
+    with repo._connect() as conn:  # noqa: SLF001 - legacy byte-preservation fixture
+        row = conn.execute(
+            "SELECT event_json FROM trade_events WHERE event_id=?",
+            (event_id,),
+        ).fetchone()
+        payload = json.loads(str(row["event_json"]))
+        payload["fee_provenance"] = {
+            "basis": "estimated",
+            "source": "legacy_fee_estimate",
+        }
+        payload["raw_payload"]["unknown_legacy_key"] = {"keep": True}
+        conn.execute(
+            "UPDATE trade_events SET event_json=?, updated_at_ms=? WHERE event_id=?",
+            (json.dumps(payload, ensure_ascii=False), 1500, event_id),
+        )
+    run_position_projection_forced_full(repo)
+    lot = repo.list_position_lots()[0]
+    ledger_manual_trades.persist_manual_close_event(
+        repo,
+        record_id=lot["record_id"],
+        fields=lot["fields"],
+        contracts_to_close=1,
+        close_price=1.2,
+        close_reason="manual_buy_to_close",
+        as_of_ms=2000,
+    )
+    monkeypatch.setattr(cli, "resolve_option_positions_repo", lambda **_kwargs: (tmp_path / "data.json", repo))
+
+    def stored_state() -> tuple[str, int, list[dict], int]:
+        with repo._connect() as conn:  # noqa: SLF001 - exact storage proof
+            row = conn.execute(
+                "SELECT event_json, ingest_seq FROM trade_events WHERE event_id=?",
+                (event_id,),
+            ).fetchone()
+        generation = int(repo.read_position_projection_source_state().get("source_generation") or 0)
+        return str(row["event_json"]), int(row["ingest_seq"]), repo.list_position_lots(), generation
+
+    before_json, before_ingest_seq, before_lots, before_generation = stored_state()
+    args = [
+        "repair",
+        event_id,
+        "--futu-account-id",
+        "123",
+        "--order-id",
+        "order-1",
+        "--reason",
+        "OpenD manual evidence: deal-1",
+        "--format",
+        "json",
+    ]
+
+    assert cli.main([*args, "--dry-run"]) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["mode"] == "dry_run"
+    assert preview["advisory"] is True
+    assert preview["expected_before_sha256"] == hashlib.sha256(before_json.encode()).hexdigest()
+    assert preview["write_applied"] is False
+    assert stored_state() == (before_json, before_ingest_seq, before_lots, before_generation)
+
+    assert cli.main([*args, "--confirm"]) == 0
+    applied = json.loads(capsys.readouterr().out)
+    after_json, after_ingest_seq, after_lots, after_generation = stored_state()
+    assert applied["mode"] == "applied"
+    assert applied["write_applied"] is True
+    assert "void_event_id" not in applied and "repair_event_id" not in applied
+    assert after_ingest_seq == before_ingest_seq
+    assert after_lots == before_lots
+    assert after_generation == before_generation + 1
+    before_payload = json.loads(before_json)
+    after_payload = json.loads(after_json)
+    before_outer = deepcopy(before_payload)
+    after_outer = deepcopy(after_payload)
+    before_outer.pop("raw_payload")
+    after_outer.pop("raw_payload")
+    assert after_outer == before_outer
+    assert after_payload["fee_provenance"] == before_payload["fee_provenance"]
+    after_raw = deepcopy(after_payload["raw_payload"])
+    provenance = after_raw.pop("order_identity_provenance")
+    assert after_raw.pop("futu_account_id") == "123"
+    assert after_raw.pop("order_id") == "order-1"
+    assert after_raw == before_payload["raw_payload"]
+    assert provenance["expected_before_sha256"] == preview["expected_before_sha256"]
+    assert len(repo.list_trade_events()) == 2
+
+    assert cli.main([*args, "--confirm"]) == 0
+    no_op = json.loads(capsys.readouterr().out)
+    assert no_op["mode"] == "no_op"
+    assert no_op["write_applied"] is False
+    assert stored_state() == (after_json, after_ingest_seq, after_lots, after_generation)
+
+
+@pytest.mark.parametrize(
+    ("identity_args", "reason", "message"),
+    [
+        (["--futu-account-id", "123"], "OpenD manual evidence: deal-1", "requires both"),
+        (
+            ["--futu-account-id", "", "--order-id", ""],
+            "OpenD manual evidence: deal-1",
+            "requires both",
+        ),
+        (
+            ["--futu-account-id", "00123", "--order-id", "order-1"],
+            "OpenD manual evidence: deal-1",
+            "canonical positive integer",
+        ),
+        (
+            ["--futu-account-id", "123", "--order-id", "order 1"],
+            "OpenD manual evidence: deal-1",
+            "whitespace or control",
+        ),
+        (
+            ["--futu-account-id", "123", "--order-id", " order-1"],
+            "OpenD manual evidence: deal-1",
+            "whitespace or control",
+        ),
+        (
+            ["--futu-account-id", "123", "--order-id", "order-1"],
+            "manual_repair",
+            "manual OpenD evidence",
+        ),
+    ],
+)
+def test_trade_events_identity_repair_rejects_invalid_identity_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+    identity_args: list[str],
+    reason: str,
+    message: str,
+) -> None:
+    import src.interfaces.cli.trade_events as cli
+
+    repo, event_id = _repo_with_open_event(tmp_path)
+    monkeypatch.setattr(cli, "resolve_option_positions_repo", lambda **_kwargs: (tmp_path / "data.json", repo))
+    before = repo.list_trade_events()
+
+    assert cli.main(
+        [
+            "repair",
+            event_id,
+            *identity_args,
+            "--reason",
+            reason,
+            "--confirm",
+        ]
+    ) == 2
+
+    assert message in capsys.readouterr().out
+    assert repo.list_trade_events() == before
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("partial", "partial or conflicting identity"),
+        ("actual", "actual fee evidence"),
+        ("duplicate", "already used by active event"),
+        ("voided", "already voided"),
+    ],
+)
+def test_trade_events_identity_repair_rejects_ineligible_state_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+    case: str,
+    message: str,
+) -> None:
+    import src.interfaces.cli.trade_events as cli
+    from domain.domain.option_position_lots import OpenPositionCommand
+    from src.application.ledger.interventions import persist_manual_order_identity_binding
+
+    repo, event_id = _repo_with_open_event(tmp_path)
+    if case in {"partial", "actual"}:
+        with repo._connect() as conn:  # noqa: SLF001 - ineligible legacy-row fixture
+            row = conn.execute(
+                "SELECT event_json FROM trade_events WHERE event_id=?",
+                (event_id,),
+            ).fetchone()
+            payload = json.loads(str(row["event_json"]))
+            if case == "partial":
+                payload["raw_payload"]["futu_account_id"] = "123"
+            else:
+                payload["raw_payload"]["fee_provenance"] = {
+                    "basis": "actual",
+                    "amount": 0,
+                    "source": "test",
+                }
+            conn.execute(
+                "UPDATE trade_events SET event_json=? WHERE event_id=?",
+                (json.dumps(payload, ensure_ascii=False), event_id),
+            )
+    elif case == "duplicate":
+        ledger_manual_trades.persist_manual_open_event(
+            repo,
+            OpenPositionCommand(
+                broker="富途",
+                account="lx",
+                symbol="NVDA",
+                option_type="put",
+                side="short",
+                contracts=1,
+                currency="USD",
+                strike=100.0,
+                multiplier=100,
+                expiration_ymd="2026-04-29",
+                premium_per_share=2.0,
+                opened_at_ms=1100,
+            ),
+        )
+        other_event_id = next(
+            item["event_id"] for item in repo.list_trade_events() if item["event_id"] != event_id
+        )
+        persist_manual_order_identity_binding(
+            repo,
+            target_event_id=other_event_id,
+            overrides={"futu_account_id": "123", "order_id": "order-1"},
+            repair_reason="OpenD manual evidence: deal-1",
+        )
+    else:
+        _append_canonical_void_event(
+            repo,
+            target_event_id=event_id,
+            event_id="canonical-void-open",
+            event_time_ms=2000,
+        )
+    monkeypatch.setattr(cli, "resolve_option_positions_repo", lambda **_kwargs: (tmp_path / "data.json", repo))
+    before = repo.list_trade_events()
+
+    assert cli.main(
+        [
+            "repair",
+            event_id,
+            "--futu-account-id",
+            "123",
+            "--order-id",
+            "order-1",
+            "--reason",
+            "OpenD manual evidence: deal-1",
+            "--confirm",
+        ]
+    ) == 2
+
+    assert message in capsys.readouterr().out
+    assert repo.list_trade_events() == before
+
+
+def test_trade_events_identity_repair_rolls_back_projection_failure(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    import src.application.ledger.interventions as interventions
+    import src.interfaces.cli.trade_events as cli
+
+    repo, event_id = _repo_with_open_event(tmp_path)
+    monkeypatch.setattr(cli, "resolve_option_positions_repo", lambda **_kwargs: (tmp_path / "data.json", repo))
+    with repo._connect() as conn:  # noqa: SLF001 - rollback proof
+        before_json = str(
+            conn.execute(
+                "SELECT event_json FROM trade_events WHERE event_id=?",
+                (event_id,),
+            ).fetchone()["event_json"]
+        )
+    before_generation = repo.read_position_projection_source_state()["source_generation"]
+    monkeypatch.setattr(
+        interventions,
+        "run_position_projection_in_transaction",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("injected projection failure")),
+    )
+
+    assert cli.main(
+        [
+            "repair",
+            event_id,
+            "--futu-account-id",
+            "123",
+            "--order-id",
+            "order-1",
+            "--reason",
+            "OpenD manual evidence: deal-1",
+            "--confirm",
+        ]
+    ) == 2
+    assert "injected projection failure" in capsys.readouterr().out
+    with repo._connect() as conn:  # noqa: SLF001 - rollback proof
+        after_json = str(
+            conn.execute(
+                "SELECT event_json FROM trade_events WHERE event_id=?",
+                (event_id,),
+            ).fetchone()["event_json"]
+        )
+    assert after_json == before_json
+    assert repo.read_position_projection_source_state()["source_generation"] == before_generation
+
+
+def test_trade_events_identity_repair_rejects_cas_conflict_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    import src.interfaces.cli.trade_events as cli
+
+    repo, event_id = _repo_with_open_event(tmp_path)
+    monkeypatch.setattr(cli, "resolve_option_positions_repo", lambda **_kwargs: (tmp_path / "data.json", repo))
+    monkeypatch.setattr(
+        type(repo),
+        "compare_and_swap_trade_event_order_identity_json",
+        lambda *_args, **_kwargs: False,
+    )
+    before = repo.list_trade_events()
+
+    assert cli.main(
+        [
+            "repair",
+            event_id,
+            "--futu-account-id",
+            "123",
+            "--order-id",
+            "order-1",
+            "--reason",
+            "OpenD manual evidence: deal-1",
+            "--confirm",
+        ]
+    ) == 2
+
+    assert "CAS conflict" in capsys.readouterr().out
+    assert repo.list_trade_events() == before
 
 
 def test_trade_events_repair_close_record_id_updates_canonical_target_lot(monkeypatch, tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add controlled in-place binding of Futu account and order identities for historical opening trade events
- preserve economic fields while enforcing validation, CAS, projection refresh, and current-decision maintenance
- keep fee sync raw-event preservation and global projection fencing covered by regression tests

## Verification
- 119 focused tests passed
- Ruff passed on touched Python files
- dependency graph check passed
- repository guardrails passed

No release, version bump, deployment, or production-data operation is included.