### PR TITLE
fix(positions): stop settled puts consuming collateral

### DIFF
--- a/docs/candidate_strategy.md
+++ b/docs/candidate_strategy.md
@@ -170,7 +170,7 @@ annualized_net_return = period_net_return * 365 / DTE
   才能达到一张合约时，候选因资金证据不足 fail closed。
 - 保留当前现金组成：明确的分币种 cash 加 OpenD `fund_assets`。
 - 已知限制：OpenD `fund_assets` 是聚合基金资产，无法区分普通基金与货币基金；本策略接受当前口径。
-- 已有开放 Short Put 先按 gross `strike * multiplier` 扣除担保占用，不抵扣历史权利金。
+- 已有开放 Short Put 先按 gross `strike * multiplier` 扣除担保占用，不抵扣历史权利金。到期日和随后一个自然日仍计入，以覆盖指派结算窗口；自到期后第二个自然日起，过期 lot 可继续保留在生命周期视图中，但不再作为当前期权担保占用。
 - 不额外读取或扣除待成交挂单、`frozen_cash`；操作员负责避免候选间重复使用。
 
 ```text
@@ -436,7 +436,7 @@ hash 有效的 snapshot；不允许调用方传任意文件系统路径。
 | C06 | CSP 先用同币种现金，不足部分按新鲜 OpenD 汇率折算其他币种 | §5.3 |
 | C07 | 跨币种资金不保留 0.95 或其他安全折扣 | §5.3 |
 | C08 | 现金组成保留当前 `cash_by_currency + fund_assets` 口径，货币基金算入 | §5.3 |
-| C09 | 已有 Short Put 按 gross strike notional 占用担保，不抵扣历史权利金 | §5.3 |
+| C09 | 已有 Short Put 在到期后一日缓冲期结束前按 gross strike notional 占用担保 | §5.3 |
 | C10 | 不考虑 CSP 待成交挂单或 frozen cash，候选共享资金不可相加 | §5.3 |
 | C11 | 每张候选按一张合约计算，最大张数用资金或股票整除 multiplier | §5.3、§6.3 |
 | C12 | CC 使用 OpenD qty/can_sell_qty 和 SQLite 已开放 Short Call 锁定 | §6.3 |

--- a/src/application/positions/context_builder.py
+++ b/src/application/positions/context_builder.py
@@ -275,6 +275,11 @@ def build_context(
             locked_shares_by_symbol[symbol] = locked_shares_by_symbol.get(symbol, 0) + int(locked)
 
         if side == "short" and option_type == "put":
+            if (
+                it.expiration_date is not None
+                and (as_of_date - it.expiration_date).days > 1
+            ):
+                continue
             cash_secured = compute_short_put_cash_secured(
                 contracts_open=contracts_open,
                 contracts_total=contracts_total,

--- a/tests/test_positions_context_builder_partial_close.py
+++ b/tests/test_positions_context_builder_partial_close.py
@@ -358,6 +358,55 @@ def test_build_context_scales_cash_secured_for_partial_close() -> None:
     assert ctx["open_positions_min"][0]["contracts_closed"] == 3
 
 
+def test_build_context_excludes_expired_put_after_one_day_settlement_buffer() -> None:
+    observed_at = datetime(2026, 9, 4, 1, 40, tzinfo=timezone.utc)
+    records = []
+    for record_id, expiration, secured in (
+        ("expired", "2026-03-30", 10_000),
+        ("expired-yesterday", "2026-09-03", 11_000),
+        ("expires-today", "2026-09-04", 12_000),
+    ):
+        records.append(
+            {
+                "record_id": record_id,
+                "fields": {
+                    "broker": "富途",
+                    "account": "lx",
+                    "symbol": "PDD",
+                    "status": "open",
+                    "side": "short",
+                    "option_type": "put",
+                    "contracts": 1,
+                    "contracts_open": 1,
+                    "cash_secured_amount": secured,
+                    "currency": "USD",
+                    "expiration": int(
+                        datetime.fromisoformat(expiration)
+                        .replace(tzinfo=timezone.utc)
+                        .timestamp()
+                        * 1000
+                    ),
+                },
+            }
+        )
+
+    ctx = build_context(
+        records,
+        broker="富途",
+        account="lx",
+        rates={"USDCNY": 7.2},
+        observed_at=observed_at,
+    )
+
+    assert [row["record_id"] for row in ctx["open_positions_min"]] == [
+        "expired",
+        "expired-yesterday",
+        "expires-today",
+    ]
+    assert ctx["cash_secured_total_by_ccy"] == {"USD": 23_000.0}
+    assert ctx["cash_secured_total_cny"] == 165_600.0
+
+
 def test_build_context_scales_locked_shares_for_partial_close() -> None:
     records = [
         {


### PR DESCRIPTION
Exclude expired short puts from collateral after a one-natural-day assignment settlement buffer while retaining them in lifecycle views. Adds focused regression coverage and updates the candidate strategy contract. Verified with 115 focused tests, Ruff, diff checks, and repository guardrails. Source-only change: no VERSION, release, deployment, notification, or production write.