### PR TITLE
perf(required-data): share chain requests and warm HK opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Improvements
+- Reduced overlapping put/call required-data chain requests by partitioning expirations at the shared merger, and reused the existing opening warmer for scheduled HK ticks while preserving fresh formal quotes.
+
 ## 3.4.10 - 2026-09-05
 
 ### Improvements

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1012 (`src`: 541, `domain`: 79, `scripts`: 12, `tests`: 380)
-- Internal import edges: 6808 total, 2945 production/script edges excluding tests
+- Internal import edges: 6823 total, 2945 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,7 +46,7 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2863| application
+  tests -->|2878| application
   tests -->|431| domain
   tests -->|2| domain_services
   tests -->|234| infrastructure
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2863 |
+| tests | application | 2878 |
 | tests | domain | 431 |
 | tests | interfaces | 245 |
 | tests | infrastructure | 234 |

--- a/src/application/multi_account_tick.py
+++ b/src/application/multi_account_tick.py
@@ -157,7 +157,7 @@ def _opening_chain_warmup_context(
     account_ids: list[str],
     scheduler_decisions_by_account: dict[str, dict[str, Any]],
 ) -> dict[str, str] | None:
-    if trigger_kind != "scheduled" or scheduler_markets != ["US"]:
+    if trigger_kind != "scheduled" or scheduler_markets not in (["US"], ["HK"]):
         return None
     schedule = base_cfg.get(scheduler_schedule_key)
     if not isinstance(schedule, dict):

--- a/src/application/required_data_plan_identity.py
+++ b/src/application/required_data_plan_identity.py
@@ -270,13 +270,10 @@ def validate_required_data_expected_fetch_contract(
         raise ValueError(
             "success-rows required-data plan lacks expiration targets"
         )
-    if not _canonical_values_equal(
-        validated_nested_side_plans,
-        active_top_side_plans,
-    ):
-        raise ValueError(
-            "required-data nested and top-level side plans contradict"
-        )
+    _validate_side_plan_partitions(
+        nested_side_plans=validated_nested_side_plans,
+        top_side_plans=active_top_side_plans,
+    )
     plan_expirations = _unique_preserve_order(
         expiration
         for side_plan in validated_top_side_plans
@@ -346,6 +343,55 @@ def _canonical_sha256(value: Mapping[str, Any]) -> str:
         separators=(",", ":"),
     )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_side_plan_partitions(
+    *,
+    nested_side_plans: list[dict[str, Any]],
+    top_side_plans: list[dict[str, Any]],
+) -> None:
+    top_by_side = {plan["option_type"]: plan for plan in top_side_plans}
+    expected_scopes = {
+        (plan["option_type"], expiration)
+        for plan in top_side_plans
+        for expiration in plan["explicit_expirations"]
+    }
+    actual_scopes: set[tuple[str, str]] = set()
+    for nested in nested_side_plans:
+        option_type = nested["option_type"]
+        top = top_by_side.get(option_type)
+        expirations = nested["explicit_expirations"]
+        if top is None or not set(expirations).issubset(
+            top["explicit_expirations"]
+        ):
+            raise ValueError(
+                "required-data nested and top-level side plans contradict"
+            )
+        expected = {
+            **top,
+            "explicit_expirations": list(expirations),
+            "expiration_count": len(expirations),
+            "required_exact_strikes_by_expiration": {
+                expiration: strikes
+                for expiration, strikes in top[
+                    "required_exact_strikes_by_expiration"
+                ].items()
+                if expiration in expirations
+            },
+        }
+        scopes = {(option_type, expiration) for expiration in expirations}
+        if actual_scopes.intersection(scopes) or not _canonical_values_equal(
+            nested,
+            expected,
+        ):
+            raise ValueError(
+                "required-data nested and top-level side plans contradict"
+            )
+        actual_scopes.update(scopes)
+    if actual_scopes != expected_scopes:
+        raise ValueError(
+            "required-data nested and top-level side plans contradict"
+        )
 
 
 def _validate_fetch_request_shape(

--- a/src/application/required_data_planning.py
+++ b/src/application/required_data_planning.py
@@ -1044,14 +1044,41 @@ def _merge_side_plans(
 ) -> list[RequiredDataFetchSpec]:
     if not isinstance(include_realized_volatility, bool):
         raise TypeError("required-data RV authority must be a bool")
-    groups: dict[tuple[str, ...], list[OptionSideFetchPlan]] = {}
-    for plan in side_plans:
-        if not plan.explicit_expirations:
-            continue
-        key = tuple(plan.explicit_expirations)
-        groups.setdefault(key, []).append(plan)
+    active_plans = [plan for plan in side_plans if plan.explicit_expirations]
+    expirations = _unique_preserve_order(
+        [
+            expiration
+            for plan in active_plans
+            for expiration in plan.explicit_expirations
+        ]
+    )
+    groups: dict[tuple[int, ...], list[str]] = {}
+    for expiration in expirations:
+        key = tuple(
+            index
+            for index, plan in enumerate(active_plans)
+            if expiration in plan.explicit_expirations
+        )
+        groups.setdefault(key, []).append(expiration)
     merged: list[RequiredDataFetchSpec] = []
-    for expirations_key, plans in groups.items():
+    for plan_indexes, group_expirations in groups.items():
+        plans: list[OptionSideFetchPlan] = []
+        for index in plan_indexes:
+            plan = active_plans[index]
+            if plan.explicit_expirations != group_expirations:
+                plan = replace(
+                    plan,
+                    explicit_expirations=list(group_expirations),
+                    required_exact_strikes_by_expiration={
+                        expiration: list(
+                            plan.required_exact_strikes_by_expiration[expiration]
+                        )
+                        for expiration in sorted(group_expirations)
+                        if expiration
+                        in plan.required_exact_strikes_by_expiration
+                    },
+                )
+            plans.append(plan)
         option_types = tuple(plan.option_type for plan in plans)
         side_strike_windows = {
             plan.option_type: {
@@ -1067,7 +1094,7 @@ def _merge_side_plans(
                 host=host,
                 port=port,
                 option_types=option_types,
-                explicit_expirations=list(expirations_key),
+                explicit_expirations=list(group_expirations),
                 min_dte=min((plan.min_dte for plan in plans if plan.min_dte is not None), default=None),
                 max_dte=max((plan.max_dte for plan in plans if plan.max_dte is not None), default=None),
                 side_strike_windows=side_strike_windows,

--- a/tests/test_combo_yield_research.py
+++ b/tests/test_combo_yield_research.py
@@ -189,6 +189,52 @@ def _fake_capture_plan(**kwargs) -> RequiredDataFetchPlanBundle:
     )
 
 
+def test_combo_capture_union_partitions_partial_put_call_overlap() -> None:
+    from src.application.shadow_replay.combo_capture import _union_bundles
+
+    expirations = [
+        "2026-08-21",
+        "2026-09-18",
+        "2026-10-16",
+        "2026-11-20",
+        "2026-12-18",
+    ]
+    window = StrikeWindowPlan(min_strike=80, max_strike=140, source="test")
+
+    def bundle(option_type: str, dates: list[str]) -> RequiredDataFetchPlanBundle:
+        return RequiredDataFetchPlanBundle(
+            symbol="0700.HK",
+            spot_reference=110,
+            side_plans=[
+                OptionSideFetchPlan(
+                    option_type=option_type,
+                    min_dte=1,
+                    max_dte=180,
+                    explicit_expirations=dates,
+                    strike_window=window,
+                    planning_reason="test",
+                )
+            ],
+            merged_specs=[],
+        )
+
+    union = _union_bundles(
+        symbol="0700.HK",
+        bundles=[bundle("put", expirations), bundle("call", expirations[1:])],
+        host="127.0.0.1",
+        port=11111,
+    )
+
+    assert [spec.option_types for spec in union.merged_specs] == [
+        ("put",),
+        ("put", "call"),
+    ]
+    assert [spec.explicit_expirations for spec in union.merged_specs] == [
+        expirations[:1],
+        expirations[1:],
+    ]
+
+
 def test_proposed_rank_ignores_premium_funding_score_and_keeps_put_rank_dominant() -> None:
     policy = _policy()
     high_put = {

--- a/tests/test_multi_account_tick.py
+++ b/tests/test_multi_account_tick.py
@@ -660,7 +660,18 @@ def test_main_uses_env_runtime_root_for_stateful_tick_flows(monkeypatch, tmp_pat
     assert captured["guard_vpy"] == Path(sys.executable)
 
 
-def test_main_scheduler_skip_does_not_create_output_run_workspace(monkeypatch, tmp_path) -> None:
+@pytest.mark.parametrize(
+    "blocked_reason",
+    [
+        "non-trading day: US (weekend)",
+        "non-trading day: US (calendar override)",
+    ],
+)
+def test_main_scheduler_skip_does_not_create_output_run_workspace(
+    monkeypatch,
+    tmp_path,
+    blocked_reason: str,
+) -> None:
     import json
     from zoneinfo import ZoneInfo
 
@@ -714,7 +725,7 @@ def test_main_scheduler_skip_does_not_create_output_run_workspace(monkeypatch, t
             "schema_version": "1.0",
             "should_run_scan": False,
             "is_notify_window_open": False,
-            "reason": "当前运行点已处理，等待下一个运行点。",
+            "reason": blocked_reason,
         }
         return TickSchedulerOutcome(
             should_continue=True,
@@ -743,6 +754,7 @@ def test_main_scheduler_skip_does_not_create_output_run_workspace(monkeypatch, t
     monkeypatch.setattr(mod.state_repo, "claim_idempotency_record", lambda *args, **kwargs: {"claimed": True})
     monkeypatch.setattr(mod, "run_tick_guard_flow", _run_tick_guard_flow)
     monkeypatch.setattr(mod, "build_tick_scheduler_context", _scheduler_context)
+    monkeypatch.setenv("OM_TRIGGER_SOURCE", "cron")
     monkeypatch.setattr(
         mod,
         "prepare_tick_run_workspace",
@@ -757,6 +769,13 @@ def test_main_scheduler_skip_does_not_create_output_run_workspace(monkeypatch, t
         mod,
         "run_tick_notification_flow",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("skip must not run notification flow")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "warm_required_data_chain_cache",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("trading-day block must not warm")
+        ),
     )
 
     rc = mod.main(["--config", str(cfg), "--accounts", "lx"])
@@ -795,11 +814,13 @@ def test_daily_brief_trigger_kind_distinguishes_schedule_manual_and_force() -> N
     ("notification_rc", "smoke"),
     [(0, False), (1, False), (0, True)],
 )
+@pytest.mark.parametrize("market", ["US", "HK"])
 def test_main_scheduler_no_scan_warms_only_after_successful_delivery(
     monkeypatch,
     tmp_path,
     notification_rc: int,
     smoke: bool,
+    market: str,
 ) -> None:
     import json
     from zoneinfo import ZoneInfo
@@ -809,14 +830,16 @@ def test_main_scheduler_no_scan_warms_only_after_successful_delivery(
     from src.application.tick_guard_flow import TickGuardOutcome
     from src.application.tick_scheduler_context import TickSchedulerContext, TickSchedulerOutcome
 
-    cfg = tmp_path / "config.us.json"
+    schedule_key = "schedule_hk" if market == "HK" else "schedule"
+    symbol = "0700.HK" if market == "HK" else "NVDA"
+    cfg = tmp_path / f"config.{market.lower()}.json"
     cfg.write_text(
         json.dumps(
             {
-                "_generated": {"schema_version": "1.0", "generator": "options-monitor", "source_format": "yaml", "market": "us"},
+                "_generated": {"schema_version": "1.0", "generator": "options-monitor", "source_format": "yaml", "market": market.lower()},
                 "accounts": ["lx"],
-                "symbols": [{"symbol": "NVDA", "broker": "US"}],
-                "schedule": {"enabled": True, "cron_interval_min": 10},
+                "symbols": [{"symbol": symbol, "broker": market}],
+                schedule_key: {"enabled": True, "cron_interval_min": 10},
                 "notifications": {"daily_brief": {"enabled": True}},
                 "portfolio": {},
             }
@@ -837,16 +860,28 @@ def test_main_scheduler_no_scan_warms_only_after_successful_delivery(
     def guard(request):
         return TickGuardOutcome(True, 0, request.base_cfg, request.accounts, request.default_account, ZoneInfo("Asia/Shanghai"))
 
+    market_times = (
+        {
+            "now_market": "2026-07-21T09:30:05+08:00",
+            "now_beijing": "2026-07-21T09:30:05+08:00",
+            "run_window_start_beijing": "2026-07-21T09:30:00+08:00",
+            "next_run_market": "2026-07-21T09:40:00+08:00",
+        }
+        if market == "HK"
+        else {
+            "now_market": "2026-07-21T09:30:05-04:00",
+            "now_beijing": "2026-07-21T21:30:05+08:00",
+            "run_window_start_beijing": "2026-07-21T21:30:00+08:00",
+            "next_run_market": "2026-07-21T09:40:00-04:00",
+        }
+    )
     decision = {
         "schema_kind": "scheduler_decision",
         "schema_version": "1.0",
         "should_run_scan": False,
         "is_notify_window_open": False,
         "in_run_window": True,
-        "now_market": "2026-07-21T09:30:05-04:00",
-        "now_beijing": "2026-07-21T21:30:05+08:00",
-        "run_window_start_beijing": "2026-07-21T21:30:00+08:00",
-        "next_run_market": "2026-07-21T09:40:00-04:00",
+        **market_times,
         "reason": "当前没有待执行运行点。",
     }
 
@@ -855,10 +890,10 @@ def test_main_scheduler_no_scan_warms_only_after_successful_delivery(
             True,
             0,
             TickSchedulerContext(
-                markets_to_run=["US"],
-                scheduler_markets=["US"],
+                markets_to_run=[market],
+                scheduler_markets=[market],
                 state_path=runtime_root / "output_shared/state/scheduler_state.json",
-                scheduler_schedule_key="schedule",
+                scheduler_schedule_key=schedule_key,
                 scheduler_ms=1,
                 scheduler_decision=decision,
                 scheduler_view=SchedulerDecisionView.from_payload(decision),
@@ -912,53 +947,199 @@ def test_main_scheduler_no_scan_warms_only_after_successful_delivery(
     if notification_rc == 0 and not smoke:
         assert order.index("notification") < order.index("warmup")
         assert order.index("warmup") < order.index("opening_chain_warmup")
-        assert captured["warmup"]["next_formal_target_utc"] == "2026-07-21T13:40:00Z"
+        expected_target = (
+            "2026-07-21T01:40:00Z"
+            if market == "HK"
+            else "2026-07-21T13:40:00Z"
+        )
+        assert captured["warmup"]["next_formal_target_utc"] == expected_target
     else:
         assert "warmup" not in order
     assert not (runtime_root / "output_runs").exists()
 
 
-def test_opening_chain_warmup_context_requires_first_us_no_scan_window() -> None:
-    from src.application import multi_account_tick as mod
+@pytest.mark.parametrize(
+    ("market", "schedule_key"),
+    [("US", "schedule"), ("HK", "schedule_hk"), ("HK", "schedule")],
+)
+def test_opening_chain_warmup_context_requires_first_no_scan_window(
+    market: str,
+    schedule_key: str,
+) -> None:
+    from datetime import datetime, timedelta, timezone
+    from zoneinfo import ZoneInfo
 
-    decision = {
-        "in_run_window": True,
-        "should_run_scan": False,
-        "now_beijing": "2026-12-21T22:30:05+08:00",
-        "run_window_start_beijing": "2026-12-21T22:30:00+08:00",
-        "next_run_market": "2026-12-21T09:40:00-05:00",
+    from src.application import multi_account_tick as mod
+    from src.application.scan_scheduler import decide
+
+    schedule = {
+        "enabled": True,
+        "timezone": (
+            "Asia/Hong_Kong" if market == "HK" else "America/New_York"
+        ),
+        "beijing_timezone": "Asia/Shanghai",
+        "cron_interval_min": 10,
+        "run_window": {"start": "09:30", "end": "16:00", "breaks": []},
+        "run_points": {
+            "start_plus_min": 10,
+            "hourly_minute": 0,
+            "end_minus_min": 10,
+        },
     }
+    now_utc = datetime(
+        2026,
+        12,
+        21,
+        1 if market == "HK" else 14,
+        30,
+        5,
+        tzinfo=timezone.utc,
+    )
+    decision = decide(
+        schedule,
+        {},
+        now_utc,
+        account="lx",
+        schedule_key=schedule_key,
+    ).__dict__
 
     context = mod._opening_chain_warmup_context(
         trigger_kind="scheduled",
-        scheduler_markets=["US"],
-        base_cfg={"schedule": {"cron_interval_min": 10}},
-        scheduler_schedule_key="schedule",
+        scheduler_markets=[market],
+        base_cfg={schedule_key: schedule},
+        scheduler_schedule_key=schedule_key,
         account_ids=["lx", "sy"],
         scheduler_decisions_by_account={"lx": decision, "sy": dict(decision)},
     )
 
+    target_hour = "01" if market == "HK" else "14"
     assert context == {
-        "next_formal_target_utc": "2026-12-21T14:40:00Z",
-        "worker_stop_at_utc": "2026-12-21T14:37:50Z",
-        "lock_release_by_utc": "2026-12-21T14:38:00Z",
+        "next_formal_target_utc": f"2026-12-21T{target_hour}:40:00Z",
+        "worker_stop_at_utc": f"2026-12-21T{target_hour}:37:50Z",
+        "lock_release_by_utc": f"2026-12-21T{target_hour}:38:00Z",
     }
+    cutoff_beijing = (
+        datetime.fromisoformat(decision["next_run_market"])
+        - timedelta(seconds=130)
+    ).astimezone(ZoneInfo("Asia/Shanghai"))
     assert (
         mod._opening_chain_warmup_context(
             trigger_kind="scheduled",
-            scheduler_markets=["US"],
-            base_cfg={"schedule": {"cron_interval_min": 10}},
-            scheduler_schedule_key="schedule",
+            scheduler_markets=[market],
+            base_cfg={schedule_key: schedule},
+            scheduler_schedule_key=schedule_key,
             account_ids=["lx"],
             scheduler_decisions_by_account={
                 "lx": {
                     **decision,
-                    "now_beijing": "2026-12-21T22:50:00+08:00",
+                    "now_beijing": cutoff_beijing.isoformat(),
                 }
             },
         )
         is None
     )
+    next_target = datetime.fromisoformat(decision["next_run_market"])
+    run_start = datetime.fromisoformat(
+        decision["run_window_start_beijing"]
+    )
+    valid_args = {
+        "trigger_kind": "scheduled",
+        "scheduler_markets": [market],
+        "base_cfg": {schedule_key: schedule},
+        "scheduler_schedule_key": schedule_key,
+        "account_ids": ["lx", "sy"],
+        "scheduler_decisions_by_account": {
+            "lx": decision,
+            "sy": dict(decision),
+        },
+    }
+    rejected = [
+        {"trigger_kind": "manual"},
+        {"trigger_kind": "force"},
+        {"scheduler_markets": [market, "US" if market == "HK" else "HK"]},
+        {"account_ids": ["lx", "missing"]},
+        {
+            "scheduler_decisions_by_account": {
+                "lx": {**decision, "should_run_scan": True},
+                "sy": dict(decision),
+            }
+        },
+        {
+            "scheduler_decisions_by_account": {
+                "lx": decision,
+                "sy": {
+                    **decision,
+                    "next_run_market": (
+                        next_target + timedelta(minutes=10)
+                    ).isoformat(),
+                },
+            }
+        },
+        {
+            "scheduler_decisions_by_account": {
+                "lx": {
+                    **decision,
+                    "now_beijing": (
+                        run_start + timedelta(minutes=10)
+                    ).isoformat(),
+                },
+                "sy": dict(decision),
+            }
+        },
+    ]
+    for override in rejected:
+        assert (
+            mod._opening_chain_warmup_context(
+                **{**valid_args, **override},  # type: ignore[arg-type]
+            )
+            is None
+        )
+
+
+def test_hk_opening_chain_warmup_rejects_lunch_and_afternoon_decisions() -> None:
+    from datetime import datetime, timezone
+
+    from src.application import multi_account_tick as mod
+    from src.application.scan_scheduler import decide
+
+    schedule = {
+        "enabled": True,
+        "timezone": "Asia/Hong_Kong",
+        "beijing_timezone": "Asia/Shanghai",
+        "cron_interval_min": 10,
+        "run_window": {
+            "start": "09:30",
+            "end": "16:00",
+            "breaks": [{"start": "12:00", "end": "13:00"}],
+        },
+        "run_points": {
+            "start_plus_min": 10,
+            "hourly_minute": 0,
+            "end_minus_min": 10,
+        },
+    }
+    for now_utc in (
+        datetime(2026, 12, 21, 4, 30, tzinfo=timezone.utc),
+        datetime(2026, 12, 21, 5, 30, tzinfo=timezone.utc),
+    ):
+        decision = decide(
+            schedule,
+            {},
+            now_utc,
+            account="lx",
+            schedule_key="schedule_hk",
+        ).__dict__
+        assert (
+            mod._opening_chain_warmup_context(
+                trigger_kind="scheduled",
+                scheduler_markets=["HK"],
+                base_cfg={"schedule_hk": schedule},
+                scheduler_schedule_key="schedule_hk",
+                account_ids=["lx"],
+                scheduler_decisions_by_account={"lx": decision},
+            )
+            is None
+        )
 
 
 def test_duplicate_unsupported_tick_failure_returns_nonzero_without_rerun(monkeypatch, tmp_path) -> None:

--- a/tests/test_opend_chain_cache_minimal.py
+++ b/tests/test_opend_chain_cache_minimal.py
@@ -369,6 +369,220 @@ def test_option_chain_single_side_request_passes_option_type_to_opend(tmp_path: 
     assert captured[0]["option_type"] == "PUT"
 
 
+def test_partitioned_incident_plan_makes_17_calls_for_21_side_date_scopes(
+    tmp_path: Path,
+) -> None:
+    import pandas as pd
+
+    from src.application.opend_symbol_fetching import fetch_symbol
+    from src.application.required_data_planning import (
+        OptionSideFetchPlan,
+        StrikeWindowPlan,
+        _merge_side_plans,
+    )
+
+    calls: list[dict[str, Any]] = []
+    snapshot_calls: list[list[str]] = []
+
+    class _Gateway:
+        def get_option_chain(self, **kwargs):  # noqa: ANN001, ANN201
+            calls.append(dict(kwargs))
+            underlier = str(kwargs["code"])
+            expiration = str(kwargs["start"])
+            requested = kwargs.get("option_type")
+            sides = [str(requested)] if requested else ["PUT", "CALL"]
+            return pd.DataFrame([
+                {
+                    "code": f"{underlier}.{expiration}.{side[0]}100",
+                    "strike_time": expiration,
+                    "strike_price": 100,
+                    "option_type": side,
+                    "option_standard_type": "STANDARD",
+                    "stock_owner": underlier,
+                    "stock_type": "DRVT",
+                    "suspension": False,
+                    "lot_size": 100,
+                }
+                for side in sides
+            ])
+
+        def get_snapshot(self, codes):  # noqa: ANN001, ANN201
+            snapshot_calls.append(list(codes))
+            return pd.DataFrame(
+                [
+                    {
+                        "code": code,
+                        "last_price": 1.0,
+                        "bid_price": 0.9,
+                        "ask_price": 1.1,
+                        "bid_vol": 10,
+                        "ask_vol": 12,
+                        "price_spread": 0.01,
+                        "sec_status": "NORMAL",
+                        "suspension": False,
+                        "option_contract_multiplier": 100,
+                    }
+                    for code in codes
+                ]
+            )
+
+    def side_plan(option_type: str, expirations: list[str]) -> OptionSideFetchPlan:
+        return OptionSideFetchPlan(
+            option_type=cast(Any, option_type),
+            min_dte=1,
+            max_dte=365,
+            explicit_expirations=expirations,
+            strike_window=StrikeWindowPlan(
+                min_strike=80.0,
+                max_strike=120.0,
+                source=f"fixture.{option_type}",
+            ),
+            planning_reason=f"fixture {option_type}",
+        )
+
+    shared = [
+        "2026-08-21",
+        "2026-09-18",
+        "2026-10-16",
+        "2026-11-20",
+    ]
+    symbol_plans = [
+        (
+            "0700.HK",
+            [side_plan("put", [*shared, "2026-12-18"]), side_plan("call", shared)],
+        ),
+        ("9988.HK", [side_plan("put", ["2026-08-28", "2026-09-25", "2026-10-30", "2026-11-27"])]),
+        ("9999.HK", [side_plan("put", ["2026-08-14", "2026-09-11", "2026-10-09", "2026-11-13"])]),
+        ("1211.HK", [side_plan("call", ["2026-08-07", "2026-09-04", "2026-10-02", "2026-11-06"])]),
+    ]
+    gateway = _Gateway()
+    covered_scopes: set[tuple[str, str, str]] = set()
+    for symbol, side_plans in symbol_plans:
+        specs = _merge_side_plans(
+            symbol=symbol,
+            limit_expirations=0,
+            host="127.0.0.1",
+            port=11111,
+            side_plans=side_plans,
+        )
+        for spec in specs:
+            result = fetch_symbol(
+                symbol,
+                host="127.0.0.1",
+                port=11111,
+                spot_override=100.0,
+                fetch_spot_if_missing=False,
+                base_dir=tmp_path,
+                option_types=",".join(spec.option_types),
+                side_strike_windows=spec.side_strike_windows,
+                min_dte=spec.min_dte,
+                max_dte=spec.max_dte,
+                explicit_expirations=spec.explicit_expirations,
+                trading_date="2026-07-01",
+                no_retry=True,
+                chain_cache=False,
+                max_wait_sec=1,
+                option_chain_window_sec=0.01,
+                option_chain_max_calls=100,
+                snapshot_max_wait_sec=1,
+                snapshot_window_sec=0.01,
+                snapshot_max_calls=100,
+                gateway=gateway,
+            )
+            assert result["meta"]["status"] == "ok"
+            assert result["meta"]["snapshot_complete"] is True
+            request_scopes = {
+                (symbol, option_type, expiration)
+                for option_type in spec.option_types
+                for expiration in spec.explicit_expirations
+            }
+            result_scopes = {
+                (
+                    symbol,
+                    str(row["option_type"]).lower(),
+                    str(row["expiration"]),
+                )
+                for row in result["rows"]
+            }
+            assert result_scopes == request_scopes
+            covered_scopes.update(result_scopes)
+
+    expected_scopes = {
+        (symbol, plan.option_type, expiration)
+        for symbol, side_plans in symbol_plans
+        for plan in side_plans
+        for expiration in plan.explicit_expirations
+    }
+    assert len(expected_scopes) == 21
+    assert covered_scopes == expected_scopes
+    assert len(calls) == 17
+    assert sum(len(codes) for codes in snapshot_calls) == 21
+
+
+def test_put_only_warm_cache_has_full_or_partial_formal_reuse_by_scope(
+    tmp_path: Path,
+) -> None:
+    from src.application.option_chain_fetching import (
+        OptionChainFetchRequest,
+        fetch_option_chains,
+    )
+
+    calls: list[dict[str, Any]] = []
+
+    class _Gateway:
+        def get_option_chain(self, **kwargs):  # noqa: ANN001, ANN201
+            calls.append(dict(kwargs))
+            expiration = str(kwargs["start"])
+            requested = kwargs.get("option_type")
+            sides = [str(requested)] if requested else ["PUT", "CALL"]
+            return [
+                {
+                    "code": f"HK.00700.{expiration}.{side[0]}100",
+                    "strike_time": expiration,
+                    "strike_price": 100,
+                    "option_type": side,
+                }
+                for side in sides
+            ]
+
+    expirations = [
+        "2026-08-21",
+        "2026-09-18",
+        "2026-10-16",
+        "2026-11-20",
+        "2026-12-18",
+    ]
+
+    def fetch(requested_expirations: list[str], option_types: str):
+        return fetch_option_chains(
+            gateway=_Gateway(),
+            request=OptionChainFetchRequest(
+                symbol="0700.HK",
+                underlier_code="HK.00700",
+                expirations=requested_expirations,
+                option_types=option_types,
+                base_dir=tmp_path,
+                asof_date="2026-07-27",
+                chain_cache=True,
+                max_calls=100,
+                no_retry=True,
+            ),
+            retry_call=lambda _name, fn, **_kwargs: fn(),
+        )
+
+    warm = fetch(expirations, "put")
+    matching_formal = fetch(expirations, "put")
+    mismatched_formal = fetch(expirations[:4], "put,call")
+    exclusive_formal = fetch(expirations[4:], "put")
+
+    assert warm.opend_call_count == 5
+    assert matching_formal.opend_call_count == 0
+    assert matching_formal.from_cache_expirations == expirations
+    assert mismatched_formal.opend_call_count == 4
+    assert exclusive_formal.opend_call_count == 0
+    assert len(calls) == 9
+
+
 def test_option_chain_legacy_option_type_fallback_records_rate_limit() -> None:
 
     from src.application.option_chain_fetching import OptionChainFetchRequest, _fetch_one_chain

--- a/tests/test_pipeline_fetch_read_model_boundary.py
+++ b/tests/test_pipeline_fetch_read_model_boundary.py
@@ -1286,6 +1286,182 @@ def test_child_request_evidence_binds_actual_payload_and_rejects_collision() -> 
 
 
 @pytest.mark.parametrize(
+    ("call_expirations", "expected_requests"),
+    [
+        (["2026-09-18", "2026-08-21"], 1),
+        (["2026-09-18"], 2),
+    ],
+)
+def test_single_symbol_facade_preserves_complete_and_partial_overlap_evidence(
+    call_expirations: list[str],
+    expected_requests: int,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.application.opend_symbol_chain_fetching import (
+        OptionExpirationDiscoveryResult,
+    )
+    from src.application.required_data_planning import (
+        OptionSideFetchPlan,
+        RequiredDataFetchPlanBundle,
+        StrikeWindowPlan,
+        _merge_side_plans,
+    )
+    import src.application.required_data_steps as steps
+
+    expirations = ["2026-08-21", "2026-09-18"]
+    put_plan = OptionSideFetchPlan(
+        option_type="put",
+        min_dte=10,
+        max_dte=60,
+        explicit_expirations=list(expirations),
+        strike_window=StrikeWindowPlan(
+            min_strike=100.0,
+            max_strike=100.0,
+            source="test",
+            base_min_strike=100.0,
+            base_max_strike=100.0,
+        ),
+        planning_reason="single-symbol put demand",
+    )
+    call_plan = OptionSideFetchPlan(
+        option_type="call",
+        min_dte=10,
+        max_dte=60,
+        explicit_expirations=list(call_expirations),
+        strike_window=StrikeWindowPlan(
+            min_strike=130.0,
+            max_strike=130.0,
+            source="test",
+            base_min_strike=130.0,
+            base_max_strike=130.0,
+        ),
+        planning_reason="single-symbol call demand",
+    )
+    specs = _merge_side_plans(
+        symbol="NVDA",
+        limit_expirations=2,
+        host="127.0.0.1",
+        port=11111,
+        side_plans=[put_plan, call_plan],
+        trading_date=datetime.fromisoformat(_TEST_TRADING_DATE).date(),
+    )
+    fetch_plan = RequiredDataFetchPlanBundle(
+        symbol="NVDA",
+        spot_reference=120.0,
+        side_plans=[put_plan, call_plan],
+        merged_specs=specs,
+        expiration_discovery=OptionExpirationDiscoveryResult(
+            outcome="success_rows",
+            reason_code=None,
+            expirations=list(expirations),
+            observed_at_utc=_TEST_EVIDENCE_OBSERVED_AT.isoformat(),
+            completed_at_utc=_TEST_EVIDENCE_COMPLETED_AT.isoformat(),
+            request_identity={
+                "symbol": "NVDA",
+                "underlier": "US.NVDA",
+                "source": "opend",
+                "host": "127.0.0.1",
+                "port": 11111,
+                "trading_date": _TEST_TRADING_DATE,
+            },
+        ),
+        projection_outcome="success_rows",
+        projected_expirations=list(expirations),
+        require_realized_volatility=False,
+    )
+    requests: list[object] = []
+
+    def execute(*, base: Path, request):  # type: ignore[no-untyped-def]
+        del base
+        requests.append(request)
+        rows: list[dict[str, object]] = []
+        codes: list[str] = []
+        for expiration in request.explicit_expirations:
+            dte = (
+                datetime.fromisoformat(expiration).date()
+                - datetime.fromisoformat(_TEST_TRADING_DATE).date()
+            ).days
+            for option_type in request.option_types.split(","):
+                strike = 100.0 if option_type == "put" else 130.0
+                code = (
+                    f"US.NVDA.{expiration}."
+                    f"{'P' if option_type == 'put' else 'C'}{strike:g}"
+                )
+                child = _typed_success_row_payload(
+                    symbol="NVDA",
+                    expiration=expiration,
+                    dte=dte,
+                    contract_symbol=code,
+                    option_type=option_type,
+                    strike=strike,
+                )
+                rows.append(dict(child["rows"][0]))
+                codes.append(code)
+        payload = _typed_success_row_payload(
+            symbol="NVDA",
+            expiration=request.explicit_expirations[0],
+            dte=(
+                datetime.fromisoformat(request.explicit_expirations[0]).date()
+                - datetime.fromisoformat(_TEST_TRADING_DATE).date()
+            ).days,
+            contract_symbol=codes[0],
+        )
+        payload["expirations"] = list(request.explicit_expirations)
+        payload["expiration_count"] = len(request.explicit_expirations)
+        payload["rows"] = rows
+        meta = payload["meta"]
+        assert isinstance(meta, dict)
+        sorted_codes = sorted(codes)
+        meta.update(
+            {
+                "snapshot_requested_codes": len(sorted_codes),
+                "snapshot_returned_codes": len(sorted_codes),
+                "snapshot_requested_code_set": sorted_codes,
+                "snapshot_returned_code_set": sorted_codes,
+            }
+        )
+        return payload
+
+    monkeypatch.setattr(steps, "execute_required_data_opend", execute)
+    required, _state_dir = _make_dirs(tmp_path)
+    evidence = steps.ensure_required_data(
+        py="python3",
+        base=tmp_path,
+        symbol="NVDA",
+        required_data_dir=required,
+        limit_expirations=2,
+        want_put=True,
+        want_call=True,
+        timeout_sec=5,
+        is_scheduled=True,
+        fetch_source="opend",
+        fetch_host="127.0.0.1",
+        fetch_port=11111,
+        fetch_plan=fetch_plan,
+        source_producer_run_id=f"run-single-symbol-{expected_requests}",
+    )
+
+    assert isinstance(evidence, dict)
+    assert len(requests) == expected_requests
+    assert len(list(required.rglob("receipt.json"))) == 1
+    raw = json.loads(
+        (required / "raw" / "NVDA_required_data.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert len(raw["rows"]) == (4 if expected_requests == 1 else 3)
+    if expected_requests == 1:
+        assert requests[0].option_types == "put,call"  # type: ignore[attr-defined]
+        assert "requests" not in raw["meta"]
+        assert "request_index" not in raw["meta"]
+    else:
+        assert [
+            child["request_index"] for child in raw["meta"]["requests"]
+        ] == [0, 1]
+
+
+@pytest.mark.parametrize(
     ("invalid_time_kind", "error_match"),
     [
         (

--- a/tests/test_required_data_expected_contract_integrity.py
+++ b/tests/test_required_data_expected_contract_integrity.py
@@ -127,6 +127,49 @@ def _success_rows_plan() -> dict[str, object]:
     }
 
 
+def _partitioned_success_rows_plan() -> dict[str, object]:
+    plan = _success_rows_plan()
+    put, call = plan["side_plans"]
+    assert isinstance(put, dict) and isinstance(call, dict)
+    put["max_dte"] = 60
+    put["explicit_expirations"] = ["2026-08-21", "2026-09-18"]
+    put["expiration_count"] = 2
+    put["required_exact_strikes_by_expiration"] = {
+        "2026-08-21": [95.0],
+        "2026-09-18": [96.0],
+    }
+    call["explicit_expirations"] = ["2026-09-18"]
+    call["expiration_count"] = 1
+
+    put_shared = deepcopy(put)
+    put_shared["explicit_expirations"] = ["2026-09-18"]
+    put_shared["expiration_count"] = 1
+    put_shared["required_exact_strikes_by_expiration"] = {
+        "2026-09-18": [96.0]
+    }
+    shared = {
+        **_request(put_shared),
+        "option_types": ["put", "call"],
+        "explicit_expirations": ["2026-09-18"],
+        "min_dte": 20,
+        "max_dte": 60,
+        "side_strike_windows": {
+            "put": {"min_strike": 90.0, "max_strike": 100.0},
+            "call": {"min_strike": 120.0, "max_strike": 140.0},
+        },
+        "side_plans": [put_shared, deepcopy(call)],
+        "planning_reason": "shared expirations -> merged request",
+    }
+    put_only = deepcopy(put)
+    put_only["explicit_expirations"] = ["2026-08-21"]
+    put_only["expiration_count"] = 1
+    put_only["required_exact_strikes_by_expiration"] = {
+        "2026-08-21": [95.0]
+    }
+    plan["merged_requests"] = [shared, _request(put_only)]
+    return plan
+
+
 def _success_rows_plan_with_empty_top_side() -> dict[str, object]:
     plan = _success_rows_plan()
     side_plans = plan["side_plans"]
@@ -204,6 +247,30 @@ def test_expected_contract_accepts_empty_top_evidence_without_executable_child()
         "completion_unit": "request_option_type_expiration",
         "allow_proven_empty_scopes": True,
     }
+
+
+def test_expected_contract_accepts_exact_side_plan_partitions() -> None:
+    plan = _partitioned_success_rows_plan()
+
+    contract = _build(plan)
+
+    assert contract["fetch_plan"] == plan
+
+
+@pytest.mark.parametrize("mutation", ["missing", "duplicate"])
+def test_expected_contract_rejects_incomplete_or_duplicate_side_plan_partitions(
+    mutation: str,
+) -> None:
+    plan = _partitioned_success_rows_plan()
+    requests = plan["merged_requests"]
+    assert isinstance(requests, list)
+    if mutation == "missing":
+        requests.pop()
+    else:
+        requests.append(deepcopy(requests[-1]))
+
+    with pytest.raises(ValueError, match="nested and top-level"):
+        _build(plan)
 
 
 def test_expected_contract_accepts_closed_success_empty_projection() -> None:

--- a/tests/test_required_data_fetch_planning.py
+++ b/tests/test_required_data_fetch_planning.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date
 from pathlib import Path
 
@@ -827,6 +828,158 @@ def test_put_and_call_same_expirations_merge_into_single_request(monkeypatch, tm
         side_plan["required_exact_strikes_by_expiration"] == {}
         for side_plan in plan.to_debug_dict()["side_plans"]
     )
+
+
+def test_partial_put_call_overlap_fetches_each_expiration_once() -> None:
+    import src.application.required_data_planning as mod
+    from src.application.opend_symbol_chain_fetching import (
+        OptionExpirationDiscoveryResult,
+    )
+    from src.application.required_data_plan_identity import (
+        build_required_data_expected_fetch_contract,
+    )
+
+    expirations = [
+        "2026-09-18",
+        "2026-08-21",
+        "2026-10-16",
+        "2026-11-20",
+        "2026-12-18",
+    ]
+    put = mod.OptionSideFetchPlan(
+        option_type="put",
+        min_dte=20,
+        max_dte=150,
+        explicit_expirations=list(expirations),
+        strike_window=mod.StrikeWindowPlan(
+            min_strike=400.0,
+            max_strike=460.0,
+            source="fixture.put",
+        ),
+        planning_reason="fixture put",
+        required_exact_strikes_by_expiration={
+            "2026-08-21": [420.0],
+            "2026-09-18": [425.0],
+            "2026-12-18": [430.0],
+        },
+    )
+    call = mod.OptionSideFetchPlan(
+        option_type="call",
+        min_dte=20,
+        max_dte=150,
+        explicit_expirations=list(reversed(expirations[:4])),
+        strike_window=mod.StrikeWindowPlan(
+            min_strike=500.0,
+            max_strike=560.0,
+            source="fixture.call",
+        ),
+        planning_reason="fixture call",
+        required_exact_strikes_by_expiration={"2026-09-18": [520.0]},
+    )
+    original = [put.to_debug_dict(), call.to_debug_dict()]
+
+    specs = mod._merge_side_plans(
+        symbol="0700.HK",
+        limit_expirations=5,
+        host="127.0.0.1",
+        port=11111,
+        side_plans=[put, call],
+        trading_date=date(2026, 7, 27),
+    )
+
+    assert sum(len(spec.explicit_expirations) for spec in specs) == 5
+    assert [spec.option_types for spec in specs] == [
+        ("put", "call"),
+        ("put",),
+    ]
+    assert specs[0].explicit_expirations == expirations[:4]
+    assert [
+        side.explicit_expirations for side in specs[0].side_plans
+    ] == [expirations[:4], expirations[:4]]
+    assert specs[0].side_plans[0].required_exact_strikes_by_expiration == {
+        "2026-08-21": [420.0],
+        "2026-09-18": [425.0],
+    }
+    assert specs[0].side_plans[1].required_exact_strikes_by_expiration == {
+        "2026-09-18": [520.0]
+    }
+    assert specs[1].explicit_expirations == ["2026-12-18"]
+    assert specs[1].side_plans[0].required_exact_strikes_by_expiration == {
+        "2026-12-18": [430.0]
+    }
+    assert [put.to_debug_dict(), call.to_debug_dict()] == original
+
+    bundle = mod.RequiredDataFetchPlanBundle(
+        symbol="0700.HK",
+        spot_reference=None,
+        side_plans=[put, call],
+        merged_specs=specs,
+        expiration_discovery=OptionExpirationDiscoveryResult(
+            outcome="success_rows",
+            reason_code=None,
+            expirations=sorted(expirations),
+            observed_at_utc="2026-07-27T01:00:00Z",
+            completed_at_utc="2026-07-27T01:00:01Z",
+            request_identity={
+                "symbol": "0700.HK",
+                "underlier": "HK.00700",
+                "source": "opend",
+                "host": "127.0.0.1",
+                "port": 11111,
+                "trading_date": "2026-07-27",
+            },
+        ),
+        projection_outcome="success_rows",
+        projected_expirations=list(expirations),
+    )
+    contract = build_required_data_expected_fetch_contract(
+        symbol="0700.HK",
+        fetch_plan=bundle.to_debug_dict(),
+        source="opend",
+        host="127.0.0.1",
+        port=11111,
+    )
+    assert contract["fetch_plan"]["merged_requests"][0][
+        "explicit_expirations"
+    ] == expirations[:4]
+
+    same_set_put = replace(
+        put,
+        explicit_expirations=list(expirations[:4]),
+        required_exact_strikes_by_expiration={
+            "2026-08-21": [420.0],
+            "2026-09-18": [425.0],
+        },
+    )
+    same_specs = mod._merge_side_plans(
+        symbol="0700.HK",
+        limit_expirations=4,
+        host="127.0.0.1",
+        port=11111,
+        side_plans=[same_set_put, call],
+        trading_date=date(2026, 7, 27),
+    )
+    assert len(same_specs) == 1
+    assert same_specs[0].option_types == ("put", "call")
+    assert same_specs[0].explicit_expirations == expirations[:4]
+    assert bundle.expiration_discovery is not None
+    same_contract = build_required_data_expected_fetch_contract(
+        symbol="0700.HK",
+        fetch_plan=replace(
+            bundle,
+            side_plans=[same_set_put, call],
+            merged_specs=same_specs,
+            expiration_discovery=replace(
+                bundle.expiration_discovery,
+                expirations=sorted(expirations[:4]),
+            ),
+            projected_expirations=list(expirations[:4]),
+        ).to_debug_dict(),
+        source="opend",
+        host="127.0.0.1",
+        port=11111,
+    )
+    assert len(same_contract["fetch_plan"]["merged_requests"]) == 1
 
 
 def test_put_and_call_different_expirations_split_requests(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_required_data_prefetch_inprocess.py
+++ b/tests/test_required_data_prefetch_inprocess.py
@@ -1367,12 +1367,19 @@ def test_inprocess_multi_spec_executes_each_exact_request_and_finalizes_once(
 
     _patch_0700_plan_discovery(
         monkeypatch,
-        ["2026-06-29", "2026-07-17"],
+        [
+            "2026-06-29",
+            "2026-07-17",
+            "2026-07-31",
+            "2026-08-21",
+            "2026-09-04",
+        ],
         spot=444.8,
     )
     watchlist = [
         {
             "symbol": "0700.HK",
+            "broker": "HK",
             "fetch": {
                 "source": "futu",
                 "host": "127.0.0.1",
@@ -1381,13 +1388,14 @@ def test_inprocess_multi_spec_executes_each_exact_request_and_finalizes_once(
             "sell_put": {
                 "enabled": True,
                 "min_dte": 20,
-                "max_dte": 25,
+                "max_dte": 90,
                 "max_strike": 450,
             },
             "sell_call": {"enabled": False},
         },
         {
             "symbol": "0700.HK",
+            "broker": "HK",
             "fetch": {
                 "source": "futu",
                 "host": "127.0.0.1",
@@ -1396,21 +1404,81 @@ def test_inprocess_multi_spec_executes_each_exact_request_and_finalizes_once(
             "sell_put": {"enabled": False},
             "sell_call": {
                 "enabled": True,
-                "min_dte": 30,
-                "max_dte": 60,
+                "min_dte": 39,
+                "max_dte": 90,
                 "min_strike": 550,
             },
         },
     ]
-    gateway = _Gateway()
+    class FacadeGateway(_Gateway):
+        def __init__(self) -> None:
+            super().__init__()
+            self.chain_calls: list[dict[str, object]] = []
+            self.snapshot_calls: list[list[str]] = []
+
+        def get_option_chain(self, **kwargs: object):  # noqa: ANN201
+            import pandas as pd
+
+            self.chain_calls.append(dict(kwargs))
+            expiration = str(kwargs["start"])
+            requested_side = str(kwargs.get("option_type") or "").upper()
+            sides = [requested_side] if requested_side else ["PUT", "CALL"]
+            return pd.DataFrame(
+                [
+                    {
+                        "code": f"HK.00700.{expiration}.{side[0]}{strike:g}",
+                        "strike_time": expiration,
+                        "strike_price": strike,
+                        "option_type": side,
+                        "option_standard_type": "STANDARD",
+                        "stock_owner": "HK.00700",
+                        "stock_type": "DRVT",
+                        "suspension": False,
+                        "lot_size": 100,
+                    }
+                    for side, strike in (
+                        (side, 420.0 if side == "PUT" else 560.0)
+                        for side in sides
+                    )
+                ]
+            )
+
+        def get_snapshot(self, codes: list[str]):  # noqa: ANN201
+            import pandas as pd
+
+            self.snapshot_calls.append(list(codes))
+            return pd.DataFrame(
+                [
+                    {
+                        "code": code,
+                        "last_price": 1.0,
+                        "bid_price": 0.9,
+                        "ask_price": 1.1,
+                        "bid_vol": 10,
+                        "ask_vol": 12,
+                        "price_spread": 0.01,
+                        "sec_status": "NORMAL",
+                        "suspension": False,
+                        "option_contract_multiplier": 100,
+                    }
+                    for code in codes
+                ]
+            )
+
+    gateway = FacadeGateway()
     fetch_calls: list[dict[str, object]] = []
     merge_calls: list[list[dict[str, object]]] = []
     finalize_calls: list[dict[str, object]] = []
     save_calls: list[dict[str, object]] = []
 
-    def fake_fetch_symbol(symbol: str, **kwargs: object) -> dict[str, object]:
+    real_fetch_symbol = mod.fetch_symbol
+
+    def fetch_through_real_facade(
+        symbol: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
         fetch_calls.append({"symbol": symbol, **kwargs})
-        return _strict_success_rows_for_fetch(symbol, kwargs)
+        return real_fetch_symbol(symbol, **kwargs)  # type: ignore[arg-type]
 
     original_merge = mod.merge_required_data_payloads
 
@@ -1436,8 +1504,64 @@ def test_inprocess_multi_spec_executes_each_exact_request_and_finalizes_once(
         "src.infrastructure.futu_gateway.build_ready_futu_gateway",
         lambda **kwargs: gateway,
     )
-    monkeypatch.setattr(mod, "resolve_watchlist_config", lambda cfg: watchlist)
-    monkeypatch.setattr(mod, "fetch_symbol", fake_fetch_symbol)
+    from src.application.short_vol_metrics import (
+        RealizedVolatilitySnapshot,
+        TermMatchedRVObservation,
+    )
+
+    def fetch_realized_volatility_snapshot(
+        _gateway: object,
+        *,
+        trading_day: date,
+        expirations: list[str],
+        **_kwargs: object,
+    ) -> RealizedVolatilitySnapshot:
+        terms = {
+            expiration: TermMatchedRVObservation(
+                schema_version="term_matched_rv.v1",
+                expiration=expiration,
+                status="ok",
+                reason=None,
+                term_matched_rv=0.22,
+                remaining_sessions=max(
+                    1,
+                    (date.fromisoformat(expiration) - trading_day).days,
+                ),
+                lookback_sessions=max(
+                    20,
+                    (date.fromisoformat(expiration) - trading_day).days,
+                ),
+                input_start="2026-01-02",
+                input_end=trading_day.isoformat(),
+                input_close_session_count=max(
+                    20,
+                    (date.fromisoformat(expiration) - trading_day).days,
+                )
+                + 1,
+                input_return_count=max(
+                    20,
+                    (date.fromisoformat(expiration) - trading_day).days,
+                ),
+                input_hash="a" * 64,
+            )
+            for expiration in expirations
+        }
+        return RealizedVolatilitySnapshot(
+            rv_20=0.20,
+            rv_60=0.24,
+            rv_120=0.28,
+            sample_count=120,
+            status="ok",
+            term_matched=terms,
+            qfq_history_evidence={"status": "ok"},
+            trading_calendar_evidence={"status": "ok"},
+        )
+
+    monkeypatch.setattr(
+        "src.application.opend_symbol_fetching.fetch_realized_volatility_snapshot",
+        fetch_realized_volatility_snapshot,
+    )
+    monkeypatch.setattr(mod, "fetch_symbol", fetch_through_real_facade)
     monkeypatch.setattr(mod, "merge_required_data_payloads", merge_once)
     monkeypatch.setattr(
         mod,
@@ -1451,29 +1575,151 @@ def test_inprocess_multi_spec_executes_each_exact_request_and_finalizes_once(
         lambda *args, **kwargs: None,
     )
     shared_required = tmp_path / "shared_required"
+    base_cfg = {
+        "symbols": watchlist,
+        "runtime": {
+            "opend_rate_limits": {
+                "option_chain": {
+                    "max_calls": 100,
+                    "window_sec": 0.01,
+                    "max_wait_sec": 1,
+                }
+            },
+            "prefetch": {
+                "execution_mode": "inprocess",
+                "max_workers": 1,
+            }
+        },
+    }
+    cfg_path = tmp_path / "config.hk.json"
+    account_configs = {
+        account: mod.build_account_runtime_config(
+            base_cfg=base_cfg,
+            cfg_path=cfg_path,
+            account=account,
+            markets_to_run=["HK"],
+        )
+        for account in ("lx", "sy")
+    }
+    formal_cfg = mod.build_cross_account_prefetch_config(
+        base_config=base_cfg,
+        account_configs=account_configs,
+        prepared_portfolio_contexts={
+            "lx": {
+                "portfolio_source_name": "futu",
+                "capacity_authority": {"status": "available"},
+                "stocks_by_symbol": {"0700.HK": {"avg_cost": 500.0}},
+            },
+            "sy": None,
+        },
+    )
+    cold_base = tmp_path / "cold"
+    cold_base.mkdir()
+    cold_required = cold_base / "required_data"
+    cold = mod.prefetch_required_data(
+        vpy=tmp_path / "python",
+        base=cold_base,
+        cfg=formal_cfg,
+        shared_required=cold_required,
+        producer_run_id="run-real-cold-two-spec",
+    )
+
+    assert cold["fetched_ok"] == 1, cold["results"]
+    assert [call["option_types"] for call in fetch_calls] == [
+        "put",
+        "put,call",
+    ]
+    assert len(gateway.chain_calls) == 5
+    assert sum(len(codes) for codes in gateway.snapshot_calls) == 9
+    assert len(merge_calls) == 1
+    assert len(finalize_calls) == 1
+    assert len(save_calls) == 1
+    assert len(list(cold_required.rglob("receipt.json"))) == 1
+    cold_raw = json.loads(
+        (cold_required / "raw" / "0700.HK_required_data.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert len(cold_raw["rows"]) == 9
+    assert [
+        child["request_index"] for child in cold_raw["meta"]["requests"]
+    ] == [0, 1]
+    fetch_calls.clear()
+    merge_calls.clear()
+    finalize_calls.clear()
+    save_calls.clear()
+    gateway.chain_calls.clear()
+    gateway.snapshot_calls.clear()
+    stop = (
+        datetime.now(timezone.utc) + timedelta(seconds=30)
+    ).isoformat().replace("+00:00", "Z")
+
+    warmup = mod._warm_required_data_chain_cache_inprocess(
+        base=tmp_path,
+        base_cfg=base_cfg,
+        cfg_path=cfg_path,
+        accounts=["lx", "sy"],
+        markets_to_run=["HK"],
+        symbols_arg=None,
+        next_formal_target_utc=stop,
+        worker_stop_at_utc=stop,
+        lock_release_by_utc=stop,
+    )
+
+    assert warmup["status"] == "ready"
+    assert warmup["planned_shards"] == 5
+    assert warmup["fetched_shards"] == 5
+    assert warmup["option_contract_snapshot_requested_codes"] == 0
+    assert len(gateway.chain_calls) == 5
+    assert all(call.get("option_type") == "PUT" for call in gateway.chain_calls)
+    assert gateway.snapshot_calls == []
+
+    matching_cfg = mod.build_cross_account_prefetch_config(
+        base_config=base_cfg,
+        account_configs=account_configs,
+        prepared_portfolio_contexts={"lx": None, "sy": None},
+    )
+    matching = mod.prefetch_required_data(
+        vpy=tmp_path / "python",
+        base=tmp_path,
+        cfg=matching_cfg,
+        shared_required=tmp_path / "matching_required",
+        producer_run_id="run-real-matching-warmup",
+    )
+
+    assert matching["fetched_ok"] == 1
+    assert [call["option_types"] for call in fetch_calls] == ["put"]
+    assert len(gateway.chain_calls) == 5
+    assert sum(len(codes) for codes in gateway.snapshot_calls) == 5
+    fetch_calls.clear()
+    merge_calls.clear()
+    finalize_calls.clear()
+    save_calls.clear()
+    gateway.snapshot_calls.clear()
 
     result = mod.prefetch_required_data(
         vpy=tmp_path / "python",
         base=tmp_path,
-        cfg={
-            "runtime": {
-                "prefetch": {
-                    "execution_mode": "inprocess",
-                    "max_workers": 1,
-                }
-            }
-        },
+        cfg=formal_cfg,
         shared_required=shared_required,
         producer_run_id="run-real-two-spec",
     )
 
-    assert result["fetched_ok"] == 1
+    assert result["fetched_ok"] == 1, result["results"]
     assert result["errors"] == 0
     assert len(fetch_calls) == 2
-    assert [call["option_types"] for call in fetch_calls] == ["put", "call"]
+    assert [call["option_types"] for call in fetch_calls] == [
+        "put",
+        "put,call",
+    ]
     assert [call["explicit_expirations"] for call in fetch_calls] == [
         ["2026-06-29"],
-        ["2026-07-17"],
+        [
+            "2026-07-17",
+            "2026-07-31",
+            "2026-08-21",
+            "2026-09-04",
+        ],
     ]
     assert [call["trading_date"] for call in fetch_calls] == [
         "2026-06-08",
@@ -1481,6 +1727,15 @@ def test_inprocess_multi_spec_executes_each_exact_request_and_finalizes_once(
     ]
     assert all(call["fetch_spot_if_missing"] is False for call in fetch_calls)
     assert all(call["gateway"] is gateway for call in fetch_calls)
+    assert len(gateway.chain_calls) == 9
+    assert [call.get("option_type") for call in gateway.chain_calls[5:]] == [
+        None,
+        None,
+        None,
+        None,
+    ]
+    assert len(gateway.snapshot_calls) == 2
+    assert sum(len(codes) for codes in gateway.snapshot_calls) == 9
     assert len(merge_calls) == 1
     assert len(finalize_calls) == 1
     assert len(save_calls) == 1
@@ -1492,6 +1747,10 @@ def test_inprocess_multi_spec_executes_each_exact_request_and_finalizes_once(
         )
     )
     children = raw["meta"]["requests"]
+    assert len(raw["rows"]) == 9
+    assert all(
+        row["opening_contract_status"] == "ready" for row in raw["rows"]
+    )
     planned = result["global_required_data_plan"]["symbols"][0][
         "fetch_plan"
     ]["merged_requests"]
@@ -3087,6 +3346,46 @@ def test_opening_chain_warmup_supervisor_stops_child_waiting_on_prefetch_lock(
     assert summary["status"] == "deadline_reached"
     assert summary["child_terminated"] is True
     assert "worker_deadline_reached" in summary["reason_codes"]
+    with exclusive_private_file_lock(lock_path):
+        pass
+
+
+def test_opening_chain_warmup_termination_releases_child_owned_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fork_context = mod.multiprocessing.get_context("fork")
+    marker = tmp_path / "provider-entered"
+
+    def block_in_provider(**_kwargs: object) -> dict[str, object]:
+        marker.write_text("entered", encoding="utf-8")
+        while True:
+            time.sleep(1)
+
+    monkeypatch.setattr(mod.multiprocessing, "get_context", lambda _mode: fork_context)
+    monkeypatch.setattr(
+        mod,
+        "_warm_required_data_chain_cache_inprocess",
+        block_in_provider,
+    )
+    now = datetime.now(timezone.utc)
+    worker_stop = (now + timedelta(seconds=0.5)).isoformat().replace("+00:00", "Z")
+    summary = mod.warm_required_data_chain_cache(
+        base=tmp_path,
+        base_cfg={"symbols": []},
+        cfg_path=tmp_path / "config.hk.json",
+        accounts=["lx"],
+        markets_to_run=["HK"],
+        symbols_arg=None,
+        next_formal_target_utc=(now + timedelta(seconds=130)).isoformat().replace("+00:00", "Z"),
+        worker_stop_at_utc=worker_stop,
+        lock_release_by_utc=(now + timedelta(seconds=120)).isoformat().replace("+00:00", "Z"),
+    )
+
+    assert marker.read_text(encoding="utf-8") == "entered"
+    assert summary["status"] == "deadline_reached"
+    assert summary["child_terminated"] is True
+    lock_path = tmp_path / "output_shared" / "state" / "required_data_prefetch.lock"
     with exclusive_private_file_lock(lock_path):
         pass
 


### PR DESCRIPTION
## Summary\n\n- Merge overlapping put/call expiration requests with strict side/date evidence validation.\n- Reuse the scheduled opening warmer for HK while keeping formal quotes fresh.\n- Add regression coverage and update the Unreleased improvement note.\n\n## Validation\n\n- Focused required-data/Tick suites: 375 passed\n- Broader Tick suites: 72 passed\n- Full suite: 5874 passed, 5 warnings\n- Ruff, guardrails, dependency graph check, and git diff --check passed\n\nNo release, version change, or deployment is included.