### PR TITLE
fix(ledger): restore OpenD trade times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking Changes
 - Reject the retired `runtime.pipeline_symbol_max_workers` and `runtime.watchlist_max_workers` settings instead of silently ignoring them.
 
+### Bug Fixes
+- Added an audited OpenD-evidence repair for incorrect historical Futu trade times, preserving event identity and projection lineage while invalidating stale event-time cash conversions for explicit backfill.
+
 ## 3.4.3 - 2026-09-03
 
 ### Breaking Changes

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1009 (`src`: 541, `domain`: 78, `scripts`: 12, `tests`: 378)
-- Internal import edges: 6762 total, 2936 production/script edges excluding tests
+- Internal import edges: 6765 total, 2936 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,11 +46,11 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2832| application
+  tests -->|2833| application
   tests -->|429| domain
   tests -->|2| domain_services
   tests -->|233| infrastructure
-  tests -->|243| interfaces
+  tests -->|245| interfaces
   tests -->|23| scripts
   tests -->|18| storage
 ```
@@ -79,9 +79,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2832 |
+| tests | application | 2833 |
 | tests | domain | 429 |
-| tests | interfaces | 243 |
+| tests | interfaces | 245 |
 | tests | infrastructure | 233 |
 | tests | scripts | 23 |
 | tests | storage | 18 |

--- a/docs/LEDGER_ARCHITECTURE.md
+++ b/docs/LEDGER_ARCHITECTURE.md
@@ -302,8 +302,8 @@ release、deploy 和生产写入继续是独立授权边界。
 - 绑定后的同范围 `fees-sync` dry-run 选中该订单，actual fee 写入后再次 dry-run 收敛为 no-op。
 
 本变更不支持 close、expire-close、assignment、exercise 或 assigned-stock sale；不自动匹配 OpenD
-历史订单，不进行批量映射、部分身份补齐、事件时间纠正、经济事实更改、下游链重写、
-schema/config 变更或生产回填。账本与 OpenD 时间相差 12 小时等情况仍需操作员独立确认；
+历史订单，不进行批量映射、部分身份补齐、经济事实更改、下游链重写、
+schema/config 变更或生产回填。账本与 OpenD 时间不一致时必须走下述独立时间修正路径；
 近似时间、合约、数量或价格不会被代码提升成持久订单身份。
 
 ### 当前事实与选定方案
@@ -418,6 +418,24 @@ identity-only 的文本回执、help 和 rollback hint 必须明确不会生成 
 开放项：无。当前能力不需要新 schema、public command 或 provider capability。发布/升级和
 生产回填继续是独立授权边界。
 
+## OpenD 历史开仓时间修正
+
+`trade-events repair --trade-time-ms` 的 time-only 请求是第二个受控原位例外。它只接受未 void 的
+canonical Futu open，要求事件已保存 `opend_order_evidence.v1`，订单数量合计等于事件 contracts，
+且目标时间精确等于证据中最早订单的成交时间。命令不连接 provider，也不接受近似匹配或与其他
+override 混用。
+
+apply 在同一个 `BEGIN IMMEDIATE` 事务内以旧 JSON 和旧 SQL 时间做 CAS，保留 `event_id`、
+`ingest_seq`、lot identity 与 downstream lineage，只同步修改 SQL/JSON 时间并写入
+`opend_trade_time_correction.v1` provenance。SQLite immutable trigger 只在上述 provenance、已存
+OpenD 证据和最早成交时间同时吻合时放行；其他交易时间更新仍被拒绝。随后强制全量投影，并要求
+只有目标 lot 的 `opened_at` 改变，否则整体回滚。
+
+旧事件时间形成的 `cash_conversions` 会在同一 CAS 中移除并记录失效的 fact kind，避免错误时点的
+CNY 金额继续通过读取校验。批次时间修正后必须独立 dry-run/apply 现有
+`option-performance cash-conversion backfill`；旧 backfill audit 保留，新换算写入独立时间修正 audit，
+再验证月度报告。备份、生产写入和运行环境升级仍是独立授权边界。
+
 ## 读取语义
 
 运行时风险、Close Advice、Performance 和 Agent tools 从 canonical read model 读取：
@@ -452,8 +470,9 @@ Agent 通过 `option_positions_read action=events` 分页读取 canonical `trade
 不会插入正在进行的结果流，分页条数可以在 1–20 之间变化，也不会导致已返回成员重复。
 
 这个 snapshot 冻结的是成员集合、筛选字段和排序字段，不是整行 JSON 的历史版本。事件成员
-不可删除，`ingest_seq`、事件身份、交易时间、账户、市场、position effect 和合约筛选字段不可
-修改；价格等不参与查询的补充字段仍可按现有账本语义更新。完整 TradeEvent 的编码与验证继续
+不可删除，`ingest_seq`、事件身份、账户、市场、position effect 和合约筛选字段不可修改；交易
+时间只允许上述 OpenD 证据约束的原位修正，其他时间更新仍不可变。价格等不参与查询的补充字段
+仍可按现有账本语义更新。完整 TradeEvent 的编码与验证继续
 由 Python canonical codec 负责，SQLite 不实现第二套领域 JSON 校验器。
 
 旧库只声明新增列，不在普通启动时扫描回填。必须通过受控 position-projection migration 分批

--- a/docs/OPTION_POSITIONS_REPAIR.md
+++ b/docs/OPTION_POSITIONS_REPAIR.md
@@ -141,7 +141,43 @@ OpenD 订单后先预览；`reason` 必须写明 OpenD 核对证据：
 等其他 override 混用。写入后仍要单独 dry-run/apply `trade-events fees-sync`；本命令不连接 OpenD，
 也不自动补 fee。
 
-### 场景 E：Futu 当前期权条款与账本不同
+### 场景 E：历史 Futu 开仓时间与 OpenD 证据不一致
+
+只适用于未 void 的 canonical Futu open 事件，包括已有下游 close 的已平仓 lot。事件必须已经保存
+`opend_order_evidence.v1`；修正时间只能等于证据中最早一笔订单的 `trade_time_ms`，不能人工指定
+其他时间。先核对目标、时间、订单 ID 和写前哈希：
+
+```bash
+./om trade-events repair <open_event_id> \
+  --trade-time-ms <earliest_opend_trade_time_ms> \
+  --reason "OpenD stored evidence: <order_ids>" \
+  --dry-run --format json
+```
+
+生产执行前另行创建并验证 SQLite 备份，再单独确认写入：
+
+```bash
+./om trade-events repair <open_event_id> \
+  --trade-time-ms <earliest_opend_trade_time_ms> \
+  --reason "OpenD stored evidence: <order_ids>" \
+  --confirm --format json
+```
+
+该路径保留 `event_id`、`ingest_seq`、lot identity 和 downstream lineage，只修正事件时间并强制全量
+重建投影。旧时间形成的 `cash_conversions` 会被移除，避免把错误时点的汇率继续当作有效证据；完成
+同一月份的时间修正后，必须先预览再回填该月份的历史换算：
+
+```bash
+./om option-performance cash-conversion backfill \
+  --config-key us --account lx --start-date 2026-05-01 --end-date 2026-05-31
+./om option-performance cash-conversion backfill \
+  --config-key us --account lx --start-date 2026-05-01 --end-date 2026-05-31 --apply
+```
+
+只在 dry-run 选出的事件与本次时间修正目标一致时 apply，并对其他账户分别执行。任一事件缺少 OpenD 证据、订单数量与事件数量不一致、目标时间不是证据最早
+成交时间、事件已 void 或投影出现额外变更时，命令都会失败且整个事务回滚。
+
+### 场景 F：Futu 当前期权条款与账本不同
 
 分红、拆并股等公司行动可能调整存量合约的 strike、multiplier 或其他交割条款。
 此时 Futu 的期权代码只用于定位合约；当前经济条款必须以该代码对应的 market
@@ -180,7 +216,7 @@ divergence，不会建议 `adjust-lot`。系统不会做模糊 strike 匹配，�
 
 ---
 
-### 场景 F：你怀疑投影脏了，但账本本身没问题
+### 场景 G：你怀疑投影脏了，但账本本身没问题
 
 默认只预览投影差异：
 

--- a/src/application/ledger/cash_conversion_migration.py
+++ b/src/application/ledger/cash_conversion_migration.py
@@ -811,28 +811,7 @@ def _apply_plan(
         if correction
         else "cash_conversion_backfill_audit"
     )
-    primary_key = (
-        "UNIQUE(event_kind, event_id, cash_fact_id, rate_evidence_fact_id)"
-        if correction
-        else "PRIMARY KEY(event_kind, event_id, cash_fact_id)"
-    )
-    conn.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {audit_table}(
-          batch_id TEXT NOT NULL,
-          event_kind TEXT NOT NULL,
-          event_id TEXT NOT NULL,
-          cash_fact_id TEXT NOT NULL,
-          previous_conversion_json TEXT,
-          new_conversion_json TEXT NOT NULL,
-          previous_event_sha256 TEXT NOT NULL,
-          new_event_sha256 TEXT NOT NULL,
-          rate_evidence_fact_id TEXT,
-          migrated_at_ms INTEGER NOT NULL,
-          {primary_key}
-        )
-        """
-    )
+    _ensure_cash_conversion_audit_table(conn, correction=correction)
     for event_change in plan.event_changes:
         table = "trade_events" if event_change.event_kind == "trade_event" else "assigned_stock_events"
         id_column = "event_id" if event_change.event_kind == "trade_event" else "stock_event_id"
@@ -869,21 +848,76 @@ def _apply_plan(
             if event_change.event_kind == "trade_event"
             else before_payload.get("cash_conversions", {})
         )
+        time_correction = (
+            before_payload.get("raw_payload", {}).get("trade_time_correction_provenance")
+            if event_change.event_kind == "trade_event"
+            else None
+        )
         previous_hash = hashlib.sha256(event_change.previous_json.encode("utf-8")).hexdigest()
         new_hash = hashlib.sha256(event_change.new_json.encode("utf-8")).hexdigest()
         for conversion_change in event_change.conversion_changes:
+            target_audit_table = audit_table
+            if not correction:
+                prior = conn.execute(
+                    """
+                    SELECT 1 FROM cash_conversion_backfill_audit
+                    WHERE event_kind=? AND event_id=? AND cash_fact_id=?
+                    """,
+                    (
+                        conversion_change.event_kind,
+                        conversion_change.event_id,
+                        conversion_change.cash_fact_id,
+                    ),
+                ).fetchone()
+                if prior is not None:
+                    fact_kind = conversion_change.cash_fact_id.split(":", 1)[0]
+                    invalidated = (
+                        time_correction.get("invalidated_cash_conversion_keys")
+                        if isinstance(time_correction, Mapping)
+                        else None
+                    )
+                    if (
+                        not isinstance(time_correction, Mapping)
+                        or str(time_correction.get("schema_version") or "")
+                        != "opend_trade_time_correction.v1"
+                        or str(time_correction.get("provider") or "") != "opend"
+                        or str(time_correction.get("source") or "")
+                        != "manual_trade_event_repair"
+                        or not str(time_correction.get("correction_id") or "").startswith(
+                            "opend_trade_time_correction_"
+                        )
+                        or int(time_correction.get("after_trade_time_ms") or 0)
+                        != int(before_payload.get("event_time_ms") or 0)
+                        or int(time_correction.get("before_trade_time_ms") or 0)
+                        == int(before_payload.get("event_time_ms") or 0)
+                        or not isinstance(invalidated, list)
+                        or fact_kind not in invalidated
+                    ):
+                        raise ValueError(
+                            "cash conversion backfill audit already exists without "
+                            "an OpenD trade-time correction"
+                        )
+                    target_audit_table = "cash_conversion_trade_time_repair_audit"
+                    _ensure_trade_time_repair_audit_table(conn)
             previous = None
             if isinstance(before_conversions, Mapping):
                 fact_kind = conversion_change.cash_fact_id.split(":", 1)[0]
                 previous = before_conversions.get(fact_kind)
+            columns = (
+                ""
+                if target_audit_table != "cash_conversion_trade_time_repair_audit"
+                else ", trade_time_correction_id"
+            )
+            placeholders = "" if not columns else ", ?"
+            values = () if not columns else (str(time_correction["correction_id"]),)
             conn.execute(
                 f"""
-                INSERT INTO {audit_table}(
+                INSERT INTO {target_audit_table}(
                   batch_id, event_kind, event_id, cash_fact_id,
                   previous_conversion_json, new_conversion_json,
                   previous_event_sha256, new_event_sha256,
-                  rate_evidence_fact_id, migrated_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                  rate_evidence_fact_id, migrated_at_ms{columns}
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?{placeholders})
                 """,
                 (
                     batch_id,
@@ -900,8 +934,60 @@ def _apply_plan(
                     new_hash,
                     conversion_change.conversion.get("rate_evidence_fact_id"),
                     int(migrated_at_ms),
+                    *values,
                 ),
             )
+
+
+def _ensure_cash_conversion_audit_table(conn: Any, *, correction: bool) -> None:
+    audit_table = (
+        "cash_conversion_correction_audit"
+        if correction
+        else "cash_conversion_backfill_audit"
+    )
+    primary_key = (
+        "UNIQUE(event_kind, event_id, cash_fact_id, rate_evidence_fact_id)"
+        if correction
+        else "PRIMARY KEY(event_kind, event_id, cash_fact_id)"
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {audit_table}(
+          batch_id TEXT NOT NULL,
+          event_kind TEXT NOT NULL,
+          event_id TEXT NOT NULL,
+          cash_fact_id TEXT NOT NULL,
+          previous_conversion_json TEXT,
+          new_conversion_json TEXT NOT NULL,
+          previous_event_sha256 TEXT NOT NULL,
+          new_event_sha256 TEXT NOT NULL,
+          rate_evidence_fact_id TEXT,
+          migrated_at_ms INTEGER NOT NULL,
+          {primary_key}
+        )
+        """
+    )
+
+
+def _ensure_trade_time_repair_audit_table(conn: Any) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS cash_conversion_trade_time_repair_audit(
+          batch_id TEXT NOT NULL,
+          event_kind TEXT NOT NULL,
+          event_id TEXT NOT NULL,
+          cash_fact_id TEXT NOT NULL,
+          previous_conversion_json TEXT,
+          new_conversion_json TEXT NOT NULL,
+          previous_event_sha256 TEXT NOT NULL,
+          new_event_sha256 TEXT NOT NULL,
+          rate_evidence_fact_id TEXT,
+          migrated_at_ms INTEGER NOT NULL,
+          trade_time_correction_id TEXT NOT NULL,
+          UNIQUE(event_kind, event_id, cash_fact_id, trade_time_correction_id)
+        )
+        """
+    )
 
 
 def _result_from_plan(

--- a/src/application/ledger/commands.py
+++ b/src/application/ledger/commands.py
@@ -21,10 +21,13 @@ from domain.domain.trade_contract_identity import normalize_trade_side
 from src.application.ledger.interventions import (
     build_manual_repair_preview,
     build_manual_void_preview,
+    is_opend_trade_time_repair_request,
     is_order_identity_repair_request,
+    persist_manual_opend_trade_time_correction,
     persist_manual_order_identity_binding,
     persist_manual_repair_event,
     persist_manual_void_event,
+    preview_manual_opend_trade_time_correction,
     preview_manual_order_identity_binding,
 )
 from src.application.ledger.lot_resolver import (
@@ -2238,6 +2241,13 @@ def preview_trade_event_repair(
             overrides=overrides,
             repair_reason=reason,
         )
+    if is_opend_trade_time_repair_request(overrides):
+        return preview_manual_opend_trade_time_correction(
+            repo,
+            target_event_id=event_id,
+            overrides=overrides,
+            repair_reason=reason,
+        )
     from src.application.ledger.queries import trade_event_log, trade_event_projection_preview
 
     preview = build_manual_repair_preview(
@@ -2271,6 +2281,13 @@ def record_trade_event_repair(
 ) -> dict[str, Any]:
     if is_order_identity_repair_request(overrides):
         return persist_manual_order_identity_binding(
+            repo,
+            target_event_id=event_id,
+            overrides=overrides,
+            repair_reason=reason,
+        )
+    if is_opend_trade_time_repair_request(overrides):
+        return persist_manual_opend_trade_time_correction(
             repo,
             target_event_id=event_id,
             overrides=overrides,

--- a/src/application/ledger/interventions.py
+++ b/src/application/ledger/interventions.py
@@ -46,6 +46,9 @@ from src.infrastructure.feishu_bitable import safe_float
 
 _ORDER_IDENTITY_OVERRIDE_KEYS = frozenset({"futu_account_id", "order_id"})
 _ORDER_IDENTITY_PROVENANCE_SCHEMA = "futu_order_identity_binding.v1"
+_OPEND_TRADE_TIME_OVERRIDE_KEYS = frozenset({"trade_time_ms"})
+_OPEND_TRADE_TIME_EVIDENCE_SCHEMA = "opend_order_evidence.v1"
+_OPEND_TRADE_TIME_PROVENANCE_SCHEMA = "opend_trade_time_correction.v1"
 
 
 def _canonical_trade_symbol(value: Any) -> str:
@@ -388,6 +391,11 @@ def is_order_identity_repair_request(overrides: dict[str, Any]) -> bool:
     return identity_requested and not (keys - _ORDER_IDENTITY_OVERRIDE_KEYS)
 
 
+def is_opend_trade_time_repair_request(overrides: dict[str, Any]) -> bool:
+    effective = _repair_override_payload(overrides)
+    return set(effective) == _OPEND_TRADE_TIME_OVERRIDE_KEYS
+
+
 def _normalized_order_identity(overrides: dict[str, Any]) -> tuple[str, str]:
     effective = _repair_override_payload(overrides)
     if set(effective) != _ORDER_IDENTITY_OVERRIDE_KEYS:
@@ -411,6 +419,13 @@ def _order_identity_reason(repair_reason: str) -> str:
     reason = str(repair_reason or "").strip()
     if reason == "manual_repair" or "opend" not in reason.lower():
         raise ValueError("order identity repair reason must reference the manual OpenD evidence")
+    return reason
+
+
+def _opend_trade_time_reason(repair_reason: str) -> str:
+    reason = str(repair_reason or "").strip()
+    if reason == "manual_repair" or "opend" not in reason.lower():
+        raise ValueError("trade time correction reason must reference the OpenD evidence")
     return reason
 
 
@@ -443,6 +458,13 @@ def _binding_id(event_id: str, futu_account_id: str, order_id: str) -> str:
     return f"order_identity_binding_{digest}"
 
 
+def _trade_time_correction_id(event_id: str, before_ms: int, after_ms: int) -> str:
+    digest = hashlib.sha256(
+        "\x1f".join((event_id, str(before_ms), str(after_ms))).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"opend_trade_time_correction_{digest}"
+
+
 def _assert_identity_only_payload_change(
     before: dict[str, Any],
     after: dict[str, Any],
@@ -458,6 +480,82 @@ def _assert_identity_only_payload_change(
         after_raw.pop(key, None)
     if before_raw != after_raw:
         raise ValueError("order identity repair changed non-identity raw payload data")
+
+
+def _assert_trade_time_only_payload_change(
+    before: dict[str, Any],
+    after: dict[str, Any],
+) -> None:
+    before_outer = deepcopy(before)
+    after_outer = deepcopy(after)
+    before_outer.pop("event_time_ms", None)
+    after_outer.pop("event_time_ms", None)
+    before_raw = before_outer.pop("raw_payload", {})
+    after_raw = after_outer.pop("raw_payload", {})
+    if before_outer != after_outer or not isinstance(before_raw, dict) or not isinstance(after_raw, dict):
+        raise ValueError("trade time correction changed non-time event data")
+    if "cash_conversions" in after_raw:
+        raise ValueError("trade time correction retained stale cash conversions")
+    before_raw.pop("cash_conversions", None)
+    before_raw.pop("trade_time_correction_provenance", None)
+    after_raw.pop("trade_time_correction_provenance", None)
+    if before_raw != after_raw:
+        raise ValueError("trade time correction changed unrelated raw payload data")
+
+def _validated_opend_trade_time_evidence(
+    event: TradeEvent,
+    raw_payload: dict[str, Any],
+) -> tuple[int, list[str], int]:
+    evidence = raw_payload.get("opend_order_evidence")
+    if not isinstance(evidence, dict):
+        raise ValueError("trade time correction requires stored OpenD order evidence")
+    if str(evidence.get("provider") or "").strip().lower() != "opend":
+        raise ValueError("trade time correction evidence provider must be OpenD")
+    if str(evidence.get("schema_version") or "").strip() != _OPEND_TRADE_TIME_EVIDENCE_SCHEMA:
+        raise ValueError("trade time correction requires opend_order_evidence.v1")
+    orders = evidence.get("orders")
+    if not isinstance(orders, list) or not orders:
+        raise ValueError("trade time correction requires at least one OpenD order")
+    classification = str(evidence.get("classification") or "").strip()
+    if classification in {"single_order", "contract_lineage"} and len(orders) != 1:
+        raise ValueError("single-order OpenD evidence must contain exactly one order")
+    if classification == "multi_order_aggregate" and len(orders) < 2:
+        raise ValueError("multi_order_aggregate OpenD evidence must contain multiple orders")
+    if classification not in {
+        "single_order",
+        "contract_lineage",
+        "multi_order_aggregate",
+        "opend_price_override",
+    }:
+        raise ValueError("trade time correction OpenD evidence classification is unsupported")
+
+    order_ids: list[str] = []
+    trade_times: list[int] = []
+    quantity = 0
+    for order in orders:
+        if not isinstance(order, dict):
+            raise ValueError("trade time correction OpenD order must be an object")
+        order_id = str(order.get("order_id") or "").strip()
+        futu_account_id = str(order.get("futu_account_id") or "").strip()
+        raw_time = order.get("trade_time_ms")
+        raw_quantity = order.get("quantity")
+        if not order_id or not futu_account_id:
+            raise ValueError("trade time correction OpenD order identity is incomplete")
+        if isinstance(raw_time, bool) or not isinstance(raw_time, int) or raw_time <= 0:
+            raise ValueError("trade time correction OpenD order time is invalid")
+        if isinstance(raw_quantity, bool) or not isinstance(raw_quantity, int) or raw_quantity <= 0:
+            raise ValueError("trade time correction OpenD order quantity is invalid")
+        order_ids.append(order_id)
+        trade_times.append(raw_time)
+        quantity += raw_quantity
+    if len(order_ids) != len(set(order_ids)):
+        raise ValueError("trade time correction OpenD order ids must be unique")
+    if quantity != int(event.contracts):
+        raise ValueError("trade time correction OpenD quantity does not match the event")
+    observed_at_ms = evidence.get("observed_at_ms")
+    if isinstance(observed_at_ms, bool) or not isinstance(observed_at_ms, int) or observed_at_ms <= 0:
+        raise ValueError("trade time correction OpenD observation time is invalid")
+    return min(trade_times), sorted(order_ids), observed_at_ms
 
 
 def _order_identity_binding_plan(
@@ -704,6 +802,307 @@ def persist_manual_order_identity_binding(
                 }
             ).items()
             if key not in {"before_json", "after_json", "binding_status"}
+        }
+
+    return with_sqlite_repo_transaction(
+        repo,
+        _run,
+        require_projection_publication=True,
+    )
+
+
+def _opend_trade_time_correction_plan(
+    repo: Any,
+    *,
+    target_event_id: str,
+    overrides: dict[str, Any],
+    repair_reason: str,
+    conn: sqlite3.Connection | None = None,
+    corrected_at_ms: int | None = None,
+) -> dict[str, Any]:
+    effective = _repair_override_payload(overrides)
+    if set(effective) != _OPEND_TRADE_TIME_OVERRIDE_KEYS:
+        raise ValueError("OpenD trade time correction only accepts --trade-time-ms")
+    requested_time_ms = effective["trade_time_ms"]
+    if isinstance(requested_time_ms, bool) or not isinstance(requested_time_ms, int) or requested_time_ms <= 0:
+        raise ValueError("trade_time_ms must be a positive integer")
+    reason = _opend_trade_time_reason(repair_reason)
+    rows = _storage_trade_event_rows(repo, conn=conn)
+    target_id = str(target_event_id or "").strip()
+    target_row = next((item for item in rows if str(item.get("event_id") or "") == target_id), None)
+    if target_row is None:
+        raise ValueError(f"trade event not found: {target_event_id}")
+    payloads = [(item, _storage_payload(item)) for item in rows]
+    if target_id in {
+        target
+        for _row, payload in payloads
+        if (target := valid_void_target_event_id(payload))
+    }:
+        raise ValueError(f"trade event already voided: {target_id}")
+
+    before_json = str(target_row["event_json"])
+    before_payload = _storage_payload(target_row)
+    event, diagnostics = stored_trade_event_to_ledger_event(before_payload)
+    errors = [item.code for item in diagnostics if item.severity == "error"]
+    if event is None or errors:
+        raise ValueError(
+            "trade time correction requires a canonical trade event: "
+            f"{target_id}; diagnostics={','.join(errors) or 'event_decode_failed'}"
+        )
+    if event.event_type != "open":
+        raise ValueError("trade time correction only supports option open events")
+    if normalize_broker(event.contract_key.broker) != "富途":
+        raise ValueError("trade time correction only supports Futu events")
+    stored_time_ms = int(target_row.get("trade_time_ms") or 0)
+    if stored_time_ms != int(event.event_time_ms):
+        raise ValueError("trade event SQL and JSON times conflict")
+    raw_payload = before_payload.get("raw_payload") or {}
+    if not isinstance(raw_payload, dict):
+        raise ValueError("trade event raw_payload must be an object")
+    evidence_time_ms, evidence_order_ids, evidence_observed_at_ms = (
+        _validated_opend_trade_time_evidence(event, raw_payload)
+    )
+    if requested_time_ms != evidence_time_ms:
+        raise ValueError(
+            f"trade_time_ms must equal the earliest stored OpenD order time: {evidence_time_ms}"
+        )
+
+    expected_before_sha256 = _sha256_text(before_json)
+    common = {
+        "operation": "opend_trade_time_correction",
+        "target_event_id": target_id,
+        "target_lot_id": event.lot_id or f"lot_{event.event_id}",
+        "before_trade_time_ms": stored_time_ms,
+        "after_trade_time_ms": requested_time_ms,
+        "evidence_order_ids": evidence_order_ids,
+        "evidence_observed_at_ms": evidence_observed_at_ms,
+        "expected_before_sha256": expected_before_sha256,
+        "cash_conversion_backfill_required": (
+            stored_time_ms != requested_time_ms
+            or not isinstance(raw_payload.get("cash_conversions"), dict)
+        ),
+    }
+    if stored_time_ms == requested_time_ms:
+        return common | {
+            "correction_status": "no_op",
+            "before_json": before_json,
+            "after_json": before_json,
+            "after_sha256": expected_before_sha256,
+        }
+    if "trade_time_correction_provenance" in raw_payload:
+        raise ValueError("trade time correction provenance already exists")
+    if corrected_at_ms is None:
+        return common | {"correction_status": "ready", "before_json": before_json}
+
+    after_payload = deepcopy(before_payload)
+    after_payload["event_time_ms"] = requested_time_ms
+    after_raw = dict(raw_payload)
+    removed_conversions = after_raw.pop("cash_conversions", None)
+    invalidated_conversion_keys = (
+        sorted(str(key) for key in removed_conversions)
+        if isinstance(removed_conversions, dict)
+        else []
+    )
+    after_raw["trade_time_correction_provenance"] = {
+        "schema_version": _OPEND_TRADE_TIME_PROVENANCE_SCHEMA,
+        "correction_id": _trade_time_correction_id(target_id, stored_time_ms, requested_time_ms),
+        "source": "manual_trade_event_repair",
+        "provider": "opend",
+        "reason": reason,
+        "before_trade_time_ms": stored_time_ms,
+        "after_trade_time_ms": requested_time_ms,
+        "evidence_schema_version": _OPEND_TRADE_TIME_EVIDENCE_SCHEMA,
+        "evidence_order_ids": evidence_order_ids,
+        "evidence_observed_at_ms": evidence_observed_at_ms,
+        "expected_before_sha256": expected_before_sha256,
+        "invalidated_cash_conversion_keys": invalidated_conversion_keys,
+        "corrected_at_ms": int(corrected_at_ms),
+    }
+    after_payload["raw_payload"] = after_raw
+    _assert_trade_time_only_payload_change(before_payload, after_payload)
+    after_event, after_diagnostics = stored_trade_event_to_ledger_event(after_payload)
+    if after_event is None or any(item.severity == "error" for item in after_diagnostics):
+        raise ValueError("trade time correction produced an invalid canonical trade event")
+    after_json = json.dumps(after_payload, ensure_ascii=False, sort_keys=True)
+    return common | {
+        "correction_status": "ready",
+        "before_json": before_json,
+        "after_json": after_json,
+        "after_sha256": _sha256_text(after_json),
+        "corrected_at_ms": int(corrected_at_ms),
+        "invalidated_cash_conversion_count": (
+            len(invalidated_conversion_keys)
+        ),
+    }
+
+
+def preview_manual_opend_trade_time_correction(
+    repo: Any,
+    *,
+    target_event_id: str,
+    overrides: dict[str, Any],
+    repair_reason: str,
+) -> dict[str, Any]:
+    plan = _opend_trade_time_correction_plan(
+        repo,
+        target_event_id=target_event_id,
+        overrides=overrides,
+        repair_reason=repair_reason,
+    )
+    return {
+        key: value
+        for key, value in (
+            plan
+            | {
+                "mode": "no_op" if plan["correction_status"] == "no_op" else "dry_run",
+                "advisory": True,
+            }
+        ).items()
+        if key not in {"before_json", "after_json", "correction_status"}
+    }
+
+
+def _assert_only_target_lot_opened_at_changed(
+    before_lots: list[dict[str, Any]],
+    after_lots: list[dict[str, Any]],
+    *,
+    target_lot_id: str,
+    before_trade_time_ms: int,
+    after_trade_time_ms: int,
+) -> None:
+    before_by_id = {str(item.get("record_id") or ""): deepcopy(item) for item in before_lots}
+    after_by_id = {str(item.get("record_id") or ""): deepcopy(item) for item in after_lots}
+    if set(before_by_id) != set(after_by_id) or target_lot_id not in before_by_id:
+        raise ValueError("trade time correction changed position lot membership")
+    changed_ids = {
+        record_id
+        for record_id in before_by_id
+        if before_by_id[record_id] != after_by_id[record_id]
+    }
+    if changed_ids != {target_lot_id}:
+        raise ValueError("trade time correction changed an unexpected position lot")
+    before_target = before_by_id[target_lot_id]
+    after_target = after_by_id[target_lot_id]
+    before_fields = before_target.get("fields")
+    after_fields = after_target.get("fields")
+    if not isinstance(before_fields, dict) or not isinstance(after_fields, dict):
+        raise ValueError("trade time correction target lot fields are invalid")
+    if int(before_fields.get("opened_at") or 0) != before_trade_time_ms:
+        raise ValueError("trade time correction target lot has an unexpected opening time")
+    if int(after_fields.get("opened_at") or 0) != after_trade_time_ms:
+        raise ValueError("trade time correction target lot opening time was not updated")
+    before_fields.pop("opened_at", None)
+    after_fields.pop("opened_at", None)
+    if before_target != after_target:
+        raise ValueError("trade time correction changed non-time position lot data")
+
+
+def persist_manual_opend_trade_time_correction(
+    repo: Any,
+    *,
+    target_event_id: str,
+    overrides: dict[str, Any],
+    repair_reason: str,
+) -> dict[str, Any]:
+    def _run(sqlite_repo: Any, conn: sqlite3.Connection | None) -> dict[str, Any]:
+        if conn is None:
+            raise TypeError("trade time correction requires SQLite transaction authority")
+        applied_at_ms = now_ms()
+        plan = _opend_trade_time_correction_plan(
+            sqlite_repo,
+            target_event_id=target_event_id,
+            overrides=overrides,
+            repair_reason=repair_reason,
+            conn=conn,
+            corrected_at_ms=applied_at_ms,
+        )
+        if plan["correction_status"] == "no_op":
+            return {
+                key: value
+                for key, value in (plan | {"mode": "no_op", "advisory": False}).items()
+                if key not in {"before_json", "after_json", "correction_status"}
+            }
+
+        before_lots = sqlite_repo.list_position_lots(conn=conn)
+        before_fingerprint = position_lots_fingerprint(before_lots)
+        source_before = int(
+            sqlite_repo.read_position_projection_source_state(conn=conn).get("source_generation") or 0
+        )
+        fence = capture_trade_event_decision_projection_fence(sqlite_repo, conn=conn)
+        updated = sqlite_repo.compare_and_swap_trade_event_time(
+            event_id=plan["target_event_id"],
+            expected_event_json=plan["before_json"],
+            expected_trade_time_ms=plan["before_trade_time_ms"],
+            replacement_event_json=plan["after_json"],
+            replacement_trade_time_ms=plan["after_trade_time_ms"],
+            updated_at_ms=applied_at_ms,
+            conn=conn,
+        )
+        if not updated:
+            raise ValueError(f"trade time correction CAS conflict: {plan['target_event_id']}")
+        readback = next(
+            (
+                item
+                for item in _storage_trade_event_rows(sqlite_repo, conn=conn)
+                if str(item.get("event_id") or "") == plan["target_event_id"]
+            ),
+            None,
+        )
+        if (
+            readback is None
+            or str(readback.get("event_json") or "") != plan["after_json"]
+            or int(readback.get("trade_time_ms") or 0) != plan["after_trade_time_ms"]
+        ):
+            raise ValueError(f"trade time correction readback failed: {plan['target_event_id']}")
+
+        runtime = run_position_projection_in_transaction(
+            sqlite_repo,
+            (),
+            conn=conn,
+            mode="forced_full",
+        )
+        publication = runtime.publication
+        if publication.added or publication.removed or publication.changed != 1:
+            raise ValueError("trade time correction changed unexpected position lots")
+        after_lots = sqlite_repo.list_position_lots(conn=conn)
+        _assert_only_target_lot_opened_at_changed(
+            before_lots,
+            after_lots,
+            target_lot_id=plan["target_lot_id"],
+            before_trade_time_ms=plan["before_trade_time_ms"],
+            after_trade_time_ms=plan["after_trade_time_ms"],
+        )
+        after_fingerprint = position_lots_fingerprint(after_lots)
+        decision = (
+            finalize_current_decision_projection(
+                sqlite_repo,
+                fence=fence,
+                updated_at_ms=applied_at_ms,
+                conn=conn,
+            )
+            if fence is not None
+            else None
+        )
+        sqlite_repo.assert_foreign_keys_clean(conn=conn)
+        source_after = int(
+            sqlite_repo.read_position_projection_source_state(conn=conn).get("source_generation") or 0
+        )
+        return {
+            key: value
+            for key, value in (
+                plan
+                | {
+                    "mode": "applied",
+                    "advisory": False,
+                    "position_lot_count": int(runtime.position_lot_count),
+                    "position_lots_fingerprint_before": before_fingerprint,
+                    "position_lots_fingerprint_after": after_fingerprint,
+                    "projection_source_generation_before": source_before,
+                    "projection_source_generation_after": source_after,
+                    "decision_projection": decision,
+                }
+            ).items()
+            if key not in {"before_json", "after_json", "correction_status"}
         }
 
     return with_sqlite_repo_transaction(

--- a/src/application/ledger/repository_schema.py
+++ b/src/application/ledger/repository_schema.py
@@ -107,6 +107,7 @@ from .repository_trade_schema import (
     _TRADE_EVENT_PAGINATION_MISSING,
     _backfill_trade_event_pagination_schema,
     _create_index_if_table_empty,
+    _ensure_opend_trade_time_correction_guard,
     _ensure_trade_event_pagination_schema,
     _publish_trade_event_pagination_schema,
     _trade_event_pagination_missing_row,

--- a/src/application/ledger/repository_trade_events.py
+++ b/src/application/ledger/repository_trade_events.py
@@ -4,6 +4,7 @@ from .repository_schema import (
     Any,
     Sequence,
     TradeEventPaginationUnavailable,
+    _ensure_opend_trade_time_correction_guard,
     _trade_event_pagination_schema_ready,
     _trade_event_query_projections,
     encode_trade_event_for_storage,
@@ -121,6 +122,37 @@ class TradeEventRepositoryMixin:
                 int(updated_at_ms),
                 str(event_id),
                 str(expected_event_json),
+            ),
+        )
+        return int(updated.rowcount or 0) == 1
+
+    def compare_and_swap_trade_event_time(
+        self,
+        *,
+        event_id: str,
+        expected_event_json: str,
+        expected_trade_time_ms: int,
+        replacement_event_json: str,
+        replacement_trade_time_ms: int,
+        updated_at_ms: int,
+        conn: sqlite3.Connection,
+    ) -> bool:
+        if conn is None or not conn.in_transaction:
+            raise ValueError("trade time correction requires an active transaction")
+        _ensure_opend_trade_time_correction_guard(conn)
+        updated = conn.execute(
+            """
+            UPDATE trade_events
+            SET event_json = ?, trade_time_ms = ?, updated_at_ms = ?
+            WHERE event_id = ? AND event_json = ? AND trade_time_ms = ?
+            """,
+            (
+                str(replacement_event_json),
+                int(replacement_trade_time_ms),
+                int(updated_at_ms),
+                str(event_id),
+                str(expected_event_json),
+                int(expected_trade_time_ms),
             ),
         )
         return int(updated.rowcount or 0) == 1

--- a/src/application/ledger/repository_trade_schema.py
+++ b/src/application/ledger/repository_trade_schema.py
@@ -29,6 +29,8 @@ TRADE_EVENT_PAGINATION_TRIGGERS = (
     "trg_trade_events_delete_immutable",
 )
 
+_OPEND_TRADE_TIME_CORRECTION_SCHEMA = "opend_trade_time_correction.v1"
+
 _TRADE_EVENT_PAGINATION_MISSING = """
     ingest_seq IS NULL
     OR typeof(ingest_seq) != 'integer' OR ingest_seq < 1
@@ -140,6 +142,119 @@ def _trade_event_pagination_schema_ready(conn: sqlite3.Connection) -> bool:
     }
     return required.issubset(present) and _trade_event_pagination_missing_row(conn) is None
 
+
+def _publish_trade_event_query_projection_immutable_trigger(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TRIGGER IF EXISTS trg_trade_events_query_projection_immutable")
+    conn.execute(
+        f"""
+        CREATE TRIGGER trg_trade_events_query_projection_immutable
+        BEFORE UPDATE OF event_id, account, event_json, trade_time_ms,
+          market, position_effect ON trade_events
+        WHEN OLD.ingest_seq IS NOT NULL AND (
+          NEW.event_id IS NOT OLD.event_id
+          OR NEW.account IS NOT OLD.account
+          OR NEW.market IS NOT OLD.market
+          OR NEW.position_effect IS NOT OLD.position_effect
+          OR json_extract(NEW.event_json, '$.event_id')
+             IS NOT json_extract(OLD.event_json, '$.event_id')
+          OR json_extract(NEW.event_json, '$.event_type')
+             IS NOT json_extract(OLD.event_json, '$.event_type')
+          OR json_extract(NEW.event_json, '$.contract_key.account')
+             IS NOT json_extract(OLD.event_json, '$.contract_key.account')
+          OR json_extract(NEW.event_json, '$.contract_key.broker')
+             IS NOT json_extract(OLD.event_json, '$.contract_key.broker')
+          OR json_extract(NEW.event_json, '$.contract_key.underlying_symbol')
+             IS NOT json_extract(OLD.event_json, '$.contract_key.underlying_symbol')
+          OR json_extract(NEW.event_json, '$.contract_key.option_type')
+             IS NOT json_extract(OLD.event_json, '$.contract_key.option_type')
+          OR json_extract(NEW.event_json, '$.contract_key.strike')
+             IS NOT json_extract(OLD.event_json, '$.contract_key.strike')
+          OR json_extract(NEW.event_json, '$.contract_key.expiration_ymd')
+             IS NOT json_extract(OLD.event_json, '$.contract_key.expiration_ymd')
+          OR (
+            (
+              NEW.trade_time_ms IS NOT OLD.trade_time_ms
+              OR json_extract(NEW.event_json, '$.event_time_ms')
+                 IS NOT json_extract(OLD.event_json, '$.event_time_ms')
+            )
+            AND NOT (
+              NEW.trade_time_ms IS NOT OLD.trade_time_ms
+              AND json_extract(NEW.event_json, '$.event_time_ms')
+                  IS NOT json_extract(OLD.event_json, '$.event_time_ms')
+              AND json_type(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance'
+              ) IS 'object'
+              AND json_extract(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance.schema_version'
+              ) = '{_OPEND_TRADE_TIME_CORRECTION_SCHEMA}'
+              AND json_extract(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance.provider'
+              ) = 'opend'
+              AND json_extract(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance.source'
+              ) = 'manual_trade_event_repair'
+              AND json_type(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance.before_trade_time_ms'
+              ) IS 'integer'
+              AND CAST(json_extract(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance.before_trade_time_ms'
+              ) AS INTEGER) IS OLD.trade_time_ms
+              AND json_type(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance.after_trade_time_ms'
+              ) IS 'integer'
+              AND CAST(json_extract(
+                NEW.event_json,
+                '$.raw_payload.trade_time_correction_provenance.after_trade_time_ms'
+              ) AS INTEGER) IS NEW.trade_time_ms
+              AND json_extract(
+                NEW.event_json,
+                '$.raw_payload.opend_order_evidence.provider'
+              ) = 'opend'
+              AND json_extract(
+                NEW.event_json,
+                '$.raw_payload.opend_order_evidence.schema_version'
+              ) = 'opend_order_evidence.v1'
+              AND json_array_length(
+                NEW.event_json,
+                '$.raw_payload.opend_order_evidence.orders'
+              ) > 0
+              AND NEW.trade_time_ms = (
+                SELECT MIN(CAST(json_extract(value, '$.trade_time_ms') AS INTEGER))
+                FROM json_each(
+                  NEW.event_json,
+                  '$.raw_payload.opend_order_evidence.orders'
+                )
+              )
+            )
+          )
+        )
+        BEGIN
+          SELECT RAISE(ABORT, 'trade event query projection is immutable');
+        END
+        """
+    )
+
+
+def _ensure_opend_trade_time_correction_guard(conn: sqlite3.Connection) -> None:
+    row = conn.execute(
+        """
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'trigger' AND name = 'trg_trade_events_query_projection_immutable'
+        """
+    ).fetchone()
+    if row is None or _OPEND_TRADE_TIME_CORRECTION_SCHEMA not in str(row["sql"] or ""):
+        _publish_trade_event_query_projection_immutable_trigger(conn)
+
 def _publish_trade_event_pagination_schema(conn: sqlite3.Connection) -> None:
     missing = _trade_event_pagination_missing_row(conn)
     if missing is not None:
@@ -189,41 +304,7 @@ def _publish_trade_event_pagination_schema(conn: sqlite3.Connection) -> None:
         END
         """
     )
-    conn.execute(
-        """
-        CREATE TRIGGER IF NOT EXISTS trg_trade_events_query_projection_immutable
-        BEFORE UPDATE OF event_id, account, event_json, trade_time_ms,
-          market, position_effect ON trade_events
-        WHEN OLD.ingest_seq IS NOT NULL AND (
-          NEW.event_id IS NOT OLD.event_id
-          OR NEW.account IS NOT OLD.account
-          OR NEW.trade_time_ms IS NOT OLD.trade_time_ms
-          OR NEW.market IS NOT OLD.market
-          OR NEW.position_effect IS NOT OLD.position_effect
-          OR json_extract(NEW.event_json, '$.event_id')
-             IS NOT json_extract(OLD.event_json, '$.event_id')
-          OR json_extract(NEW.event_json, '$.event_time_ms')
-             IS NOT json_extract(OLD.event_json, '$.event_time_ms')
-          OR json_extract(NEW.event_json, '$.event_type')
-             IS NOT json_extract(OLD.event_json, '$.event_type')
-          OR json_extract(NEW.event_json, '$.contract_key.account')
-             IS NOT json_extract(OLD.event_json, '$.contract_key.account')
-          OR json_extract(NEW.event_json, '$.contract_key.broker')
-             IS NOT json_extract(OLD.event_json, '$.contract_key.broker')
-          OR json_extract(NEW.event_json, '$.contract_key.underlying_symbol')
-             IS NOT json_extract(OLD.event_json, '$.contract_key.underlying_symbol')
-          OR json_extract(NEW.event_json, '$.contract_key.option_type')
-             IS NOT json_extract(OLD.event_json, '$.contract_key.option_type')
-          OR json_extract(NEW.event_json, '$.contract_key.strike')
-             IS NOT json_extract(OLD.event_json, '$.contract_key.strike')
-          OR json_extract(NEW.event_json, '$.contract_key.expiration_ymd')
-             IS NOT json_extract(OLD.event_json, '$.contract_key.expiration_ymd')
-        )
-        BEGIN
-          SELECT RAISE(ABORT, 'trade event query projection is immutable');
-        END
-        """
-    )
+    _publish_trade_event_query_projection_immutable_trigger(conn)
     projection_guard = """
       SELECT CASE
         WHEN json_valid(NEW.event_json) != 1

--- a/src/interfaces/cli/trade_events.py
+++ b/src/interfaces/cli/trade_events.py
@@ -90,7 +90,7 @@ def main(argv: list[str] | None = None) -> int:
 
     p_repair = sub.add_parser(
         "repair",
-        help="repair an event; identity-only Futu order metadata is bound in place",
+        help="repair an event; verified Futu identity/time metadata is corrected in place",
     )
     p_repair.add_argument("--runtime-root", default=None, help="runtime root for active ledger store")
     p_repair.add_argument("event_id")
@@ -261,15 +261,17 @@ def main(argv: list[str] | None = None) -> int:
             print(str(exc))
             return 2
         identity_binding = payload.get("operation") == "futu_order_identity_binding"
-        write_applied = bool(payload.get("mode") == "applied") if identity_binding else should_apply
+        time_correction = payload.get("operation") == "opend_trade_time_correction"
+        in_place_repair = identity_binding or time_correction
+        write_applied = bool(payload.get("mode") == "applied") if in_place_repair else should_apply
         payload["ledger_store"] = ledger_store
         payload = attach_write_contract(
             payload,
             dry_run=not should_apply,
             write_applied=write_applied,
             rollback_hint=(
-                "identity binding creates no backup or void event; restore a separately verified pre-write SQLite backup"
-                if identity_binding
+                "in-place repair creates no backup or void event; restore a separately verified pre-write SQLite backup"
+                if in_place_repair
                 else "void repair events or restore option_positions SQLite from backup"
             ),
         )
@@ -282,6 +284,20 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 f"[{state}] {verb} Futu order identity event_id={args.event_id} "
                 f"futu_account_id={payload.get('futu_account_id')} order_id={payload.get('order_id')}"
+            )
+            return 0
+        if time_correction:
+            state = str(payload.get("mode") or "").upper()
+            verb = (
+                "would correct"
+                if payload.get("mode") == "dry_run"
+                else "already corrected"
+                if payload.get("mode") == "no_op"
+                else "corrected"
+            )
+            print(
+                f"[{state}] {verb} OpenD trade time event_id={args.event_id} "
+                f"from={payload.get('before_trade_time_ms')} to={payload.get('after_trade_time_ms')}"
             )
             return 0
         if should_apply:

--- a/tests/test_cash_conversion_backfill.py
+++ b/tests/test_cash_conversion_backfill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -158,6 +159,64 @@ def test_backfill_dry_run_apply_and_second_apply_are_auditable_and_idempotent(
             "SELECT COUNT(*) FROM cash_conversion_backfill_audit"
         ).fetchone()[0]
     assert audit_count == 2
+
+
+def test_backfill_after_opend_time_correction_preserves_prior_audit(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "option_positions.sqlite3"
+    repo = SQLiteOptionPositionsRepository(db_path)
+    repo.upsert_trade_event(_event("open-1"))
+    evidence_repo = PerformanceEvidenceSQLiteRepository(db_path)
+    _import_rate(evidence_repo)
+    backfill_cash_conversions(
+        repo,
+        evidence_repo,
+        account="lx",
+        apply=True,
+        migrated_at_ms=MIGRATION_MS,
+    )
+
+    with repo._connect() as conn:  # noqa: SLF001 - exact audit recovery fixture
+        row = conn.execute(
+            "SELECT event_json FROM trade_events WHERE event_id='open-1'"
+        ).fetchone()
+        payload = json.loads(str(row["event_json"]))
+        payload["raw_payload"].pop("cash_conversions")
+        payload["raw_payload"]["trade_time_correction_provenance"] = {
+            "schema_version": "opend_trade_time_correction.v1",
+            "correction_id": "opend_trade_time_correction_test",
+            "provider": "opend",
+            "source": "manual_trade_event_repair",
+            "before_trade_time_ms": EVENT_MS - 1,
+            "after_trade_time_ms": EVENT_MS,
+            "invalidated_cash_conversion_keys": [
+                "option_fee_cash",
+                "option_trade_cash_gross",
+            ],
+        }
+        conn.execute(
+            "UPDATE trade_events SET event_json=? WHERE event_id='open-1'",
+            (json.dumps(payload, ensure_ascii=False, sort_keys=True),),
+        )
+
+    reapplied = backfill_cash_conversions(
+        repo,
+        evidence_repo,
+        account="lx",
+        apply=True,
+        migrated_at_ms=MIGRATION_MS + 1,
+    )
+
+    assert reapplied.changed_event_count == 1
+    assert reapplied.migrated_conversion_count == 2
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM cash_conversion_backfill_audit"
+        ).fetchone()[0] == 2
+        assert conn.execute(
+            "SELECT COUNT(*) FROM cash_conversion_trade_time_repair_audit"
+        ).fetchone()[0] == 2
 
 
 def test_backfill_preserves_observed_conversion_and_does_not_use_stale_fx(

--- a/tests/test_position_projection_facade_inventory.py
+++ b/tests/test_position_projection_facade_inventory.py
@@ -141,6 +141,11 @@ def test_projection_runtime_facade_modes_are_fully_inventoried() -> None:
                 "'forced_full'",
             ): 1,
             (
+                "src/application/ledger/interventions.py",
+                "persist_manual_opend_trade_time_correction>_run",
+                "'forced_full'",
+            ): 1,
+            (
                 "src/application/ledger/manual_trades.py",
                 "persist_manual_adjust_events>_run",
                 "'fast_if_safe'",

--- a/tests/test_trade_events_cli.py
+++ b/tests/test_trade_events_cli.py
@@ -38,6 +38,60 @@ def _repo_with_open_event(tmp_path: Path):
     event_id = repo.list_trade_events()[0]["event_id"]
     return repo, event_id
 
+def _attach_opend_time_evidence(
+    repo,
+    *,
+    event_id: str,
+    trade_time_ms: int = 900,
+    quantity: int = 1,
+) -> None:
+    with repo._connect() as conn:  # noqa: SLF001 - exact persisted evidence fixture
+        row = conn.execute(
+            "SELECT event_json FROM trade_events WHERE event_id=?",
+            (event_id,),
+        ).fetchone()
+        payload = json.loads(str(row["event_json"]))
+        payload["raw_payload"]["opend_order_evidence"] = {
+            "schema_version": "opend_order_evidence.v1",
+            "provider": "opend",
+            "classification": "single_order",
+            "observed_at_ms": 3000,
+            "orders": [
+                {
+                    "futu_account_id": "123",
+                    "order_id": "order-1",
+                    "deal_ids": ["deal-1"],
+                    "quantity": quantity,
+                    "price": "3.930000",
+                    "trade_time_ms": trade_time_ms,
+                }
+            ],
+        }
+        payload["raw_payload"]["cash_conversions"] = {
+            "option_trade_cash_gross": {"status": "observed"}
+        }
+        conn.execute(
+            "UPDATE trade_events SET event_json=?, updated_at_ms=? WHERE event_id=?",
+            (json.dumps(payload, ensure_ascii=False), 1500, event_id),
+        )
+
+
+def _install_legacy_trade_time_immutable_trigger(repo) -> None:
+    with repo._connect() as conn:  # noqa: SLF001 - deployed-schema upgrade fixture
+        conn.execute("DROP TRIGGER trg_trade_events_query_projection_immutable")
+        conn.execute(
+            """
+            CREATE TRIGGER trg_trade_events_query_projection_immutable
+            BEFORE UPDATE OF event_json, trade_time_ms ON trade_events
+            WHEN NEW.trade_time_ms IS NOT OLD.trade_time_ms
+              OR json_extract(NEW.event_json, '$.event_time_ms')
+                 IS NOT json_extract(OLD.event_json, '$.event_time_ms')
+            BEGIN
+              SELECT RAISE(ABORT, 'trade event query projection is immutable');
+            END
+            """
+        )
+
 
 def _append_canonical_void_event(
     repo,
@@ -466,6 +520,168 @@ def test_trade_events_identity_repair_binds_in_place_with_downstream_and_is_idem
     assert no_op["mode"] == "no_op"
     assert no_op["write_applied"] is False
     assert stored_state() == (after_json, after_ingest_seq, after_lots, after_generation)
+
+
+def test_trade_events_opend_time_correction_updates_in_place_with_downstream_and_is_idempotent(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    import src.interfaces.cli.trade_events as cli
+    from src.application.ledger.position_projection_runtime import run_position_projection_forced_full
+
+    repo, event_id = _repo_with_open_event(tmp_path)
+    _attach_opend_time_evidence(repo, event_id=event_id)
+    run_position_projection_forced_full(repo)
+    lot = repo.list_position_lots()[0]
+    ledger_manual_trades.persist_manual_close_event(
+        repo,
+        record_id=lot["record_id"],
+        fields=lot["fields"],
+        contracts_to_close=1,
+        close_price=1.2,
+        close_reason="manual_buy_to_close",
+        as_of_ms=2000,
+    )
+    _install_legacy_trade_time_immutable_trigger(repo)
+    monkeypatch.setattr(
+        cli,
+        "resolve_option_positions_repo",
+        lambda **_kwargs: (tmp_path / "data.json", repo),
+    )
+
+    def stored_state() -> tuple[str, int, int, list[dict], int]:
+        with repo._connect() as conn:  # noqa: SLF001 - exact storage proof
+            row = conn.execute(
+                "SELECT event_json, trade_time_ms, ingest_seq FROM trade_events WHERE event_id=?",
+                (event_id,),
+            ).fetchone()
+        generation = int(repo.read_position_projection_source_state().get("source_generation") or 0)
+        return (
+            str(row["event_json"]),
+            int(row["trade_time_ms"]),
+            int(row["ingest_seq"]),
+            repo.list_position_lots(),
+            generation,
+        )
+
+    before_json, before_time, before_ingest_seq, before_lots, before_generation = stored_state()
+    args = [
+        "repair",
+        event_id,
+        "--trade-time-ms",
+        "900",
+        "--reason",
+        "OpenD stored evidence: order-1",
+        "--format",
+        "json",
+    ]
+
+    assert cli.main([*args, "--dry-run"]) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["operation"] == "opend_trade_time_correction"
+    assert preview["mode"] == "dry_run"
+    assert preview["before_trade_time_ms"] == 1000
+    assert preview["after_trade_time_ms"] == 900
+    assert preview["evidence_order_ids"] == ["order-1"]
+    assert preview["write_applied"] is False
+    assert stored_state() == (
+        before_json,
+        before_time,
+        before_ingest_seq,
+        before_lots,
+        before_generation,
+    )
+
+    assert cli.main([*args, "--confirm"]) == 0
+    applied = json.loads(capsys.readouterr().out)
+    after_json, after_time, after_ingest_seq, after_lots, after_generation = stored_state()
+    assert applied["mode"] == "applied"
+    assert applied["write_applied"] is True
+    assert applied["invalidated_cash_conversion_count"] == 1
+    assert after_time == 900
+    assert after_ingest_seq == before_ingest_seq
+    assert after_generation == before_generation + 1
+    assert len(repo.list_trade_events()) == 2
+    assert after_lots[0]["fields"]["opened_at"] == 900
+    before_without_time = deepcopy(before_lots)
+    after_without_time = deepcopy(after_lots)
+    before_without_time[0]["fields"].pop("opened_at")
+    after_without_time[0]["fields"].pop("opened_at")
+    assert after_without_time == before_without_time
+    after_payload = json.loads(after_json)
+    assert "cash_conversions" not in after_payload["raw_payload"]
+    provenance = after_payload["raw_payload"]["trade_time_correction_provenance"]
+    assert provenance["schema_version"] == "opend_trade_time_correction.v1"
+    assert provenance["invalidated_cash_conversion_keys"] == ["option_trade_cash_gross"]
+    assert provenance["expected_before_sha256"] == preview["expected_before_sha256"]
+    with repo._connect() as conn:  # noqa: SLF001 - deployed trigger upgrade proof
+        trigger_sql = str(
+            conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name='trg_trade_events_query_projection_immutable'"
+            ).fetchone()["sql"]
+        )
+    assert "opend_trade_time_correction.v1" in trigger_sql
+
+    assert cli.main([*args, "--confirm"]) == 0
+    no_op = json.loads(capsys.readouterr().out)
+    assert no_op["mode"] == "no_op"
+    assert no_op["write_applied"] is False
+    assert stored_state() == (
+        after_json,
+        after_time,
+        after_ingest_seq,
+        after_lots,
+        after_generation,
+    )
+
+
+@pytest.mark.parametrize(
+    ("evidence_time_ms", "quantity", "requested_time_ms", "message"),
+    [
+        (900, 2, 900, "quantity does not match"),
+        (900, 1, 800, "earliest stored OpenD order time"),
+    ],
+)
+def test_trade_events_opend_time_correction_rejects_unmatched_evidence(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+    evidence_time_ms: int,
+    quantity: int,
+    requested_time_ms: int,
+    message: str,
+) -> None:
+    import src.interfaces.cli.trade_events as cli
+
+    repo, event_id = _repo_with_open_event(tmp_path)
+    _attach_opend_time_evidence(
+        repo,
+        event_id=event_id,
+        trade_time_ms=evidence_time_ms,
+        quantity=quantity,
+    )
+    monkeypatch.setattr(
+        cli,
+        "resolve_option_positions_repo",
+        lambda **_kwargs: (tmp_path / "data.json", repo),
+    )
+    before = repo.list_trade_events()
+
+    assert cli.main(
+        [
+            "repair",
+            event_id,
+            "--trade-time-ms",
+            str(requested_time_ms),
+            "--reason",
+            "OpenD stored evidence: order-1",
+            "--confirm",
+        ]
+    ) == 2
+
+    assert message in capsys.readouterr().out
+    assert repo.list_trade_events() == before
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- allow a narrowly audited in-place correction of historical Futu open-event times when persisted OpenD order evidence proves the exact timestamp
- preserve event/lot lineage, rebuild and verify projections, and invalidate stale event-time cash conversions
- allow explicit re-backfill after a time correction while preserving the original cash-conversion audit

## Validation
- 5814 passed
- 45 focused ledger/CLI tests passed
- Ruff checks passed
- dependency graph current; production cycles 0
- repository guardrails passed
- production-backup clone simulation: 50 time corrections, 45 FX re-backfills, integrity/foreign keys clean
- live OpenD read-only verification: 61/61 orders matched

No release, deployment, service change, or production ledger write is included in this PR.