### PR TITLE
fix(quality): keep public OpenD source snapshots schema-compatible

### DIFF
--- a/docs/quality-monitoring/om-operator.md
+++ b/docs/quality-monitoring/om-operator.md
@@ -104,3 +104,81 @@ systemd renderer 默认不改变现有部署。生产准备时显式加入：
 - `options-monitor-quality-day-end-hk.timer`：香港 `16:30`。
 
 renderer 只生成文件和安装命令，不会自行写 `/etc`、启用 timer 或启动服务。
+
+## Public source snapshot contract
+
+`datasets[*].source_snapshots[*]` is the public
+`investment.quality_status.v1` boundary. `OpenDOptionSnapshot.public_source_snapshot()`
+must be an explicit allowlist projection. The repaired producer must emit exactly
+these eight fields: `provider`, `snapshot_id`, `observed_at_utc`, `complete`,
+`refresh_cache`, `account_fingerprint`, `environment`, and `market`. The current
+`origin/main` implementation still spreads four internal fields into this object;
+that is the defect being removed.
+`source_currency` and `payload_sha256` are permitted by the vendored schema but
+are not emitted by this producer today.
+
+OpenD position-input fields such as `scope`, `completeness`, `quality`, and
+`source_as_of_utc` remain in the internal `snapshot_input` used by position
+checks. They must never be deleted or cleared merely to make publication pass,
+and they are never copied into a public source snapshot. The current
+`sourceSnapshot` schema has no source-level `extensions` slot; dataset-level
+extensions must not be used as an undocumented escape hatch. Any future
+producer-specific field requires an upstream contract decision owned by
+`investment-quality`, not a local schema edit or a new schema version.
+
+The relevant call chain is:
+
+```text
+OMQualityService._refresh
+  -> OpenDOptionPositionAdapter.fetch
+  -> build_opend_runtime_check / build_position_dataset
+  -> public_source_snapshot (position dataset path)
+  -> validate_payload
+  -> artifact_repository.write_atomic
+```
+
+Normal refreshes, `source_ok=false` incomplete/error results, and explicit
+integrity refreshes all use the same public projection. The repair therefore has
+one code owner and does not change OpenD queries, position comparison, quality
+decisions, artifact paths, or production write semantics.
+
+`status.v1.json` and `control_state.v1.json` are each written atomically but are
+not one cross-file transaction. Control state is persisted before payload
+validation; when validation fails, the previous status artifact remains and the
+control state may already contain the new probe metadata. This existing split is
+documented residual risk for the quality-service maintainer's next
+`quality-refresh` reliability work unit, not part of this minimal contract
+repair. Carried-forward snapshots are likewise not sanitized in this change;
+the quality artifact owner must address that in a separate data-integrity work
+unit only if an existing artifact is shown to contain undeclared source fields.
+
+Validation must include an adapter key-set regression and quality-service tests
+with enriched `snapshot_input` for both complete and incomplete/error paths, plus
+the normal release preflight and the explicit `tests/quality/*` suite. A deployed
+oneshot refresh is successful only when its exit result is success and the
+published status artifact validates and can be read back; HTTP health, timer
+activity, or process presence alone is insufficient. Publishing and remote
+upgrade remain separate authorization gates. An upstream contract extension is
+not part of this producer-side repair.
+
+## Hotfix scope and implementation slices
+
+目标是让带有内部 `snapshot_input` 的 OpenD 结果重新能够通过现有
+`investment.quality_status.v1` 校验并发布，同时保持质量判断和生产扫描行为不变。
+验收信号是：公共 source snapshot 的键集合严格等于上述八个字段；完整和不完整/错误
+结果都能完成服务级 schema 校验；quality-refresh oneshot 以成功结果退出并能读回
+有效 status artifact。
+
+实现只分两个行为切片：
+
+1. 在 `OpenDOptionSnapshot.public_source_snapshot()` 保留显式八字段 allowlist，
+   不修改或清空 `snapshot_input`，也不改变 `fetch`、position checks 或 artifact writer。
+2. 在 adapter 和 quality service 的公共边界补回归：用带内部哨兵字段的完整、
+   不完整/错误 snapshot 验证精确键集合和 schema 通过；保留旧的八字段 snapshot
+   仍可通过。测试必须走 `build_position_dataset`/service 真实发布路径，而不是只测
+   一个未被调用的 helper。
+
+以下不属于本 hotfix：修改 vendored schema、增加 source-level `extensions` 或新版本、
+改变 OpenD 查询或消费者、重写跨文件事务、清洗历史 carry-forward artifact、修改
+发布工作流。发布前只读校验现有 status artifact；若发现历史 artifact 已含未声明字段，
+保留原始事实并另开数据修复工作，不在本 hotfix 中覆盖它。

--- a/src/application/quality/opend_position_adapter.py
+++ b/src/application/quality/opend_position_adapter.py
@@ -81,12 +81,6 @@ class OpenDOptionSnapshot:
             "account_fingerprint": self.account_fingerprint,
             "environment": self.environment,
             "market": self.market,
-            **({
-                "scope": self.snapshot_input.get("scope"),
-                "completeness": self.snapshot_input.get("completeness"),
-                "quality": self.snapshot_input.get("quality"),
-                "source_as_of_utc": self.snapshot_input.get("source_as_of_utc"),
-            } if self.snapshot_input else {}),
         }
 
 

--- a/tests/quality/test_om_quality_checks.py
+++ b/tests/quality/test_om_quality_checks.py
@@ -117,6 +117,35 @@ def _snapshot(*, qty: int = 1, trading_days: list[date] | None = None) -> OpenDO
     )
 
 
+def test_public_source_snapshot_allowlists_internal_position_input() -> None:
+    snapshot = replace(
+        _snapshot(),
+        snapshot_input={
+            "scope": {"markets": ["US"], "asset_types": ["option"]},
+            "completeness": "complete",
+            "quality": {"status": "ready"},
+            "source_as_of_utc": "2026-07-13T09:59:00Z",
+            "internal_sentinel": "must-not-cross-public-boundary",
+        },
+    )
+
+    public = snapshot.public_source_snapshot()
+
+    assert set(public) == {
+        "provider",
+        "snapshot_id",
+        "observed_at_utc",
+        "complete",
+        "refresh_cache",
+        "account_fingerprint",
+        "environment",
+        "market",
+    }
+    assert snapshot.snapshot_input["internal_sentinel"] == (
+        "must-not-cross-public-boundary"
+    )
+
+
 def test_position_convergence_matches_exact_identity_and_quantity() -> None:
     now = datetime(2026, 7, 13, 10, tzinfo=timezone.utc)
     dataset, state = build_position_dataset(

--- a/tests/quality/test_om_quality_service.py
+++ b/tests/quality/test_om_quality_service.py
@@ -22,22 +22,41 @@ from src.application.quality.opend_position_adapter import OpenDOptionSnapshot
 
 
 class _OpenD:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        complete: bool = True,
+        environment: str = "REAL",
+        error_code: str | None = None,
+        snapshot_input_factory=None,
+        account_fingerprint: str | None = None,
+    ) -> None:
         self.calls: list[tuple[str, str]] = []
+        self.complete = complete
+        self.environment = environment
+        self.error_code = error_code
+        self.snapshot_input_factory = snapshot_input_factory
+        self.account_fingerprint = account_fingerprint
 
     def fetch(self, *, account: str, market: str, **_kwargs) -> OpenDOptionSnapshot:
         self.calls.append((account, market))
         return OpenDOptionSnapshot(
             account=account,
             market=market,
-            environment="REAL",
-            account_fingerprint="sha256:" + ("b" * 64),
+            environment=self.environment,
+            account_fingerprint=self.account_fingerprint or "sha256:" + ("b" * 64),
             observed_at_utc="2026-07-13T10:00:00Z",
             snapshot_id=f"snapshot-{account}",
-            complete=True,
+            complete=self.complete,
             refresh_cache=True,
             rows=[],
             trading_days=[date(2026, 7, 13), date(2026, 7, 14)],
+            error_code=self.error_code,
+            snapshot_input=(
+                self.snapshot_input_factory(account, market)
+                if self.snapshot_input_factory is not None
+                else {}
+            ),
         )
 
 
@@ -69,9 +88,40 @@ def _trusted_empty_current_projection() -> dict:
     }
 
 
+def _enriched_snapshot_input(account: str, market: str, *, complete: bool) -> dict:
+    return {
+        "schema_version": "position_snapshot.v1",
+        "snapshot_id": f"internal-{account}-{market}",
+        "source_id": "futu-opend.positions",
+        "broker_account_ref": {
+            "broker_account_id": "futu:REAL:123456",
+            "broker_id": "futu",
+            "external_account_id": "123456",
+            "environment": "REAL",
+            "account_label": account,
+        },
+        "scope": {
+            "markets": [market.upper()],
+            "asset_types": ["option"],
+            "filtered": False,
+        },
+        "observed_at_utc": "2026-07-13T10:00:00Z",
+        "source_as_of_utc": "2026-07-13T09:59:00Z",
+        "completeness": "complete" if complete else "partial",
+        "quality": {"status": "ready" if complete else "unknown"},
+        "rows": [],
+        "evidence_refs": [],
+        "source_evidence": [],
+        "errors": [],
+        "internal_sentinel": "must-not-cross-public-boundary",
+    }
+
+
+@pytest.mark.parametrize("complete", [True, False], ids=["complete", "incomplete"])
 def test_service_publishes_schema_valid_artifact_without_business_writes(
     monkeypatch,
     tmp_path: Path,
+    complete: bool,
 ) -> None:
     ledger_path = tmp_path / "option_positions.sqlite3"
     SQLiteOptionPositionsRepository(ledger_path)
@@ -150,7 +200,17 @@ def test_service_publishes_schema_valid_artifact_without_business_writes(
     service = OMQualityService(
         artifact_repository=artifact,
         control_repository=QualityControlStateRepository(tmp_path / "control.v1.json"),
-        opend_adapter=_OpenD(),
+        opend_adapter=_OpenD(
+            complete=complete,
+            environment="REAL" if complete else "UNKNOWN",
+            error_code=None if complete else "OPEND_TEST_INCOMPLETE",
+            snapshot_input_factory=lambda account, market: _enriched_snapshot_input(
+                account, market, complete=complete
+            ),
+            account_fingerprint=(
+                "sha256:8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92"
+            ),
+        ),
         runtime_status_fn=lambda *_args: {"ok": True, "data": runtime},
         now_fn=lambda: now,
         instance_id="test-instance",
@@ -158,6 +218,35 @@ def test_service_publishes_schema_valid_artifact_without_business_writes(
     payload = service.refresh(config_keys=["us"])
     assert artifact.read() == payload
     assert payload["producer"]["service"] == "options-monitor"
+    position_snapshots = [
+        snapshot
+        for dataset in payload["datasets"]
+        for snapshot in dataset.get("source_snapshots") or []
+    ]
+    assert position_snapshots
+    assert all(
+        set(snapshot)
+        == {
+            "provider",
+            "snapshot_id",
+            "observed_at_utc",
+            "complete",
+            "refresh_cache",
+            "account_fingerprint",
+            "environment",
+            "market",
+        }
+        for snapshot in position_snapshots
+    )
+    assert all(
+        "internal_sentinel" not in snapshot for snapshot in position_snapshots
+    )
+    position_dataset = next(
+        dataset
+        for dataset in payload["datasets"]
+        if dataset["dataset_id"] == "om.option_positions"
+    )
+    assert position_dataset["status"] == ("trusted" if complete else "unavailable")
     check_ids = {
         check["check_id"]
         for dataset in payload["datasets"]


### PR DESCRIPTION
## Summary

- Keep OpenD public source snapshots within the existing investment.quality_status.v1 contract by removing the internal snapshot_input field spread.
- Preserve snapshot_input for internal position validation and comparison.
- Add adapter and service regressions for complete and incomplete/error snapshots, including an internal-field sentinel.

## Verification

- ruff check: passed
- tests/quality: 94 passed
- full pytest suite: 5894 passed, 1 warning
- guardrails_check: OK
- git diff --check: passed

Deepreview: pass-with-risks, no blocking findings. This PR is source delivery only; no version, release, deployment, or production configuration changes.