### PR TITLE
fix(config): reject ineffective symbol worker settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Breaking Changes
+- Reject the retired `runtime.pipeline_symbol_max_workers` and `runtime.watchlist_max_workers` settings instead of silently ignoring them.
+
 ## 3.4.3 - 2026-09-03
 
 ### Breaking Changes

--- a/CONFIGS.md
+++ b/CONFIGS.md
@@ -60,6 +60,17 @@ env-file 不是合并进生成快照的配置层；它在进程启动或工具�
 Close Advice 详细固定规则见
 [Close Advice Contract](docs/CLOSE_ADVICE_CONTRACT.md)。
 
+## Symbol 并发配置
+
+Symbol 扫描在受支持的 `scan-pipeline` 主线程中串行执行，以保留
+`runtime.symbol_timeout_sec` 的可中断 deadline。以下旧键从配置合同中移除，且没有替代键：
+
+- `runtime.pipeline_symbol_max_workers`
+- `runtime.watchlist_max_workers`
+
+出现任一键时配置验证会失败；迁移方式是删除该键。account 与 required-data prefetch
+并发配置不受此变更影响。详细运行说明见 [Configuration Guide](CONFIGURATION_GUIDE.md)。
+
 ## 生成与验证
 
 ```bash

--- a/CONFIGURATION_GUIDE.md
+++ b/CONFIGURATION_GUIDE.md
@@ -90,6 +90,15 @@ portfolio_management:
 
 系统默认值在 `src/application/config_defaults.py::DEFAULT_CONFIG`。不需要把所有默认字段复制进 `config.yaml`。
 
+## Symbol 扫描并发
+
+Symbol pipeline 不提供 worker 数配置。它按输入顺序串行处理 Symbol，使受支持的
+Linux/macOS `scan-pipeline` 主线程中的 `runtime.symbol_timeout_sec` 能真正中断超时处理。
+整次 Tick 的 wall-clock 最终边界仍由 `tick-cron --timeout` 负责。
+
+不要设置 `runtime.pipeline_symbol_max_workers` 或 `runtime.watchlist_max_workers`；
+这两个键已退役，配置验证会要求删除。数据预取并发与账户并发是独立合同，不受影响。
+
 ## 账户
 
 支持两种账户类型：

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1009 (`src`: 541, `domain`: 78, `scripts`: 12, `tests`: 378)
-- Internal import edges: 6753 total, 2936 production/script edges excluding tests
+- Internal import edges: 6754 total, 2936 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,7 +46,7 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2823| application
+  tests -->|2824| application
   tests -->|429| domain
   tests -->|2| domain_services
   tests -->|233| infrastructure
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2823 |
+| tests | application | 2824 |
 | tests | domain | 429 |
 | tests | interfaces | 243 |
 | tests | infrastructure | 233 |

--- a/src/application/config_loader.py
+++ b/src/application/config_loader.py
@@ -24,7 +24,7 @@ from src.application.portfolio_management import (
 )
 
 
-SCHEDULED_CONFIG_VALIDATOR_VERSION = 'notification-renderer-v2'
+SCHEDULED_CONFIG_VALIDATOR_VERSION = 'runtime-config-v3'
 
 
 def data_config_candidates(*, base: Path) -> list[Path]:

--- a/src/application/config_validator.py
+++ b/src/application/config_validator.py
@@ -964,6 +964,18 @@ def _validate_template_use(item: dict, *, templates: dict, symbol: str) -> None:
         die(f"{symbol}.use references unknown templates: {', '.join(unknown)}")
 
 
+def validate_retired_symbol_worker_config(cfg: dict) -> None:
+    runtime = cfg.get('runtime')
+    if not isinstance(runtime, dict):
+        return
+    for key in ('pipeline_symbol_max_workers', 'watchlist_max_workers'):
+        if key in runtime:
+            die(
+                f'runtime.{key} is no longer supported; Symbol scans are '
+                'serial under the hard timeout contract and have no worker setting'
+            )
+
+
 def validate_config(cfg: dict):
     try:
         normalize_portfolio_management_config(cfg)
@@ -1049,6 +1061,7 @@ def validate_config(cfg: dict):
     if runtime and not isinstance(runtime, dict):
         die('runtime must be an object')
     if isinstance(runtime, dict):
+        validate_retired_symbol_worker_config(cfg)
         st = runtime.get('symbol_timeout_sec', 120)
         pt = runtime.get('portfolio_timeout_sec', 60)
         try:

--- a/src/application/multi_account_tick.py
+++ b/src/application/multi_account_tick.py
@@ -15,7 +15,10 @@ from src.infrastructure.io_utils import (
 from src.infrastructure.run_log import RunLogger
 from src.application.account_config import resolve_configured_accounts
 from src.application.config_sections import resolve_watchlist_config
-from src.application.config_validator import validate_config
+from src.application.config_validator import (
+    validate_config,
+    validate_retired_symbol_worker_config,
+)
 from domain.domain.fetch_source import resolve_symbol_fetch_source
 
 from src.application.multi_tick.opend_guard import (
@@ -262,6 +265,8 @@ def main(argv: list[str] | None = None) -> int:
         require_sibling_external=True,
     )
     base_cfg = json.loads(cfg_path.read_text(encoding='utf-8'))
+    if not isinstance(base_cfg, dict):
+        raise SystemExit(f'[CONFIG_ERROR] runtime config must be a JSON object: {cfg_path}')
     requested_market = str(getattr(args, 'market_config', 'auto') or 'auto').strip().lower()
     try:
         ensure_runtime_config_identity(
@@ -293,6 +298,8 @@ def main(argv: list[str] | None = None) -> int:
         # The emergency override skips source-freshness comparison only. It must
         # never revive schema fields removed by the currently running release.
         validate_config(deepcopy(base_cfg))
+    else:
+        validate_retired_symbol_worker_config(base_cfg)
     try:
         args.accounts = resolve_configured_accounts(base_cfg, args.accounts)
     except ValueError as exc:

--- a/src/application/pipeline_runtime.py
+++ b/src/application/pipeline_runtime.py
@@ -279,21 +279,25 @@ def main(argv: list[str] | None = None) -> int:
     )
     shared_context_dir = Path(args.shared_context_dir).resolve() if getattr(args, "shared_context_dir", None) else None
 
+    cfg = load_runtime_pipeline_config(
+        base=repo_root,
+        config_path=cfg_path,
+        is_scheduled=is_scheduled,
+        log=log,
+        state_dir=state_dir,
+        config_payload=authority_config,
+    )
+
     if bool(getattr(args, "refresh_multiplier_cache", False)):
         try:
             from domain.domain.fetch_source import is_futu_fetch_source
             from src.application import multiplier_cache
 
             cache_path = multiplier_cache.default_cache_path(runtime_root)
-            cfg0 = (
-                dict(authority_config)
-                if authority_config is not None
-                else json.loads(cfg_path.read_text(encoding="utf-8"))
-            )
-            opend_kwargs = opend_fetch_kwargs(cfg0)
+            opend_kwargs = opend_fetch_kwargs(cfg)
             syms = [
                 item
-                for item in resolve_watchlist_config(cfg0)
+                for item in resolve_watchlist_config(cfg)
                 if is_futu_fetch_source((item.get("fetch") or {}).get("source"))
             ]
             cache = multiplier_cache.load_cache(cache_path)
@@ -320,14 +324,6 @@ def main(argv: list[str] | None = None) -> int:
         except Exception:
             pass
 
-    cfg = load_runtime_pipeline_config(
-        base=repo_root,
-        config_path=cfg_path,
-        is_scheduled=is_scheduled,
-        log=log,
-        state_dir=state_dir,
-        config_payload=authority_config,
-    )
     py = sys.executable
 
     if "symbols" in cfg:

--- a/src/application/pipeline_watchlist.py
+++ b/src/application/pipeline_watchlist.py
@@ -11,7 +11,6 @@ Design:
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -84,7 +83,6 @@ LIQUIDITY_COMMON_FIELDS = (
     'min_volume',
     'max_spread_ratio',
 )
-DEFAULT_PIPELINE_SYMBOL_MAX_WORKERS = 4
 _CAPTURE_STATUSES = frozenset(
     {"completed", "not_applicable", "failed", "incomplete", "unavailable"}
 )
@@ -141,25 +139,6 @@ def _enforce_symbol_timeout(
                 max(0.001, previous_remaining - elapsed),
                 previous_interval,
             )
-
-
-def _to_positive_int(value, default: int) -> int:
-    try:
-        parsed = int(value)
-    except Exception:
-        parsed = int(default)
-    return max(1, parsed)
-
-
-def _resolve_pipeline_symbol_max_workers(cfg: dict, symbol_count: int) -> int:
-    if symbol_count <= 1:
-        return 1
-    runtime = cfg.get('runtime') if isinstance(cfg.get('runtime'), dict) else {}
-    raw = runtime.get('pipeline_symbol_max_workers')
-    if raw is None:
-        raw = runtime.get('watchlist_max_workers')
-    workers = _to_positive_int(raw, DEFAULT_PIPELINE_SYMBOL_MAX_WORKERS)
-    return min(symbol_count, workers)
 
 
 def _parse_symbols_whitelist(symbols_arg: str | None) -> set[str] | None:
@@ -839,25 +818,8 @@ def run_watchlist_pipeline(
             return _failure_rows(item0, exc)
 
     summary_rows: list[dict] = []
-    max_workers = _resolve_pipeline_symbol_max_workers(cfg, len(watchlist_items))
-    if symbol_timeout_sec > 0:
-        # A hard POSIX timer is process-main-thread scoped. Keep symbol work
-        # sequential so the configured deadline covers fetch, scan, and writes.
-        max_workers = 1
-    if max_workers <= 1:
-        for item0 in watchlist_items:
-            summary_rows.extend(_process_item_with_timeout(item0))
-    else:
-        rows_by_index: dict[int, list[dict]] = {}
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_by_index = {
-                executor.submit(_process_item_with_timeout, item0): idx
-                for idx, item0 in enumerate(watchlist_items)
-            }
-            for future in as_completed(future_by_index):
-                rows_by_index[future_by_index[future]] = future.result()
-        for idx in range(len(watchlist_items)):
-            summary_rows.extend(rows_by_index.get(idx, []))
+    for item0 in watchlist_items:
+        summary_rows.extend(_process_item_with_timeout(item0))
 
     if want_fn('scan'):
         build_symbols_summary_fn(summary_rows)

--- a/tests/test_config_yaml.py
+++ b/tests/test_config_yaml.py
@@ -273,6 +273,20 @@ def test_runtime_config_rejects_retired_ai_decision_advice_key() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "key",
+    ("pipeline_symbol_max_workers", "watchlist_max_workers"),
+)
+def test_runtime_config_rejects_retired_symbol_worker_keys(key: str) -> None:
+    with pytest.raises(SystemExit, match=rf"runtime\.{key} is no longer supported"):
+        validate_config(
+            {
+                "symbols": [{"symbol": "NVDA"}],
+                "runtime": {key: 1},
+            }
+        )
+
+
 def test_yaml_config_resolves_user_overrides_and_defaults(tmp_path: Path) -> None:
     config_path = _write_yaml(tmp_path / "config.yaml", _minimal_yaml())
 

--- a/tests/test_multi_account_tick.py
+++ b/tests/test_multi_account_tick.py
@@ -190,9 +190,33 @@ def test_explicit_empty_cli_account_fails_before_run_artifacts(
     assert not (tmp_path / "output_runs").exists()
 
 
-def test_allow_stale_config_still_rejects_removed_runtime_fields_before_run_artifacts(
+@pytest.mark.parametrize(
+    ("runtime", "combo_yield", "extra_args", "error", "freshness_calls"),
+    (
+        (
+            {"pipeline_symbol_max_workers": 1},
+            None,
+            (),
+            "pipeline_symbol_max_workers is no longer supported",
+            1,
+        ),
+        (
+            {},
+            {"enabled": True, "output_mode": "separate"},
+            ("--allow-stale-config",),
+            "output_mode has been removed",
+            0,
+        ),
+    ),
+)
+def test_tick_rejects_retired_config_before_run_artifacts(
     monkeypatch,
     tmp_path: Path,
+    runtime: dict,
+    combo_yield: dict | None,
+    extra_args: tuple[str, ...],
+    error: str,
+    freshness_calls: int,
 ) -> None:
     import json
 
@@ -202,18 +226,16 @@ def test_allow_stale_config_still_rejects_removed_runtime_fields_before_run_arti
     config_path.write_text(
         json.dumps(
             {
-                "accounts": ["lx"],
-                "symbols": [
-                    {
-                        "symbol": "NVDA",
-                        "sell_put": {"enabled": False},
-                        "sell_call": {"enabled": False},
-                        "combo_yield": {
-                            "enabled": True,
-                            "output_mode": "separate",
-                        },
-                    }
-                ],
+                    "accounts": ["lx"],
+                    "runtime": runtime,
+                    "symbols": [
+                        {
+                            "symbol": "NVDA",
+                            "sell_put": {"enabled": False},
+                            "sell_call": {"enabled": False},
+                            **({"combo_yield": combo_yield} if combo_yield else {}),
+                        }
+                    ],
             }
         ),
         encoding="utf-8",
@@ -239,13 +261,8 @@ def test_allow_stale_config_still_rejects_removed_runtime_fields_before_run_arti
         "ensure_runtime_schedule_matches_market",
         lambda *_args, **_kwargs: {"market": "us"},
     )
-    monkeypatch.setattr(
-        mod,
-        "ensure_runtime_config_freshness",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("allow-stale-config must skip freshness only")
-        ),
-    )
+    freshness_events: list[int] = []
+    monkeypatch.setattr(mod, "ensure_runtime_config_freshness", lambda *_args, **_kwargs: freshness_events.append(1) or {"fresh": True})
     monkeypatch.setattr(
         mod,
         "RunLogger",
@@ -254,17 +271,18 @@ def test_allow_stale_config_still_rejects_removed_runtime_fields_before_run_arti
         ),
     )
 
-    with pytest.raises(SystemExit, match="output_mode has been removed"):
+    with pytest.raises(SystemExit, match=error):
         mod.main(
             [
                 "--config",
                 str(config_path),
                 "--market-config",
                 "us",
-                "--allow-stale-config",
+                *extra_args,
             ]
         )
 
+    assert len(freshness_events) == freshness_calls
     assert not (tmp_path / "output_runs").exists()
 
 

--- a/tests/test_pipeline_capture_status_routing.py
+++ b/tests/test_pipeline_capture_status_routing.py
@@ -639,7 +639,7 @@ def _run_full_symbol_capture(
         base=tmp_path,
         cfg={
             "portfolio": {"account": "lx"},
-            "runtime": {"pipeline_symbol_max_workers": 1},
+            "runtime": {},
             "symbols": [
                 _symbol_config(
                     symbol,

--- a/tests/test_pipeline_runtime_paths.py
+++ b/tests/test_pipeline_runtime_paths.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import base64
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 
-def test_scan_pipeline_defaults_runtime_outputs_to_runtime_root(monkeypatch, tmp_path: Path) -> None:
+def test_scan_pipeline_uses_runtime_root_and_loaded_config_for_refresh(monkeypatch, tmp_path: Path) -> None:
+    from src.application import multiplier_cache
     from src.application import pipeline_runtime
     from src.application import pipeline_watchlist
 
@@ -14,22 +16,30 @@ def test_scan_pipeline_defaults_runtime_outputs_to_runtime_root(monkeypatch, tmp
     config_path = tmp_path / "config.us.json"
     config_path.write_text("{}", encoding="utf-8")
     captured: dict[str, object] = {}
+    events: list[str] = []
+    cfg = {
+        "symbols": [
+            {
+                "symbol": "MSFT",
+                "fetch": {"source": "opend"},
+                "sell_put": {"enabled": False},
+                "sell_call": {"enabled": False},
+            }
+        ],
+        "portfolio": {"broker": "富途", "data_config": "portfolio.runtime.json"},
+        "notifications": {"enabled": False},
+    }
 
     def _fake_load_config(**kwargs):
+        events.append("load")
         captured["load_config_base"] = kwargs["base"]
         captured["load_config_path"] = kwargs["config_path"]
-        return {
-            "symbols": [
-                {
-                    "symbol": "MSFT",
-                    "fetch": {"source": "opend"},
-                    "sell_put": {"enabled": False},
-                    "sell_call": {"enabled": False},
-                }
-            ],
-            "portfolio": {"broker": "富途", "data_config": "portfolio.runtime.json"},
-            "notifications": {"enabled": False},
-        }
+        return cfg
+
+    def _opend_kwargs(loaded: dict) -> dict:
+        assert loaded is cfg
+        events.append("opend_kwargs")
+        return {}
 
     def _fake_run_watchlist_pipeline_default(**kwargs):
         captured["pipeline_base"] = kwargs["base"]
@@ -40,6 +50,14 @@ def test_scan_pipeline_defaults_runtime_outputs_to_runtime_root(monkeypatch, tmp
 
     monkeypatch.setenv("OM_RUNTIME_ROOT", str(runtime_root))
     monkeypatch.setattr(pipeline_runtime, "load_runtime_pipeline_config", _fake_load_config)
+    monkeypatch.setattr(pipeline_runtime, "opend_fetch_kwargs", _opend_kwargs)
+    monkeypatch.setattr(multiplier_cache, "load_cache", lambda _path: {})
+    monkeypatch.setattr(multiplier_cache, "save_cache", lambda *_args: None)
+    monkeypatch.setattr(
+        multiplier_cache,
+        "refresh_via_opend",
+        lambda **_kwargs: events.append("refresh") or SimpleNamespace(ok=False, multiplier=None),
+    )
     monkeypatch.setattr(pipeline_watchlist, "run_watchlist_pipeline_default", _fake_run_watchlist_pipeline_default)
 
     rc = pipeline_runtime.main([
@@ -48,10 +66,12 @@ def test_scan_pipeline_defaults_runtime_outputs_to_runtime_root(monkeypatch, tmp
         "--stage",
         "fetch",
         "--no-context",
+        "--refresh-multiplier-cache",
     ])
 
     repo_root = Path(__file__).resolve().parents[1]
     assert rc == 0
+    assert events == ["load", "opend_kwargs", "refresh"]
     assert captured["load_config_base"] == repo_root
     assert captured["load_config_path"] == config_path.resolve()
     assert captured["pipeline_base"] == runtime_root.resolve()

--- a/tests/test_pipeline_watchlist_whitelist.py
+++ b/tests/test_pipeline_watchlist_whitelist.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import threading
 import time
 from pathlib import Path
 
@@ -287,7 +286,7 @@ def test_watchlist_symbol_timeout_covers_the_whole_processor() -> None:
                 {"symbol": "MSFT", "sell_put": {"enabled": True}},
             ],
             "templates": {},
-            "runtime": {"pipeline_symbol_max_workers": 4},
+            "runtime": {},
         },
         report_dir=Path("."),
         is_scheduled=True,
@@ -604,68 +603,6 @@ def test_watchlist_fetch_stage_preserves_strategy_config_but_skips_scan_output()
     assert out == []
     assert seen == [(True, True, True)]
     assert summary_called == []
-
-
-def test_watchlist_pipeline_processes_symbols_in_parallel_when_configured() -> None:
-    from src.application.pipeline_watchlist import run_watchlist_pipeline
-
-    started: list[str] = []
-    lock = threading.Lock()
-    both_started = threading.Event()
-    warnings: list[str] = []
-
-    def _apply_profiles(item: dict, profiles: dict) -> dict:
-        return dict(item)
-
-    def _process_symbol(*args, **kwargs):
-        item = args[2]
-        symbol = str(item.get("symbol"))
-        with lock:
-            started.append(symbol)
-            if len(started) == 2:
-                both_started.set()
-        assert both_started.wait(1.0), "symbol processing did not overlap"
-        return [{"symbol": symbol, "strategy": "sell_put", "candidate_count": 1}]
-
-    def _build_ctx(**kwargs):
-        return ({}, None, None, None)
-
-    def _noop(*args, **kwargs):
-        return None
-
-    cfg = {
-        "symbols": [
-            {"symbol": "0700.HK", "sell_put": {"enabled": True}, "sell_call": {"enabled": False}},
-            {"symbol": "3690.HK", "sell_put": {"enabled": True}, "sell_call": {"enabled": False}},
-        ],
-        "templates": {},
-        "runtime": {"pipeline_symbol_max_workers": 2},
-    }
-
-    out = run_watchlist_pipeline(
-        py="python",
-        base=Path("."),
-        cfg=cfg,
-        report_dir=Path("."),
-        is_scheduled=True,
-        top_n=3,
-        symbol_timeout_sec=0,
-        portfolio_timeout_sec=1,
-        want_scan=True,
-        no_context=True,
-        symbols_arg=None,
-        log=lambda msg: warnings.append(msg),
-        want_fn=lambda _: True,
-        apply_profiles_fn=_apply_profiles,
-        process_symbol_fn=_process_symbol,
-        build_pipeline_context_fn=_build_ctx,
-        build_symbols_summary_fn=_noop,
-        build_symbols_digest_fn=_noop,
-    )
-
-    assert warnings == []
-    assert [row["symbol"] for row in out] == ["0700.HK", "3690.HK"]
-    assert sorted(started) == ["0700.HK", "3690.HK"]
 
 
 def test_resolve_watchlist_item_runtime_config_centralizes_template_expansion() -> None:


### PR DESCRIPTION
Reject the retired Symbol worker settings instead of silently ignoring them, remove the dead Symbol thread-pool path while preserving the hard-timeout contract, and validate direct scan configuration before provider-adjacent refresh work. Verification: 5798 full-suite tests passed before the final test-only consolidation; the final focused suite passed 176 tests; Ruff, guardrails, config validation/build dry-runs, diff checks, and dependency-graph checks passed. No VERSION, release, deployment, runtime, provider, or notification changes.