### PR TITLE
perf(ledger): bound batch adjustment preflight

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1009 (`src`: 541, `domain`: 78, `scripts`: 12, `tests`: 378)
-- Internal import edges: 6753 total, 2936 production/script edges excluding tests
+- Internal import edges: 6761 total, 2936 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,7 +46,7 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2823| application
+  tests -->|2831| application
   tests -->|429| domain
   tests -->|2| domain_services
   tests -->|233| infrastructure
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2823 |
+| tests | application | 2831 |
 | tests | domain | 429 |
 | tests | interfaces | 243 |
 | tests | infrastructure | 233 |

--- a/docs/LEDGER_ARCHITECTURE.md
+++ b/docs/LEDGER_ARCHITECTURE.md
@@ -147,6 +147,139 @@ position-projection migration 的 `_write_connection()` 持有同一 `<db>.write
 `--request-id`。相同 request ID 与相同 intent 返回原结果；同一 ID 绑定不同 intent
 会 fail closed。确认前检查响应中的目标 SQLite、account、lot/event identity、数量和写入合同。
 
+## 批量 adjustment 投影成本
+
+### 目标、边界与成功信号
+
+`record_manual_position_adjustments()` 在一次原子批量写入前复用同一份 current projection，
+并把全部候选 adjustment 作为一个集合只预览一次，不按 adjustment 数量重复读取和投影完整
+`trade_events` 历史。
+
+成功信号：
+
+- 两项及更多 adjustment 的预检固定为一次 current preview 和一次 combined candidate preview；
+  全历史读取次数不随 batch cardinality 线性增长；
+- trusted checkpoint 下完整入口至多两次 full-prefix read：一次 combined candidate fallback 和一次
+  事务内最终 projection；checkpoint disabled 或 untrusted 时至多三次：current preview、combined candidate
+  preview 和事务内最终 projection 各一次；两种模式都不随 batch cardinality 增长；
+- preflight 返回字段、patch、event time 和写入结果保持兼容，forced-full 与优化路径的最终 lot
+  fingerprint 完全一致；
+- 任一 target、current fields、contract identity、patch 或 combined projection 无效时，整批零写入；
+  事务内仍重读当前 lot，并要求重读字段与 preflight advisory 字段逐字典相等，再完成最终 projection、
+  current-decision finalize 和 commit；
+- 完整 projection 缺少可恢复 state 时继续 fail closed，不发布 read model、不提交事务，也不新建
+  checkpoint；warning-only/no-state 行为只增加 characterization regression，不修改 runtime 源码；
+- Phase 3A 的 special Combo fixture 使用晚于既有历史且早于 expiration 的开仓时间，完整场景不再因
+  fixture 自身的 `economic_adjust_invalid` warning 中断。
+
+该实现没有让 adjustment 支持 tail projection，也没有达到 Phase 3A 冻结的 `500 ms`、`64 MiB` 和零
+full-prefix-read 门槛。本地 `1` warmup / `3` repetitions non-acceptance smoke 在 10,000 events / 100
+open lots 的两项 batch 上，fast 路径 wall/CPU P95 为 `0.880 s` / `0.863 s`、两次 full-prefix read，
+forced-full 路径为 `1.158 s` / `1.137 s`、三次 full-prefix read；最终 lot fingerprint 完全一致，fast
+路径 Python peak allocation 为 `79,110,743` bytes。该 smoke 只证明当前主机上的结构性收益，不是
+跨主机 acceptance 结论。
+
+当前仓库中该 batch facade 的唯一调用者是 Phase 3A benchmark；本分片只改善 admission/benchmark
+路径，不宣称生产 tick、通知或交易入口会因此加速。若未来接入生产 caller，必须先解决下述响应丢失
+后的批量重试风险。
+
+不修改 schema、公开 facade、CLI、config、正常 read path 或单笔 close path，不发布、部署或写入生产
+账本和运行环境。不处理通用事件 JSON 解码/复制成本，也不增加 cache、后台任务或新依赖。
+
+### 当前事实与选定方案
+
+原 batch command 对每个输入分别调用 `_preflight_lot_adjust()`。该函数先读取 trusted current
+projection，再对单个 `adjust` 候选调用 `preview_position_projection_append()`；领域 projector 把
+`adjust` 视为 control event，candidate tail 因此回退 full replay。事务内
+`persist_manual_adjust_events()` 又必须对最终事件集合重算一次投影。批量项越多，写前 full replay
+越多；单笔 close 和 current projection read 不经过这条重复链路，保持不动。
+
+当前实现保留 singular preflight 和事务 writer 的职责，只抽出一段共享的
+“基于已读取 current preview 构造一个 adjustment preflight result 与候选 event”逻辑：
+
+1. singular `_preflight_lot_adjust()` 读取一次 current preview，构造一个候选并预览一次；外部行为不变；
+2. 新的 batch preflight 读取一次 current preview，按既有顺序验证每个唯一 `record_id`、current
+   fields、open 状态和 contract identity，并构造各自 patch、event time 与候选 event；
+3. batch preflight 将全部候选 events 交给一次 `_preview_append_projection()`，沿用既有 error/ineligible
+   阻断规则；warning 保留在 preview 结果中，但不放宽事务内最终完整 projection 的发布条件；
+4. command 把每项 preflight 的 advisory current fields 和 event time 交给现有
+   `persist_manual_adjust_events()`；后者在同一 SQLite transaction 内重读目标，并在构造任何正式 event
+   前要求 `current_fields == fields`；任一字段漂移都 rollback，随后才检查 group collision、构造正式
+   events、发布最终 projection 和 current-decision，并一次 commit 或 rollback；
+5. 不把 advisory preview 对象或投影状态带入写事务，不降低 transaction-time revalidation。
+
+`ensure_projection_publishable()` 的 error/ineligible 规则只负责 preview 资格；事务内 `_run_full_path()`
+仍要求完整 resumable state。warning 导致 state 缺失时继续抛错并由 transaction rollback，不发布
+position lots，也不推进 trusted head。Phase 3A 当前中断来自 synthetic special Combo 开仓时间晚于
+expiration；只把该 fixture 的时间改为 `1_850_000_000_500` ms，使其晚于基线历史且早于
+`2028-12-15`，并用 regression 证明 warning-only/no-state 的 fail-closed 行为没有漂移。
+
+拒绝的替代方案：
+
+- 允许所有 `adjust` 直接 tail-resume：会扩大 domain control-event 契约，经济字段、合约身份和策略
+  metadata 的安全边界需要另行设计；没有当前收益证据时不做；
+- 修改 generic projector 为 streaming 或重写事件 codec：改动面远大于已定位的 batch 重复调用；
+- 为 warning 新增 allowlist、持久化 head diagnostics 或改变全局发布语义：当前 fixture 修正后没有必要；
+- 新增 repository latest-event query 以省掉 disabled/untrusted 下的 current full read：只少一次固定读取，
+  却扩大 persistence API，当前 benchmark-only 收益不成立；
+- 新增 batch projector、cache 或 checkpoint 类型：现有 preview 与 transaction runtime 足够表达本分片。
+
+### Owner、数据流与失败语义
+
+受影响 owner：
+
+- `src/application/ledger/commands.py`：batch 输入归一化、调用 batch preflight、组装兼容结果；
+- `src/application/ledger/preflight.py`：共享 adjustment 构造校验和一次 combined preview；
+- `src/application/ledger/manual_trades.py`：事务内 advisory/current exact-equality fence；
+- `scripts/benchmark_data_storage_projection.py`：只修正 synthetic special Combo event time；
+- `tests/test_position_projection_runtime.py`、`tests/test_research_performance_baseline.py`：行为、计数、
+  原子性、runtime characterization 和 fixture 回归。
+
+```text
+record_manual_position_adjustments(adjustments)
+  -> normalize batch + reject missing/duplicate record_id
+  -> current preview once
+  -> per target: current fields + identity + patch + candidate event
+  -> combined candidate preview once
+  -> persist_manual_adjust_events(existing transaction owner)
+       -> BEGIN IMMEDIATE + reread all targets
+       -> exact advisory/current fields fence
+       -> group collision checks + rebuild official events
+       -> final projection + current-decision finalize
+       -> commit | rollback
+```
+
+preflight 仍是 advisory；正式事务内的 `current_fields == fields` 是 batch 专属并发 fence，不新增 hash、
+版本列或通用比较 helper。combined preview 比逐项 preview 多检查 batch 内相互作用，只可能把失败提前到
+写事务前，不允许原先被拒绝的写入。重复 target、缺失 target、closed lot、identity mismatch、invalid
+patch、projection error、任一字段漂移和最终 projection/finalize 失败都保持整批零写入。
+
+批量写入在提交成功但响应丢失后重试，当前可能因相同 event ID 携带不同 `event_time` 而冲突；本分片不
+扩张为幂等协议改造。owner 为 `src/application/ledger/manual_trades.py`，影响是该 facade 暂不适合新增生产
+caller；在任何生产接入前，必须复用单笔 adjust 的 existing-event 语义并补响应丢失回归。
+
+### 实现与验证
+
+1. 在 `preflight.py` 复用现有校验构造共享 helper，增加 batch preflight；在 `commands.py` 仅替换
+   per-item preflight loop；在 `manual_trades.py` 增加 exact-equality fence。参数化验证一、二、三项 batch
+   在 trusted 模式分别保持至多两次 full-prefix read，在 disabled/untrusted 模式分别保持至多三次；
+   同时覆盖相同 `as_of_ms` 下的结果顺序，以及 trusted/disabled 模式的最终 fingerprint parity。
+2. 增加 duplicate target、单个 invalid item、transaction-time 任一字段漂移和 final projection/finalize
+   late failure 的 public batch facade 回归，全部断言 event、lot 和 current-decision 零写入；保留一条
+   warning-only/no-state forced-full 继续 fail closed 的 runtime characterization。只修正 special Combo
+   fixture 时间，并验证完整 fixture 零 diagnostics、可完成。
+3. 运行 focused tests、Ruff、dependency-graph check、guardrails、`git diff --check` 和完整 pytest；
+   再运行 Phase 3A `1` warmup / `3` repetitions smoke，比较 wall/CPU、allocation、full-prefix reads、
+   parity 和原子性。该 smoke 必须标记为 non-acceptance，不替代指定 reference host 上的正式 `5/30`。
+
+验收首先看结构性计数和正确性：full-prefix reads 对 batch cardinality 有界、fingerprint parity、任一
+失败零写入、warning/no-state 继续 fail closed。优化后绝对耗时和 peak allocation 如仍超过冻结门槛，
+只记录实测差距，不把结构性计数达标表述成 Phase 3A acceptance；只有出现真实生产调用压力或正式
+admission 需求，才重新评估 metadata-only tail support。
+
+开放项：无。批量响应丢失重试作为明确 deferred risk，在生产接入前解决。commit、push、merge、
+release、deploy 和生产写入继续是独立授权边界。
+
 ## Futu 订单身份补录
 
 ### 目标、边界与成功信号

--- a/scripts/benchmark_data_storage_projection.py
+++ b/scripts/benchmark_data_storage_projection.py
@@ -1742,7 +1742,7 @@ def _phase_3a_operation(repo: Any, *, key: str, spec: Mapping[str, Any]) -> Any:
         event = TradeEvent(
             event_id="bench-phase3a-special-call-open",
             event_type="open",
-            event_time_ms=1_900_000_000_500,
+            event_time_ms=1_850_000_000_500,
             contract_key=call_key,
             contracts=1,
             price=0.5,

--- a/src/application/ledger/commands.py
+++ b/src/application/ledger/commands.py
@@ -54,6 +54,7 @@ from src.application.ledger.preflight import (
     _existing_open_event_result,
     _manual_open_ledger_inputs,
     _preflight_lot_adjust,
+    _preflight_lot_adjustments,
     _preflight_manual_repair_payload,
     _preflight_manual_void_payload,
     _preflight_open_event,
@@ -330,13 +331,16 @@ def record_manual_position_adjustments(
 ) -> list[ManualAdjustLedgerResult]:
     """Preflight and persist multiple lot adjustments atomically."""
 
-    prepared: list[dict[str, Any]] = []
-    preflight_results: list[Any] = []
+    normalized: list[dict[str, Any]] = []
+    seen_record_ids: set[str] = set()
     for raw in adjustments:
         item = dict(raw or {})
         record_id = str(item.pop("record_id", "") or "").strip()
         if not record_id:
             raise ValueError("manual adjustment batch requires record_id")
+        if record_id in seen_record_ids:
+            raise ValueError(f"manual adjustment batch contains duplicate record_id: {record_id}")
+        seen_record_ids.add(record_id)
         item.setdefault("fields", None)
         item.setdefault("contracts", None)
         item.setdefault("strike", None)
@@ -345,20 +349,21 @@ def record_manual_position_adjustments(
         item.setdefault("multiplier", None)
         item.setdefault("opened_at_ms", None)
         item.setdefault("as_of_ms", None)
-        preflight_result = _preflight_lot_adjust(
-            repo,
-            record_id=record_id,
-            source="manual_adjust_batch_preflight",
-            operation_label="manual adjustment batch",
-            **item,
-        )
+        normalized.append({"record_id": record_id, **item})
+
+    preflight_results = _preflight_lot_adjustments(
+        repo,
+        adjustments=normalized,
+        source="manual_adjust_batch_preflight",
+        operation_label="manual adjustment batch",
+    )
+    prepared: list[dict[str, Any]] = []
+    for item, preflight_result in zip(normalized, preflight_results, strict=True):
         event_time_ms = preflight_result.ledger_preflight.event_time_ms
         if event_time_ms is None:
             raise RuntimeError("manual adjustment batch preflight did not provide event_time_ms")
-        preflight_results.append(preflight_result)
         prepared.append(
             {
-                "record_id": record_id,
                 **item,
                 "fields": preflight_result.fields,
                 "as_of_ms": int(event_time_ms),

--- a/src/application/ledger/manual_trades.py
+++ b/src/application/ledger/manual_trades.py
@@ -662,6 +662,15 @@ def persist_manual_adjust_events(
             for row in current_rows
             if str(row.get("record_id") or "").strip()
         }
+        for record_id, fields, _item in validated:
+            current_fields = current_by_record_id.get(record_id)
+            if current_fields is None:
+                raise ValueError(f"manual adjustment batch target lot not found: {record_id}")
+            if current_fields != fields:
+                raise ValueError(
+                    "manual adjustment batch target fields changed since preflight: "
+                    f"{record_id}"
+                )
         desired_group_ids = {
             str(item.get("strategy_group_id") or "").strip()
             for _record_id, _fields, item in validated
@@ -690,9 +699,7 @@ def persist_manual_adjust_events(
 
         prepared: list[tuple[str, TradeEvent, PositionLotPatch]] = []
         for record_id, fields, item in validated:
-            current_fields = current_by_record_id.get(record_id)
-            if current_fields is None:
-                raise ValueError(f"manual adjustment batch target lot not found: {record_id}")
+            current_fields = current_by_record_id[record_id]
             event, patch_contract = _build_manual_adjust_event(
                 sqlite_repo,
                 record_id=record_id,

--- a/src/application/ledger/preflight.py
+++ b/src/application/ledger/preflight.py
@@ -634,6 +634,104 @@ def _preflight_lot_adjust(
     strategy_group_id: str | None = None,
     strategy_snapshot: dict[str, Any] | None = None,
 ) -> ManualAdjustPreflightResult:
+    result, adjust_event = _build_lot_adjust_preflight_candidate(
+        repo,
+        current=None,
+        record_id=record_id,
+        fields=fields,
+        contracts=contracts,
+        strike=strike,
+        expiration_ymd=expiration_ymd,
+        premium_per_share=premium_per_share,
+        multiplier=multiplier,
+        opened_at_ms=opened_at_ms,
+        as_of_ms=as_of_ms,
+        source=source,
+        operation_label=operation_label,
+        strategy=strategy,
+        leg_role=leg_role,
+        strategy_group_id=strategy_group_id,
+        strategy_snapshot=strategy_snapshot,
+    )
+    _preview_append_projection(
+        repo,
+        events=[adjust_event],
+        operation_label=operation_label,
+        details={"record_id": str(record_id or "").strip()},
+        candidate_error=(
+            "adjust_projection_invalid",
+            f"{operation_label} ledger preflight rejected projected adjust event",
+        ),
+    )
+    return result
+
+
+def _preflight_lot_adjustments(
+    repo: Any,
+    *,
+    adjustments: list[dict[str, Any]],
+    source: str,
+    operation_label: str,
+) -> list[ManualAdjustPreflightResult]:
+    if not adjustments:
+        raise ValueError("manual adjustment batch requires at least one adjustment")
+
+    record_ids = [str(item.get("record_id") or "").strip() for item in adjustments]
+    current = _preview_append_projection(
+        repo,
+        events=[],
+        operation_label=operation_label,
+        details={"record_ids": record_ids},
+    )
+    results: list[ManualAdjustPreflightResult] = []
+    candidate_events: list[TradeEvent] = []
+    for raw in adjustments:
+        item = dict(raw)
+        record_id = str(item.pop("record_id", "") or "").strip()
+        result, candidate_event = _build_lot_adjust_preflight_candidate(
+            repo,
+            current=current,
+            record_id=record_id,
+            source=source,
+            operation_label=operation_label,
+            **item,
+        )
+        results.append(result)
+        candidate_events.append(candidate_event)
+
+    _preview_append_projection(
+        repo,
+        events=candidate_events,
+        operation_label=operation_label,
+        details={"record_ids": record_ids},
+        candidate_error=(
+            "adjust_projection_invalid",
+            f"{operation_label} ledger preflight rejected projected adjust events",
+        ),
+    )
+    return results
+
+
+def _build_lot_adjust_preflight_candidate(
+    repo: Any,
+    *,
+    current: ProjectionPreviewResult | None,
+    record_id: str,
+    fields: dict[str, Any] | None,
+    contracts: int | None,
+    strike: float | None,
+    expiration_ymd: str | None,
+    premium_per_share: float | None,
+    multiplier: float | None,
+    opened_at_ms: int | None,
+    as_of_ms: int | None,
+    source: str,
+    operation_label: str,
+    strategy: str | None = None,
+    leg_role: str | None = None,
+    strategy_group_id: str | None = None,
+    strategy_snapshot: dict[str, Any] | None = None,
+) -> tuple[ManualAdjustPreflightResult, TradeEvent]:
     resolved_record_id = str(record_id or "").strip()
     if not resolved_record_id:
         raise LedgerPreflightError("record_id_required", f"{operation_label} ledger preflight requires record_id")
@@ -655,12 +753,13 @@ def _preflight_lot_adjust(
             details={"record_id": resolved_record_id, "contracts_open": current_open},
         )
 
-    current = _preview_append_projection(
-        repo,
-        events=[],
-        operation_label=operation_label,
-        details={"record_id": resolved_record_id},
-    )
+    if current is None:
+        current = _preview_append_projection(
+            repo,
+            events=[],
+            operation_label=operation_label,
+            details={"record_id": resolved_record_id},
+        )
     target_lots = [
         lot
         for lot in _preview_lots(current)
@@ -726,38 +825,31 @@ def _preflight_lot_adjust(
             "patch": patch,
         },
     )
-    _preview_append_projection(
-        repo,
-        events=[adjust_event],
-        operation_label=operation_label,
-        details={"record_id": resolved_record_id},
-        candidate_error=(
-            "adjust_projection_invalid",
-            f"{operation_label} ledger preflight rejected projected adjust event",
+    return (
+        ManualAdjustPreflightResult(
+            fields=current_fields,
+            patch_contract=patch_contract,
+            ledger_preflight=LedgerPreflightResult(
+                status="ok",
+                read_model="ledger_shadow",
+                fail_closed=False,
+                target_lot_id=resolved_record_id,
+                event_type="adjust",
+                contract_key=current_key.to_dict(),
+                contracts_open_before=int(target_lot.contracts_open),
+                contracts_open_after=effective_contracts_open(adjusted_fields),
+                event_time_ms=event_time_ms,
+                source_record_count=current.source_event_count,
+                imported_event_count=current.source_event_count,
+                projection_diagnostic_count=0,
+                reconciliation_issue_count=0,
+                details={
+                    "adjusted_contract_key": adjusted_key.to_dict(),
+                    **_preview_details(current),
+                },
+            ),
         ),
-    )
-    return ManualAdjustPreflightResult(
-        fields=current_fields,
-        patch_contract=patch_contract,
-        ledger_preflight=LedgerPreflightResult(
-            status="ok",
-            read_model="ledger_shadow",
-            fail_closed=False,
-            target_lot_id=resolved_record_id,
-            event_type="adjust",
-            contract_key=current_key.to_dict(),
-            contracts_open_before=int(target_lot.contracts_open),
-            contracts_open_after=effective_contracts_open(adjusted_fields),
-            event_time_ms=event_time_ms,
-            source_record_count=current.source_event_count,
-            imported_event_count=current.source_event_count,
-            projection_diagnostic_count=0,
-            reconciliation_issue_count=0,
-            details={
-                "adjusted_contract_key": adjusted_key.to_dict(),
-                **_preview_details(current),
-            },
-        ),
+        adjust_event,
     )
 
 

--- a/tests/test_position_projection_runtime.py
+++ b/tests/test_position_projection_runtime.py
@@ -1260,6 +1260,44 @@ def test_caller_owned_runtime_error_leaves_rollback_to_caller(tmp_path: Path) ->
     assert repo.list_trade_events() == []
 
 
+def test_warning_only_full_projection_without_state_remains_fail_closed(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    run_position_projection_forced_full(
+        repo,
+        [_event("open", "open", 1_000, lot_id="lot-a")],
+        seed_checkpoint=True,
+    )
+    before = {
+        "events": repo.list_trade_events(),
+        "lots": repo.list_position_lots(),
+        "source": repo.read_position_projection_source_state(),
+        "checkpoints": [dict(row) for row in _checkpoint_rows(repo)],
+    }
+    invalid_adjust = _event(
+        "adjust-too-late",
+        "adjust",
+        2_000_000_000_001,
+        target_lot_id="lot-a",
+        contracts=0,
+        raw_payload={
+            "patch": {
+                "opened_at": 2_000_000_000_000,
+                "last_action_at": 2_000_000_000_001,
+            }
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="publishable full projection lacks resumable state"):
+        run_position_projection_forced_full(repo, [invalid_adjust])
+
+    assert repo.list_trade_events() == before["events"]
+    assert repo.list_position_lots() == before["lots"]
+    assert repo.read_position_projection_source_state() == before["source"]
+    assert [dict(row) for row in _checkpoint_rows(repo)] == before["checkpoints"]
+
+
 def test_unavailable_implementation_keeps_full_projection_compatible(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_research_performance_baseline.py
+++ b/tests/test_research_performance_baseline.py
@@ -89,6 +89,39 @@ def _small_spec(
     }
 
 
+def _phase_3a_batch_adjustments(
+    spec: dict[str, Any],
+    *,
+    cardinality: int,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "record_id": module._phase_3a_record_id(spec, index),
+            "premium_per_share": 1.25 + index,
+            "as_of_ms": 1_850_000_000_100,
+        }
+        for index in range(cardinality)
+    ]
+
+
+def _phase_3a_persisted_state(repo: Any) -> dict[str, list[tuple[Any, ...]]]:
+    tables = (
+        "trade_events",
+        "trade_event_ingest_sequence",
+        "position_lots",
+        "position_projection_source_state",
+        "position_projection_heads",
+        "position_projection_checkpoints",
+        "current_decision_input_generations",
+        "current_decision_projections",
+    )
+    with repo._connect() as conn:
+        return {
+            table: [tuple(row) for row in conn.execute(f"SELECT * FROM {table} ORDER BY 1")]
+            for table in tables
+        }
+
+
 def _timing_artifact(
     fixture_manifest: dict[str, Any],
     *,
@@ -1229,6 +1262,214 @@ def test_phase_3a_pair_uses_independent_identical_database_copies() -> None:
         "base_sqlite_sha256"
     ]
     assert result["parity"]["exact"] is True
+
+
+@pytest.mark.parametrize(("checkpoint_mode", "expected_full_reads"), [("enabled", 2), ("disabled", 3)])
+@pytest.mark.parametrize("cardinality", [1, 2, 3])
+def test_phase_3a_batch_adjust_full_prefix_reads_are_bounded(
+    checkpoint_mode: str,
+    expected_full_reads: int,
+    cardinality: int,
+) -> None:
+    from src.application.ledger.commands import record_manual_position_adjustments
+
+    spec = _small_spec(
+        key="phase_3a.runtime",
+        event_count=20,
+        lot_count=4,
+        account_count=1,
+    )
+    with module._temporary_phase_3a_base(spec, seed=module.SEED) as base:
+        with module._temporary_phase_3a_clone(
+            base,
+            checkpoint_mode=checkpoint_mode,
+        ) as context:
+            with module._instrument_phase_3a_repo(context["repo"]) as counters:
+                results = record_manual_position_adjustments(
+                    context["repo"],
+                    _phase_3a_batch_adjustments(spec, cardinality=cardinality),
+                )
+
+    assert counters["full_prefix_reader_calls"] == expected_full_reads
+    assert [result.ledger_preflight.target_lot_id for result in results] == [
+        module._phase_3a_record_id(spec, index) for index in range(cardinality)
+    ]
+
+
+def test_phase_3a_batch_adjust_same_time_preserves_order_and_parity() -> None:
+    from src.application.ledger.commands import record_manual_position_adjustments
+
+    spec = _small_spec(
+        key="phase_3a.runtime",
+        event_count=20,
+        lot_count=4,
+        account_count=1,
+    )
+    observed: dict[str, dict[str, Any]] = {}
+    with module._temporary_phase_3a_base(spec, seed=module.SEED) as base:
+        for checkpoint_mode in ("enabled", "disabled"):
+            with module._temporary_phase_3a_clone(
+                base,
+                checkpoint_mode=checkpoint_mode,
+            ) as context:
+                results = record_manual_position_adjustments(
+                    context["repo"],
+                    _phase_3a_batch_adjustments(spec, cardinality=3),
+                )
+                observed[checkpoint_mode] = {
+                    "target_lot_ids": [
+                        result.ledger_preflight.target_lot_id for result in results
+                    ],
+                    "event_times": [
+                        result.ledger_preflight.event_time_ms for result in results
+                    ],
+                    "fingerprint": module._phase_3a_lot_fingerprint(context["db_path"]),
+                }
+
+    assert observed["enabled"] == observed["disabled"]
+    assert observed["enabled"]["event_times"] == [1_850_000_000_100] * 3
+
+
+def test_phase_3a_batch_adjust_invalid_item_writes_nothing() -> None:
+    from src.application.ledger.commands import record_manual_position_adjustments
+
+    spec = _small_spec(
+        key="phase_3a.runtime",
+        event_count=20,
+        lot_count=4,
+        account_count=1,
+    )
+    with module._temporary_phase_3a_base(spec, seed=module.SEED) as base:
+        with module._temporary_phase_3a_clone(base, checkpoint_mode="disabled") as context:
+            repo = context["repo"]
+            before = _phase_3a_persisted_state(repo)
+            adjustments = _phase_3a_batch_adjustments(spec, cardinality=1)
+            adjustments.append(
+                {
+                    "record_id": "missing-lot",
+                    "premium_per_share": 9.5,
+                    "as_of_ms": 1_850_000_000_100,
+                }
+            )
+
+            with pytest.raises(ValueError, match="missing-lot"):
+                record_manual_position_adjustments(repo, adjustments)
+
+            assert _phase_3a_persisted_state(repo) == before
+
+
+def test_phase_3a_batch_adjust_duplicate_target_writes_nothing() -> None:
+    from src.application.ledger.commands import record_manual_position_adjustments
+
+    spec = _small_spec(
+        key="phase_3a.runtime",
+        event_count=20,
+        lot_count=4,
+        account_count=1,
+    )
+    with module._temporary_phase_3a_base(spec, seed=module.SEED) as base:
+        with module._temporary_phase_3a_clone(base, checkpoint_mode="disabled") as context:
+            repo = context["repo"]
+            before = _phase_3a_persisted_state(repo)
+            adjustment = _phase_3a_batch_adjustments(spec, cardinality=1)[0]
+
+            with pytest.raises(ValueError, match="duplicate record_id"):
+                record_manual_position_adjustments(repo, [adjustment, adjustment])
+
+            assert _phase_3a_persisted_state(repo) == before
+
+
+def test_phase_3a_batch_adjust_transaction_drift_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.application.ledger.commands import record_manual_position_adjustments
+
+    spec = _small_spec(
+        key="phase_3a.runtime",
+        event_count=20,
+        lot_count=4,
+        account_count=1,
+    )
+    with module._temporary_phase_3a_base(spec, seed=module.SEED) as base:
+        with module._temporary_phase_3a_clone(base, checkpoint_mode="disabled") as context:
+            repo = context["repo"]
+            before = _phase_3a_persisted_state(repo)
+            original = repo.get_position_lots_by_ids
+
+            def drifted_rows(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+                rows = original(*args, **kwargs)
+                rows[0] = {
+                    **rows[0],
+                    "fields": {**rows[0]["fields"], "note": "concurrent drift"},
+                }
+                return rows
+
+            monkeypatch.setattr(repo, "get_position_lots_by_ids", drifted_rows)
+            with pytest.raises(ValueError, match="fields changed since preflight"):
+                record_manual_position_adjustments(
+                    repo,
+                    _phase_3a_batch_adjustments(spec, cardinality=2),
+                )
+
+            assert _phase_3a_persisted_state(repo) == before
+
+
+def test_phase_3a_batch_adjust_late_failure_rolls_back_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.application.ledger.manual_trades as manual_trades
+    from src.application.ledger.commands import record_manual_position_adjustments
+
+    spec = _small_spec(
+        key="phase_3a.runtime",
+        event_count=20,
+        lot_count=4,
+        account_count=1,
+    )
+    with module._temporary_phase_3a_base(spec, seed=module.SEED) as base:
+        with module._temporary_phase_3a_clone(base, checkpoint_mode="disabled") as context:
+            repo = context["repo"]
+            before = _phase_3a_persisted_state(repo)
+
+            def fail_finalization(*_args: Any, **_kwargs: Any) -> None:
+                raise RuntimeError("synthetic late finalization failure")
+
+            monkeypatch.setattr(
+                manual_trades,
+                "_finish_trade_event_decision_projection",
+                fail_finalization,
+            )
+            with pytest.raises(RuntimeError, match="synthetic late finalization failure"):
+                record_manual_position_adjustments(
+                    repo,
+                    _phase_3a_batch_adjustments(spec, cardinality=2),
+                )
+
+            assert _phase_3a_persisted_state(repo) == before
+
+
+def test_phase_3a_special_combo_fixture_completes_without_diagnostics() -> None:
+    from src.application.ledger.publisher import project_stored_trade_events_to_position_lots
+
+    spec = _small_spec(
+        key="phase_3a.runtime",
+        event_count=20,
+        lot_count=4,
+        account_count=1,
+    )
+    with module._temporary_phase_3a_base(spec, seed=module.SEED) as base:
+        with module._temporary_phase_3a_clone(base, checkpoint_mode="disabled") as context:
+            result = module._phase_3a_operation(
+                context["repo"],
+                key="special_combo_identity_membership",
+                spec=spec,
+            )
+            projection = project_stored_trade_events_to_position_lots(
+                context["repo"].list_trade_events()
+            )
+
+    assert result["event_created"] is True
+    assert not projection.diagnostics
 
 
 def test_parent_failure_leaves_absent_output_unmodified(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- reuse one current projection and one combined candidate preview for batch adjustments
- add transaction-time exact field revalidation and atomic rollback coverage
- repair the Phase 3A special Combo fixture and document measured non-acceptance results

## Validation

- full pytest: 5807 passed, 4 warnings
- focused projection/performance tests: 108 passed
- Ruff, guardrails, dependency graph check, and git diff --check passed
- Phase 3A 1/3 smoke preserved exact final lot fingerprint parity

## Boundaries

- no VERSION or release metadata changes
- no release, deployment, runtime upgrade, or production write