### PR TITLE
fix(trades): recover intake results and delivery receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+- Preserved verified account and environment evidence from OpenD trade push headers so valid fills can be recorded on first delivery without guessing account identity.
+- Preserved active SQLite transaction locks while securing database and sidecar file permissions.
+- Added bounded trade-intake and notification recovery with actionable failure receipts and distinct recovery-success receipts, while preventing duplicate economic effects and blind resends after ambiguous delivery.
+
 ## 3.5.0 - 2026-09-09
 
 ### New Features

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 978 (`src`: 509, `domain`: 82, `scripts`: 11, `tests`: 376)
-- Internal import edges: 6744 total, 2834 production/script edges excluding tests
+- Python files scanned: 982 (`src`: 509, `domain`: 82, `scripts`: 11, `tests`: 380)
+- Internal import edges: 6783 total, 2836 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,10 +46,10 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2906| application
-  tests -->|466| domain
+  tests -->|2935| application
+  tests -->|467| domain
   tests -->|2| domain_services
-  tests -->|228| infrastructure
+  tests -->|232| infrastructure
   tests -->|226| interfaces
   tests -->|21| scripts
   tests -->|18| storage
@@ -79,9 +79,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2906 |
-| tests | domain | 466 |
-| tests | infrastructure | 228 |
+| tests | application | 2935 |
+| tests | domain | 467 |
+| tests | infrastructure | 232 |
 | tests | interfaces | 226 |
 | tests | scripts | 21 |
 | tests | storage | 18 |

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 982 (`src`: 509, `domain`: 82, `scripts`: 11, `tests`: 380)
-- Internal import edges: 6783 total, 2836 production/script edges excluding tests
+- Internal import edges: 6785 total, 2836 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,7 +46,7 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|2935| application
+  tests -->|2937| application
   tests -->|467| domain
   tests -->|2| domain_services
   tests -->|232| infrastructure
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 2935 |
+| tests | application | 2937 |
 | tests | domain | 467 |
 | tests | infrastructure | 232 |
 | tests | interfaces | 226 |

--- a/docs/FUTU_TRADE_HOLDINGS_SYNC.md
+++ b/docs/FUTU_TRADE_HOLDINGS_SYNC.md
@@ -239,34 +239,277 @@ provider 失败不回滚成交或改变 settled Inbox、同一订单并发重试
 
 ## Push 来源身份
 
-Futu deal push 通过 OM 主动连接的 OpenD TCP 端口进入，不是独立 webhook。
-每个 push 必须在写入 durable inbox 之前绑定可信的 source 配置，并记录：
+Futu deal push 经 OM 主动连接的 OpenD TCP 端口进入。transport 保留响应头与成交行的
+来源证据，source binder 校验允许的物理账户、环境与内部账户映射。PID 只用于诊断，
+不进入业务幂等键。缺少真实物理身份、环境不符或来源冲突不得凭单账户配置猜测归属。
 
-```text
-source_id
-account
-futu_account_id
-opend_process=FutuOpenD
-opend_host
-opend_port
-received_at_utc
-deal_id
-```
+当前 canonical execution identity 由 `domain/domain/trade_execution.py` 拥有，应用经
+`src/application/ledger/api.py` 和 `src/application/trades/deal_identity.py` 复用，键为
+`execution:v1:<hash>`。`futu:<account>:<physical_account_id>:<deal_id>` 保留为兼容或
+外部事件键，不替代 canonical identity。`trade_account_identity.py` 只负责账户字段提取。
 
-`source_id + opend_host + opend_port` 是稳定的逻辑进程身份；操作系统 PID
-会在 OpenD 重启后变化，只用于实时诊断，不进入业务幂等键。若 push payload
-缺少账户 ID，只允许从绑定到单一 Futu 账户的 source 补齐；若 payload 身份
-与 source 配置冲突，必须在入箱前拒绝并写
-`push_source_identity_rejected` 审计，不能退化为裸 `deal_id`。
+推送头字段保留、错误门修复与 push/history 收敛要求见下节；不得通过放松来源校验修复
+SDK 转换丢字段。无身份记录只保留证据，关联必须经既有证据导入机制证明。
 
-Push 与 history backfill 随后统一使用账户级 broker deal key：
+## 成交录入与回执恢复
 
-```text
-futu:<account>:<futu_account_id>:<deal_id>
-```
+### 目标与边界
 
-因此无论 push 或 backfill 谁先到，后到者都只能命中同一业务成交，不能因
-传输顺序生成第二条 inbox 记录。
+普通成交尽量在首次推送时完成录入并发送成功回执。首次失败时说明具体原因、是否自动重试及
+用户下一步；重试录入成功后发送独立的成功回执。交易已成交、OM 已记录、通知已送达是三个
+不同事实，不以其中一个推断另一个。由 trade-intake 与 private-storage owners 负责。
+
+验收要求：可信推送无需等待 history 才获得账户身份；SQLite 权限维护不释放活动事务的锁；
+重复推送、回补、崩溃恢复均只产生一次经济效果；失败、恢复、重试耗尽都可解释；通知恢复不
+重放成交。外部发送结果不明时不能保证恰好一次，不允许用盲目重发制造这一保证。
+
+范围限于推送身份传递、共享 SQLite 文件权限维护，以及普通 intake 回执与现有重试循环的
+衔接。不改变策略、费用计算或 lifecycle outbox 的业务归属，不引入通用消息平台或历史全量
+扫描。本设计不授权生产重放、账本补录、真实回执补发、配置变更、发布或升级。
+
+### 已修复缺陷与约束
+
+- 修复前推送入口调用 SDK `TradeDealHandlerBase.on_recv_rsp` 后只转发 DataFrame 行。SDK 的列清单
+  不包含物理账户 ID；原始响应 `s2c.header` 则携带交易环境和账户标识。下游先设置
+  `missing:push_physical_account`，导致应用层已有 source 身份绑定被跳过。
+- history 可以提供完整身份并重新进入录入。现有 canonical identity owner 负责命名空间、
+  账户映射与 broker execution 幂等，不能以配置账户标签或裸 deal ID 替代。
+- 修复前 `secure_sqlite_artifacts` 打开并关闭数据库与 sidecar 文件以执行 `fchmod`。
+  Linux 上额外的 `close` 会释放本进程在同一文件上的 POSIX 锁；已用临时 SQLite WAL 数据库
+  和另一进程的锁探针复现。`ensure_private_file` 对已存在数据库的 open/close 也必须覆盖。
+  这是已证实的共享存储缺陷；缺少故障 SQL 堆栈，不能断言它是个别 `locking protocol`
+  异常的唯一原因。
+- 修复前普通回执在 Inbox 中保存一次 `receipt_json`；只要已有回执，后续业务结果就被
+  `durable_receipt_*` 拦截。失败通知送达因此会阻止后来成功通知。
+- 修复前 retry 列表默认按 60 秒筛选、以 `attempt_count < 20` 过滤；claim 本身不检查到期
+  时间、不递增计数，计数实际在结算时增加。因此崩溃重领没有统一预算保证，现有 claim 将计数与到期检查收敛在同一事务。通知失败、provider 接受但未确认、业务耗尽不能都表示为“未记录”。
+- lifecycle outbox 已有独立投递所有权；有可读回 outbox 的 lifecycle 结果不得转为普通直发。
+
+### 方案与责任边界
+
+沿用现有入口、Inbox、ledger facade 与重试循环，只修复它们之间的契约。
+
+| Owner | 责任 |
+|---|---|
+| `src/infrastructure/futu_trade_push.py` | 在 SDK 行转换丢字段前保留可信响应头身份；验证行与头的冲突 |
+| `domain/domain/trade_execution.py` 经 ledger facade/deal_identity；现有 source binder | 复用执行身份生成；binder 校验 source 与映射，transport 不生成平行主键 |
+| `src/infrastructure/private_storage.py` | 所有 SQLite caller 共用的私有权限、文件类型与锁保护 |
+| `src/application/trades/intake.py` | 返回真实持久化结果、结构化失败分类与可重试性 |
+| `src/application/trades/inbox.py` | 持久化业务 claim、实际重试政策和有版本的回执记录，使用事务与 CAS |
+| `src/application/trades/receipt.py` 与 `receipt_compensation.py` | 共用 Inbox 发送资格；保留人工补偿的预览与确认边界 |
+| `src/application/trades/auto_intake.py` | 复用当前循环协调业务重试和仅通知恢复，保持账户/source 隔离 |
+
+不以延长 timeout 或对全部 `OperationalError` 盲目重试掩盖锁问题；不让历史回补承担本可从
+推送头获得的身份；不清空旧 `receipt_json` 来补发成功；不新建并行的交易状态库或通用队列。
+
+### 推送身份与首次录入
+
+数据流为原始 SDK 响应头与成交行 → transport 保留来源证据 → source/account identity 验证
+→ canonical execution key → durable Inbox → 现有录入 facade。响应头中的账户 ID 只有通过
+当前 source、交易环境、订阅/可见账户与映射校验后才可作为物理身份。
+
+行与头同时有身份时必须一致；缺少、格式不合法、环境不匹配或多账户歧义继续拒绝录入并
+保留可诊断证据，不能清除真实错误来绕过校验。配置只约束允许的账户，不凭配置推断成交
+属于谁。移除或收紧 source binder 中无证据的单账户推断分支；单账户 source 但无响应头/
+可验证行身份也必须拒绝。直接注入 listener 的测试/兼容入口仍经过同一身份验证。
+
+同一有效成交的 push 与 backfill 必须收敛到现有 canonical key。已有身份缺失行不按裸
+`deal_id` 强制合并；只有现有证据导入机制可证明等价时才关联，未证明的继续保留待复核。
+无法证明账户归属的入口错误只进入既有本地 audit/status，不借单账户通知 route 猜测
+归属；已有可信账户的规范化/录入错误才可产生该账户的失败回执。这是来源安全下的明确
+限制，不承诺所有缺身份推送都能即时发出账户回执。
+
+### SQLite 权限与锁
+
+连接建立前仅在目标不存在时创建私有空文件；发现已有文件不额外 open/close。
+新建复用 `tempfile.mkstemp` 在同一私有目录创建唯一临时 inode，设置 0600 并先关闭 fd，
+然后以不覆盖目标的 `os.link` 原子发布到数据库路径，最后删除临时名称。目标已存在则
+丢弃自己的临时文件并验证已有目标，禁止 replace 已有数据库。发布前没有可由普通 DB
+读写入口连接的目标 inode；发布后权限维护不再打开它，从而避免“创建者关闭 fd 释放
+并发连接锁”的窗口。临时文件清理使用 finally，失败不能留下非私有目标。
+
+全部 SQLite 创建入口经共享 helper，不对数据库调用通用 `ensure_private_file`。
+不要求只读 `mode=ro` 入口执行 chmod、创建或获得业务锁；它们可能在发布后立即连接，
+仍不会被 helper 的额外 close 破坏锁。初始化采用私有临时文件而非扩大连接锁覆盖范围，
+以保留只读边界；验证中加入发布前后并发只读连接与创建竞争。
+数据库与 journal/WAL/SHM 的权限维护使用不打开文件内容的 metadata 操作，并明确禁止
+跟随符号链接。优先使用标准库提供的 no-follow 操作；不支持的平台应明确失败，不能
+回退到跟随 symlink 的 chmod。检查路径类型、父目录私有性和操作后的状态，保留既有
+0600 文件、0700 目录及特殊文件拒绝契约；sidecar 正常消失可容忍，权限异常不可吞掉。
+
+全面核对共享 helper 的调用者，包括同进程多连接、初始化、事务内调用及关闭后的维护。
+新文件初始化也不得对另一个活动连接的同名 inode 执行危险 open/close。连接建立后若
+权限维护失败必须关闭新连接。检查与 chmod 之间的路径替换风险纳入安全测试；采用受控
+私有目录与 no-follow 元数据操作，不引入会再次释放 SQLite 锁的文件描述符校验。
+
+不新增连接准备锁；现有 ledger writer lock 和 SQLite transaction 继续负责业务事务串行性。metadata no-follow 调用必须通过实际 Linux 锁探针验证，不能仅凭 API 名称
+假定其实现没有额外 open/close。信任已配置 runtime 根及既有祖先目录；直接父目录须为受控私有目录，
+对直接父目录和数据库文件执行 no-follow 类型、inode 与权限复核；
+不把同 UID 恶意进程修改其自身私有目录宣称为已隔离的安全边界。
+只对已明确分类且确认可安全重试的临时故障沿用 durable 重试；本轮不增加进程内 sleep
+或第二套快速重试政策。首发成功率主要通过修复身份与锁缺陷提升。
+
+### 普通成交回执与恢复
+
+以现有 Inbox 为唯一持久化 owner。扩展 `receipt_json` 为显式版本的记录，按语义保存
+`pending_retry`、`recorded`、`manual_required`、`verification_pending` 回执，而不是每次异常建立新通知。
+这些是普通回执的结果版本，不是新的交易生命周期状态。JSON envelope 包含 schema_version、
+current_result_key 与按语义键索引的 receipts；`verification_pending` 专指经济状态待核对，
+与投递 unknown 分离。键由 Inbox identity 与结果语义构成，不随
+传输来源、重试次数或无经济变化的关联补充变化。同一语义只冻结一份内容，发送尝试用独立
+attempt ID；保留各结果的 route/message、送达证据、次数、下次可尝试时间与停止原因。
+
+普通即时发送、重复入口和通知恢复都先走 Inbox 的同一结果/attempt claim。state.json
+只保留兼容投影，不得以旧 delivery_confirmed/unknown 否决新结果、复活旧结果或绕过
+预算。没有 Inbox 的旧兼容路径保留原有抑制规则，不能用其状态猜测迁移后的发送资格。
+
+所有正常、normalize 失败、resolve 失败及已知辅助异常出口统一先收敛经济事实，再以
+claim/payload CAS 写入结果、重试决定和回执意图，最后进行外部发送。禁止异常分支绕过
+该持久化步骤，禁止发送回调失败把已记录业务改回 pending。ledger 与 Inbox 的提交窗口
+由 canonical readback 恢复；无法可靠读回时只进入待核对，不再执行经济写入。
+恢复的账本读回与 Inbox 结果更新共用现有 ledger writer lock，等待仍在提交的过期 claim。
+沿用 compensation → ledger → Inbox 的加锁顺序，外部发送前释放锁，不能把未提交快照中的缺失当成最终未记录。
+Inbox 不可写时不发送无法持久化防重的通知；记录现有日志/status，存储恢复后继续协调。
+
+成功回执的内容截止于收敛时已知的 ledger 及 before-receipt 结果（如 combo）；不等待后续
+lifecycle timing、费用或 PM 刷新完成。这些后续结果继续由各自现有 status/audit 呈现，
+不会追改冻结消息或新增辅助工作流通知。发送完成只更新投递记录与兼容投影。
+
+| 业务事实 | 用户回执 | 后续动作 |
+|---|---|---|
+| 首次持久化并读回成功 | ✅ 已记录 | 一次成功回执 |
+| 未持久化、可安全重试且未耗尽 | ⚠️ 暂未记录；原因；至少 60 秒后自动重试 | 同一失败阶段不重复刷屏；恢复后独立成功回执 |
+| 不可自动重试或达到上限 | ❌ 暂未记录；原因；不会继续自动重试；处理建议 | 一次需处理回执；等待经授权的复核/修复 |
+| 持久化成功，回执截止前已知辅助步骤失败 | ✅ 已记录；注明当时已知的未完成步骤 | 后续辅助任务由原有状态入口呈现，不重复写交易 |
+| 未获得可靠持久化结论 | ⚠️ 记录状态待核对 | 先按 canonical key 读回；不能猜测成功或再次执行经济效果 |
+
+业务重试政策集中在 Inbox claim 边界：首次可立即认领；以后所有处理入口均在同一 CAS
+中检查 due time、lease、attempt_count 与可重试结论。成功 claim 原子消费一次现有计数，
+最多 20 次；settle 不再递增。正常失败从结算时间起至少 60 秒后到期；claim 中断须先等
+租约到期，不能以直接 processor 调用跳过期限。存储恢复读回与通知协调不消费业务预算。
+旧计数按已结算次数保留，不虚构此前崩溃次数；迁移后每次新 claim 都按新政策消费。
+
+第 20 次 claim 后崩溃也先执行无经济写入的 readback：确认已记录则恢复成功结果；明确
+未记录则耗尽；读回不可用则“记录状态待核对”，不可写成“未记录”。人工 resume 保留
+既有显式 operator 门与审计，重新开启预算不代表授权重发已确认或 unknown 的相同回执。
+
+intake 分类稳定原因码；仅确认可安全恢复的暂态 SQLite busy/locked/protocol 等错误可
+自动重试，权限、磁盘空间、schema、身份冲突等须给出对应处理建议，不能只凭异常类型。
+已提交或提交状态不明的异常先读回，禁止绕过唯一事件/lot 约束。渲染读取持久化的
+attempt/remaining/retryable、到期下限和调度条件，不自行计数或承诺精确执行时间。
+用户看到可执行的原因和动作，原始异常/堆栈只进诊断，不泄漏路径或凭据。
+
+`pending_retry` → `recorded` 或 `manual_required` 是不同可发送结果。重复的失败与重复
+成功都不能新增经济效果或重复已确认回执。成功必须来自 ledger facade 的持久化与读回
+证据；历史已处理但无新失败的成交继续保持历史抑制，不能因升级批量补发旧成交成功消息。
+
+提交边界不明或最后一次 claim 中断且 ledger 暂不可读时，冻结 `verification_pending`：
+“记录状态待核对；暂不重复录入；系统将继续核对”。每轮到期协调仅经 ledger 只读 facade
+按 canonical key 核验事件/lot，不调用可能补关联的 resolver；本地读取可每 60 秒再次到期，
+每批有上限，不消费经济或发送预算，也不重复发已确认的待核对通知。读取仍失败则保留
+该结果；确认已记录则推进到 recorded；确认未记录且有预算则 pending_retry；确认未记录
+且无预算/不可重试则 manual_required。每次推进按同一 supersession/CAS 规则废止旧未发
+消息，允许最终明确结果独立发送；未知不能当有效零结果。核对与真实投递各自 unknown
+字段不得混用。
+
+保留当前 `begin/finish` attempt fence，扩展到结果版本、payload version/hash、账户及
+冻结 route/message。claim 和 finish 必须核对当前 attempt ID 与版本；过期 worker 的
+完成回调不能覆盖新结果。旧结果已在发送中时，不能宣称撤销该外部发送；新成功内容应
+清楚说明为恢复结果，不能因为旧失败的已发送标记而跳过。结果推进时，原子撤销被替代
+失败或待核对结果未来的发送资格；尚未发送、无 route 或明确未接受的旧结果只保留审计，不能在
+成功或需处理结果之后再发送。claim 再核对 current_result_key。已经开始的旧 attempt
+允许按自身 ID 完成记录，但不能修改当前结果或恢复自身重试资格。
+
+投递状态沿用现有 `sent`、`failed`、`unknown` 语义：只有 delivery confirmation 才为
+sent；明确未接受为 failed，允许在既有循环中按持久化节奏仅重试通知；accepted/unconfirmed、
+超时或发送中崩溃为 unknown，禁止自动重发同一结果，状态诊断说明需核对投递。没有可用
+通知路由时保留待发送与原因，不伪造已送达。新业务成功属于新结果，不被旧失败通知的
+unknown 阻止；若同一成功通知 unknown 则继续防止重复发送。
+
+通知恢复独立于业务 pending 查询，从相同 Inbox 选择有新结果或明确未接受的待发送回执；
+已处理成交不重新进入 pipeline。用当前账户/source enabled、receipt enabled、route 与
+身份校验约束选择；保留 notify_applied、notify_failed、notify_unresolved 等现有子开关：
+recorded 属 applied，暂态/耗尽失败属 failed，身份明确的待复核属 unresolved；
+verification_pending 沿用产生该结果的原通知类别并持久化，不借恢复绕过用户抑制。
+停用时不发送，恢复启用后才继续。每个发送阶段必须有持久化意图，
+业务结果提交后、意图冻结前崩溃，可由 Inbox 结果与 ledger readback 恢复，不依赖新 push。
+source 拥有同一个到期协调函数，在正常循环、启动前与 reconnect 等待片段中调用。
+transport 的 `start` 复用已有 SDK 初始化线程，在当前 `queue.get(timeout=0.1)` 等待点
+提供可选 on_wait 回调；只暴露等待机会，不包含业务查询或发送逻辑。source 注入到期函数，
+因此初始化长时间未完成也能恢复通知；回调每次先检查 stop/due，实际工作受批量与发送
+超时约束，异常只进 status，不逃逸中断 SDK 等待。取消后不开始新的通知尝试。
+
+同步 health 查询须有 SDK 连接等待与请求超时：transport 使用现有
+`set_sync_query_connect_timeout` 设置有限连接等待，并沿用 SDK 请求超时；不能只依靠
+_queue 轮询超时。恢复最早到期为 60 秒，实际还受本轮有界 I/O 延迟影响，不承诺精确周期。
+测试初始化线程保持未完成、首轮通知明确失败、时钟到期后再次发送及 stop，不能只用
+立即抛错的 listener stub。沿用现有线程与协调，不新建常驻服务或通用 supervisor。
+
+达到上限时，即使下一轮业务查询已排除该行，也必须由现有循环的状态协调产生最后的需
+处理意图。通知重试使用独立计数，不能消耗或复活业务 retry budget；同样有上限和终止
+原因，以免永久刷接口。沿用 60 秒/20 次默认政策，不增加配置键或服务；通知 attempt
+认领时原子消费其独立预算，未知发送不续发，无路由只是等待条件、不消费发送次数。
+路由首次有效时冻结，重试前验证当前账户与 route 仍匹配；路由变更则停下待核对，不能
+把冻结消息自动发往另一个目标。通知预算耗尽/unknown 由现有 intake status 的 Inbox
+摘要展示结果、原因、最后 attempt 和处理建议；只读核对后另行授权补发，不自动发送
+一张“发送失败”的通知来递归通知失败。
+
+人工 `receipt_compensation` 必须先检查该成交是否由新版 Inbox 管理：是则 fail closed，
+返回 Inbox 当前投递状态和恢复策略，禁止通过独立补偿 JSON 再次发送。旧补偿仍保留其
+preview/hash/confirm 门。接管旧无路由记录前，在现有 compensation lock 内核对同一
+account/canonical deal 的补偿证据并完成 Inbox 接管；旧补偿 apply 在同一锁内重新检查
+Inbox 归属，避免先预览后并发发送。已有 send_started/unknown 视为歧义，confirmed 视为
+已送达；多成交合并补偿的任一成员都不能再次自动发送。缺失/无法归属的证据 fail closed。
+通知网络调用不持该迁移锁；新记录认领后由 Inbox 独立 CAS 防重。
+
+旧单回执读取必须兼容：sent/unknown 保留其原状态；只有保存了明确失败业务结果且当前
+已持久化成功，才建立恢复成功的新结果。无法证明旧回执对应何种结果时 fail closed 并
+显示诊断，禁止猜测补发。旧失败 sent/unknown 只约束其旧语义，不能挡住有证据的新成功。
+已有历史成功和空旧 receipt 不因升级批量补发；仅 live、可证明为本流程尚待完成的回执
+进入恢复，保留 delivery_purpose 与 receipt_recovery_allowed 的历史保护。
+
+扩展现有 `trade_inbox_writer_version()` 与 SQLite writer triggers：迁移在单一事务中
+检查版本并替换旧 guard，新写入要求新 writer version；先安装 guard 再写新格式。
+旧连接、旧二进制及不兼容降级必须在写入前失败，不得覆盖新版 JSON。新 reader 兼容旧
+单回执；损坏/未知版本 fail closed。测试旧连接在迁移前已打开、迁移并发和降级写入，
+不通过新增部署锁或文档提醒代替持久化兼容门。
+
+### 实现切片与验证
+
+1. **可信推送首次录入**：以真实 SDK 形状的响应头进入公开 listener，验证转换、source
+   绑定、入箱与同一成交的 history 收敛；覆盖缺头、多账户、账户/环境冲突，不伪造默认账户。
+2. **权限维护保持事务锁**：临时目录中复现 Linux SQLite WAL 写锁；独立进程在 helper
+   前后都应无法取得锁，事务提交正确。覆盖同进程第二连接、权限修复、新建竞态、symlink、
+   特殊文件、sidecar 消失和异常连接释放；macOS 通过不能替代 Linux 锁验收。
+3. **失败到恢复的完整回执**：用真实 Inbox/ledger 与 fake sender 经过 auto-intake facade，
+   验证首次成功、失败到成功、不可重试、耗尽、仅通知重试、无路由、unknown、进程重启、
+   旧回执兼容、旧 worker 迟到、账户停用和 lifecycle outbox 交接。内部顺序为统一结果与
+   原子预算 → 版本回执/兼容 guard → 外层通知恢复及补偿互斥，整体交付前不启用半成品发送。
+   覆盖失败待发→成功后旧失败失效，失败已送达→耗尽仍发新结果；claim 后/最后一次
+   claim 后崩溃、直接未到期认领、异常出口发送前后崩溃；OpenD 持续失败时仍恢复；
+   补偿先完成或并发自动恢复、无 route 后恢复、route 变更、旧 writer 及两存储状态冲突；
+   第20次 claim 崩溃→ledger 暂不可读→最终已记录/明确未记录，待核对通知失败/送达后
+   最终结果仍正确发送，且核对阶段经济写入次数为零；初始化一直未完成时再次到期发送
+   和取消可达；子开关抑制沿原类别生效。
+   断言唯一事件/lot，
+   冻结内容、发送次数及持久化确认；不以函数返回成功替代投递事实。
+
+验证以现有 `test_trades_push_listener.py`、`test_private_storage.py`、
+`test_trade_receipt_recovery.py`、`test_trade_receipt_claim_fence.py`、
+`test_trade_receipt_concurrency.py`、`test_trades_inbox.py` 与 auto-intake 对应测试为基础，
+按入口补最小回归，不复制实现做镜像测试。执行相关 import/依赖边界、文案与敏感信息 guardrails，
+测试/import 变化时重新生成 `docs/DEPENDENCY_GRAPH.md`。
+
+待落实的风险由对应 owner 处理：transport 需核对运行 SDK header 契约；private-storage
+需证明无符号链接跟随和 Linux 锁保持；Inbox 需验证旧格式迁移、compensation 证据归属与混合 writer 保护；
+status 的只读诊断不得把 unknown 提示成可直接安全重发。任何需要生产动作的验证先使用临时数据和 fake provider，
+真实补发与部署另行取得授权。
+
+业务到期时间由 Inbox 的 `next_attempt_at_ms` 保存，避免新推送补充关联信息时更新
+`updated_at_ms` 而推迟或绕过重试窗口。既有非零次数按原更新时间迁移到期时间；只有真实
+claim/settle 才推进业务重试到期时间，核对已确认缺失不会继续推迟录入。无法核对的结果
+每 60 秒再次只读核对，显式操作员恢复才重置预算。迁移和 writer-version guard 在同一
+事务内完成，调用方复用该事务，不再嵌套 `BEGIN`。
 
 ## 审计
 

--- a/src/application/ledger/read_only_evidence.py
+++ b/src/application/ledger/read_only_evidence.py
@@ -6,7 +6,10 @@ from contextlib import closing
 from pathlib import Path
 from typing import Any
 
-from src.application.ledger.event_codec import trade_event_application_payload
+from src.application.ledger.event_codec import (
+    stored_trade_event_to_ledger_event,
+    trade_event_application_payload,
+)
 from src.application.ledger.sqlite_row_codec import (
     read_current_decision_projection_inputs_from_conn,
 )
@@ -43,6 +46,20 @@ class _ReadOnlyTradeReconciliationEvidenceRepository:
         with closing(self._connect()) as conn:
             rows = self._read_position_lots(conn)
         return rows
+
+    def read_trade_receipt_evidence(self) -> dict[str, list[dict[str, Any]]]:
+        """Read required execution and projection evidence from one read-only snapshot."""
+        with closing(self._connect()) as conn:
+            conn.execute("BEGIN")
+            if not self._tables_exist(conn, "trade_events", "position_lots"):
+                raise sqlite3.DatabaseError("trade receipt evidence requires trade_events and position_lots tables")
+            events = self._read_trade_events(conn, strict=True)
+            for payload in events:
+                event, diagnostics = stored_trade_event_to_ledger_event(payload)
+                if event is None or any(item.severity == "error" for item in diagnostics):
+                    raise ValueError("trade receipt evidence contains an invalid canonical trade event")
+            lots = self._read_position_lots(conn, strict=True)
+            return {"trade_events": events, "position_lots": lots}
 
     def read_current_decision_projection_inputs(
         self,
@@ -83,14 +100,14 @@ class _ReadOnlyTradeReconciliationEvidenceRepository:
         out: list[dict[str, Any]] = []
         for row in rows:
             try:
-                fields = json.loads(str(row["fields_json"]) or "{}")
-            except (TypeError, ValueError):
+                fields = json.loads(row["fields_json"] if strict else str(row["fields_json"]) or "{}")
+            except (TypeError, ValueError) as exc:
                 if strict:
-                    raise
+                    raise ValueError("stored ledger position lot contains invalid JSON") from exc
                 continue
             if not isinstance(fields, dict):
                 if strict:
-                    fields = {}
+                    raise ValueError("stored ledger position lot JSON value must be an object")
                 else:
                     continue
             out.append(
@@ -437,13 +454,15 @@ class _ReadOnlyTradeReconciliationEvidenceRepository:
         out: list[dict[str, Any]] = []
         for row in rows:
             try:
-                payload = json.loads(str(row["event_json"]) or "{}")
-            except (TypeError, ValueError):
+                payload = json.loads(row["event_json"] if strict else str(row["event_json"]) or "{}")
+            except (TypeError, ValueError) as exc:
                 if strict:
-                    raise
+                    raise ValueError("stored ledger trade event contains invalid JSON") from exc
                 continue
             if isinstance(payload, dict):
                 out.append(trade_event_application_payload(payload))
+            elif strict:
+                raise ValueError("stored ledger trade event JSON value must be an object")
         return out
 
     @classmethod

--- a/src/application/trades/auto_intake.py
+++ b/src/application/trades/auto_intake.py
@@ -46,7 +46,10 @@ from src.application.trades.order_fee_sync import (
     recover_order_fee_targets,
     sync_order_fees,
 )
-from src.application.trades.deal_identity import broker_deal_key_from_payload
+from src.application.trades.deal_identity import (
+    broker_deal_key_from_payload, completed_ledger_execution_events,
+    structured_deal_keys_from_ledger_event,
+)
 from src.infrastructure.futu_history_deals import OpenDHistoryDealClient
 from src.application.trades.state_reconcile import reconcile_trade_intake_state
 from src.infrastructure.futu_trade_push import (
@@ -77,6 +80,7 @@ from src.application.trades.receipt import (
 from src.application.trades.receipt_compensation import (
     LEGACY_FALSE_OUTBOX_REASON,
     compensate_trade_intake_receipts,
+    receipt_compensation_takeover,
 )
 from src.application.trades.inbox_authority import resolve_execution_inbox_path
 from src.application.trades.inbox import (
@@ -89,6 +93,9 @@ from src.application.trades.inbox import (
     claim_trade_payload_refresh_intent,
     enqueue_trade_payload,
     list_retryable_trade_payloads,
+    list_trade_receipt_recovery_rows,
+    prepare_trade_receipt_result,
+    TradePayloadClaimLost,
     list_unclaimed_trade_payload_refresh_intents,
     mark_trade_payload_retryable,
     mark_trade_payload_review,
@@ -101,6 +108,9 @@ from src.application.opend_fetch_config import opend_fetch_kwargs
 from src.application.futu_quote_routing import resolve_futu_quote_route
 from src.application.ledger.api import (
     open_position_ledger_from_runtime_config,
+    open_trade_reconciliation_evidence_repo,
+    broker_external_event_key,
+    with_sqlite_repo_writer_lock,
     resolve_position_ledger_sqlite_path,
     record_trade_event_with_wheel_intent,
 )
@@ -288,6 +298,128 @@ def _attach_combo_reconciliation_after_open(
     return result
 
 
+def _receipt_deal_snapshot(deal: Any) -> dict[str, Any]:
+    return {key: getattr(deal, key, None) for key in (
+        "deal_id", "internal_account", "futu_account_id", "symbol", "option_type", "side",
+        "position_effect", "contracts", "price", "strike", "multiplier", "expiration_ymd",
+        "currency", "trade_time_ms", "asset_type", "execution_input",
+    )} if deal is not None else {}
+
+
+@contextlib.contextmanager
+def _receipt_preparation_scope(*, source: dict[str, Any], deal: Any, result: dict[str, Any]):
+    key = broker_external_event_key(deal) if deal is not None else ""
+    parts = key.split(":")
+    if len(parts) != 4 or parts[0] != "futu" or not parts[2].isdigit() or not parts[3].isdigit():
+        yield result
+        return
+    with receipt_compensation_takeover(source=source, account=deal.internal_account,
+                                      canonical_deal_id=key) as evidence:
+        yield {**result, "_receipt_legacy_evidence": evidence}
+
+
+def _readback_trade_receipt_result(*, repo: Any, deal: Any,
+                                  result: dict[str, Any]) -> dict[str, Any]:
+    """Resolve uncertain writes from one read-only snapshot, never through the writer."""
+    diagnostics = dict(result.get("diagnostics") or {})
+    try:
+        if deal is None or not getattr(deal, "execution_input", None):
+            raise ValueError("execution identity unavailable for readback")
+        if getattr(deal, "asset_type", None) != "option":
+            raise ValueError("non-option execution requires its existing ledger owner readback")
+        path = getattr(getattr(repo, "primary_repo", repo), "db_path", None)
+        if not isinstance(path, (str, Path)):
+            raise ValueError("ledger readback path unavailable")
+        evidence = open_trade_reconciliation_evidence_repo(path).read_trade_receipt_evidence()
+        events = evidence["trade_events"]
+        complete = completed_ledger_execution_events(events, deal)
+        if complete:
+            if getattr(deal, "position_effect", None) != "open":
+                # Lifecycle closes retain their own durable receipt owner.
+                raise ValueError("lifecycle result requires lifecycle readback")
+            projected = {str(row["fields"].get("source_event_id") or "") for row in evidence["position_lots"]}
+            if not all(str(event["event_id"]) in projected for event in complete):
+                raise ValueError("recorded execution projection unavailable")
+            diagnostics.update(retryable=False, verification_pending=False, recovered_from_ledger=True)
+            return {**result, "status": "applied", "action": "open", "reason": "applied_open",
+                    "account": deal.internal_account, "deal_id": deal.deal_id,
+                    "receipt_kind": "recorded", "diagnostics": diagnostics,
+                    "_receipt_payload": _receipt_deal_snapshot(deal)}
+        keys = {broker_deal_key_from_payload(deal.execution_input, account_mapping=None),
+                broker_external_event_key(deal)} - {""}
+        if any(keys.intersection(structured_deal_keys_from_ledger_event(event)) for event in events):
+            raise ValueError("execution evidence voided or incomplete")
+        if result.get("receipt_kind") == "recorded" or result.get("status") == "applied":
+            raise ValueError("previously recorded execution is absent")
+        diagnostics["verification_pending"] = False
+        # A crashed claim with no result can retry only after absence is established.
+        retryable = bool(diagnostics.get("retryable") or diagnostics.get("verification_retryable") or not result)
+        diagnostics.update(retryable=retryable, readback="absent")
+        return {**result, "status": "failed", "reason": result.get("reason") or "interrupted_before_recording",
+                "account": deal.internal_account, "deal_id": deal.deal_id,
+                "receipt_kind": "pending_retry" if retryable else "manual_required",
+                "diagnostics": diagnostics, "_receipt_payload": _receipt_deal_snapshot(deal)}
+    except Exception as exc:
+        diagnostics.setdefault("notification_category", result.get("status") or "failed")
+        diagnostics["verification_retryable"] = bool(diagnostics.get("verification_retryable") or diagnostics.get("retryable") or not result)
+        diagnostics.update(retryable=False, verification_pending=True,
+                           readback_error=f"{type(exc).__name__}: {exc}")
+        return {**result, "status": result.get("status") if result.get("status") in {"failed", "unresolved"} else "failed",
+                "receipt_kind": "verification_pending", "diagnostics": diagnostics,
+                "_receipt_payload": _receipt_deal_snapshot(deal)}
+
+
+def recover_trade_intake_receipts(*, repo: Any, source: dict[str, Any],
+                                  receipt_callback: Callable[[dict[str, Any]], Any],
+                                  stop_event: threading.Event) -> dict[str, Any]:
+    """Run bounded local readback and notification work independently of OpenD."""
+    path = source["inbox_path"]
+    counts: dict[str, Any] = {"checked": 0, "sent": 0, "errors": []}
+    if not source.get("enabled", True) or not (source.get("receipt") or {}).get("enabled", True):
+        return counts
+    for row in list_trade_receipt_recovery_rows(path, account_ids=source.get("futu_account_ids") or [], limit=100):
+        if stop_event.is_set():
+            break
+        try:
+            result = dict(row.get("result") or {})
+            snapshot = result.get("_receipt_payload") or (row.get("receipt") or {}).get("payload")
+            if snapshot:
+                deal = SimpleNamespace(**snapshot)
+            elif result.get("receipt_kind") == "manual_required" and result.get("account"):
+                deal = SimpleNamespace(internal_account=result["account"], deal_id=result.get("deal_id"))
+            else:
+                deal = normalize_trade_deal(row["payload"], futu_account_mapping=source.get("account_mapping"),
+                                            allow_opend_refresh=False)
+            execution = row["payload"].get("execution_input") or row["payload"]
+            physical = str((execution.get("broker_account_ref") or {}).get("external_account_id")
+                           or extract_primary_account_id(row["payload"]) or "")
+            account = str(getattr(deal, "internal_account", "") or "")
+            if (not account or (source.get("account") and account != source["account"])
+                    or (source.get("account_mapping") or {}).get(physical) != account):
+                continue
+            with _receipt_preparation_scope(source={**source, "account": account}, deal=deal, result=result) as prepared:
+                # Keep compensation -> repository -> Inbox order; an expired lease may still be committing.
+                with with_sqlite_repo_writer_lock(repo):
+                    if row["status"] == "pending":
+                        prepared = {**prepared, **_readback_trade_receipt_result(repo=repo, deal=deal, result=result)}
+                    prepared.setdefault("_receipt_payload", _receipt_deal_snapshot(deal))
+                    result = prepare_trade_receipt_result(path, inbox_id=row["inbox_id"], result=prepared,
+                        expected_payload_version=row["payload_version"], expected_result=row.get("result"))
+            if stop_event.is_set():
+                break
+            sent = receipt_callback({"result": result, "deal": deal, "effective_payload": result["_receipt_payload"],
+                "payload": row["payload"], "state": {}, "state_path": source["state_path"],
+                "audit_path": source.get("audit_path"), "apply_changes": True,
+                "inbox_path": path, "inbox_id": row["inbox_id"], "source": row["source"]})
+            counts["checked"] += 1
+            counts["sent"] += int(bool(isinstance(sent, dict) and sent.get("delivery_confirmed") and sent.get("status") == "sent"))
+        except TradePayloadClaimLost:
+            continue
+        except Exception as exc:
+            counts["errors"].append({"inbox_id": row["inbox_id"], "error": f"{type(exc).__name__}: {exc}"})
+    return counts
+
+
 def _process_payload(
     payload: dict[str, Any],
     *,
@@ -372,8 +504,10 @@ def _process_payload(
         return {"status": "unresolved", "reason": review_reason,
                 "diagnostics": {"errors": input_errors, "retryable": False}}
 
+    normalized_deal = None
     opend_config = opend_fetch_kwargs(config) if isinstance(config, dict) else None
     def normalize_fn(raw: dict[str, Any], *, futu_account_mapping=None):
+        nonlocal normalized_deal
         deal = normalize_trade_deal(
             raw, futu_account_mapping=futu_account_mapping, repo_base=repo_base,
             runtime_root=runtime_root, config_path=config_path, config=config,
@@ -382,6 +516,7 @@ def _process_payload(
         )
         associations = dict((claim or {}).get("associations") or {})
         if not associations:
+            normalized_deal = deal
             return deal
         execution = dict(deal.execution_input or {})
         changes = {}
@@ -398,7 +533,8 @@ def _process_payload(
                 if existing and existing != value:
                     raise ValueError(f"trade claim association conflict: {field}")
                 changes[attribute] = value
-        return replace(deal, execution_input=execution, **changes)
+        normalized_deal = replace(deal, execution_input=execution, **changes)
+        return normalized_deal
 
     def _enrich_payload(raw: dict[str, Any]) -> Any:
         return enrich_trade_push_payload_with_account_id(
@@ -439,10 +575,23 @@ def _process_payload(
             return resolved
 
     def _before_receipt(current: dict[str, Any]) -> dict[str, Any]:
+        if not current.get("account"):
+            execution = payload.get("execution_input") or payload
+            physical = extract_primary_account_id(payload) or (execution.get("broker_account_ref") or {}).get("external_account_id")
+            if str(physical or "") in futu_account_ids and str(physical or "") in account_mapping:
+                current = {**current, "account": account_mapping[str(physical)]}
+        if claim is not None and (current.get("diagnostics") or {}).get("exception_stage") in {"resolve", "post_resolve"}:
+            current = _readback_trade_receipt_result(repo=repo, deal=normalized_deal, result=current)
         if before_receipt_fn is not None:
             current = before_receipt_fn(current) or current
+        if _lifecycle_notification_is_outbox_owned({"deal": normalized_deal, "result": current}):
+            current = {**current, "receipt_notification_owner": "lifecycle_outbox"}
         if claim is not None:
-            save_trade_payload_result(inbox_path, claim=claim, result=current)
+            with _receipt_preparation_scope(source={"state_path": state_path,
+                    "account": getattr(normalized_deal, "internal_account", None)},
+                    deal=normalized_deal, result=current) as prepared:
+                current = save_trade_payload_result(inbox_path, claim=claim, result={
+                    **prepared, "_receipt_payload": _receipt_deal_snapshot(normalized_deal)})
         return current
 
     def _write_state(path: Path, current: dict[str, Any]) -> Path:
@@ -461,6 +610,18 @@ def _process_payload(
             )
 
     def _receipt(context: dict[str, Any]) -> dict[str, Any] | None:
+        if claim is not None:
+            current = context["result"]
+            if not current.get("receipt_kind") and (current.get("diagnostics") or {}).get("exception_stage") in {"resolve", "post_resolve"}:
+                current = _readback_trade_receipt_result(repo=repo, deal=context.get("deal"), result=current)
+            if _lifecycle_notification_is_outbox_owned({**context, "result": current}):
+                current = {**current, "receipt_notification_owner": "lifecycle_outbox"}
+            with _receipt_preparation_scope(source={"state_path": state_path,
+                    "account": getattr(context.get("deal"), "internal_account", None)},
+                    deal=context.get("deal"), result=current) as prepared:
+                enriched = save_trade_payload_result(inbox_path, claim=claim, result={
+                    **prepared, "_receipt_payload": _receipt_deal_snapshot(context.get("deal"))})
+            context["result"].update(enriched)
         if claim is not None and claim.get("association_enrichment"):
             return {"status": "skipped", "reason": "execution_association_enrichment", "delivery_confirmed": False}
         if claim is not None and claim["delivery_purpose"] == "historical":
@@ -497,6 +658,8 @@ def _process_payload(
         retry_failed_deal=retry_failed_deal,
         source=source,
     )
+    except TradePayloadClaimLost:
+        raise
     except Exception as exc:
         if claim is not None:
             mark_trade_payload_retryable(inbox_path, inbox_id=claim["inbox_id"],
@@ -541,12 +704,9 @@ def _bind_push_payload_to_source(
                 f"source_id={source_id or '-'} port={port} "
                 f"payload={futu_account_id} configured={','.join(configured_account_ids)}"
             )
-    elif len(configured_account_ids) == 1:
-        futu_account_id = configured_account_ids[0]
-        out["futu_account_id"] = futu_account_id
     else:
         raise ValueError(
-            "push OpenD source binding requires exactly one futu_account_id when "
+            "push OpenD source binding requires verified futu_account_id when "
             f"the payload omits account identity: source_id={source_id or '-'} "
             f"port={port} configured_count={len(configured_account_ids)}"
         )
@@ -1994,10 +2154,29 @@ def _run_listener_source_loop(
     backfill_cfg = dict(source.get("backfill") or intake_cfg.get("backfill") or {})
     reconnect_floor_sec = max(1, int(source.get("reconnect_sec") or intake_cfg.get("reconnect_sec") or 5))
     reconnect_delay_sec = reconnect_floor_sec
+    last_receipt_recovery_monotonic = None
+
+    def _recover_receipts_if_due() -> None:
+        nonlocal last_receipt_recovery_monotonic
+        now = time.monotonic()
+        if (not apply_changes or stop.is_set() or (last_receipt_recovery_monotonic is not None
+                and now - last_receipt_recovery_monotonic < 60)):
+            return
+        last_receipt_recovery_monotonic = now
+        try:
+            with process_lock:
+                status_state["receipt_recovery"] = recover_trade_intake_receipts(
+                    repo=repo, source=source, receipt_callback=receipt_callback, stop_event=stop)
+        except Exception as exc:
+            status_state["receipt_recovery"] = {"error": f"{type(exc).__name__}: {exc}"}
+        _write_listener_status(status_path, status_state, status=str(status_state.get("status") or "starting"),
+                               stage="receipt_recovery")
+
     while not stop.is_set():
         try:
+            _recover_receipts_if_due()
             _write_listener_status(status_path, status_state, status="starting", stage="listener_start", restart_count=restart_count)
-            listener.start(cancel_event=stop)
+            listener.start(cancel_event=stop, on_wait=_recover_receipts_if_due)
             _log(f"[OK] auto trade intake listener started source={source.get('id')} {host}:{port}")
             if status_state.get("last_error"):
                 status_state["recovered_at"] = utc_now()
@@ -2006,6 +2185,7 @@ def _run_listener_source_loop(
             if bool(backfill_cfg.get("enabled", True)) and not bool(backfill_cfg.get("startup_check", True)) and last_backfill_monotonic is None:
                 last_backfill_monotonic = time.monotonic()
             while not stop.is_set():
+                _recover_receipts_if_due()
                 listener.check_health()
                 reconnect_delay_sec = reconnect_floor_sec
                 now_mono = time.monotonic()
@@ -2360,8 +2540,10 @@ def _run_listener_source_loop(
                 reconnect_delay_sec=reconnect_delay_sec,
             )
             _log(f"[WARN] listener source={source.get('id')} exited: {exc}; retry in {reconnect_delay_sec} sec")
-            if stop.wait(reconnect_delay_sec):
-                break
+            reconnect_until = time.monotonic() + reconnect_delay_sec
+            while not stop.is_set() and time.monotonic() < reconnect_until:
+                _recover_receipts_if_due()
+                stop.wait(min(1, max(0, reconnect_until - time.monotonic())))
             reconnect_delay_sec = min(reconnect_delay_sec * 2, 60)
     listener.close()
     history_client.close()

--- a/src/application/trades/inbox.py
+++ b/src/application/trades/inbox.py
@@ -33,6 +33,7 @@ from src.infrastructure.private_storage import connect_private_sqlite
 SETTLEMENT_ATTEMPT_MIN_LEASE_MS = 120_000
 TRADE_EVIDENCE_SET_REF_PREFIX = "trade-inbox-evidence-set:v1:"
 LEGACY_ADAPTER_VERSION = "legacy/unversioned"
+_UNOBSERVED_RECEIPT_RESULT = object()
 TRADE_INTAKE_ADAPTER_VERSIONS = {
     "push": "om.trade-intake.push.v1",
     "backfill": "om.trade-intake.history.v1",
@@ -485,10 +486,16 @@ def claim_trade_payload(path: str | Path, *, inbox_id: str, repo: Any = None,
     with with_sqlite_repo_writer_lock(repo), closing(_connect(Path(path))) as conn, conn:
         _ensure_schema(conn)
         changed = conn.execute(
-            """UPDATE trade_inbox SET claim_id = ?, claim_until_ms = ?, claim_owner = ?
+            """UPDATE trade_inbox SET claim_id = ?, claim_until_ms = ?, claim_owner = ?,
+                attempt_count = attempt_count + 1, next_attempt_at_ms = ?
             WHERE inbox_id = ? AND status = 'pending' AND attempt_count < 20
-              AND (claim_id IS NULL OR claim_until_ms <= ?)""",
-            (token, now_ms + max(1, int(lease_ms)), str(owner), inbox_id, now_ms),
+              AND (claim_id IS NULL OR claim_until_ms <= ?)
+              AND next_attempt_at_ms <= ?
+              AND (result_json IS NULL OR json_extract(result_json, '$.receipt_kind') IS NULL
+                   OR json_extract(result_json, '$.receipt_kind') = 'pending_retry'
+                   OR (last_error = 'execution_association_enrichment'
+                       AND json_extract(result_json, '$.receipt_kind') IN ('recorded', 'manual_required')))""",
+            (token, now_ms + max(1, int(lease_ms)), str(owner), now_ms + 60_000, inbox_id, now_ms, now_ms),
         ).rowcount
         if not changed:
             return None
@@ -540,6 +547,28 @@ def trade_payload_commit_scope(path: str | Path, *, claim: Mapping[str, Any], re
         yield
 
 
+def _receipt_envelope(raw: str | None) -> dict[str, Any] | None:
+    value = json.loads(raw) if raw else None
+    if value is not None and not isinstance(value, dict):
+        raise ValueError("invalid trade receipt envelope")
+    if value is not None and "schema_version" in value:
+        if (value["schema_version"] != 2 or not isinstance(value.get("receipts"), dict)
+                or value.get("current_result_key") not in value["receipts"]):
+            raise ValueError("unsupported trade receipt envelope")
+    return value
+
+
+def _trade_payload_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(row)
+    out["payload"] = json.loads(out.pop("payload_json"))
+    out["result"] = json.loads(out.pop("result_json", None) or "null")
+    envelope = _receipt_envelope(out.pop("receipt_json", None))
+    out["receipt_envelope"] = envelope
+    out["receipt"] = (envelope["receipts"][envelope["current_result_key"]]
+                      if envelope and envelope.get("schema_version") == 2 else envelope)
+    return out
+
+
 def read_trade_payload(path: str | Path, *, inbox_id: str, read_only: bool = False) -> dict[str, Any] | None:
     if not Path(path).exists():
         return None
@@ -550,75 +579,278 @@ def read_trade_payload(path: str | Path, *, inbox_id: str, read_only: bool = Fal
         if not read_only:
             _ensure_schema(conn)
         row = conn.execute("SELECT * FROM trade_inbox WHERE inbox_id = ?", (inbox_id,)).fetchone()
-    if row is None:
-        return None
-    out = dict(row)
-    out["payload"] = json.loads(out.pop("payload_json"))
-    out["result"] = json.loads(out.pop("result_json", None) or "null")
-    out["receipt"] = json.loads(out.pop("receipt_json", None) or "null")
-    return out
+    return _trade_payload_row(row) if row is not None else None
 
 
-def save_trade_payload_result(path: str | Path, *, claim: Mapping[str, Any], result: dict[str, Any]) -> None:
+def _trade_result_policy(row: Mapping[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+    diagnostics = result.get("diagnostics") or {}
+    status = result.get("status")
+    retryable = (status in {"failed", "unresolved"} and bool(diagnostics.get("retryable"))
+                 and not diagnostics.get("broker_evidence_accepted")
+                 and result.get("reason") not in {"waiting_settlement_evidence", "awaiting_out_of_order_pair",
+                                                  "awaiting_settlement_evidence", "lifecycle_conflict_requires_review"})
+    count = int(row["attempt_count"])
+    kind = result.get("receipt_kind")
+    if kind is None:
+        kind = ("verification_pending" if diagnostics.get("verification_pending") else
+                "recorded" if status == "applied" else
+                "pending_retry" if retryable and count < 20 else
+                "manual_required" if status in {"failed", "unresolved"} else None)
+    if kind not in {None, "pending_retry", "recorded", "manual_required", "verification_pending"}:
+        raise ValueError("invalid trade receipt result kind")
+    if kind == "pending_retry" and count >= 20:
+        kind = "manual_required"
+    retryable = bool(retryable and count < 20 and kind == "pending_retry")
+    return {**result, "receipt_kind": kind, "receipt_result_key": kind,
+            "retry_policy": {"attempt_count": count, "max_attempts": 20,
+                             "remaining": max(0, 20 - count), "retryable": retryable,
+                             "retry_delay_sec": 60}}
+
+
+def _prepare_trade_receipt_result(conn: sqlite3.Connection, row: Mapping[str, Any],
+                                   result: dict[str, Any]) -> dict[str, Any]:
+    enriched = _trade_result_policy(row, result)
+    kind = enriched["receipt_kind"]
+    envelope = _receipt_envelope(row["receipt_json"])
+    old_result = json.loads(row["result_json"] or "null") or {}
+    if envelope is not None and envelope.get("schema_version") != 2:
+        # Old delivery evidence can only be assigned semantics from its saved business result.
+        old_kind = _trade_result_policy(row, old_result)["receipt_kind"]
+        old_diagnostics = old_result.get("diagnostics") or {}
+        old_failed = old_result.get("status") == "failed" or (
+            old_result.get("status") == "unresolved" and old_diagnostics.get("retryable")
+            and not old_diagnostics.get("broker_evidence_accepted")
+            and not old_diagnostics.get("verification_pending"))
+        if not old_kind or not old_failed:
+            enriched["receipt_suppression_reason"] = "legacy_receipt_history_unproven"
+            envelope = None
+            kind = None
+        else:
+            envelope = {"schema_version": 2, "current_result_key": old_kind,
+                        "receipts": {old_kind: {**envelope, "result_key": old_kind,
+                                                "receipt_kind": old_kind, "business_result": old_result,
+                                                "attempt_count": int(bool(envelope.get("attempt_id"))),
+                                                "legacy": True}}}
+    elif envelope is None and (not row["receipt_recovery_allowed"] or (
+            row["status"] == "handled" and old_result.get("status") == "applied"
+            and not old_result.get("receipt_kind"))):
+        # New caller claims can process legacy rows, but cannot authorize historical delivery.
+        enriched["receipt_suppression_reason"] = "legacy_receipt_history_unproven"
+        kind = None
+    lifecycle_owned = (result.get("receipt_notification_owner") == "lifecycle_outbox"
+                       or (result.get("diagnostics") or {}).get("notification_authority") == "lifecycle_outbox")
+    if lifecycle_owned:
+        kind = None
+        if envelope and envelope.get("schema_version") == 2:
+            previous = envelope["receipts"][envelope["current_result_key"]]
+            previous.update(superseded_by="lifecycle_outbox", stop_reason="lifecycle_outbox_handoff")
+    if kind is not None and row["delivery_purpose"] == "live":
+        envelope = envelope or {"schema_version": 2, "current_result_key": kind, "receipts": {}}
+        receipts = envelope["receipts"]
+        current = envelope["current_result_key"]
+        if current == "recorded" and kind != "recorded" and not (
+                kind == "verification_pending" and (result.get("diagnostics") or {}).get("verification_pending")):
+            raise TradePayloadClaimLost("recorded trade result cannot regress")
+        if current != kind and current in receipts:
+            receipts[current].update(superseded_by=kind, stop_reason="result_superseded")
+        if kind not in receipts:
+            receipts[kind] = {"result_key": kind, "receipt_kind": kind,
+                              "receipt_id": f"trade-receipt:{row['inbox_id']}" + (f":{kind}" if receipts else ""),
+                              "status": "pending", "attempt_count": 0,
+                              "business_result": enriched,
+                              "payload": enriched.get("_receipt_payload"),
+                              "payload_version": row["payload_version"],
+                              "economic_payload_hash": row["economic_payload_hash"],
+                              "created_at_ms": int(time.time() * 1000)}
+        # Revisited semantics retain their original send evidence and frozen content.
+        receipts[kind].pop("superseded_by", None)
+        if receipts[kind].get("stop_reason") == "result_superseded":
+            receipts[kind].pop("stop_reason")
+        envelope["current_result_key"] = kind
+        legacy_evidence = result.get("_receipt_legacy_evidence") or {}
+        if (kind == "recorded" and legacy_evidence.get("blocked")
+                and receipts[kind].get("status") not in {"sent", "unknown"}):
+            confirmed = legacy_evidence.get("status") == "confirmed"
+            receipts[kind].update(status="sent" if confirmed else "unknown",
+                                  stop_reason="legacy_compensation_owned",
+                                  result={"delivery_confirmed": confirmed,
+                                          "legacy_compensation_evidence": legacy_evidence})
+        receipt_json = json.dumps(envelope, ensure_ascii=False, default=str)
+    else:
+        receipt_json = (json.dumps(envelope, ensure_ascii=False, default=str)
+                        if lifecycle_owned and envelope and envelope.get("schema_version") == 2
+                        else row["receipt_json"])
+    conn.execute("""UPDATE trade_inbox SET result_json = ?, result_status = ?, result_reason = ?,
+                    receipt_json = ? WHERE inbox_id = ?""",
+                 (json.dumps(enriched, ensure_ascii=False, default=str), enriched.get("status"),
+                  enriched.get("reason"), receipt_json, row["inbox_id"]))
+    return enriched
+
+
+def save_trade_payload_result(path: str | Path, *, claim: Mapping[str, Any],
+                              result: dict[str, Any]) -> dict[str, Any]:
     with closing(_connect(Path(path))) as conn, conn:
         _ensure_schema(conn)
-        changed = conn.execute(
-            """UPDATE trade_inbox SET result_json = ? WHERE inbox_id = ? AND status = 'pending'
-               AND claim_id = ? AND payload_version = ?""",
-            (json.dumps(result, ensure_ascii=False, default=str), claim["inbox_id"],
-             claim["claim_id"], claim["payload_version"]),
-        ).rowcount
-        if not changed:
+        row = conn.execute("SELECT * FROM trade_inbox WHERE inbox_id = ?", (claim["inbox_id"],)).fetchone()
+        if (row is None or row["status"] != "pending" or row["claim_id"] != claim["claim_id"]
+                or row["payload_version"] != claim["payload_version"]
+                or row["economic_payload_hash"] != claim["economic_payload_hash"]):
             raise TradePayloadClaimLost("trade result claim lost")
+        enriched = _prepare_trade_receipt_result(conn, row, result)
         intent = result.get("portfolio_refresh_intent")
         if isinstance(intent, Mapping):
             _record_trade_payload_refresh_intent(conn, inbox_id=claim["inbox_id"], intent=intent)
+        return enriched
+
+
+def prepare_trade_receipt_result(path: str | Path, *, inbox_id: str, result: dict[str, Any],
+                                 expected_payload_version: int | None = None,
+                                 expected_result: Any = _UNOBSERVED_RECEIPT_RESULT) -> dict[str, Any]:
+    """Reconcile readback without an economic claim; compare the exact observed result."""
+    if expected_payload_version is None and expected_result is _UNOBSERVED_RECEIPT_RESULT:
+        raise TradePayloadClaimLost("receipt recovery requires observed result or payload version")
+    with closing(_connect(Path(path))) as conn, conn:
+        _ensure_schema(conn)
+        row = conn.execute("SELECT * FROM trade_inbox WHERE inbox_id = ?", (inbox_id,)).fetchone()
+        if (row is None or row["status"] == "conflict"
+                or (row["claim_id"] and int(row["claim_until_ms"] or 0) > int(time.time() * 1000))
+                or (expected_payload_version is not None and row["payload_version"] != expected_payload_version)
+                or (expected_result is not _UNOBSERVED_RECEIPT_RESULT
+                    and json.loads(row["result_json"] or "null") != expected_result)):
+            raise TradePayloadClaimLost("receipt recovery observation changed")
+        enriched = _prepare_trade_receipt_result(conn, row, result)
+        # Readback can settle a crashed claim without consuming another economic attempt.
+        status = "pending" if enriched["receipt_kind"] in {"pending_retry", "verification_pending"} else "handled"
+        next_attempt_at_ms = (int(time.time() * 1000) + 60_000
+                              if enriched["receipt_kind"] == "verification_pending"
+                              else row["next_attempt_at_ms"])
+        conn.execute("""UPDATE trade_inbox SET status = ?, claim_id = NULL, claim_until_ms = NULL,
+                        updated_at_ms = ?, next_attempt_at_ms = ? WHERE inbox_id = ?""",
+                     (status, int(time.time() * 1000), next_attempt_at_ms, inbox_id))
+        return enriched
 
 
 def begin_trade_receipt_attempt(path: str | Path, *, inbox_id: str,
                                 route: dict[str, Any], message: str,
-                                claim: Mapping[str, Any] | None = None) -> dict[str, Any]:
-    """Freeze one ordinary receipt before external I/O; an interrupted attempt stays unknown."""
+                                claim: Mapping[str, Any] | None = None,
+                                result_key: str | None = None) -> dict[str, Any]:
+    """Claim the current semantic result; mark unknown before any external I/O."""
+    now_ms = int(time.time() * 1000)
     with closing(_connect(Path(path))) as conn, conn:
         _ensure_schema(conn)
-        conn.commit()
-        conn.execute("BEGIN IMMEDIATE")
-        row = conn.execute("SELECT * FROM trade_inbox WHERE inbox_id = ?",
-                           (inbox_id,)).fetchone()
+        row = conn.execute("SELECT * FROM trade_inbox WHERE inbox_id = ?", (inbox_id,)).fetchone()
         if claim is not None and (
-            row is None or row["status"] != "pending"
-            or row["claim_id"] != claim.get("claim_id")
+            row is None or row["status"] != "pending" or row["claim_id"] != claim.get("claim_id")
             or row["payload_version"] != claim.get("payload_version")
             or row["economic_payload_hash"] != claim.get("economic_payload_hash")
         ):
             raise TradePayloadClaimLost("trade receipt claim no longer permits delivery")
         if row is None or row["status"] == "conflict" or row["delivery_purpose"] == "historical":
             return {"claimed": False, "status": "suppressed"}
-        if row["receipt_json"]:
-            return {**json.loads(row["receipt_json"]), "claimed": False}
-        frozen = {"receipt_id": f"trade-receipt:{inbox_id}", "status": "unknown",
-                  "route": route, "message": message, "attempt_id": uuid.uuid4().hex,
-                  "attempted_at_ms": int(time.time() * 1000)}
+        if claim is None and row["claim_id"] and int(row["claim_until_ms"] or 0) > now_ms:
+            return {"claimed": False, "status": "pending", "reason": "economic_claim_active"}
+        envelope = _receipt_envelope(row["receipt_json"])
+        if envelope is None:
+            return {"claimed": False, "status": "suppressed", "reason": "durable_receipt_intent_missing"}
+        if envelope.get("schema_version") != 2:
+            return {**envelope, "claimed": False}
+        key = envelope["current_result_key"]
+        frozen = envelope["receipts"][key]
+        if result_key is not None and result_key != key:
+            raise TradePayloadClaimLost("trade receipt result superseded")
+        if frozen.get("status") not in {"pending", "failed"} or frozen.get("stop_reason"):
+            return {**frozen, "claimed": False}
+        if frozen.get("route") is not None and frozen["route"] != route:
+            frozen["stop_reason"] = "route_changed_requires_review"
+        elif int(frozen.get("attempt_count", 0)) >= 20:
+            frozen["stop_reason"] = "notification_attempts_exhausted"
+        elif int(frozen.get("next_attempt_at_ms", 0)) > now_ms:
+            return {**frozen, "claimed": False}
+        elif not route:
+            return {**frozen, "claimed": False, "reason": "route_unavailable"}
+        else:
+            if frozen.get("attempt_id"):
+                frozen.setdefault("attempts", []).append({name: frozen.get(name) for name in
+                    ("attempt_id", "attempted_at_ms", "status", "result")})
+            frozen.update(status="unknown", attempt_id=uuid.uuid4().hex, attempted_at_ms=now_ms,
+                          attempt_count=int(frozen.get("attempt_count", 0)) + 1,
+                          route=frozen.get("route", route), message=frozen.get("message", message))
+            frozen.pop("result", None)
         conn.execute("UPDATE trade_inbox SET receipt_json = ? WHERE inbox_id = ?",
-                     (json.dumps(frozen, ensure_ascii=False), inbox_id))
-        return {**frozen, "claimed": True}
+                     (json.dumps(envelope, ensure_ascii=False), inbox_id))
+        return {**frozen, "claimed": not bool(frozen.get("stop_reason"))}
 
 
 def finish_trade_receipt_attempt(path: str | Path, *, inbox_id: str, attempt_id: str,
                                  result: dict[str, Any]) -> None:
     with closing(_connect(Path(path))) as conn, conn:
         _ensure_schema(conn)
-        conn.commit()
-        conn.execute("BEGIN IMMEDIATE")
         row = conn.execute("SELECT receipt_json FROM trade_inbox WHERE inbox_id = ?", (inbox_id,)).fetchone()
-        frozen = json.loads(row[0] or "{}") if row else {}
-        if frozen.get("attempt_id") != attempt_id:
+        envelope = _receipt_envelope(row[0]) if row else None
+        entries = list(envelope["receipts"].values()) if envelope and envelope.get("schema_version") == 2 else [envelope]
+        attempts = [attempt for entry in entries if entry
+                    for attempt in [entry, *entry.get("attempts", [])]]
+        frozen = next((attempt for attempt in attempts if attempt.get("attempt_id") == attempt_id), None)
+        if frozen is None:
             raise TradePayloadClaimLost("trade receipt attempt changed")
+        # A repeated/contradictory callback cannot reopen confirmed or explicitly rejected attempts.
+        if frozen.get("result") is not None:
+            return
         status = ("sent" if result.get("delivery_confirmed") else
                   "failed" if result.get("explicit_pre_acceptance_failure") else "unknown")
         frozen.update(result=result, status=status)
+        if status == "failed":
+            frozen["next_attempt_at_ms"] = int(time.time() * 1000) + 60_000
+            if int(frozen.get("attempt_count", 0)) >= 20:
+                frozen["stop_reason"] = "notification_attempts_exhausted"
         conn.execute("UPDATE trade_inbox SET receipt_json = ? WHERE inbox_id = ?",
-                     (json.dumps(frozen, ensure_ascii=False), inbox_id))
+                     (json.dumps(envelope, ensure_ascii=False), inbox_id))
+
+
+def list_trade_receipt_recovery_rows(path: str | Path, *, account_ids: Iterable[str],
+                                     limit: int = 100) -> list[dict[str, Any]]:
+    allowed = {str(value).strip() for value in account_ids if str(value).strip()}
+    if not allowed or not Path(path).exists():
+        return []
+    now_ms = int(time.time() * 1000)
+    out = []
+    with closing(_connect(Path(path))) as conn, conn:
+        _ensure_schema(conn)
+        rows = conn.execute("""SELECT * FROM trade_inbox WHERE delivery_purpose = 'live'
+            AND receipt_recovery_allowed = 1 AND source IN ('push', 'backfill')
+            AND status != 'conflict' AND (claim_id IS NULL OR claim_until_ms <= ?)
+            AND (result_json IS NOT NULL OR attempt_count > 0)
+            ORDER BY updated_at_ms, received_at_ms, inbox_id""", (now_ms,))
+        for row in rows:
+            item = _trade_payload_row(row)
+            payload = item["payload"]
+            execution = payload.get("execution_input") or payload
+            ref = execution.get("broker_account_ref") or {}
+            physical = str(ref.get("external_account_id") or extract_primary_account_id(payload) or "").strip()
+            if physical not in allowed:
+                continue
+            receipt = item["receipt"] or {}
+            if (item["status"] == "pending" and item["attempt_count"] == 0
+                    and (item["result"] or {}).get("receipt_kind") != "verification_pending"):
+                # An unclaimed/resumed execution belongs to processing, not receipt readback.
+                continue
+            needs_readback = (item["status"] == "pending" and (item["attempt_count"] > 0
+                              or (item["result"] or {}).get("receipt_kind") == "verification_pending"))
+            if needs_readback and item["next_attempt_at_ms"] > now_ms:
+                continue
+            if not needs_readback and receipt:
+                if receipt.get("status") not in {"pending", "failed"} or receipt.get("stop_reason"):
+                    continue
+                if int(receipt.get("next_attempt_at_ms", 0)) > now_ms:
+                    continue
+            if not receipt and item["status"] == "handled" and item["result"] and item["result"].get("status") == "applied":
+                # Only a saved new-writer semantic result can prove the pre-intent crash window.
+                if not item["result"].get("receipt_kind"):
+                    continue
+            out.append(item)
+            if len(out) >= max(1, int(limit)):
+                break
+    return out
 
 
 def resume_trade_payload(path: str | Path, *, inbox_id: str, operator: str, repo: Any = None) -> bool:
@@ -627,8 +859,13 @@ def resume_trade_payload(path: str | Path, *, inbox_id: str, operator: str, repo
     with with_sqlite_repo_writer_lock(repo), closing(_connect(Path(path))) as conn, conn:
         _ensure_schema(conn)
         changed = conn.execute(
-            """UPDATE trade_inbox SET attempt_count = 0, claim_id = NULL, claim_until_ms = NULL,
-               last_error = ?, updated_at_ms = ? WHERE inbox_id = ? AND status = 'pending'""",
+            """UPDATE trade_inbox SET status = 'pending', attempt_count = 0, next_attempt_at_ms = 0,
+               claim_id = NULL, claim_until_ms = NULL,
+               last_error = ?, updated_at_ms = ?, result_json = CASE WHEN result_json IS NULL THEN NULL
+                   WHEN json_extract(result_json, '$.receipt_kind') = 'verification_pending' THEN result_json
+                   ELSE json_set(result_json, '$.receipt_kind', 'pending_retry', '$.retry_policy.retryable', json('true')) END
+               WHERE inbox_id = ? AND (status = 'pending' OR (status = 'handled'
+                   AND json_extract(result_json, '$.receipt_kind') = 'manual_required'))""",
             (f"resumed_by:{operator}", int(time.time() * 1000), inbox_id),
         ).rowcount
         if changed:
@@ -664,11 +901,16 @@ def list_retryable_trade_payloads(
                 FROM trade_inbox
                 WHERE status = 'pending'
                   AND attempt_count < ?
-                  AND (attempt_count = 0 OR updated_at_ms <= ?)
+                  AND (claim_id IS NULL OR claim_until_ms <= ?)
+                  AND (result_json IS NULL OR json_extract(result_json, '$.receipt_kind') IS NULL
+                       OR json_extract(result_json, '$.receipt_kind') = 'pending_retry'
+                   OR (last_error = 'execution_association_enrichment'
+                       AND json_extract(result_json, '$.receipt_kind') IN ('recorded', 'manual_required')))
+                  AND (attempt_count = 0 OR next_attempt_at_ms - 60000 <= ?)
                 ORDER BY received_at_ms ASC, inbox_id ASC
                 LIMIT ?
                 """,
-                (int(max_attempts), cutoff_ms, row_limit if allowed is None else -1),
+                (int(max_attempts), int(time.time() * 1000), cutoff_ms, row_limit if allowed is None else -1),
             )
             # ponytail: scoped recovery is O(n); add an account index if backlog measurements require it.
             for row in rows:
@@ -703,127 +945,50 @@ def list_retryable_trade_payloads(
     return out
 
 
-def mark_trade_payload_handled(
-    path: str | Path,
-    *,
-    inbox_id: str,
-    result: dict[str, Any] | None,
-    claim: Mapping[str, Any] | None = None,
-) -> None:
-    inbox_path = Path(path)
-    now_ms = int(time.time() * 1000)
-    result_payload = result if isinstance(result, dict) else {}
-    with closing(_connect(inbox_path)) as conn:
-        with conn:
-            _ensure_schema(conn)
-            conn.execute(
-                """
-                UPDATE trade_inbox
-                SET status = 'handled',
-                    attempt_count = attempt_count + 1,
-                    updated_at_ms = ?,
-                    last_error = NULL, claim_id = NULL, claim_until_ms = NULL,
-                    result_json = ?, result_status = ?,
-                    result_reason = ?
-                WHERE inbox_id = ? AND status = 'pending'
-                  AND (claim_id = ? OR (claim_id IS NULL AND ? IS NULL))
-                  AND (? IS NULL OR payload_version = ?)
-                """,
-                (
-                    now_ms,
-                    json.dumps(result_payload, ensure_ascii=False, sort_keys=True),
-                    str(result_payload.get("status") or "").strip() or None,
-                    str(result_payload.get("reason") or "").strip() or None,
-                    str(inbox_id),
-                    (claim or {}).get("claim_id"), (claim or {}).get("claim_id"),
-                    (claim or {}).get("payload_version"), (claim or {}).get("payload_version"),
-                ),
-            )
+def _settle_trade_payload(path: str | Path, *, inbox_id: str, result: dict[str, Any] | None,
+                           claim: Mapping[str, Any] | None, retry: bool, error: str | None = None) -> None:
+    with closing(_connect(Path(path))) as conn, conn:
+        _ensure_schema(conn)
+        row = conn.execute("SELECT * FROM trade_inbox WHERE inbox_id = ?", (inbox_id,)).fetchone()
+        if (row is None or row["status"] != "pending"
+                or row["claim_id"] != (claim or {}).get("claim_id")
+                or (claim is not None and row["payload_version"] != claim.get("payload_version"))):
+            return
+        if result is None:
+            result = json.loads(row["result_json"] or "null")
+            if result is None:
+                result = {"status": "unresolved", "reason": "callback_exception",
+                          "diagnostics": {"verification_pending": True, "retryable": False}}
+        enriched = _prepare_trade_receipt_result(conn, row, result)
+        if enriched["receipt_kind"] == "recorded":
+            retry = False
+        elif enriched["receipt_kind"] == "verification_pending":
+            retry = True
+        elif enriched["receipt_kind"] == "manual_required":
+            retry = False
+        conn.execute("""UPDATE trade_inbox SET status = ?, updated_at_ms = ?, last_error = ?,
+                        claim_id = NULL, claim_until_ms = NULL, next_attempt_at_ms = ? WHERE inbox_id = ?""",
+                     ("pending" if retry else "handled", int(time.time() * 1000), error,
+                      int(time.time() * 1000) + 60_000, inbox_id))
 
 
-def mark_trade_payload_retryable(
-    path: str | Path,
-    *,
-    inbox_id: str,
-    error: str | None,
-    result: dict[str, Any] | None = None,
-    claim: Mapping[str, Any] | None = None,
-) -> None:
-    inbox_path = Path(path)
-    now_ms = int(time.time() * 1000)
-    result_payload = result if isinstance(result, dict) else {}
-    with closing(_connect(inbox_path)) as conn:
-        with conn:
-            _ensure_schema(conn)
-            conn.execute(
-                """
-                UPDATE trade_inbox
-                SET status = 'pending',
-                attempt_count = attempt_count + 1,
-                updated_at_ms = ?,
-                last_error = ?, claim_id = NULL, claim_until_ms = NULL,
-                result_json = ?, result_status = ?,
-                result_reason = ?
-            WHERE inbox_id = ? AND status = 'pending'
-                  AND (claim_id = ? OR (claim_id IS NULL AND ? IS NULL))
-                  AND (? IS NULL OR payload_version = ?)
-            """,
-                (
-                    now_ms,
-                    str(error) if error else None,
-                    json.dumps(result_payload, ensure_ascii=False, sort_keys=True),
-                    str(result_payload.get("status") or "exception"),
-                    str(result_payload.get("reason") or "callback_exception"),
-                    str(inbox_id),
-                    (claim or {}).get("claim_id"), (claim or {}).get("claim_id"),
-                    (claim or {}).get("payload_version"), (claim or {}).get("payload_version"),
-                ),
-            )
+def mark_trade_payload_handled(path: str | Path, *, inbox_id: str,
+                                result: dict[str, Any] | None,
+                                claim: Mapping[str, Any] | None = None) -> None:
+    _settle_trade_payload(path, inbox_id=inbox_id, result=result, claim=claim, retry=False)
 
 
-def settle_trade_payload_result(
-    path: str | Path,
-    *,
-    inbox_id: str,
-    result: dict[str, Any] | None,
-    claim: Mapping[str, Any] | None = None,
-) -> None:
-    result_payload = result if isinstance(result, dict) else {}
-    diagnostics = (
-        result_payload.get("diagnostics")
-        if isinstance(result_payload.get("diagnostics"), dict)
-        else {}
-    )
-    result_status = str(result_payload.get("status") or "").strip().lower()
-    lifecycle_pending_or_review = str(
-        result_payload.get("reason") or ""
-    ).strip().lower() in {
-        "waiting_settlement_evidence",
-        "awaiting_out_of_order_pair",
-        "awaiting_settlement_evidence",
-        "lifecycle_conflict_requires_review",
-    }
-    retryable = (
-        result_status in {"failed", "unresolved"}
-        and bool(diagnostics.get("retryable"))
-        and not bool(diagnostics.get("broker_evidence_accepted"))
-        and not lifecycle_pending_or_review
-    )
-    if retryable:
-        mark_trade_payload_retryable(
-            path,
-            inbox_id=inbox_id,
-            error=None,
-            result=result_payload,
-            claim=claim,
-        )
-        return
-    mark_trade_payload_handled(
-        path,
-        inbox_id=inbox_id,
-        result=result_payload,
-        claim=claim,
-    )
+def mark_trade_payload_retryable(path: str | Path, *, inbox_id: str, error: str | None,
+                                  result: dict[str, Any] | None = None,
+                                  claim: Mapping[str, Any] | None = None) -> None:
+    _settle_trade_payload(path, inbox_id=inbox_id, result=result, claim=claim, retry=True, error=error)
+
+
+def settle_trade_payload_result(path: str | Path, *, inbox_id: str, result: dict[str, Any] | None,
+                                 claim: Mapping[str, Any] | None = None) -> None:
+    diagnostics = (result or {}).get("diagnostics") or {}
+    _settle_trade_payload(path, inbox_id=inbox_id, result=result, claim=claim,
+                          retry=bool(diagnostics.get("retryable")))
 
 
 def record_trade_payload_refresh_intent(
@@ -955,13 +1120,40 @@ def trade_inbox_summary(path: str | Path) -> dict[str, Any]:
             "handled_count": 0,
             "identity_needs_review_count": 0,
             "max_attempt_count": 0,
+            "receipt_status_counts": {},
+            "receipt_kind_counts": {},
+            "receipt_attention": [],
         }
+    receipt_status_counts: dict[str, int] = {}
+    receipt_kind_counts: dict[str, int] = {}
+    receipt_attention = []
     with closing(_connect(inbox_path)) as conn:
         with conn:
             _ensure_schema(conn)
+            for item in conn.execute("SELECT inbox_id, receipt_json FROM trade_inbox WHERE receipt_json IS NOT NULL"):
+                envelope = _receipt_envelope(item["receipt_json"])
+                if not envelope:
+                    continue
+                receipt = (envelope["receipts"][envelope["current_result_key"]]
+                           if envelope.get("schema_version") == 2 else envelope)
+                status = str(receipt.get("status") or "unknown")
+                kind = str(receipt.get("receipt_kind") or "legacy")
+                receipt_status_counts[status] = receipt_status_counts.get(status, 0) + 1
+                receipt_kind_counts[kind] = receipt_kind_counts.get(kind, 0) + 1
+                if len(receipt_attention) < 20 and (status == "unknown" or receipt.get("stop_reason")):
+                    receipt_attention.append({"inbox_id": item["inbox_id"], "receipt_kind": kind,
+                        "status": status, "attempt_count": receipt.get("attempt_count", 0),
+                        "last_attempt_at_ms": receipt.get("attempted_at_ms"),
+                        "reason": receipt.get("stop_reason") or "delivery_requires_verification",
+                        "next_action": "verify_delivery_before_explicit_compensation"})
             eligibility = conn.execute(
-                """SELECT SUM(status = 'pending' AND attempt_count < 20) AS eligible,
-                          SUM(status = 'pending' AND attempt_count >= 20) AS exhausted
+                """SELECT SUM(status = 'pending' AND attempt_count < 20 AND (
+                              result_json IS NULL OR json_extract(result_json, '$.receipt_kind') IS NULL
+                              OR json_extract(result_json, '$.receipt_kind') = 'pending_retry'
+                              OR (last_error = 'execution_association_enrichment'
+                                  AND json_extract(result_json, '$.receipt_kind') IN ('recorded', 'manual_required')))) AS eligible,
+                          SUM(attempt_count >= 20 AND (status = 'pending'
+                              OR json_extract(result_json, '$.receipt_kind') = 'manual_required')) AS exhausted
                    FROM trade_inbox"""
             ).fetchone()
             rows = conn.execute(
@@ -981,6 +1173,9 @@ def trade_inbox_summary(path: str | Path) -> dict[str, Any]:
             0,
         ),
         "conflict_count": counts.get("conflict", 0),
+        "receipt_status_counts": receipt_status_counts,
+        "receipt_kind_counts": receipt_kind_counts,
+        "receipt_attention": receipt_attention,
         "retryable_count": int(eligibility["eligible"] or 0),
         "exhausted_count": int(eligibility["exhausted"] or 0),
         "max_attempt_count": max(
@@ -1174,7 +1369,6 @@ def claim_settlement_attempt(
     )
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             cursor = conn.execute(
                 """
@@ -1241,7 +1435,6 @@ def reserve_settlement_attempt_invocation(
     inbox_path.parent.mkdir(parents=True, exist_ok=True)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             cursor = conn.execute(
                 """
@@ -1335,7 +1528,6 @@ def mark_settlement_attempt_provider_started(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             cursor = conn.execute(
                 """
@@ -1404,7 +1596,6 @@ def finish_settlement_attempt_provider_invocation(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             current = _read_settlement_attempt_row(
                 conn,
@@ -1534,7 +1725,6 @@ def replace_finished_settlement_attempt_provider_invocation(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             current = _read_settlement_attempt_row(
                 conn,
@@ -1718,7 +1908,6 @@ def reconcile_settlement_attempt_invocation(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             current = _read_settlement_attempt_row(
                 conn,
@@ -1870,7 +2059,6 @@ def claim_settlement_provider_batch(
     inbox_path.parent.mkdir(parents=True, exist_ok=True)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             cursor = conn.execute(
                 """
@@ -1918,7 +2106,6 @@ def renew_settlement_provider_batch_claim(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             cursor = conn.execute(
                 """
@@ -1952,7 +2139,6 @@ def release_settlement_provider_batch_claim(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             cursor = conn.execute(
                 """
@@ -1995,7 +2181,6 @@ def renew_settlement_attempt_claim(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             cursor = conn.execute(
                 """
@@ -2041,7 +2226,6 @@ def complete_settlement_attempt(
     inbox_path = Path(path)
     with closing(_connect(inbox_path)) as conn:
         _ensure_schema(conn)
-        conn.execute("BEGIN IMMEDIATE")
         try:
             current = _read_settlement_attempt_row(
                 conn,
@@ -2280,7 +2464,7 @@ def require_trade_inbox_store_readable(path: str | Path) -> None:
 def _connect(path: Path) -> sqlite3.Connection:
     conn = connect_private_sqlite(path, timeout=30)
     conn.row_factory = sqlite3.Row
-    conn.create_function("trade_inbox_writer_version", 0, lambda: 1)
+    conn.create_function("trade_inbox_writer_version", 0, lambda: 2)
     return conn
 
 
@@ -2340,6 +2524,8 @@ def _settlement_attempt_scope(
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
+    if not conn.in_transaction:
+        conn.execute("BEGIN IMMEDIATE")
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS trade_inbox (
@@ -2456,7 +2642,11 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         "portfolio_refresh_attempted_at_ms",
         "INTEGER",
     )
+    # Economic retry due time must survive metadata/enrichment updates to updated_at_ms.
+    retry_deadline_missing = "next_attempt_at_ms" not in {
+        row["name"] for row in conn.execute("PRAGMA table_info(trade_inbox)")}
     for column, sql_type in (
+        ("next_attempt_at_ms", "INTEGER NOT NULL DEFAULT 0"),
         ("payload_version", "INTEGER NOT NULL DEFAULT 1"),
         ("claim_id", "TEXT"), ("claim_until_ms", "INTEGER"), ("claim_owner", "TEXT"),
         ("result_json", "TEXT"), ("receipt_json", "TEXT"),
@@ -2476,6 +2666,24 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         ON trade_inbox_evidence(inbox_id)
         WHERE evidence_id IS NULL OR evidence_json IS NULL"""
     )
+    conn.execute("""CREATE TABLE IF NOT EXISTS trade_inbox_recovery (
+        inbox_id TEXT NOT NULL, operator TEXT NOT NULL, resumed_at_ms INTEGER NOT NULL)""")
+    for table in ("trade_inbox", "trade_inbox_evidence", "trade_inbox_recovery"):
+        if not conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)).fetchone():
+            continue
+        for operation in ("INSERT", "UPDATE", "DELETE"):
+            name = f"{table}_{operation.lower()}_writer_guard"
+            guard = conn.execute("SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?", (name,)).fetchone()
+            if guard and "trade_inbox_writer_version() != 2" in guard[0]:
+                continue
+            if guard and "trade_inbox_writer_version() != 1" not in guard[0]:
+                raise ValueError("unsupported trade inbox writer guard")
+            conn.execute(f"DROP TRIGGER IF EXISTS {name}")
+            conn.execute(f"""CREATE TRIGGER {name} BEFORE {operation} ON {table}
+                WHEN trade_inbox_writer_version() != 2
+                BEGIN SELECT RAISE(ABORT, 'trade inbox requires compatible writer'); END""")
+    if retry_deadline_missing:
+        conn.execute("UPDATE trade_inbox SET next_attempt_at_ms = updated_at_ms + 60000 WHERE attempt_count > 0")
     _migrate_trade_source_evidence(conn)
     conn.execute(
         """CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_inbox_evidence_id
@@ -2483,12 +2691,6 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     )
     conn.execute("""CREATE TABLE IF NOT EXISTS trade_inbox_recovery (
         inbox_id TEXT NOT NULL, operator TEXT NOT NULL, resumed_at_ms INTEGER NOT NULL)""")
-    for table in ("trade_inbox", "trade_inbox_evidence", "trade_inbox_recovery"):
-        for operation in ("INSERT", "UPDATE", "DELETE"):
-            conn.execute(f"""CREATE TRIGGER IF NOT EXISTS {table}_{operation.lower()}_writer_guard
-                BEFORE {operation} ON {table}
-                WHEN trade_inbox_writer_version() != 1
-                BEGIN SELECT RAISE(ABORT, 'trade inbox requires compatible writer'); END""")
     existing_attempt_columns = {
         str(row["name"])
         for row in conn.execute(

--- a/src/application/trades/inbox.py
+++ b/src/application/trades/inbox.py
@@ -220,6 +220,8 @@ def enqueue_trade_payload(
                 conn.execute(
                     """UPDATE trade_inbox SET payload_version = payload_version + 1,
                        claim_id = NULL, claim_until_ms = NULL, updated_at_ms = ?,
+                       next_attempt_at_ms = CASE WHEN status = 'handled' THEN 0
+                           ELSE next_attempt_at_ms END,
                        receipt_recovery_allowed = CASE
                            WHEN status = 'handled' AND ? THEN 0
                            ELSE receipt_recovery_allowed END,

--- a/src/application/trades/intake.py
+++ b/src/application/trades/intake.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import sqlite3
 from typing import Any, Callable, Mapping, Protocol, cast
 
 from domain.domain.trade_execution import normalize_execution_input
@@ -27,7 +28,7 @@ TRADE_INTAKE_SOURCE_CONTEXT_SCHEMA = "trade_intake_source.v1"
 def _payload_deal_id(payload: dict[str, Any] | None) -> str | None:
     if not isinstance(payload, dict):
         return None
-    for key in ("deal_id", "dealID", "id"):
+    for key in ("deal_id", "dealID", "id", "external_execution_id"):
         raw = payload.get(key)
         value = str(raw or "").strip()
         if value:
@@ -96,6 +97,19 @@ def _exception_result_dict(
         position_effect = str(getattr(deal, "position_effect", "") or "").strip().lower()
         if position_effect in {"open", "close"}:
             action = position_effect
+    sqlite_code = getattr(exc, "sqlite_errorcode", None)
+    primary_code = (sqlite_code & 0xff) if isinstance(sqlite_code, int) else None
+    transient = isinstance(exc, sqlite3.OperationalError) and (
+        primary_code in {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED, sqlite3.SQLITE_PROTOCOL}
+        or (primary_code is None and str(exc).lower() in {
+            "database is locked", "database table is locked", "locking protocol",
+        })
+    )
+    category = ("sqlite_transient" if transient else "storage_permission" if isinstance(exc, PermissionError)
+                or primary_code in {sqlite3.SQLITE_PERM, sqlite3.SQLITE_READONLY, sqlite3.SQLITE_AUTH}
+                else "storage_full" if primary_code == sqlite3.SQLITE_FULL
+                else "storage_schema" if isinstance(exc, sqlite3.Error)
+                else "invalid_input" if stage == "normalize" else "processing_error")
     return {
         "status": "failed",
         "action": action,
@@ -107,7 +121,9 @@ def _exception_result_dict(
             "exception_stage": str(stage),
             "exception_type": type(exc).__name__,
             "exception_message": str(exc),
-            "retryable": bool(retryable),
+            "retryable": bool(retryable and transient),
+            "failure_category": category,
+            "sqlite_errorcode": sqlite_code,
         },
     }
 
@@ -366,7 +382,7 @@ def _finalize_trade_payload_result(
                 "payload": payload,
                 "effective_payload": effective_payload,
                 "deal": deal,
-                "result": dict(result_dict),
+                "result": result_dict,
                 "state": state,
                 "apply_changes": apply_changes,
                 "state_path": state_path,
@@ -540,6 +556,8 @@ def process_trade_payload(
             stage="normalize",
             retryable=True,
         )
+        if before_receipt_fn is not None:
+            result_dict = before_receipt_fn(result_dict) or result_dict
         append_trade_intake_audit_fn(
             audit_path,
             build_trade_intake_audit_event("failed", source=source, payload=effective_payload, result=result_dict),
@@ -594,7 +612,6 @@ def process_trade_payload(
         )
         if portfolio_refresh_intent is not None:
             result_dict["portfolio_refresh_intent"] = portfolio_refresh_intent
-        append_trade_intake_audit_fn(audit_path, build_trade_intake_audit_event("resolved", source=source, deal=deal, result=result_dict))
     except TradePayloadClaimLost:
         raise
     except Exception as exc:
@@ -607,65 +624,45 @@ def process_trade_payload(
         )
         if portfolio_refresh_intent is not None:
             result_dict["portfolio_refresh_intent"] = portfolio_refresh_intent
-        append_trade_intake_audit_fn(
-            audit_path,
-            build_trade_intake_audit_event("failed", source=source, deal=deal, result=result_dict),
-        )
-        if apply_changes:
-            state = _record_failed_deal_state(
-                state=state,
-                state_path=state_path,
-                result_dict=result_dict,
-                write_trade_intake_state_fn=write_trade_intake_state_fn,
-                upsert_deal_state_fn=upsert_deal_state_fn,
-                deal_key=broker_deal_key(deal),
-            )
-        return _finalize_trade_payload_result(
-            result_dict=result_dict,
-            state=state,
-            state_path=state_path,
-            audit_path=audit_path,
-            payload=payload,
-            effective_payload=effective_payload,
-            deal=deal,
-            apply_changes=apply_changes,
-            write_trade_intake_state_fn=write_trade_intake_state_fn,
-            append_trade_intake_audit_fn=append_trade_intake_audit_fn,
-            on_result_fn=on_result_fn,
-            source=source,
-        )
 
     if before_receipt_fn is not None:
         enriched_result = before_receipt_fn(result_dict)
         if isinstance(enriched_result, dict):
             result_dict = enriched_result
 
+    append_trade_intake_audit_fn(
+        audit_path,
+        build_trade_intake_audit_event(
+            "failed" if result_dict.get("status") == "failed" else "resolved",
+            source=source, deal=deal, result=result_dict,
+        ),
+    )
     deal_key = broker_deal_key(deal)
     economic_payload_hash = lifecycle_deal_economic_hash(deal)
     if apply_changes and deal_key:
-        if result.status == "applied" or _is_terminal_ledger_result(result_dict):
-            reconciled_terminal = result.status != "applied"
+        if result_dict.get("status") == "applied" or _is_terminal_ledger_result(result_dict):
+            reconciled_terminal = result_dict.get("status") != "applied"
             state = upsert_deal_state_fn(
                 state,
                 bucket="processed_deal_ids",
                 deal_id=deal_key,
                 payload={
                     "status": "reconciled" if reconciled_terminal else "applied",
-                    "action": result.action,
-                    "account": result.account,
+                    "action": result_dict.get("action"),
+                    "account": result_dict.get("account"),
                     "source_deal_id": deal.deal_id,
                     "futu_account_id": deal.futu_account_id,
                     "broker_deal_key": deal_key,
                     "economic_payload_hash": economic_payload_hash,
-                    "applied_record_ids": [op.record_id for op in result.operations if op.record_id],
-                    "reason": result.reason,
+                    "applied_record_ids": [op["record_id"] for op in result_dict.get("operations", []) if op.get("record_id")],
+                    "reason": result_dict.get("reason"),
                     "diagnostics": (
                         {
                             "reconciled_from": "terminal_ledger_result",
                             **dict(result_dict.get("diagnostics") or {}),
                         }
                         if reconciled_terminal
-                        else {}
+                        else dict(result_dict.get("diagnostics") or {})
                     ),
                 },
             )
@@ -676,7 +673,7 @@ def process_trade_payload(
                     "phase": "ledger_persisted",
                     "source": source,
                     "deal_id": deal.deal_id,
-                    "account": result.account,
+                    "account": result_dict.get("account"),
                     "event_id": deal_key,
                 },
             )
@@ -687,8 +684,8 @@ def process_trade_payload(
                 deal_id=deal_key,
                 payload={
                     "status": "skipped",
-                    "action": result.action,
-                    "account": result.account,
+                    "action": result_dict.get("action"),
+                    "account": result_dict.get("account"),
                     "source_deal_id": deal.deal_id,
                     "futu_account_id": deal.futu_account_id,
                     "broker_deal_key": deal_key,
@@ -699,7 +696,7 @@ def process_trade_payload(
                 },
             )
             write_trade_intake_state_fn(state_path, state)
-        elif result.status == "unresolved":
+        elif result_dict.get("status") == "unresolved":
             try:
                 prior = dict((state.get("unresolved_deal_ids") or {}).get(deal_key) or {})
             except Exception:
@@ -708,14 +705,14 @@ def process_trade_payload(
             retryable = bool(diagnostics.get("retryable"))
             payload = {
                 "status": "unresolved",
-                "action": result.action,
-                "account": result.account,
+                "action": result_dict.get("action"),
+                "account": result_dict.get("account"),
                 "source_deal_id": deal.deal_id,
                 "futu_account_id": deal.futu_account_id,
                 "broker_deal_key": deal_key,
                 "economic_payload_hash": economic_payload_hash,
                 "applied_record_ids": [],
-                "reason": result.reason,
+                "reason": result_dict.get("reason"),
                 "retryable": retryable,
                 "attempt_count": int(prior.get("attempt_count") or 0) + 1,
                 "diagnostics": diagnostics,
@@ -730,18 +727,18 @@ def process_trade_payload(
                 payload=payload,
             )
             write_trade_intake_state_fn(state_path, state)
-        elif result.status == "failed":
+        elif result_dict.get("status") == "failed":
             prior_receipt = _prior_receipt(state, deal_key)
             payload = {
                 "status": "failed",
-                "action": result.action,
-                "account": result.account,
+                "action": result_dict.get("action"),
+                "account": result_dict.get("account"),
                 "source_deal_id": deal.deal_id,
                 "futu_account_id": deal.futu_account_id,
                 "broker_deal_key": deal_key,
                 "economic_payload_hash": economic_payload_hash,
                 "applied_record_ids": [],
-                "reason": result.reason,
+                "reason": result_dict.get("reason"),
                 "diagnostics": dict(result_dict.get("diagnostics") or {}),
             }
             if prior_receipt:

--- a/src/application/trades/receipt.py
+++ b/src/application/trades/receipt.py
@@ -46,7 +46,7 @@ def send_trade_intake_receipt(
     decision = decide_trade_intake_receipt(
         receipt_config=cfg,
         apply_changes=apply_changes,
-        state=state,
+        state={} if inbox_path is not None and inbox_id else state,
         deal_id=(
             str(broker_deal_key(deal) or "").strip()
             or _deal_id(deal, result, payload)
@@ -93,12 +93,15 @@ def send_trade_intake_receipt(
             attempt = begin_trade_receipt_attempt(
                 inbox_path, inbox_id=inbox_id, message=message,
                 route={key: route.get(key) for key in ("provider", "channel", "target")},
-                claim=inbox_claim,
+                claim=inbox_claim, result_key=result.get("receipt_result_key"),
             )
             if not attempt["claimed"]:
                 return {"enabled": True, "status": "skipped",
                         "reason": f"durable_receipt_{attempt['status']}",
                         "delivery_confirmed": attempt["status"] == "sent", "message_id": None}
+        if attempt is not None:
+            message = attempt["message"]
+            provider, channel, target = (attempt["route"][key] for key in ("provider", "channel", "target"))
         send_result = resolved_send_fn(
             base=base,
             channel=str(channel),
@@ -672,6 +675,8 @@ def decide_trade_intake_receipt(
 
     status = str(result.get("status") or "").strip().lower()
     reason = str(result.get("reason") or "").strip().lower()
+    if result.get("receipt_kind") == "verification_pending":
+        status = str((result.get("diagnostics") or {}).get("notification_category") or status)
     if status == "applied":
         return {"should_send": bool(cfg.get("notify_applied", True)), "reason": "applied"}
     if status == "unresolved":
@@ -728,7 +733,14 @@ def build_trade_intake_receipt_message(
     diagnostics_raw = result.get("diagnostics")
     diagnostics = cast(dict[str, Any], diagnostics_raw) if isinstance(diagnostics_raw, dict) else {}
     needs_lot_confirmation = status == "unresolved" and reason == "ambiguous_assigned_stock_sale"
-    if status == "failed" and reason == "projection_verification_failed":
+    kind = result.get("receipt_kind")
+    if kind == "verification_pending":
+        status_text = "⚠️ 记录状态待核对"
+    elif kind == "pending_retry":
+        status_text = "⚠️ 暂未记录"
+    elif kind == "recorded":
+        status_text = "✅ 已记录"
+    elif status == "failed" and reason == "projection_verification_failed":
         status_text = "❌ 写入异常"
     elif needs_lot_confirmation:
         status_text = "⚠️ 待确认"
@@ -779,13 +791,43 @@ def build_trade_intake_receipt_message(
                 f" · 预期 {first_check.get('expected_contracts_open_after')}",
             )
         )
-    if ledger_store:
+    if ledger_store and not kind:
         fields.append(("账本", ledger_store.get("sqlite_path") or "-"))
-    if _matching_auto_combo_adoption(result):
+    if (result.get("combo_reconciliation") or {}).get("ok") is False:
+        fields.append(("组合", "组合核对未完成；请检查组合核对服务。"))
+    elif _matching_auto_combo_adoption(result):
         fields.append(("组合", "✅ 已自动归入 Combo Yield（Funding Put + Participation Call）"))
     elif _combo_yield_relation_pending(diagnostics):
         fields.append(("组合", "关系待确认；未提供 pair_intent_id，当前按单腿记录，未自动归入 Combo Yield 组。"))
-    fields.append(("诊断", reason))
+    if kind:
+        cause = {
+            "sqlite_transient": "数据库短暂争用，本次记录未完成",
+            "storage_permission": "数据库写入权限不足",
+            "storage_full": "数据库存储空间不足",
+            "storage_schema": "数据库结构或存储异常",
+            "invalid_input": "成交信息不完整或不符合记录要求",
+            "processing_error": "成交处理异常，需要检查记录服务",
+        }.get(diagnostics.get("failure_category"), {
+            "interrupted_before_recording": "处理进程中断；已核对本次尚未记录",
+        }.get(reason, reason))
+        policy = result.get("retry_policy") or {}
+        if kind == "recorded":
+            cause = "自动恢复后已确认记录成功" if diagnostics.get("recovered_from_ledger") or int(policy.get("attempt_count", 0)) > 1 else "已确认记录成功"
+            fields.append(("处理", "无需重复录入"))
+        elif kind == "verification_pending":
+            cause = "暂时无法确认账本记录状态"
+            fields.append(("重试", "每 60 秒自动核对；核对前不会重复录入"))
+            fields.append(("处理", "无需重复提交；持续未恢复时请检查记录服务"))
+        elif kind == "pending_retry" and policy.get("retryable"):
+            fields.append(("重试", f"最早 60 秒后自动重试，剩余 {policy['remaining']} 次；恢复后发送成功回执"))
+            fields.append(("处理", "无需重复提交"))
+        else:
+            exhausted = int(policy.get("attempt_count", 0)) >= int(policy.get("max_attempts", 20))
+            fields.append(("重试", f"记录尝试已达 {policy['max_attempts']} 次，不会自动重试" if exhausted else "不会自动重试"))
+            fields.append(("处理", "请检查上述原因，修复后由操作员恢复处理"))
+        fields.append(("诊断", cause))
+    else:
+        fields.append(("诊断", reason))
     sections: list[tuple[str, list[str]]] = []
     if needs_lot_confirmation:
         candidate_lines = _assigned_stock_candidate_lines(diagnostics)

--- a/src/application/trades/receipt_compensation.py
+++ b/src/application/trades/receipt_compensation.py
@@ -4,7 +4,8 @@ import fcntl
 import hashlib
 import json
 import os
-from contextlib import contextmanager
+import sqlite3
+from contextlib import closing, contextmanager
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Callable, Iterator
@@ -32,6 +33,8 @@ from src.application.trades.deal_identity import (
 from src.application.trades.lifecycle_outbox import (
     build_notification_batch_route,
 )
+from src.application.trades.inbox import read_trade_payload
+from src.application.trades.inbox_authority import resolve_execution_inbox_path
 from src.application.trades.receipt import (
     classify_trade_lifecycle_delivery_result,
 )
@@ -77,6 +80,9 @@ def compensate_trade_intake_receipts(
 
     source = _select_source(sources, account=account)
     if not apply_changes:
+        managed = _inbox_managed_result(source, repo=repo, account=account, deal_ids=deal_ids)
+        if managed is not None:
+            return {**managed, "dry_run": True}
         plan = _build_plan(
             config=config,
             source=source,
@@ -96,6 +102,9 @@ def compensate_trade_intake_receipts(
 
     lock_path = Path(source["state_path"]).parent / "receipt_compensations.lock"
     with _exclusive_lock(lock_path):
+        managed = _inbox_managed_result(source, repo=repo, account=account, deal_ids=deal_ids)
+        if managed is not None:
+            return {**managed, "dry_run": False}
         plan = _build_plan(
             config=config,
             source=source,
@@ -109,6 +118,12 @@ def compensate_trade_intake_receipts(
             plan,
             expected_payload_hash=expected_payload_hash,
         )
+        if not Path(plan["record_path"]).exists():
+            evidence = _legacy_compensation_evidence(source, account=account, deal_ids=plan["deal_ids"])
+            if evidence["blocked"]:
+                return {**_public_plan(plan), "ok": False, "status": "duplicate_suppressed",
+                        "dry_run": False, "write_applied": False,
+                        "suppression_reason": "overlapping_compensation", "compensation_evidence": evidence}
         return _execute_plan(
             base=base,
             plan=plan,
@@ -117,6 +132,82 @@ def compensate_trade_intake_receipts(
             adapter_selector=adapter_selector,
             now_fn=now_fn,
         )
+
+
+def _inbox_managed_result(source: dict[str, Any], *, repo: Any, account: str,
+                          deal_ids: list[str]) -> dict[str, Any] | None:
+    canonical = _canonical_deal_ids(deal_ids, account=account)
+    requested = source.get("inbox_path") or Path(source["state_path"]).with_name("trade_intake_inbox.sqlite3")
+    path = resolve_execution_inbox_path(repo, requested)
+    if not path.exists():
+        return None
+    keys = set(canonical)
+    for event in active_ledger_events(_list_trade_events(repo)):
+        aliases = structured_deal_keys_from_ledger_event(event)
+        if aliases.intersection(canonical):
+            keys.update(aliases)
+    with closing(sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)) as conn:
+        placeholders = ",".join("?" for _ in keys)
+        rows = conn.execute(f"SELECT inbox_id FROM trade_inbox WHERE broker_deal_key IN ({placeholders})",
+                            sorted(keys)).fetchall()
+    managed = []
+    for (inbox_id,) in rows:
+        row = read_trade_payload(path, inbox_id=inbox_id, read_only=True)
+        envelope = row.get("receipt_envelope") if row else None
+        if envelope and envelope.get("schema_version") == 2:
+            managed.append({"inbox_id": inbox_id, "current_result_key": envelope["current_result_key"],
+                            "receipt": row["receipt"], "retry_policy": (row.get("result") or {}).get("retry_policy")})
+    if not managed:
+        return None
+    return {"ok": False, "status": "inbox_managed", "write_applied": False,
+            "account": account, "deal_ids": canonical, "inbox_receipts": managed,
+            "recovery_strategy": "Use Inbox recovery; inspect unknown or exhausted delivery before separately authorized resend."}
+
+
+@contextmanager
+def receipt_compensation_takeover(*, source: dict[str, Any], account: str,
+                                  canonical_deal_id: str) -> Iterator[dict[str, Any]]:
+    """Inspect legacy sends and prepare Inbox ownership under one lock; send after exit."""
+    canonical = _canonical_deal_ids([canonical_deal_id], account=account)
+    if str(source.get("account") or "").strip() != account:
+        raise ValueError("receipt compensation takeover source account mismatch")
+    with _exclusive_lock(Path(source["state_path"]).parent / "receipt_compensations.lock"):
+        yield _legacy_compensation_evidence(source, account=account, deal_ids=canonical)
+
+
+def _legacy_compensation_evidence(source: dict[str, Any], *, account: str,
+                                  deal_ids: list[str]) -> dict[str, Any]:
+    matches = []
+    directory = Path(source["state_path"]).parent / "receipt_compensations"
+    for path in sorted(directory.glob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(record, dict) or record.get("schema_version") != COMPENSATION_SCHEMA_VERSION:
+                raise ValueError("unsupported compensation schema")
+            record_account = record["account"]
+            members = _canonical_deal_ids(record["deal_ids"], account=record_account)
+            if (record.get("compensation_id") != _compensation_id(account=record_account, deal_ids=members)
+                    or path.stem != record["compensation_id"]):
+                raise ValueError("compensation identity mismatch")
+            member_rows = record["members"]
+            if (not isinstance(member_rows, list)
+                    or any(not isinstance(item, dict) or item.get("account") != record_account for item in member_rows)
+                    or sorted(item.get("canonical_deal_id") for item in member_rows) != members):
+                raise ValueError("compensation members mismatch")
+            if record_account != account or not set(members).intersection(deal_ids):
+                continue
+            # Legacy compensation messages only describe recorded trades.
+            status = str(record.get("status") or "unknown")
+            safe_failure = (status == "explicit_failed" and record.get("explicit_pre_acceptance_failure") is True
+                            and not record.get("delivery_confirmed") and not record.get("message_id"))
+            matches.append({"compensation_id": record["compensation_id"], "status": status,
+                            "deal_ids": members, "blocks_recorded": not safe_failure})
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            raise ValueError(f"unverifiable receipt compensation evidence: {path.name}") from exc
+    blocked = any(item["blocks_recorded"] for item in matches)
+    status = ("confirmed" if any(item["status"] == "confirmed" for item in matches)
+              else "unknown" if blocked else "clear")
+    return {"blocked": blocked, "status": status, "result_key": "recorded", "records": matches}
 
 
 def _select_source(
@@ -933,4 +1024,5 @@ __all__ = [
     "COMPENSATION_SCHEMA_VERSION",
     "LEGACY_FALSE_OUTBOX_REASON",
     "compensate_trade_intake_receipts",
+    "receipt_compensation_takeover",
 ]

--- a/src/infrastructure/futu_trade_push.py
+++ b/src/infrastructure/futu_trade_push.py
@@ -50,11 +50,18 @@ class OpenDTradePushListener:
         TradeDealHandlerBase: Any = getattr(futu_mod, "TradeDealHandlerBase")
 
         class DealHandler(TradeDealHandlerBase):
-            def __init__(self, callback: Callable[[dict[str, Any]], None]) -> None:
+            def __init__(self, callback: Callable[[dict[str, Any], dict[str, Any] | None], None]) -> None:
                 super().__init__()
                 self._callback = callback
 
             def on_recv_rsp(self, rsp_pb: Any) -> tuple[int, Any]:
+                # The SDK DataFrame drops accID; retain protobuf presence before conversion.
+                header = getattr(getattr(rsp_pb, "s2c", None), "header", None)
+                header_fields = {
+                    key: getattr(header, key)
+                    for key in ("accID", "trdEnv")
+                    if header is not None and header.HasField(key)
+                }
                 ret, data = super().on_recv_rsp(rsp_pb)
                 if ret == 0 and data is not None:
                     rows = data.to_dict("records") if hasattr(data, "to_dict") else []
@@ -62,7 +69,7 @@ class OpenDTradePushListener:
                         for row in rows:
                             if isinstance(row, dict):
                                 try:
-                                    self._callback(row)
+                                    self._callback(row, header_fields if header is not None else None)
                                 except Exception as exc:
                                     print(
                                         f"[WARN] trade push callback failed: {type(exc).__name__}: {exc}",
@@ -88,6 +95,7 @@ class OpenDTradePushListener:
                 last_error = exc
         if ctx is None:
             raise RuntimeError(f"failed to initialize OpenSecTradeContext: {last_error}")
+        ctx.set_sync_query_connect_timeout(2)
         environments: dict[str, str] = {}
         ambiguous_accounts: set[str] = set()
         try:
@@ -104,12 +112,42 @@ class OpenDTradePushListener:
             # Missing account evidence remains unbound; never infer REAL from an account ID.
             pass
 
-        def receive(row: dict[str, Any]) -> None:
+        def receive(row: dict[str, Any], header: dict[str, Any] | None) -> None:
+            payload = dict(row)
+            errors: list[str] = []
             visible = extract_visible_account_fields(row)
             physical_ids = {value for key, value in visible.items() if key != "account"}
+            if any(not value.isascii() or not value.isdecimal() or int(value) <= 0 for value in physical_ids):
+                errors.append("invalid:push_physical_account")
+            if header is not None:
+                payload["_trade_intake_push_header"] = header
+                header_id = header.get("accID")
+                header_env = header.get("trdEnv")
+                if header_id is None:
+                    errors.append("missing:push_header_physical_account")
+                elif type(header_id) is not int or header_id <= 0:
+                    errors.append("invalid:push_header_physical_account")
+                else:
+                    physical_ids.add(str(header_id))
+                    if not visible.get("acc_id"):
+                        payload["acc_id"] = str(header_id)
+                if header_env is None:
+                    errors.append("missing:push_header_environment")
+                else:
+                    environment_name = (
+                        futu_mod.TrdEnv.to_string2(header_env) if type(header_env) is int else ""
+                    )
+                    if environment_name not in {"REAL", "SIMULATE"}:
+                        errors.append("invalid:push_header_environment")
+                    else:
+                        for key in ("environment", "trd_env"):
+                            supplied = str(row.get(key) or "").strip().rsplit(".", 1)[-1].upper()
+                            if supplied and supplied != environment_name:
+                                errors.append(f"conflict:push_{key}")
+                        if not row.get("trd_env"):
+                            payload["trd_env"] = environment_name
             physical = next(iter(physical_ids)) if len(physical_ids) == 1 else ""
             environment = environments.get(physical)
-            errors: list[str] = []
             if not physical_ids:
                 errors.append("missing:push_physical_account")
             elif len(physical_ids) != 1:
@@ -130,10 +168,9 @@ class OpenDTradePushListener:
                 if supplied and supplied != value:
                     errors.append(f"conflict:push_{key}")
             for key in ("environment", "trd_env"):
-                supplied = str(row.get(key) or "").strip().rsplit(".", 1)[-1].upper()
+                supplied = str(payload.get(key) or "").strip().rsplit(".", 1)[-1].upper()
                 if environment and supplied and supplied != environment:
                     errors.append(f"conflict:push_{key}")
-            payload = dict(row)
             if errors:
                 payload["_trade_intake_source_identity_errors"] = sorted(set(errors))
                 payload["_trade_intake_source_account_evidence"] = {
@@ -151,7 +188,10 @@ class OpenDTradePushListener:
             self.on_deal(payload)
         return ctx, DealHandler(receive)
 
-    def start(self, *, cancel_event: threading.Event | None = None) -> None:
+    def start(
+        self, *, cancel_event: threading.Event | None = None,
+        on_wait: Callable[[], None] | None = None,
+    ) -> None:
         results: queue.Queue[tuple[str, Any, Any]] = queue.Queue(maxsize=1)
         auth_required = threading.Event()
         auth_evidence: dict[str, str] = {}
@@ -196,6 +236,8 @@ class OpenDTradePushListener:
                 try:
                     result, value, handler = results.get(timeout=0.1)
                 except queue.Empty:
+                    if on_wait is not None and not (cancel_event is not None and cancel_event.is_set()):
+                        on_wait()
                     continue
                 if result == "error":
                     raise value

--- a/src/infrastructure/private_storage.py
+++ b/src/infrastructure/private_storage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import errno
 import fcntl
 import os
 import sqlite3
@@ -205,7 +204,26 @@ def open_private_text(path: str | Path, *, encoding: str = "utf-8") -> Iterator[
 
 
 def connect_private_sqlite(path: str | Path, **kwargs: Any) -> sqlite3.Connection:
-    target = ensure_private_file(path)
+    target = private_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True, mode=PRIVATE_DIRECTORY_MODE)
+    _secure_sqlite_directory(target.parent)
+    try:
+        target.lstat()
+    except FileNotFoundError:
+        descriptor, temp_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
+        try:
+            try:
+                os.fchmod(descriptor, PRIVATE_FILE_MODE)
+            finally:
+                os.close(descriptor)
+            # Close before publication: another SQLite connection may immediately lock this inode.
+            try:
+                os.link(temp_name, target, follow_symlinks=False)
+            except FileExistsError:
+                pass
+        finally:
+            os.unlink(temp_name)
+    _secure_sqlite_file(target)
     connection = sqlite3.connect(str(target), **kwargs)
     try:
         secure_sqlite_artifacts(target)
@@ -218,32 +236,46 @@ def connect_private_sqlite(path: str | Path, **kwargs: Any) -> sqlite3.Connectio
     return connection
 
 
+def _secure_sqlite_directory(path: Path) -> None:
+    before = path.lstat()
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISDIR(before.st_mode):
+        raise OSError(f"sensitive SQLite directory must be a directory, not a symlink: {path.name}")
+    os.chmod(path, PRIVATE_DIRECTORY_MODE, follow_symlinks=False)
+    after = path.lstat()
+    if (
+        not stat.S_ISDIR(after.st_mode)
+        or (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino)
+        or stat.S_IMODE(after.st_mode) != PRIVATE_DIRECTORY_MODE
+    ):
+        raise OSError(f"sensitive SQLite directory changed during permission maintenance: {path.name}")
+
+
+def _secure_sqlite_file(path: Path) -> None:
+    before = path.lstat()
+    if stat.S_ISLNK(before.st_mode):
+        raise OSError(f"sensitive SQLite artifact must not be a symlink: {path.name}")
+    if not stat.S_ISREG(before.st_mode):
+        raise OSError(f"sensitive SQLite artifact is not a regular file: {path.name}")
+    # Opening and closing an existing inode releases this process's POSIX SQLite locks.
+    os.chmod(path, PRIVATE_FILE_MODE, follow_symlinks=False)
+    after = path.lstat()
+    if (
+        not stat.S_ISREG(after.st_mode)
+        or (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino)
+        or stat.S_IMODE(after.st_mode) != PRIVATE_FILE_MODE
+    ):
+        raise OSError(f"sensitive SQLite artifact changed during permission maintenance: {path.name}")
+
+
 def secure_sqlite_artifacts(path: str | Path) -> None:
     target = private_path(path)
+    _secure_sqlite_directory(target.parent)
     for candidate in (target, *(Path(f"{target}{suffix}") for suffix in _SQLITE_SIDECAR_SUFFIXES)):
-        flags = (
-            os.O_RDONLY
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-            | getattr(os, "O_NONBLOCK", 0)
-        )
         try:
-            descriptor = os.open(candidate, flags)
+            _secure_sqlite_file(candidate)
         except FileNotFoundError:
             if candidate == target:
                 raise OSError(f"sensitive SQLite artifact is missing: {candidate.name}") from None
-            continue
-        except OSError as exc:
-            if exc.errno == errno.ELOOP:
-                raise OSError(f"sensitive SQLite artifact must not be a symlink: {candidate.name}") from exc
-            raise
-        try:
-            file_stat = os.fstat(descriptor)
-            if not stat.S_ISREG(file_stat.st_mode):
-                raise OSError(f"sensitive SQLite artifact is not a regular file: {candidate.name}")
-            os.fchmod(descriptor, PRIVATE_FILE_MODE)
-        finally:
-            os.close(descriptor)
 
 
 __all__ = [

--- a/tests/test_order_fee_namespace.py
+++ b/tests/test_order_fee_namespace.py
@@ -1,5 +1,6 @@
 from dataclasses import replace
 from pathlib import Path
+import sqlite3
 
 import pytest
 
@@ -8,6 +9,8 @@ from src.application.ledger.api import enrich_order_fees, execution_identity_fro
 from src.application.ledger.repository import SQLiteOptionPositionsRepository
 from src.application.trades import auto_intake
 from src.application.trades.auto_intake import _process_payload
+from src.application.trades.inbox import read_trade_payload
+from src.application.trades.inbox_authority import resolve_execution_inbox_path
 from src.application.trades.order_fee_sync import (
     fee_target_from_trusted_payload,
     recover_order_fee_targets,
@@ -41,7 +44,7 @@ def _intake(tmp_path: Path, repo, payload, *, replay=False):
         account_mapping={"123": "lx"}, futu_account_ids=["123"], host="127.0.0.1", port=11111,
         apply_changes=True, allow_external_lookup=False, source="file",
     )
-    assert result["status"] == "applied" or (replay and result["status"] == "skipped")
+    assert result["status"] == "applied" or (replay and result["status"] == "skipped"), result
 
 
 class _Provider:
@@ -244,3 +247,49 @@ def test_late_order_association_recovers_fee_target_after_ledger_commit(tmp_path
     if namespace != "futu.order":
         assert original == after
     assert recover_order_fee_targets(reopened, account="lx")["targets"] == []
+
+
+def test_late_order_association_preserves_pending_economic_retry_deadline(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    unknown = _payload("pending-order")
+    unknown.pop("external_order_id")
+    unknown.pop("external_order_namespace")
+    now = [_NOW_MS / 1000]
+    monkeypatch.setattr("src.application.trades.inbox.time.time", lambda: now[0])
+    calls = []
+    resolve = auto_intake.resolve_trade_deal
+
+    def fail_once(*args, **kwargs):
+        calls.append(True)
+        if len(calls) == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return resolve(*args, **kwargs)
+
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", fail_once)
+
+    def process(payload):
+        return _process_payload(
+            payload, repo=repo, state_path=tmp_path / "state.json", audit_path=tmp_path / "audit.jsonl",
+            account_mapping={"123": "lx"}, futu_account_ids=["123"], host="127.0.0.1", port=11111,
+            apply_changes=True, allow_external_lookup=False, source="file",
+        )
+
+    failed = process(unknown)
+    assert failed["receipt_kind"] == "pending_retry"
+    inbox = resolve_execution_inbox_path(repo, tmp_path / "unused.sqlite3")
+    before = read_trade_payload(inbox, inbox_id=failed["inbox_id"], read_only=True)
+    now[0] += 1
+    waiting = process(_payload("pending-order"))
+    assert waiting["status"] == "unresolved"
+    assert waiting["reason"] == "inbox_pending"
+    after = read_trade_payload(inbox, inbox_id=failed["inbox_id"], read_only=True)
+    assert after["next_attempt_at_ms"] == before["next_attempt_at_ms"]
+    assert after["attempt_count"] == before["attempt_count"] == 1
+    assert calls == [True]
+    assert repo.list_trade_events() == []
+    now[0] += 60
+    recovered = process(unknown)
+    assert recovered["status"] == "applied"
+    assert len(calls) == 2
+    assert len(repo.list_trade_events()) == len(repo.list_position_lots()) == 1
+    assert recover_order_fee_targets(repo, account="lx")["targets"] == [_TARGET]

--- a/tests/test_private_storage.py
+++ b/tests/test_private_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import stat
 from pathlib import Path
 import threading
@@ -314,21 +315,34 @@ def test_exclusive_private_file_lock_releases_after_body_exception(tmp_path: Pat
         assert _mode(lock_path) == 0o600
 
 
-def test_sqlite_artifact_helper_tolerates_sidecar_disappearing_before_open(
+@pytest.mark.parametrize("stage", ["stat", "chmod", "readback"])
+def test_sqlite_artifact_helper_tolerates_sidecar_disappearing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    stage: str,
 ) -> None:
     database = ensure_private_file(tmp_path / "private" / "inbox.sqlite3")
     journal = Path(f"{database}-journal")
     journal.write_bytes(b"transient")
-    real_open = os.open
+    real_lstat = Path.lstat
+    real_chmod = os.chmod
+    stats = 0
 
-    def open_after_journal_disappears(path: str | os.PathLike[str], flags: int) -> int:
-        if Path(path) == journal:
+    def stat_after_journal_disappears(path: Path):
+        nonlocal stats
+        if path == journal:
+            stats += 1
+        if path == journal and (stage == "stat" or (stage == "readback" and stats == 2)):
             journal.unlink()
-        return real_open(path, flags)
+        return real_lstat(path)
 
-    monkeypatch.setattr(private_storage.os, "open", open_after_journal_disappears)
+    def chmod_after_journal_disappears(path, mode, **kwargs):
+        if path == journal and stage == "chmod":
+            journal.unlink()
+        return real_chmod(path, mode, **kwargs)
+
+    monkeypatch.setattr(Path, "lstat", stat_after_journal_disappears)
+    monkeypatch.setattr(private_storage.os, "chmod", chmod_after_journal_disappears)
 
     secure_sqlite_artifacts(database)
 
@@ -336,7 +350,7 @@ def test_sqlite_artifact_helper_tolerates_sidecar_disappearing_before_open(
     assert not journal.exists()
 
 
-@pytest.mark.parametrize("artifact_kind", ["symlink", "directory"])
+@pytest.mark.parametrize("artifact_kind", ["symlink", "directory", "fifo"])
 def test_sqlite_artifact_helper_rejects_unsafe_sidecar(tmp_path: Path, artifact_kind: str) -> None:
     database = ensure_private_file(tmp_path / "private" / "inbox.sqlite3")
     journal = Path(f"{database}-journal")
@@ -345,8 +359,11 @@ def test_sqlite_artifact_helper_rejects_unsafe_sidecar(tmp_path: Path, artifact_
         outside.write_text("unchanged", encoding="utf-8")
         journal.symlink_to(outside)
         expected = "must not be a symlink"
-    else:
+    elif artifact_kind == "directory":
         journal.mkdir()
+        expected = "is not a regular file"
+    else:
+        os.mkfifo(journal)
         expected = "is not a regular file"
 
     with pytest.raises(OSError, match=expected):
@@ -397,3 +414,213 @@ def test_trade_inbox_ignores_permissive_umask(tmp_path: Path) -> None:
         assert _mode(database) == 0o600
     finally:
         os.umask(previous_umask)
+
+
+@pytest.mark.parametrize("artifact_kind", ["symlink", "directory", "fifo"])
+def test_sqlite_factory_rejects_unsafe_database(tmp_path: Path, artifact_kind: str) -> None:
+    database = tmp_path / "private" / "database.sqlite3"
+    database.parent.mkdir()
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"unchanged")
+    outside.chmod(0o644)
+    if artifact_kind == "symlink":
+        database.symlink_to(outside)
+    elif artifact_kind == "directory":
+        database.mkdir()
+    else:
+        os.mkfifo(database)
+    with pytest.raises(OSError, match="symlink|regular file"):
+        connect_private_sqlite(database)
+    assert outside.read_bytes() == b"unchanged"
+    assert _mode(outside) == 0o644
+
+
+@pytest.mark.parametrize("helper", [connect_private_sqlite, secure_sqlite_artifacts])
+def test_sqlite_helpers_reject_symlink_parent(tmp_path: Path, helper) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o755)
+    (outside / "database.sqlite3").touch(mode=0o644)
+    link = tmp_path / "link"
+    link.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(OSError, match="symlink"):
+        helper(link / "database.sqlite3")
+    assert _mode(outside) == 0o755
+    assert _mode(outside / "database.sqlite3") == 0o644
+
+
+def test_sqlite_helpers_do_not_open_existing_artifacts(tmp_path: Path, monkeypatch) -> None:
+    database = ensure_private_file(tmp_path / "private" / "database.sqlite3")
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        artifact = Path(f"{database}{suffix}")
+        artifact.touch()
+        artifact.chmod(0o666)
+
+    def unexpected_open(*args, **kwargs):
+        raise AssertionError("permission maintenance must not open existing artifacts")
+
+    monkeypatch.setattr(private_storage.os, "open", unexpected_open)
+    with connect_private_sqlite(database) as connection:
+        secure_sqlite_artifacts(database)
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        artifact = Path(f"{database}{suffix}")
+        if artifact.exists():
+            assert _mode(artifact) == 0o600
+
+
+@pytest.mark.parametrize("replacement", ["symlink", "regular", "directory"])
+def test_sqlite_metadata_rejects_path_replacement(tmp_path: Path, monkeypatch, replacement: str) -> None:
+    database = ensure_private_file(tmp_path / "private" / "database.sqlite3")
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"unchanged")
+    outside.chmod(0o644)
+    real_chmod = os.chmod
+
+    def replace_before_chmod(path, mode, **kwargs):
+        if path == database:
+            path.rename(path.with_suffix(".old"))
+            if replacement == "symlink":
+                path.symlink_to(outside)
+            elif replacement == "directory":
+                path.mkdir()
+            else:
+                path.touch()
+        assert kwargs == {"follow_symlinks": False}
+        return real_chmod(path, mode, **kwargs)
+
+    monkeypatch.setattr(private_storage.os, "chmod", replace_before_chmod)
+    with pytest.raises((OSError, NotImplementedError), match="changed|not implemented|not supported"):
+        secure_sqlite_artifacts(database)
+    assert outside.read_bytes() == b"unchanged"
+    assert _mode(outside) == 0o644
+
+
+@pytest.mark.parametrize("error", [PermissionError("denied"), NotImplementedError("no no-follow support")])
+def test_sqlite_metadata_errors_are_not_silenced(tmp_path: Path, monkeypatch, error) -> None:
+    database = ensure_private_file(tmp_path / "private" / "database.sqlite3")
+    journal = Path(f"{database}-journal")
+    journal.touch()
+    real_chmod = os.chmod
+
+    def failed_chmod(path, mode, **kwargs):
+        if path == journal:
+            raise error
+        return real_chmod(path, mode, **kwargs)
+
+    monkeypatch.setattr(private_storage.os, "chmod", failed_chmod)
+    with pytest.raises(type(error), match=str(error)):
+        secure_sqlite_artifacts(database)
+
+
+def test_sqlite_creation_publishes_closed_inode_and_preserves_competing_database(tmp_path: Path, monkeypatch) -> None:
+    database = tmp_path / "private" / "database.sqlite3"
+    real_mkstemp = private_storage.tempfile.mkstemp
+    real_link = os.link
+    descriptor = None
+    competitor = None
+
+    def tracked_mkstemp(**kwargs):
+        nonlocal descriptor
+        descriptor, name = real_mkstemp(**kwargs)
+        return descriptor, name
+
+    def competing_link(source, target, **kwargs):
+        nonlocal competitor
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+        assert _mode(Path(source)) == 0o600
+        assert not target.exists()
+        with pytest.raises(sqlite3.OperationalError):
+            sqlite3.connect(f"{target.as_uri()}?mode=ro", uri=True)
+        # A competing writer publishes its own DB while this creator is preparing.
+        competitor = sqlite3.connect(target)
+        competitor.execute("CREATE TABLE winner (value TEXT)")
+        competitor.execute("INSERT INTO winner VALUES ('preserved')")
+        competitor.commit()
+        with sqlite3.connect(f"{target.as_uri()}?mode=ro", uri=True) as reader:
+            assert reader.execute("SELECT value FROM winner").fetchone() == ("preserved",)
+        return real_link(source, target, **kwargs)
+
+    monkeypatch.setattr(private_storage.tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(private_storage.os, "link", competing_link)
+    try:
+        connection = connect_private_sqlite(database)
+        try:
+            assert connection.execute("SELECT value FROM winner").fetchone() == ("preserved",)
+        finally:
+            connection.close()
+    finally:
+        if competitor is not None:
+            competitor.close()
+    assert not list(database.parent.glob(".*.tmp"))
+    assert _mode(database) == 0o600
+
+
+@pytest.mark.parametrize("stage", ["fchmod", "link"])
+def test_sqlite_creation_failure_cleans_temporary_inode(tmp_path: Path, monkeypatch, stage: str) -> None:
+    database = tmp_path / "private" / "database.sqlite3"
+    real_mkstemp = private_storage.tempfile.mkstemp
+    descriptor = None
+
+    def tracked_mkstemp(**kwargs):
+        nonlocal descriptor
+        descriptor, name = real_mkstemp(**kwargs)
+        return descriptor, name
+
+    def fail(*args, **kwargs):
+        raise PermissionError("creation failed")
+
+    monkeypatch.setattr(private_storage.tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(private_storage.os, stage, fail)
+    with pytest.raises(PermissionError, match="creation failed"):
+        connect_private_sqlite(database)
+    with pytest.raises(OSError):
+        os.fstat(descriptor)
+    assert not database.exists()
+    assert not list(database.parent.glob(".*.tmp"))
+
+
+def test_sqlite_directory_replacement_does_not_chmod_symlink_destination(tmp_path: Path, monkeypatch) -> None:
+    database = ensure_private_file(tmp_path / "private" / "database.sqlite3")
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o755)
+    real_chmod = os.chmod
+
+    def replace_before_chmod(path, mode, **kwargs):
+        if path == database.parent:
+            path.rename(tmp_path / "old-private")
+            path.symlink_to(outside, target_is_directory=True)
+        assert kwargs == {"follow_symlinks": False}
+        return real_chmod(path, mode, **kwargs)
+
+    monkeypatch.setattr(private_storage.os, "chmod", replace_before_chmod)
+    with pytest.raises((OSError, NotImplementedError), match="changed|not implemented|not supported"):
+        secure_sqlite_artifacts(database)
+    assert _mode(outside) == 0o755
+
+
+def test_sqlite_concurrent_creators_use_one_published_inode(tmp_path: Path, monkeypatch) -> None:
+    database = tmp_path / "private" / "database.sqlite3"
+    barrier = threading.Barrier(4)
+    real_link = os.link
+    published = []
+
+    def synchronized_link(source, target, **kwargs):
+        barrier.wait(timeout=5)
+        real_link(source, target, **kwargs)
+        published.append(target.stat().st_ino)
+
+    def connect():
+        connection = connect_private_sqlite(database)
+        try:
+            assert connection.execute("SELECT 1").fetchone() == (1,)
+            return database.stat().st_ino
+        finally:
+            connection.close()
+
+    monkeypatch.setattr(private_storage.os, "link", synchronized_link)
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(lambda _: connect(), range(4)))
+    assert len(published) == 1
+    assert results == published * 4
+    assert not list(database.parent.glob(".*.tmp"))

--- a/tests/test_private_storage.py
+++ b/tests/test_private_storage.py
@@ -489,7 +489,7 @@ def test_sqlite_metadata_rejects_path_replacement(tmp_path: Path, monkeypatch, r
         return real_chmod(path, mode, **kwargs)
 
     monkeypatch.setattr(private_storage.os, "chmod", replace_before_chmod)
-    with pytest.raises((OSError, NotImplementedError), match="changed|not implemented|not supported"):
+    with pytest.raises((OSError, NotImplementedError), match="changed|not implemented|not supported|unavailable"):
         secure_sqlite_artifacts(database)
     assert outside.read_bytes() == b"unchanged"
     assert _mode(outside) == 0o644
@@ -594,7 +594,7 @@ def test_sqlite_directory_replacement_does_not_chmod_symlink_destination(tmp_pat
         return real_chmod(path, mode, **kwargs)
 
     monkeypatch.setattr(private_storage.os, "chmod", replace_before_chmod)
-    with pytest.raises((OSError, NotImplementedError), match="changed|not implemented|not supported"):
+    with pytest.raises((OSError, NotImplementedError), match="changed|not implemented|not supported|unavailable"):
         secure_sqlite_artifacts(database)
     assert _mode(outside) == 0o755
 

--- a/tests/test_private_storage_locking.py
+++ b/tests/test_private_storage_locking.py
@@ -1,0 +1,115 @@
+"""Standalone Linux regression: python -m unittest discover -s tests -p test_private_storage_locking.py."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from src.infrastructure import private_storage
+
+
+_LOCK_PROBE = """
+import errno, fcntl, os, sys
+fd = os.open(sys.argv[1], os.O_RDWR)
+try:
+    try:
+        fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB, 1, int(sys.argv[2]), os.SEEK_SET)
+    except OSError as exc:
+        if exc.errno not in (errno.EACCES, errno.EAGAIN):
+            raise
+        print('held')
+    else:
+        print('free')
+finally:
+    os.close(fd)
+"""
+
+
+@unittest.skipUnless(sys.platform == "linux", "Linux POSIX SQLite lock regression")
+class SQLiteLockPreservationTests(unittest.TestCase):
+    def assert_lock(self, path: Path, offset: int, expected: str = "held") -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", _LOCK_PROBE, str(path), str(offset)],
+            check=True, capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.stdout.strip(), expected)
+
+    def test_existing_database_metadata_and_second_connection_preserve_locks(self) -> None:
+        for journal_mode in ("WAL", "DELETE"):
+            with self.subTest(journal_mode=journal_mode), tempfile.TemporaryDirectory() as directory:
+                database = Path(directory) / "database.sqlite3"
+                first = private_storage.connect_private_sqlite(database)
+                second = None
+                try:
+                    self.assertEqual(first.execute(f"PRAGMA journal_mode={journal_mode}").fetchone()[0], journal_mode.lower())
+                    first.execute("CREATE TABLE entries (value TEXT)")
+                    first.commit()
+                    first.execute("BEGIN IMMEDIATE")
+                    first.execute("INSERT INTO entries VALUES ('durable')")
+                    lock_path = Path(f"{database}-shm") if journal_mode == "WAL" else database
+                    offset = 120 if journal_mode == "WAL" else 0x40000001
+                    self.assert_lock(lock_path, offset)
+                    for candidate in (database, *database.parent.glob("database.sqlite3-*")):
+                        candidate.chmod(0o666)
+                    private_storage.secure_sqlite_artifacts(database)
+                    self.assert_lock(lock_path, offset)
+                    second = private_storage.connect_private_sqlite(database)
+                    self.assertEqual(second.execute("SELECT count(*) FROM entries").fetchone(), (0,))
+                    self.assert_lock(lock_path, offset)
+                    second.close()
+                    second = None
+                    self.assert_lock(lock_path, offset)
+                    first.commit()
+                    self.assert_lock(lock_path, offset, "free")
+                    with sqlite3.connect(f"{database.as_uri()}?mode=ro", uri=True) as reader:
+                        self.assertEqual(reader.execute("SELECT value FROM entries").fetchall(), [("durable",)])
+                    for candidate in (database, *database.parent.glob("database.sqlite3-*")):
+                        self.assertEqual(candidate.stat().st_mode & 0o777, 0o600)
+                finally:
+                    if second is not None:
+                        second.close()
+                    first.close()
+
+    def test_connection_immediately_after_publication_retains_its_locks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            database = Path(directory) / "database.sqlite3"
+            real_link = os.link
+            writer = None
+
+            def publish_then_connect(source, target, **kwargs):
+                nonlocal writer
+                real_link(source, target, **kwargs)
+                self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+                with sqlite3.connect(f"{target.as_uri()}?mode=ro", uri=True) as reader:
+                    self.assertEqual(reader.execute("SELECT count(*) FROM sqlite_master").fetchone(), (0,))
+                writer = sqlite3.connect(target)
+                writer.execute("PRAGMA journal_mode=WAL")
+                writer.execute("CREATE TABLE entries (value TEXT)")
+                writer.commit()
+                writer.execute("BEGIN IMMEDIATE")
+                writer.execute("INSERT INTO entries VALUES ('winner')")
+                self.assert_lock(Path(f"{target}-shm"), 120)
+
+            try:
+                with patch.object(private_storage.os, "link", publish_then_connect):
+                    connection = private_storage.connect_private_sqlite(database)
+                try:
+                    self.assert_lock(Path(f"{database}-shm"), 120)
+                    self.assertEqual(connection.execute("SELECT count(*) FROM entries").fetchone(), (0,))
+                    writer.commit()
+                    self.assertEqual(connection.execute("SELECT value FROM entries").fetchone(), ("winner",))
+                    self.assertFalse(list(database.parent.glob(".*.tmp")))
+                finally:
+                    connection.close()
+            finally:
+                if writer is not None:
+                    writer.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trade_intake_recovery.py
+++ b/tests/test_trade_intake_recovery.py
@@ -250,7 +250,7 @@ def test_transient_processing_exception_recovers_unchanged_once(
     monkeypatch.setattr(
         auto_intake,
         owner,
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("offline transient failure")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(sqlite3.OperationalError("database is locked")),
     )
 
     first = _process(repo, tmp_path, "initial", payload, source="push")
@@ -344,6 +344,8 @@ def test_inferred_open_recovers_after_commit_with_one_receipt(tmp_path: Path, mo
     assert events[0]["raw_payload"]["execution_input"]["position_effect"] is None
     assert calls == [] and not (tmp_path / "initial/state.json").exists()
     path = resolve_execution_inbox_path(repo, tmp_path / "unused.sqlite3")
+    after_lease = time.time() + 121
+    monkeypatch.setattr("src.application.trades.inbox.time.time", lambda: after_lease)
     pending = list_retryable_trade_payloads(path, retry_delay_sec=0)[0]
     stored = read_trade_payload(path, inbox_id=pending["inbox_id"], read_only=True)
     assert stored["result"] is None and stored["receipt"] is None
@@ -431,9 +433,10 @@ def test_saved_result_keeps_pm_intent_atomic_and_claimable_once(tmp_path: Path) 
     claim = claim_trade_payload(inbox, inbox_id=inbox_id, repo=repo)
     intent = {"account": "lx", "request_id": "stock-refresh:atomic"}
     result = {"status": "skipped", "reason": "not_option", "portfolio_refresh_intent": intent}
-    save_trade_payload_result(inbox, claim=claim, result=result)
+    enriched_result = save_trade_payload_result(inbox, claim=claim, result=result)
     current = read_trade_payload(inbox, inbox_id=inbox_id, read_only=True)
-    assert current["result"] == result
+    assert current["result"] == enriched_result
+    assert enriched_result["portfolio_refresh_intent"] == result["portfolio_refresh_intent"]
     assert json.loads(current["portfolio_refresh_intent_json"]) == intent
     assert current["portfolio_refresh_attempted_at_ms"] is None
 
@@ -499,6 +502,8 @@ def test_new_known_associations_fence_old_claim_and_survive_original_payload_ret
     assert results == []
     assert len(failures) == 1
     assert repo.list_trade_events() == []
+    after_due = time.time() + 61
+    monkeypatch.setattr("src.application.trades.inbox.time.time", lambda: after_due)
     retry = _process(repo, tmp_path, "retry", initial, source="backfill")
     assert retry["status"] == "unresolved"
     assert repo.list_trade_events() == []
@@ -582,7 +587,7 @@ def test_claim_takeover_and_exhaustion_require_safe_explicit_recovery(tmp_path: 
     monkeypatch.setattr("src.application.trades.inbox.time.time", lambda: now[0])
     old_claim = claim_trade_payload(inbox, inbox_id=inbox_id, repo=repo, lease_ms=1)
     assert old_claim is not None
-    now[0] += 1
+    now[0] += 61
     current_claim = claim_trade_payload(inbox, inbox_id=inbox_id, repo=repo)
     assert current_claim is not None
     assert current_claim["claim_id"] != old_claim["claim_id"]
@@ -595,13 +600,17 @@ def test_claim_takeover_and_exhaustion_require_safe_explicit_recovery(tmp_path: 
     assert pending["claim_id"] == current_claim["claim_id"]
     assert pending["result"] is None
 
-    for attempt in range(20):
+    # The interrupted first claim already consumed one of the twenty attempts.
+    for attempt in range(19):
         if attempt:
+            now[0] += 61
             current_claim = claim_trade_payload(inbox, inbox_id=inbox_id, repo=repo)
         assert current_claim is not None
-        mark_trade_payload_retryable(inbox, inbox_id=inbox_id, error="offline failure", claim=current_claim)
+        mark_trade_payload_retryable(inbox, inbox_id=inbox_id, error="offline failure", claim=current_claim,
+                                     result={"status": "failed", "diagnostics": {"retryable": True}})
     exhausted = read_trade_payload(inbox, inbox_id=inbox_id, read_only=True)
-    assert exhausted["status"] == "pending"
+    assert exhausted["status"] == "handled"
+    assert exhausted["result"]["receipt_kind"] == "manual_required"
     assert exhausted["attempt_count"] == 20
     assert claim_trade_payload(inbox, inbox_id=inbox_id, repo=repo) is None
     assert list_retryable_trade_payloads(inbox, retry_delay_sec=0) == []
@@ -671,7 +680,7 @@ def test_conflict_after_economic_commit_preserves_original_event_across_entries(
 
 
 @pytest.mark.parametrize("phase,exit_code", [("before_commit", 81), ("after_commit", 82)])
-def test_process_crash_recovers_expired_claim_from_another_entry(tmp_path: Path, phase: str, exit_code: int) -> None:
+def test_process_crash_recovers_expired_claim_from_another_entry(tmp_path: Path, monkeypatch, phase: str, exit_code: int) -> None:
     repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
     ctx = multiprocessing.get_context("spawn")
     ready, release, results = ctx.Event(), ctx.Event(), ctx.Queue()
@@ -683,12 +692,13 @@ def test_process_crash_recovers_expired_claim_from_another_entry(tmp_path: Path,
         original = repo.list_trade_events()
         assert len(original) == int(phase == "after_commit")
         authoritative = resolve_execution_inbox_path(repo, tmp_path / "unused.sqlite3")
+        after_due = time.time() + 121
+        monkeypatch.setattr("src.application.trades.inbox.time.time", lambda: after_due)
         pending = list_retryable_trade_payloads(authoritative, account_ids=["123"], retry_delay_sec=0)
         assert len(pending) == 1
         interrupted = read_trade_payload(authoritative, inbox_id=pending[0]["inbox_id"])
         assert interrupted["result"] is None
         assert interrupted["claim_id"] is not None
-        time.sleep(0.01)  # Worker uses a real 1 ms lease; no manual resume or state repair.
         replay = _process(repo, tmp_path, "manual", _execution(), source="manual")
         final = repo.list_trade_events()
         assert len(final) == 1
@@ -701,3 +711,51 @@ def test_process_crash_recovers_expired_claim_from_another_entry(tmp_path: Path,
         assert saved["claim_id"] is None
     finally:
         _stop(process, release)
+
+
+@pytest.mark.parametrize("failure", ["postcommit", "combo"])
+def test_converged_recorded_receipt_projects_success_and_known_auxiliary_failure(tmp_path, monkeypatch, failure):
+    from src.application.agent_tools.runtime_status_impl import _trade_intake_summary
+    from src.application.trades import auto_intake, receipt
+    from src.application.trades.state import load_trade_intake_state
+
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    def sender(**kwargs):
+        calls.append(kwargs)
+        return {"ok": True, "delivery_confirmed": True, "message_id": "offline-message"}
+    monkeypatch.setattr(auto_intake, "send_trade_intake_receipt", partial(
+        receipt.send_trade_intake_receipt, send_fn=sender, normalize_fn=lambda send_result: send_result))
+    callback = auto_intake._build_receipt_callback(
+        base=tmp_path, repo=repo, receipt_config={"enabled": True},
+        cfg={"notifications": {"provider": "wechat_clawbot", "target": "wechat:offline-test"}})
+    resolver = auto_intake.resolve_trade_deal
+    def commit_then_raise(*args, **kwargs):
+        resolver(*args, **kwargs)
+        raise sqlite3.OperationalError("locking protocol")
+    def failed_combo():
+        raise RuntimeError("private diagnostic /secret/path")
+    if failure == "postcommit":
+        monkeypatch.setattr(auto_intake, "resolve_trade_deal", commit_then_raise)
+    result = _process(repo, tmp_path, "initial", _execution(), source="push", on_result_fn=callback,
+        before_receipt_fn=lambda current: auto_intake._attach_combo_reconciliation_after_open(
+            current, apply_changes=True, mode="active" if failure == "combo" else "off", reconcile_fn=failed_combo))
+    state = load_trade_intake_state(tmp_path / "initial/state.json")
+    key = broker_deal_key_from_payload(_execution(), account_mapping={"123": "lx"})
+    assert result["status"] == "applied" and result["receipt_kind"] == "recorded"
+    assert state["processed_deal_ids"][key]["status"] == "applied"
+    assert not state["failed_deal_ids"] and not state["unresolved_deal_ids"]
+    assert _trade_intake_summary(state, {})["pending_count"] == 0
+    audit = [json.loads(line) for line in (tmp_path / "initial/audit.jsonl").read_text().splitlines()]
+    assert not [item for item in audit if item["phase"] == "failed"]
+    assert len(repo.list_trade_events()) == len(repo.list_position_lots()) == len(calls) == 1
+    message = calls[0]["message"]
+    assert "✅ 已记录" in message and "无需重复录入" in message
+    if failure == "combo":
+        assert result["combo_reconciliation"]["status"] == "failed"
+        assert "组合核对未完成" in message and "请检查组合核对服务" in message
+        assert "private diagnostic" not in message and "/secret/path" not in message
+    else:
+        assert state["processed_deal_ids"][key]["diagnostics"]["recovered_from_ledger"]
+    stored = read_trade_payload(resolve_execution_inbox_path(repo, tmp_path / "unused"), inbox_id=result["inbox_id"])
+    assert stored["receipt"]["message"] == message and stored["receipt"]["status"] == "sent"

--- a/tests/test_trade_pm_intent_recovery.py
+++ b/tests/test_trade_pm_intent_recovery.py
@@ -1,6 +1,7 @@
 import json
 import multiprocessing
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -184,6 +185,8 @@ def test_pending_retry_while_pm_disabled_preserves_intent_for_enabled_restart(tm
         _core(tmp_path, _stock())
     monkeypatch.setattr(auto_intake, "update_trade_intake_state_entries", original)
     path = _inbox(tmp_path)
+    after_lease = time.time() + 121
+    monkeypatch.setattr("src.application.trades.inbox.time.time", lambda: after_lease)
     pending = list_retryable_trade_payloads(path, retry_delay_sec=0)[0]
     saved = read_trade_payload(path, inbox_id=pending["inbox_id"])
     original_intent = json.loads(saved["portfolio_refresh_intent_json"])
@@ -272,3 +275,35 @@ def test_saved_inbox_public_preview_uses_authority_and_legacy_guard(tmp_path, mo
         assert result == 0
         assert json.loads(output)["inbox_id"] == stored["inbox_id"]
     assert ledger.read_bytes() == before
+
+
+@pytest.mark.parametrize("kind", ["pending_retry", "verification_pending"])
+def test_resumed_unclaimed_work_keeps_processing_and_verification_owners(tmp_path, monkeypatch, kind):
+    from src.application.trades.deal_identity import broker_deal_key_from_payload
+    from src.application.trades.inbox import (
+        begin_trade_receipt_attempt, claim_trade_payload, finish_trade_receipt_attempt,
+        list_trade_receipt_recovery_rows, mark_trade_payload_retryable, resume_trade_payload,
+    )
+
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    path = _inbox(tmp_path)
+    payload = _stock()
+    key = broker_deal_key_from_payload(payload, account_mapping={"123": "lx"})
+    inbox_id = enqueue_trade_payload(path, payload=payload, source="push", broker_deal_key=key, repo=repo)
+    claim = claim_trade_payload(path, inbox_id=inbox_id, repo=repo)
+    mark_trade_payload_retryable(path, inbox_id=inbox_id, claim=claim, error="offline interrupted processing",
+        result={"status": "failed", "receipt_kind": kind,
+                "diagnostics": {"retryable": kind == "pending_retry", "verification_pending": kind == "verification_pending"}})
+    attempt = begin_trade_receipt_attempt(path, inbox_id=inbox_id, result_key=kind,
+        route={"provider": "wechat_clawbot", "channel": "wechat_clawbot", "target": "wechat:offline-test"}, message="offline notice")
+    assert attempt["claimed"]
+    finish_trade_receipt_attempt(path, inbox_id=inbox_id, attempt_id=attempt["attempt_id"], result={"delivery_confirmed": True})
+    assert resume_trade_payload(path, inbox_id=inbox_id, operator="offline-test", repo=repo)
+    row = read_trade_payload(path, inbox_id=inbox_id)
+    assert row["attempt_count"] == 0 and row["result"]["receipt_kind"] == kind
+    assert row["receipt"]["status"] == "sent"
+    after_due = time.time() + 61
+    monkeypatch.setattr("src.application.trades.inbox.time.time", lambda: after_due)
+    recovery = list_trade_receipt_recovery_rows(path, account_ids=["123"])
+    assert [item["inbox_id"] for item in recovery] == ([inbox_id] if kind == "verification_pending" else [])
+    assert bool(claim_trade_payload(path, inbox_id=inbox_id, repo=repo)) is (kind == "pending_retry")

--- a/tests/test_trade_receipt_claim_fence.py
+++ b/tests/test_trade_receipt_claim_fence.py
@@ -1,6 +1,7 @@
 from functools import partial
 from pathlib import Path
 import threading
+import time
 
 import pytest
 
@@ -9,6 +10,12 @@ from src.application.trades import auto_intake, inbox, receipt
 from src.application.trades.deal_identity import broker_deal_key_from_payload
 from src.application.trades.inbox_authority import resolve_execution_inbox_path
 from src.application.trades.order_fee_sync import recover_order_fee_targets
+
+
+
+def _advance_retry_clock(monkeypatch, seconds=61):
+    after_due = time.time() + seconds
+    monkeypatch.setattr(inbox.time, "time", lambda: after_due)
 
 
 def _execution():
@@ -128,6 +135,7 @@ def test_normalize_failure_state_write_requires_current_claim(tmp_path, monkeypa
     try:
         assert paused.wait(5)
         if takeover:
+            _advance_retry_clock(monkeypatch)
             known = {**payload, "order_id": "late-order", "external_order_namespace": "futu.order"}
             completed = _process(repo, tmp_path, "shared", known, callback)
             assert completed["status"] == "applied" and completed["receipt"]["delivery_confirmed"] is True
@@ -153,7 +161,9 @@ def test_normalize_failure_state_write_requires_current_claim(tmp_path, monkeypa
         assert failed["reason"] == "exception:OSError"
         assert failed["receipt"]["delivery_confirmed"] is True
         saved = inbox.read_trade_payload(path, inbox_id=results[0]["inbox_id"])
-        assert saved["status"] == "pending" and saved["result"]["status"] == "failed"
+        assert saved["status"] == "handled" and saved["result"]["status"] == "failed"
+        assert saved["result"]["receipt_kind"] == "manual_required"
+        assert saved["result"]["retry_policy"]["retryable"] is False
         assert saved["receipt"]["status"] == "sent"
         assert repo.list_trade_events() == []
         recovered = _process(
@@ -166,8 +176,11 @@ def test_normalize_failure_state_write_requires_current_claim(tmp_path, monkeypa
         )
         assert recovered["status"] == "applied"
         assert len(repo.list_trade_events()) == 1
-        assert len(calls) == 1
-        assert inbox.read_trade_payload(path, inbox_id=results[0]["inbox_id"])["receipt"] == saved["receipt"]
+        assert len(calls) == 2
+        current = inbox.read_trade_payload(path, inbox_id=results[0]["inbox_id"])
+        assert current["receipt"]["receipt_kind"] == "recorded"
+        assert current["receipt"]["status"] == "sent"
+        assert current["receipt_envelope"]["receipts"]["manual_required"]["status"] == "sent"
 
 
 def test_revoked_claim_exits_before_failed_state_or_receipt_and_new_worker_notifies(tmp_path, monkeypatch):
@@ -203,6 +216,7 @@ def test_revoked_claim_exits_before_failed_state_or_receipt_and_new_worker_notif
     assert calls == [] and repo.list_trade_events() == []
     assert not (tmp_path / "old/state.json").exists()
     assert inbox.read_trade_payload(path, inbox_id=inbox_id)["receipt"] is None
+    _advance_retry_clock(monkeypatch)
     recovered = _process(repo, tmp_path, "new", payload, callback)
     assert recovered["status"] == "applied" and recovered["receipt"]["delivery_confirmed"] is True
     assert len(calls) == len(repo.list_trade_events()) == 1
@@ -229,7 +243,8 @@ def test_takeover_between_saved_result_and_receipt_freeze_cannot_send_or_rewrite
         before = inbox.read_trade_payload(path, inbox_id=inbox_id)
         state_path = tmp_path / "old/state.json"
         state_before = state_path.read_bytes()
-        assert before["result"]["status"] == "applied" and before["receipt"] is None
+        assert before["result"]["status"] == "applied" and before["receipt"]["status"] == "pending"
+        assert before["receipt"]["attempt_count"] == 0
         assert inbox.resume_trade_payload(path, inbox_id=inbox_id, operator="test-takeover", repo=repo)
         successor = inbox.claim_trade_payload(path, inbox_id=inbox_id, owner="new-worker", repo=repo)
         assert successor["claim_id"] != before["claim_id"]
@@ -239,8 +254,9 @@ def test_takeover_between_saved_result_and_receipt_freeze_cannot_send_or_rewrite
     assert not worker.is_alive()
     assert len(errors) == 1 and isinstance(errors[0], inbox.TradePayloadClaimLost)
     assert state_path.read_bytes() == state_before
-    assert calls == [] and inbox.read_trade_payload(path, inbox_id=inbox_id)["receipt"] is None
+    assert calls == [] and inbox.read_trade_payload(path, inbox_id=inbox_id)["receipt"] == before["receipt"]
     assert inbox.resume_trade_payload(path, inbox_id=inbox_id, operator="test-process-successor", repo=repo)
+    _advance_retry_clock(monkeypatch)
     recovered = _process(repo, tmp_path, "new", payload, callback)
     assert recovered["receipt"]["delivery_confirmed"] is True
     assert len(calls) == len(repo.list_trade_events()) == 1
@@ -260,6 +276,7 @@ def test_handled_association_enrichment_preserves_existing_receipt_without_new_s
     inbox.enqueue_trade_payload(path, payload=known, source="backfill", broker_deal_key=key, repo=repo)
     pending = inbox.read_trade_payload(path, inbox_id=initial["inbox_id"])
     assert pending["status"] == "pending"
+    _advance_retry_clock(monkeypatch)
     result = _process(repo, tmp_path, "enriched", payload, callback)
     assert result["receipt"]["reason"] == "execution_association_enrichment"
     assert len(calls) == len(repo.list_trade_events()) == 1
@@ -288,6 +305,7 @@ def test_unresolved_execution_new_evidence_recovers_once_across_retry_and_state_
         raise inbox.TradePayloadClaimLost("offline interruption before economic commit")
     monkeypatch.setattr(auto_intake, "resolve_trade_deal", interrupt)
     known = {**unknown, "position_effect": "open"}
+    _advance_retry_clock(monkeypatch)
     with pytest.raises(inbox.TradePayloadClaimLost):
         _process(repo, tmp_path, recovery_entry, known, callback)
     pending = inbox.read_trade_payload(path, inbox_id=first["inbox_id"])
@@ -295,6 +313,7 @@ def test_unresolved_execution_new_evidence_recovers_once_across_retry_and_state_
     assert repo.list_trade_events() == []
     monkeypatch.setattr(auto_intake, "resolve_trade_deal", original_resolve)
     # Restart consumes the original unknown payload and the accepted durable evidence.
+    _advance_retry_clock(monkeypatch, 121)
     recovered = _process(repo, tmp_path, recovery_entry, unknown, callback)
     assert recovered["status"] == "applied" and recovered["action"] == "open"
     assert recovered["receipt"]["delivery_confirmed"] is True
@@ -337,6 +356,7 @@ def test_new_association_after_rolled_back_first_write_keeps_first_receipt_eligi
     assert repo.list_trade_events() == [] and calls == []
     monkeypatch.setattr(repo, "upsert_trade_event", upsert)
     known = {**_execution(), "external_order_id": "late-order", "external_order_namespace": "futu.order"}
+    _advance_retry_clock(monkeypatch)
     recovered = _process(repo, tmp_path, "failed", known, callback)
     assert recovered["status"] == "applied" and recovered["receipt"]["delivery_confirmed"] is True
     _process(repo, tmp_path, "another-source", known, callback)

--- a/tests/test_trade_receipt_concurrency.py
+++ b/tests/test_trade_receipt_concurrency.py
@@ -1,4 +1,5 @@
 import multiprocessing
+from src.application.trades import inbox
 
 from src.application.trades.inbox import begin_trade_receipt_attempt, enqueue_trade_payload, read_trade_payload
 
@@ -18,6 +19,11 @@ def test_two_processes_can_claim_only_one_ordinary_receipt(tmp_path):
     path = tmp_path / "inbox.sqlite3"
     inbox_id = enqueue_trade_payload(path, payload={"deal_id": "fill-1", "futu_account_id": "123"},
                                      source="push", broker_deal_key="futu:lx:123:fill-1")
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET receipt_recovery_allowed = 1 WHERE inbox_id = ?", (inbox_id,))
+    claim = inbox.claim_trade_payload(path, inbox_id=inbox_id)
+    result = inbox.save_trade_payload_result(path, claim=claim, result={"status": "applied"})
+    inbox.settle_trade_payload_result(path, inbox_id=inbox_id, claim=claim, result=result)
     context = multiprocessing.get_context("spawn")
     ready, results, release = context.Queue(), context.Queue(), context.Event()
     workers = [context.Process(target=_claim_receipt, args=(str(path), inbox_id, ready, release, results))

--- a/tests/test_trade_receipt_inbox_lifecycle.py
+++ b/tests/test_trade_receipt_inbox_lifecycle.py
@@ -1,0 +1,379 @@
+from concurrent.futures import ThreadPoolExecutor
+import json
+import sqlite3
+
+import pytest
+
+from src.application.trades import inbox
+
+
+_ROUTE = {"provider": "offline", "channel": "test", "target": "fixture"}
+_FAILED = {"status": "failed", "reason": "sqlite_busy", "diagnostics": {"retryable": True},
+           "_receipt_payload": {"account": "lx", "symbol": "NVDA"}}
+_RECORDED = {"status": "applied", "reason": "applied_open", "_receipt_payload": {"account": "lx"}}
+
+
+def _new(path, *, account="123"):
+    key = inbox.enqueue_trade_payload(path, payload={"deal_id": "one", "futu_account_id": account},
+                                     source="push", broker_deal_key=f"futu:lx:{account}:one")
+    # This fixture models a live reception already proven to precede its ledger effect.
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET receipt_recovery_allowed = 1 WHERE inbox_id = ?", (key,))
+    return key
+
+
+def _save(path, key, result):
+    claim = inbox.claim_trade_payload(path, inbox_id=key)
+    assert claim is not None
+    enriched = inbox.save_trade_payload_result(path, claim=claim, result=result)
+    inbox.settle_trade_payload_result(path, inbox_id=key, claim=claim, result=enriched)
+    return enriched
+
+
+def _attempt(path, key, *, result_key=None, route=_ROUTE, message="frozen"):
+    return inbox.begin_trade_receipt_attempt(path, inbox_id=key, route=route, message=message,
+                                             result_key=result_key)
+
+
+def _advance(monkeypatch, clock, seconds=60):
+    clock[0] += seconds
+    monkeypatch.setattr(inbox.time, "time", lambda: clock[0])
+
+
+def test_claim_budget_due_and_settle_use_one_authoritative_counter(tmp_path, monkeypatch):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    for count in range(1, 21):
+        enriched = _save(path, key, _FAILED)
+        assert enriched["retry_policy"] == {"attempt_count": count, "max_attempts": 20,
+                                            "remaining": 20 - count, "retryable": count < 20,
+                                            "retry_delay_sec": 60}
+        assert inbox.claim_trade_payload(path, inbox_id=key) is None
+        _advance(monkeypatch, clock)
+    row = inbox.read_trade_payload(path, inbox_id=key)
+    assert row["attempt_count"] == 20
+    assert row["receipt"]["receipt_kind"] == "manual_required"
+    assert set(row["receipt_envelope"]["receipts"]) == {"pending_retry", "manual_required"}
+    assert row["receipt_envelope"]["receipts"]["pending_retry"]["superseded_by"] == "manual_required"
+    assert inbox.claim_trade_payload(path, inbox_id=key) is None
+
+
+def test_last_claim_crash_has_readback_path_but_no_economic_claim(tmp_path, monkeypatch):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET attempt_count = 19, updated_at_ms = 0 WHERE inbox_id = ?", (key,))
+    claim = inbox.claim_trade_payload(path, inbox_id=key)
+    assert claim["attempt_count"] == 20
+    assert inbox.list_trade_receipt_recovery_rows(path, account_ids=["123"]) == []
+    with pytest.raises(inbox.TradePayloadClaimLost):
+        inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED,
+                                            expected_payload_version=claim["payload_version"])
+    _advance(monkeypatch, clock, 121)
+    assert inbox.claim_trade_payload(path, inbox_id=key) is None
+    rows = inbox.list_trade_receipt_recovery_rows(path, account_ids=["123"])
+    assert [row["inbox_id"] for row in rows] == [key]
+    verification = inbox.prepare_trade_receipt_result(path, inbox_id=key,
+        result={"status": "unresolved", "reason": "ledger_unavailable", "receipt_kind": "verification_pending"},
+        expected_payload_version=claim["payload_version"])
+    assert verification["retry_policy"]["attempt_count"] == 20
+    attempt = _attempt(path, key)
+    inbox.finish_trade_receipt_attempt(path, inbox_id=key, attempt_id=attempt["attempt_id"],
+                                       result={"delivery_confirmed": True})
+    _advance(monkeypatch, clock)
+    assert inbox.list_trade_receipt_recovery_rows(path, account_ids=["123"])
+    recovered = inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED,
+                                                     expected_result=verification)
+    assert recovered["receipt_kind"] == "recorded"
+    assert _attempt(path, key)["claimed"] is True
+    assert inbox.read_trade_payload(path, inbox_id=key)["attempt_count"] == 20
+
+
+@pytest.mark.parametrize("finished", [None, {"delivery_confirmed": True}, {"explicit_pre_acceptance_failure": True}])
+def test_superseded_failure_cannot_send_after_recorded_but_late_callback_retained(tmp_path, monkeypatch, finished):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    failed = _save(path, key, _FAILED)
+    prior = _attempt(path, key, result_key="pending_retry")
+    if finished:
+        inbox.finish_trade_receipt_attempt(path, inbox_id=key, attempt_id=prior["attempt_id"], result=finished)
+    recovered = inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED, expected_result=failed)
+    success = _attempt(path, key, result_key="recorded", message="recovered")
+    assert success["claimed"] is True
+    assert success["receipt_id"].endswith(":recorded")
+    with pytest.raises(inbox.TradePayloadClaimLost):
+        _attempt(path, key, result_key="pending_retry")
+    if not finished:
+        inbox.finish_trade_receipt_attempt(path, inbox_id=key, attempt_id=prior["attempt_id"],
+                                          result={"explicit_pre_acceptance_failure": True})
+    row = inbox.read_trade_payload(path, inbox_id=key)
+    assert row["result"] == recovered
+    assert row["receipt"]["attempt_id"] == success["attempt_id"]
+    assert row["receipt_envelope"]["receipts"]["pending_retry"]["stop_reason"] == "result_superseded"
+    assert _attempt(path, key)["claimed"] is False
+
+
+def test_unsent_failure_superseded_and_original_success_survives_callback_exception(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    failed = _save(path, key, _FAILED)
+    inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED, expected_result=failed)
+    with pytest.raises(inbox.TradePayloadClaimLost):
+        _attempt(path, key, result_key="pending_retry")
+    assert inbox.read_trade_payload(path, inbox_id=key)["receipt_envelope"]["receipts"]["pending_retry"]["attempt_count"] == 0
+    second = _new(tmp_path / "other.db")
+    claim = inbox.claim_trade_payload(tmp_path / "other.db", inbox_id=second)
+    stored = inbox.save_trade_payload_result(tmp_path / "other.db", claim=claim, result=_RECORDED)
+    inbox.mark_trade_payload_retryable(tmp_path / "other.db", inbox_id=second, claim=claim, error="callback failed")
+    row = inbox.read_trade_payload(tmp_path / "other.db", inbox_id=second)
+    assert row["status"] == "handled"
+    assert row["result"] == stored
+    assert row["attempt_count"] == 1
+
+
+def test_notification_rejection_budget_is_independent_and_route_message_freeze(tmp_path, monkeypatch):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    _save(path, key, _RECORDED)
+    for count in range(1, 21):
+        attempt = _attempt(path, key, message="original" if count == 1 else "changed")
+        assert attempt["claimed"] is True
+        assert attempt["attempt_count"] == count
+        assert attempt["message"] == "original"
+        inbox.finish_trade_receipt_attempt(path, inbox_id=key, attempt_id=attempt["attempt_id"],
+                                          result={"explicit_pre_acceptance_failure": True})
+        assert _attempt(path, key)["claimed"] is False
+        _advance(monkeypatch, clock)
+    row = inbox.read_trade_payload(path, inbox_id=key)
+    assert row["attempt_count"] == 1
+    assert row["receipt"]["stop_reason"] == "notification_attempts_exhausted"
+    assert len(row["receipt"]["attempts"]) == 19
+    assert _attempt(path, key)["claimed"] is False
+
+
+def test_no_route_does_not_consume_and_changed_route_stops(tmp_path, monkeypatch):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    _save(path, key, _RECORDED)
+    assert _attempt(path, key, route={})["claimed"] is False
+    assert inbox.read_trade_payload(path, inbox_id=key)["receipt"]["attempt_count"] == 0
+    sent = _attempt(path, key)
+    inbox.finish_trade_receipt_attempt(path, inbox_id=key, attempt_id=sent["attempt_id"],
+                                      result={"explicit_pre_acceptance_failure": True})
+    _advance(monkeypatch, clock)
+    changed = _attempt(path, key, route={**_ROUTE, "target": "other"})
+    assert changed["claimed"] is False
+    assert changed["stop_reason"] == "route_changed_requires_review"
+    assert changed["attempt_count"] == 1
+    assert _attempt(path, key)["claimed"] is False
+
+
+def test_parallel_attempt_and_result_cas(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    failed = _save(path, key, _FAILED)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        attempts = list(pool.map(lambda _: _attempt(path, key), range(2)))
+    assert sum(attempt["claimed"] for attempt in attempts) == 1
+    inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED, expected_result=failed)
+    with pytest.raises(inbox.TradePayloadClaimLost):
+        inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_FAILED, expected_result=failed)
+
+
+@pytest.mark.parametrize("legacy_status", ["sent", "unknown", "failed"])
+def test_legacy_failed_business_allows_independent_success_only_with_proof(tmp_path, legacy_status):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    legacy = {"status": legacy_status, "receipt_id": f"trade-receipt:{key}", "attempt_id": "legacy"}
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET receipt_json = ?, result_json = ? WHERE inbox_id = ?",
+                     (json.dumps(legacy), json.dumps(_FAILED), key))
+    assert inbox.read_trade_payload(path, inbox_id=key)["receipt"] == legacy
+    inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED, expected_result=_FAILED)
+    row = inbox.read_trade_payload(path, inbox_id=key)
+    assert row["receipt_envelope"]["receipts"]["pending_retry"]["status"] == legacy_status
+    assert _attempt(path, key)["claimed"] is True
+
+
+@pytest.mark.parametrize("legacy", [None, {"status": "sent"}, {"status": "unknown"}])
+def test_legacy_historical_success_not_recovered_on_upgrade(tmp_path, legacy):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET receipt_json = ?, result_json = ?, status = 'handled', receipt_recovery_allowed = 0 WHERE inbox_id = ?",
+                     (json.dumps(legacy) if legacy else None, json.dumps(_RECORDED), key))
+    result = inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED, expected_result=_RECORDED)
+    assert result["receipt_suppression_reason"] == "legacy_receipt_history_unproven"
+    assert _attempt(path, key)["claimed"] is False
+    assert inbox.list_trade_receipt_recovery_rows(path, account_ids=["123"]) == []
+
+
+def test_old_open_connection_and_downgrade_cannot_write_after_atomic_guard_migration(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    old = sqlite3.connect(path)
+    old.create_function("trade_inbox_writer_version", 0, lambda: 1)
+    try:
+        # Restore the prior guard to model a database opened before this migration.
+        with inbox._connect(path) as conn:
+            guards = conn.execute("SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND name LIKE '%writer_guard'").fetchall()
+            for name, sql in guards:
+                conn.execute(f"DROP TRIGGER {name}")
+                conn.execute(sql.replace("trade_inbox_writer_version() != 2", "trade_inbox_writer_version() != 1"))
+        old.execute("UPDATE trade_inbox SET last_error = 'old' WHERE inbox_id = ?", (key,))
+        old.commit()
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            rows = list(pool.map(lambda _: inbox.read_trade_payload(path, inbox_id=key), range(2)))
+        assert len(rows) == 2
+        with pytest.raises(sqlite3.IntegrityError, match="compatible writer"):
+            old.execute("UPDATE trade_inbox SET receipt_json = '{}' WHERE inbox_id = ?", (key,))
+        old.rollback()
+        with sqlite3.connect(path) as downgraded:
+            downgraded.create_function("trade_inbox_writer_version", 0, lambda: 1)
+            with pytest.raises(sqlite3.IntegrityError, match="compatible writer"):
+                downgraded.execute("DELETE FROM trade_inbox WHERE inbox_id = ?", (key,))
+    finally:
+        old.close()
+
+
+def test_unknown_schema_and_source_account_scope_fail_closed(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    _save(path, key, _RECORDED)
+    assert inbox.list_trade_receipt_recovery_rows(path, account_ids=["456"]) == []
+    assert inbox.list_trade_receipt_recovery_rows(path, account_ids=["123"])[0]["inbox_id"] == key
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET receipt_json = ? WHERE inbox_id = ?",
+                     ('{"schema_version":3,"receipts":{},"current_result_key":"recorded"}', key))
+    with pytest.raises(ValueError, match="unsupported"):
+        _attempt(path, key)
+
+
+def test_lifecycle_handoff_suppresses_ordinary_and_old_pending_failure(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    failed = _save(path, key, _FAILED)
+    result = {**_RECORDED, "diagnostics": {"notification_authority": "lifecycle_outbox"}}
+    inbox.prepare_trade_receipt_result(path, inbox_id=key, result=result, expected_result=failed)
+    assert _attempt(path, key)["claimed"] is False
+    assert inbox.read_trade_payload(path, inbox_id=key)["receipt"]["stop_reason"] == "lifecycle_outbox_handoff"
+    other = tmp_path / "other.db"
+    other_key = _new(other)
+    _save(other, other_key, result)
+    assert inbox.read_trade_payload(other, inbox_id=other_key)["receipt"] is None
+
+
+def test_recorded_verification_requires_explicit_unknown_economics_and_keeps_send_evidence(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    recorded = _save(path, key, _RECORDED)
+    attempt = _attempt(path, key)
+    with pytest.raises(inbox.TradePayloadClaimLost):
+        inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_FAILED, expected_result=recorded)
+    verifying = inbox.prepare_trade_receipt_result(path, inbox_id=key,
+        result={"status": "unresolved", "receipt_kind": "verification_pending",
+                "diagnostics": {"verification_pending": True}}, expected_result=recorded)
+    inbox.prepare_trade_receipt_result(path, inbox_id=key, result=_RECORDED, expected_result=verifying)
+    current = _attempt(path, key)
+    assert current["claimed"] is False
+    assert current["attempt_id"] == attempt["attempt_id"]
+
+
+def test_resume_resets_economic_budget_without_reopening_unknown_delivery(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET attempt_count = 19, updated_at_ms = 0 WHERE inbox_id = ?", (key,))
+    exhausted = _save(path, key, _FAILED)
+    assert exhausted["receipt_kind"] == "manual_required"
+    attempt = _attempt(path, key)
+    assert inbox.resume_trade_payload(path, inbox_id=key, operator="operator") is True
+    assert _attempt(path, key)["claimed"] is False
+    assert inbox.claim_trade_payload(path, inbox_id=key)["attempt_count"] == 1
+    summary = inbox.trade_inbox_summary(path)
+    assert summary["receipt_status_counts"]["unknown"] == 1
+    assert summary["receipt_attention"][0]["last_attempt_at_ms"] == attempt["attempted_at_ms"]
+
+
+@pytest.mark.parametrize("status", ["confirmed", "unknown"])
+def test_prior_compensation_evidence_suppresses_new_recorded_automatic_send(tmp_path, status):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    _save(path, key, {**_RECORDED, "_receipt_legacy_evidence": {
+        "blocked": True, "status": status, "records": ["compensation-1"], "result_key": "recorded"}})
+    current = _attempt(path, key)
+    assert current["claimed"] is False
+    assert current["status"] == ("sent" if status == "confirmed" else "unknown")
+    assert current["stop_reason"] == "legacy_compensation_owned"
+    assert current["attempt_count"] == 0
+
+
+def test_enrichment_timestamp_does_not_postpone_already_due_crash_recovery(tmp_path, monkeypatch):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    claim = inbox.claim_trade_payload(path, inbox_id=key)
+    _advance(monkeypatch, clock, 121)
+    # Enqueue's metadata update must not change the deadline established by the economic claim.
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET updated_at_ms = ?, payload_version = payload_version + 1, claim_id = NULL, claim_until_ms = NULL WHERE inbox_id = ?",
+                     (int(clock[0] * 1000), key))
+    recovered = inbox.claim_trade_payload(path, inbox_id=key)
+    assert recovered["attempt_count"] == 2
+    assert recovered["payload_version"] == claim["payload_version"] + 1
+
+
+def test_late_callback_for_archived_attempt_does_not_change_current_attempt(tmp_path, monkeypatch):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    _save(path, key, _RECORDED)
+    first = _attempt(path, key)
+    inbox.finish_trade_receipt_attempt(path, inbox_id=key, attempt_id=first["attempt_id"],
+                                      result={"explicit_pre_acceptance_failure": True})
+    _advance(monkeypatch, clock)
+    second = _attempt(path, key)
+    inbox.finish_trade_receipt_attempt(path, inbox_id=key, attempt_id=first["attempt_id"],
+                                      result={"delivery_confirmed": True})
+    current = inbox.read_trade_payload(path, inbox_id=key)["receipt"]
+    assert current["attempt_id"] == second["attempt_id"]
+    assert current["status"] == "unknown"
+    assert current["attempts"][0]["status"] == "failed"
+
+
+def test_explicit_empty_result_observation_is_compared_not_treated_as_omitted(tmp_path):
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    observed = inbox.read_trade_payload(path, inbox_id=key)
+    assert observed["result"] is None
+    _save(path, key, _RECORDED)
+    with pytest.raises(inbox.TradePayloadClaimLost):
+        inbox.prepare_trade_receipt_result(path, inbox_id=key,
+            result={"status": "unresolved", "receipt_kind": "verification_pending",
+                    "diagnostics": {"verification_pending": True}},
+            expected_payload_version=observed["payload_version"], expected_result=observed["result"])
+
+
+def test_readback_of_due_retry_cannot_postpone_economic_claim(tmp_path, monkeypatch):
+    clock = [1000.0]
+    _advance(monkeypatch, clock, 0)
+    path = tmp_path / "inbox.db"
+    key = _new(path)
+    failed = _save(path, key, _FAILED)
+    deadline = inbox.read_trade_payload(path, inbox_id=key)["next_attempt_at_ms"]
+    _advance(monkeypatch, clock, 61)
+    inbox.prepare_trade_receipt_result(path, inbox_id=key, result=failed, expected_result=failed)
+    assert inbox.read_trade_payload(path, inbox_id=key)["next_attempt_at_ms"] == deadline
+    assert inbox.claim_trade_payload(path, inbox_id=key)["attempt_count"] == 2

--- a/tests/test_trade_receipt_readback.py
+++ b/tests/test_trade_receipt_readback.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from domain.domain.ledger import ContractKey, TradeEvent
+from src.application.ledger.api import open_trade_reconciliation_evidence_repo
+from src.application.ledger.position_projection_runtime import run_position_projection_forced_full
+from src.application.ledger.repository import SQLiteOptionPositionsRepository
+
+
+def _event(event_id: str) -> TradeEvent:
+    return TradeEvent(
+        event_id=event_id, event_type="open", event_time_ms=1_000,
+        contract_key=ContractKey.from_values(
+            broker="futu", account="lx", underlying_symbol="NVDA", option_type="put",
+            position_side="short", strike=100, expiration_ymd="2026-09-18",
+        ),
+        contracts=1, price=2.5, currency="USD", source="test", multiplier=100,
+        lot_id=f"lot-{event_id}", raw_payload={"broker_deal_id": event_id},
+    )
+
+
+def _minimal_database(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE trade_events (event_id TEXT, event_json TEXT, trade_time_ms INTEGER)")
+        conn.execute("CREATE TABLE position_lots (record_id TEXT, fields_json TEXT, updated_at_ms INTEGER)")
+
+
+def test_receipt_readback_absence_requires_initialized_ledger(tmp_path: Path) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    SQLiteOptionPositionsRepository(database)
+    evidence = open_trade_reconciliation_evidence_repo(database).read_trade_receipt_evidence()
+    assert evidence == {"trade_events": [], "position_lots": []}
+
+
+def test_receipt_readback_returns_application_events_and_published_lots(tmp_path: Path) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    repo = SQLiteOptionPositionsRepository(database)
+    run_position_projection_forced_full(repo, [_event("deal-1")])
+
+    evidence = open_trade_reconciliation_evidence_repo(database).read_trade_receipt_evidence()
+
+    event = evidence["trade_events"][0]
+    assert event["event_id"] == "deal-1"
+    assert event["account"] == "lx"
+    assert event["symbol"] == "NVDA"
+    assert event["position_effect"] == "open"
+    assert event["raw_payload"]["broker_deal_id"] == "deal-1"
+    assert evidence["position_lots"] == repo.list_position_lots()
+    assert len(evidence["position_lots"]) == 1
+    lot = evidence["position_lots"][0]
+    assert set(lot) == {"record_id", "fields"}
+    assert lot["fields"]["source_event_id"] == "deal-1"
+
+
+def test_receipt_readback_uses_one_query_only_snapshot_during_concurrent_commit(tmp_path: Path, monkeypatch) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    writer = SQLiteOptionPositionsRepository(database)
+    run_position_projection_forced_full(writer, [_event("before")])
+    reader = open_trade_reconciliation_evidence_repo(database)
+    original_read_lots = reader._read_position_lots
+    commits = []
+
+    def commit_between_reads(conn, **kwargs):
+        assert conn.in_transaction
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            conn.execute("DELETE FROM trade_events")
+        if not commits:
+            run_position_projection_forced_full(writer, [_event("after")])
+            commits.append(True)
+        return original_read_lots(conn, **kwargs)
+
+    monkeypatch.setattr(reader, "_read_position_lots", commit_between_reads)
+    evidence = reader.read_trade_receipt_evidence()
+    assert [row["event_id"] for row in evidence["trade_events"]] == ["before"]
+    assert [row["fields"]["source_event_id"] for row in evidence["position_lots"]] == ["before"]
+    later = reader.read_trade_receipt_evidence()
+    assert {row["event_id"] for row in later["trade_events"]} == {"before", "after"}
+    assert {row["fields"]["source_event_id"] for row in later["position_lots"]} == {"before", "after"}
+
+
+@pytest.mark.parametrize("missing", ["trade_events", "position_lots"])
+def test_receipt_readback_missing_required_table_fails_closed(tmp_path: Path, missing: str) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    _minimal_database(database)
+    with sqlite3.connect(database) as conn:
+        conn.execute(f"DROP TABLE {missing}")
+    before = database.read_bytes()
+    with pytest.raises(sqlite3.DatabaseError, match="requires trade_events and position_lots"):
+        open_trade_reconciliation_evidence_repo(database).read_trade_receipt_evidence()
+    assert database.read_bytes() == before
+
+
+@pytest.mark.parametrize("table", ["trade_events", "position_lots"])
+@pytest.mark.parametrize("payload", ["{", "[]", "null", '"text"', "", None])
+def test_receipt_readback_invalid_json_fails_closed(tmp_path: Path, table: str, payload: str | None) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    _minimal_database(database)
+    with sqlite3.connect(database) as conn:
+        conn.execute(f"INSERT INTO {table} VALUES (?, ?, ?)", ("row-1", payload, 1))
+    with pytest.raises(ValueError):
+        open_trade_reconciliation_evidence_repo(database).read_trade_receipt_evidence()
+
+
+def test_receipt_readback_invalid_canonical_event_fails_closed(tmp_path: Path) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    _minimal_database(database)
+    with sqlite3.connect(database) as conn:
+        conn.execute("INSERT INTO trade_events VALUES ('broken', '{}', 1)")
+    with pytest.raises(ValueError, match="invalid canonical trade event"):
+        open_trade_reconciliation_evidence_repo(database).read_trade_receipt_evidence()
+
+
+def test_receipt_readback_missing_column_fails_closed(tmp_path: Path) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    with sqlite3.connect(database) as conn:
+        conn.execute("CREATE TABLE trade_events (event_id TEXT)")
+        conn.execute("CREATE TABLE position_lots (record_id TEXT)")
+    with pytest.raises(sqlite3.DatabaseError, match="no such column"):
+        open_trade_reconciliation_evidence_repo(database).read_trade_receipt_evidence()
+
+
+def test_receipt_readback_does_not_create_or_initialize_database(tmp_path: Path) -> None:
+    missing = tmp_path / "missing" / "ledger.sqlite3"
+    with pytest.raises(sqlite3.OperationalError):
+        open_trade_reconciliation_evidence_repo(missing).read_trade_receipt_evidence()
+    assert not missing.parent.exists()
+
+    empty = tmp_path / "empty.sqlite3"
+    sqlite3.connect(empty).close()
+    with pytest.raises(sqlite3.DatabaseError):
+        open_trade_reconciliation_evidence_repo(empty).read_trade_receipt_evidence()
+    assert empty.read_bytes() == b""
+
+
+def test_receipt_readback_uses_readonly_uri_without_file_or_permission_mutation(tmp_path: Path, monkeypatch) -> None:
+    database = tmp_path / "ledger.sqlite3"
+    _minimal_database(database)
+    database.chmod(0o640)
+    tmp_path.chmod(0o750)
+    before = {path.name: (path.read_bytes(), path.stat().st_mode, path.stat().st_mtime_ns) for path in tmp_path.iterdir()}
+    real_connect = sqlite3.connect
+    connections = []
+
+    def readonly_connect(database_uri, **kwargs):
+        assert database_uri == f"{database.resolve().as_uri()}?mode=ro"
+        assert kwargs["uri"] is True
+        connection = real_connect(database_uri, **kwargs)
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(sqlite3, "connect", readonly_connect)
+    assert open_trade_reconciliation_evidence_repo(database).read_trade_receipt_evidence() == {
+        "trade_events": [], "position_lots": [],
+    }
+    assert len(connections) == 1
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        connections[0].execute("SELECT 1")
+    assert {path.name: (path.read_bytes(), path.stat().st_mode, path.stat().st_mtime_ns) for path in tmp_path.iterdir()} == before
+    assert tmp_path.stat().st_mode & 0o777 == 0o750

--- a/tests/test_trade_receipt_recovery.py
+++ b/tests/test_trade_receipt_recovery.py
@@ -66,6 +66,22 @@ def _stored(tmp_path, payload):
     return inbox.read_trade_payload(tmp_path / "ledger.sqlite3.trade_intake_inbox.sqlite3", inbox_id=_inbox_id(payload))
 
 
+def _recover(tmp_path, repo, monkeypatch, calls, *, sender=None, routed=True):
+    cfg = {"notifications": {"provider": "wechat_clawbot", "target": "wechat:offline-test" if routed else ""}}
+    monkeypatch.setattr(auto_intake, "send_trade_intake_receipt", partial(
+        receipt.send_trade_intake_receipt, send_fn=sender or _successful_sender(calls), normalize_fn=lambda **kwargs: kwargs))
+    callback = auto_intake._build_receipt_callback(base=tmp_path, cfg=cfg, receipt_config={"enabled": True}, repo=repo)
+    return auto_intake.recover_trade_intake_receipts(repo=repo, source={
+        "state_path": tmp_path / "state.json", "inbox_path": tmp_path / "ledger.sqlite3.trade_intake_inbox.sqlite3",
+        "futu_account_ids": ["123"], "account_mapping": {"123": "lx"}, "account": "lx"},
+        receipt_callback=callback, stop_event=__import__("threading").Event())
+
+
+def _advance(monkeypatch, seconds=121):
+    after = time.time() + seconds
+    monkeypatch.setattr(inbox.time, "time", lambda: after)
+
+
 def test_ledger_commit_before_state_crash_recovers_original_open_and_one_stable_receipt(tmp_path, monkeypatch):
     payload = _payload()
     calls = []
@@ -78,14 +94,16 @@ def test_ledger_commit_before_state_crash_recovers_original_open_and_one_stable_
     before_events, before_lots = repo.list_trade_events(), repo.list_position_lots()
     assert len(before_events) == len(before_lots) == 1
     assert calls == []
-    assert _stored(tmp_path, payload)["receipt"] is None
+    assert _stored(tmp_path, payload)["receipt"]["status"] == "pending"
     monkeypatch.setattr(auto_intake, "update_trade_intake_state_entries", write_state)
     restarted = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
     process = _processor(tmp_path, restarted, monkeypatch, _successful_sender(calls))
-    recovered = process(payload)
+    _advance(monkeypatch)
+    assert _recover(tmp_path, restarted, monkeypatch, calls)["sent"] == 1
+    recovered = _stored(tmp_path, payload)["result"]
     assert recovered["status"] == "applied"
     assert recovered["reason"] == "applied_open"
-    assert recovered["receipt"]["delivery_confirmed"] is True
+    assert _stored(tmp_path, payload)["receipt"]["status"] == "sent"
     assert restarted.list_trade_events() == before_events
     assert restarted.list_position_lots() == before_lots
     assert len(calls) == 1
@@ -116,7 +134,8 @@ def test_sender_process_exit_leaves_unknown_and_restart_never_resends(tmp_path, 
     monkeypatch.setattr(inbox.time, "time", lambda: resumed_time)
     restarted = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
     replay = _processor(tmp_path, restarted, monkeypatch, _successful_sender(calls))(payload)
-    assert replay["receipt"]["reason"] == "durable_receipt_unknown"
+    assert replay["reason"] == "inbox_pending"
+    assert _recover(tmp_path, restarted, monkeypatch, calls)["sent"] == 0
     assert _stored(tmp_path, payload)["receipt"] == frozen
     assert (restarted.list_trade_events(), restarted.list_position_lots()) == before
     assert len(calls) == 1
@@ -153,7 +172,8 @@ def test_receipt_recovery_preserves_known_rejection_no_route_and_unknown_evidenc
     stored = _stored(tmp_path, _payload())
     if outcome == "no_route":
         assert result["receipt"]["reason"] == "skipped_no_route"
-        assert stored["receipt"] is None
+        assert stored["receipt"]["status"] == "pending"
+        assert stored["receipt"]["attempt_count"] == 0
         assert stored["result"]["receipt"]["reason"] == "skipped_no_route"
         assert calls == []
     else:
@@ -333,6 +353,7 @@ def test_new_order_after_commit_crash_preserves_original_first_receipt_permissio
     events, lots = repo.list_trade_events(), repo.list_position_lots()
     assert len(events) == 1 and calls == []
     assert _stored(tmp_path, unknown_order)["receipt_recovery_allowed"] == 1
+    _advance(monkeypatch)
     recovered = process(_payload(), source="backfill")
     assert recovered["reason"] == "applied_open" and recovered["receipt"]["delivery_confirmed"] is True
     stored = _stored(tmp_path, unknown_order)
@@ -344,3 +365,142 @@ def test_new_order_after_commit_crash_preserves_original_first_receipt_permissio
     assert repo.list_position_lots() == lots
     process(unknown_order)
     assert len(calls) == 1
+
+
+def test_transient_lock_failure_then_due_retry_sends_distinct_success_once(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    process = _processor(tmp_path, repo, monkeypatch, _successful_sender(calls))
+    resolver = auto_intake.resolve_trade_deal
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", lambda *_a, **_k: (_ for _ in ()).throw(sqlite3.OperationalError("locking protocol")))
+    failed = process(_payload())
+    assert failed["receipt_kind"] == "pending_retry"
+    assert failed["retry_policy"] == {"attempt_count": 1, "max_attempts": 20, "remaining": 19,
+                                      "retryable": True, "retry_delay_sec": 60}
+    assert "数据库短暂争用" in calls[0]["message"]
+    assert "剩余 19 次" in calls[0]["message"]
+    assert not repo.list_trade_events()
+    assert process(_payload())["reason"] == "inbox_pending"
+    assert len(calls) == 1
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", resolver)
+    _advance(monkeypatch, 61)
+    assert _recover(tmp_path, repo, monkeypatch, calls)["sent"] == 0
+    recovered = process(_payload(), source="backfill")
+    assert recovered["receipt_kind"] == "recorded"
+    assert len(calls) == 2 and "✅ 已记录" in calls[1]["message"]
+    assert len(repo.list_trade_events()) == len(repo.list_position_lots()) == 1
+    envelope = _stored(tmp_path, _payload())["receipt_envelope"]
+    assert envelope["receipts"]["pending_retry"]["status"] == "sent"
+    assert envelope["receipts"]["recorded"]["status"] == "sent"
+    process(_payload())
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize("error,cause", [(sqlite3.OperationalError("no such table: trade_events"), "数据库结构或存储异常"),
+                                       (PermissionError("denied"), "数据库写入权限不足")])
+def test_permanent_failure_explains_no_automatic_retry(tmp_path, monkeypatch, error, cause):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", lambda *_a, **_k: (_ for _ in ()).throw(error))
+    failed = _processor(tmp_path, repo, monkeypatch, _successful_sender(calls))(_payload())
+    assert failed["receipt_kind"] == "manual_required"
+    assert not failed["retry_policy"]["retryable"]
+    assert cause in calls[0]["message"] and "不会自动重试" in calls[0]["message"]
+    assert not inbox.list_retryable_trade_payloads(tmp_path / "ledger.sqlite3.trade_intake_inbox.sqlite3", account_ids=["123"])
+
+
+@pytest.mark.parametrize("initial", ["no_route", "rejected"])
+def test_notification_recovery_without_new_fill_never_runs_economic_writer(tmp_path, monkeypatch, initial):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    def rejected(**kwargs):
+        calls.append(kwargs)
+        return {"ok": False, "command_ok": False, "delivery_confirmed": False, "returncode": 1,
+                "explicit_pre_acceptance_failure": True, "error_code": "PROVIDER_REJECTED"}
+    _processor(tmp_path, repo, monkeypatch, rejected, routed=initial != "no_route")(_payload())
+    before = repo.list_trade_events(), repo.list_position_lots()
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", lambda *_a, **_k: pytest.fail("notification recovery invoked economic writer"))
+    _advance(monkeypatch, 61)
+    recovered = _recover(tmp_path, repo, monkeypatch, calls)
+    assert recovered["sent"] == 1 and not recovered["errors"]
+    assert len(calls) == (1 if initial == "no_route" else 2)
+    assert (repo.list_trade_events(), repo.list_position_lots()) == before
+    assert _stored(tmp_path, _payload())["attempt_count"] == 1
+    assert _recover(tmp_path, repo, monkeypatch, calls)["checked"] == 0
+
+
+def test_unknown_ledger_readback_only_checks_until_absence_is_proven(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", lambda *_a, **_k: (_ for _ in ()).throw(sqlite3.OperationalError("locking protocol")))
+    reader = auto_intake.open_trade_reconciliation_evidence_repo
+    monkeypatch.setattr(auto_intake, "open_trade_reconciliation_evidence_repo", lambda *_a: (_ for _ in ()).throw(sqlite3.OperationalError("database is locked")))
+    failed = _processor(tmp_path, repo, monkeypatch, _successful_sender(calls))(_payload())
+    assert failed["receipt_kind"] == "verification_pending"
+    assert "核对前不会重复录入" in calls[0]["message"]
+    path = tmp_path / "ledger.sqlite3.trade_intake_inbox.sqlite3"
+    _advance(monkeypatch)
+    assert inbox.claim_trade_payload(path, inbox_id=_inbox_id(_payload()), repo=repo) is None
+    assert _recover(tmp_path, repo, monkeypatch, calls)["sent"] == 0
+    assert _stored(tmp_path, _payload())["attempt_count"] == 1
+    monkeypatch.setattr(auto_intake, "open_trade_reconciliation_evidence_repo", reader)
+    _advance(monkeypatch)
+    assert _recover(tmp_path, repo, monkeypatch, calls)["sent"] == 1
+    assert _stored(tmp_path, _payload())["result"]["receipt_kind"] == "pending_retry"
+    assert _stored(tmp_path, _payload())["attempt_count"] == 1
+
+
+def test_exception_after_commit_uses_read_only_proof_and_sends_success_first(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    resolver = auto_intake.resolve_trade_deal
+    def commit_then_fail(*args, **kwargs):
+        resolver(*args, **kwargs)
+        raise sqlite3.OperationalError("locking protocol")
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", commit_then_fail)
+    result = _processor(tmp_path, repo, monkeypatch, _successful_sender(calls))(_payload())
+    assert result["receipt_kind"] == "recorded" and result["receipt"]["delivery_confirmed"]
+    assert len(calls) == 1 and "✅ 已记录" in calls[0]["message"]
+    assert len(repo.list_trade_events()) == len(repo.list_position_lots()) == 1
+
+
+def test_normalize_failure_no_route_recovers_failure_notice_without_renormalizing(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    monkeypatch.setattr(auto_intake, "normalize_trade_deal", lambda *_a, **_k: (_ for _ in ()).throw(ValueError("invalid contract")))
+    failed = _processor(tmp_path, repo, monkeypatch, _successful_sender(calls), routed=False)(_payload())
+    assert failed["receipt_kind"] == "manual_required" and failed["account"] == "lx"
+    assert failed["deal_id"] == "opening" and calls == []
+    assert _recover(tmp_path, repo, monkeypatch, calls)["sent"] == 1
+    assert "lx" in calls[0]["message"] and "不会自动重试" in calls[0]["message"]
+    assert not repo.list_trade_events()
+
+
+def test_legacy_source_recovery_uses_current_mapping_and_rejects_remapped_account(tmp_path, monkeypatch):
+    import threading
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    payload = _payload("779")
+    _processor(tmp_path, repo, monkeypatch, _successful_sender(calls), routed=False)(payload)
+    cfg = {"notifications": {"provider": "wechat_clawbot", "target": "wechat:offline-test"}}
+    callback = auto_intake._build_receipt_callback(base=tmp_path, cfg=cfg, receipt_config={"enabled": True}, repo=repo)
+    source = {"state_path": tmp_path / "state.json", "account": None,
+              "inbox_path": tmp_path / "ledger.sqlite3.trade_intake_inbox.sqlite3", "futu_account_ids": ["123"],
+              "account_mapping": {"123": "sy"}}
+    assert auto_intake.recover_trade_intake_receipts(repo=repo, source=source,
+        receipt_callback=callback, stop_event=threading.Event())["checked"] == 0
+    source["account_mapping"] = {"123": "lx"}
+    assert auto_intake.recover_trade_intake_receipts(repo=repo, source=source,
+        receipt_callback=callback, stop_event=threading.Event())["sent"] == 1
+    assert len(calls) == 1
+
+
+def test_non_option_write_uncertainty_cannot_be_proved_absent_by_option_ledger(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    calls = []
+    raw = {**_payload(), "instrument_ref": {"asset_type": "stock", "market": "US", "symbol": "NVDA", "currency": "USD"}}
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", lambda *_a, **_k: (_ for _ in ()).throw(sqlite3.OperationalError("locking protocol")))
+    result = _processor(tmp_path, repo, monkeypatch, _successful_sender(calls))(raw)
+    assert result["receipt_kind"] == "verification_pending"
+    assert not result["retry_policy"]["retryable"]
+    assert "existing ledger owner" in result["diagnostics"]["readback_error"]

--- a/tests/test_trade_receipt_source_recovery.py
+++ b/tests/test_trade_receipt_source_recovery.py
@@ -1,0 +1,327 @@
+from functools import partial
+import json
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from src.application.ledger.repository import SQLiteOptionPositionsRepository
+from src.application.trades import auto_intake, receipt
+from src.infrastructure.futu_trade_push import OpenDTradePushListener
+from tests.test_trade_receipt_recovery import _payload, _processor, _stored
+
+
+def _source(tmp_path):
+    return {"id": "lx", "account": "lx", "host": "127.0.0.1", "port": 11111,
+            "state_path": tmp_path / "state.json", "audit_path": tmp_path / "audit.jsonl",
+            "status_path": tmp_path / "status.json",
+            "inbox_path": tmp_path / "ledger.sqlite3.trade_intake_inbox.sqlite3",
+            "account_mapping": {"123": "lx"}, "futu_account_ids": ["123"],
+            "receipt": {"enabled": True}, "backfill": {"enabled": False},
+            "settlement_observation": {"enabled": False}}
+
+
+def _callback(tmp_path, repo, monkeypatch, sender, *, receipt_config=None):
+    monkeypatch.setattr(auto_intake, "send_trade_intake_receipt", partial(
+        receipt.send_trade_intake_receipt, send_fn=sender, normalize_fn=lambda send_result: send_result))
+    return auto_intake._build_receipt_callback(
+        base=tmp_path, repo=repo, receipt_config=receipt_config or {"enabled": True},
+        cfg={"notifications": {"provider": "wechat_clawbot", "target": "wechat:offline-test"}})
+
+
+def _run(tmp_path, monkeypatch, repo, source, callback, stop):
+    monkeypatch.setattr(auto_intake, "OpenDHistoryDealClient", lambda **_: SimpleNamespace(close=lambda: None))
+    return auto_intake._run_listener_source_loop(
+        source=source, repo=repo, cfg={}, cfg_path=tmp_path / "config.json", runtime_root=tmp_path,
+        runtime_root_source="test", intake_cfg={"mode": "apply", "enabled": True},
+        apply_changes=True, receipt_callback=callback, process_lock=threading.RLock(), stop_event=stop)
+
+
+def test_source_recovers_again_while_sdk_constructor_remains_unfinished(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    payload = _payload("778")
+    _processor(tmp_path, repo, monkeypatch, lambda **_: pytest.fail("no route cannot send"), routed=False)(payload)
+    before = repo.list_trade_events(), repo.list_position_lots()
+    source = _source(tmp_path)
+    clock = [0.0]
+    wall = auto_intake.time.time()
+    monkeypatch.setattr(auto_intake.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(auto_intake.time, "time", lambda: wall + clock[0])
+    monkeypatch.setattr(auto_intake, "resolve_trade_deal", lambda *_, **__: pytest.fail("receipt retry must not write a trade"))
+    release = threading.Event()
+    entered = threading.Event()
+    finished = threading.Event()
+    stop = threading.Event()
+    sends = []
+
+    def build(_self):
+        entered.set()
+        clock[0] = 61
+        try:
+            if not release.wait(5):
+                stop.set()
+            raise RuntimeError("test SDK constructor released")
+        finally:
+            finished.set()
+
+    def sender(**kwargs):
+        sends.append(kwargs)
+        if len(sends) == 1:
+            return {"ok": False, "explicit_pre_acceptance_failure": True, "error_code": "PROVIDER_REJECTED"}
+        assert entered.is_set() and not finished.is_set()
+        stop.set()
+        return {"ok": True, "command_ok": True, "delivery_confirmed": True, "message_id": "recovered-during-init"}
+
+    monkeypatch.setattr(OpenDTradePushListener, "_build_default_context", build)
+    try:
+        assert _run(tmp_path, monkeypatch, repo, source, _callback(tmp_path, repo, monkeypatch, sender), stop) == 0
+    finally:
+        release.set()
+        assert finished.wait(2)
+    assert len(sends) == 2
+    assert _stored(tmp_path, payload)["receipt"]["result"]["delivery_confirmed"] is True
+    assert _stored(tmp_path, payload)["receipt"]["attempt_count"] == 2
+    assert (repo.list_trade_events(), repo.list_position_lots()) == before
+    assert json.loads(source["status_path"].read_text())["stage"] == "start_cancelled"
+
+
+@pytest.mark.parametrize("change", ["disabled_source", "disabled_receipt", "other_account", "cancelled"])
+def test_receipt_recovery_rechecks_current_source_and_cancellation(tmp_path, monkeypatch, change):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    _processor(tmp_path, repo, monkeypatch, lambda **_: pytest.fail("no route cannot send"), routed=False)(_payload())
+    source = _source(tmp_path)
+    stop = threading.Event()
+    if change == "disabled_source":
+        source["enabled"] = False
+    elif change == "disabled_receipt":
+        source["receipt"] = {"enabled": False}
+    elif change == "other_account":
+        source["account"] = "sy"
+    else:
+        stop.set()
+    sends = []
+    result = auto_intake.recover_trade_intake_receipts(
+        repo=repo, source=source,
+        receipt_callback=_callback(tmp_path, repo, monkeypatch, lambda **kwargs: sends.append(kwargs) or {
+            "ok": True, "command_ok": True, "delivery_confirmed": True, "message_id": "must-not-send"}),
+        stop_event=stop)
+    assert sends == []
+    assert result["sent"] == 0
+
+
+def test_source_isolates_recovery_error_and_retries_during_start(tmp_path, monkeypatch):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    source = _source(tmp_path)
+    clock = [0.0]
+    monkeypatch.setattr(auto_intake.time, "monotonic", lambda: clock[0])
+    stop = threading.Event()
+    calls = []
+
+    def recover(**_):
+        calls.append(clock[0])
+        if len(calls) == 1:
+            raise OSError("temporary Inbox read failure")
+        stop.set()
+        return {"checked": 0, "sent": 0, "errors": []}
+
+    class Listener:
+        def __init__(self, **_):
+            pass
+        def start(self, *, cancel_event, on_wait):
+            saved = json.loads(source["status_path"].read_text())
+            assert "temporary Inbox read failure" in saved["receipt_recovery"]["error"]
+            clock[0] = 61
+            on_wait()
+            clock[0] = 122
+            on_wait()
+        def close(self):
+            pass
+
+    monkeypatch.setattr(auto_intake, "OpenDTradePushListener", Listener)
+    monkeypatch.setattr(auto_intake, "recover_trade_intake_receipts", recover)
+    assert _run(tmp_path, monkeypatch, repo, source, lambda _: {}, stop) == 0
+    assert calls == [0, 61]
+
+
+@pytest.mark.parametrize("phase", ["normal", "reconnect"])
+def test_source_runs_due_recovery_in_existing_normal_and_reconnect_loops(tmp_path, monkeypatch, phase):
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    source = {**_source(tmp_path), "reconnect_sec": 40}
+    clock = [0.0]
+    monkeypatch.setattr(auto_intake.time, "monotonic", lambda: clock[0])
+    recovered = []
+
+    class Stop:
+        stopped = False
+        def is_set(self):
+            return self.stopped
+        def set(self):
+            self.stopped = True
+        def wait(self, seconds):
+            clock[0] += seconds
+            return self.stopped
+
+    stop = Stop()
+
+    def recover(**kwargs):
+        assert kwargs["source"]["account"] == "lx"
+        assert not stop.is_set()
+        recovered.append(clock[0])
+        if len(recovered) == 2:
+            stop.set()
+        return {"checked": 0, "sent": 0, "errors": []}
+
+    class Listener:
+        starts = 0
+        def __init__(self, **_):
+            pass
+        def start(self, *, cancel_event, on_wait):
+            type(self).starts += 1
+            if phase == "reconnect":
+                raise ConnectionRefusedError("OpenD unavailable")
+            clock[0] = 61
+        def check_health(self):
+            pass
+        def close(self):
+            pass
+
+    monkeypatch.setattr(auto_intake, "OpenDTradePushListener", Listener)
+    monkeypatch.setattr(auto_intake, "recover_trade_intake_receipts", recover)
+    monkeypatch.setattr(auto_intake, "build_futu_gateway", lambda **_: pytest.fail("recovery must not require broker availability"))
+    assert _run(tmp_path, monkeypatch, repo, source, lambda _: {}, stop) == 0
+    assert recovered == [0, 61 if phase == "normal" else 60]
+    assert Listener.starts == (1 if phase == "normal" else 2)
+
+
+@pytest.mark.parametrize("kind,status,category,flag", [
+    ("recorded", "applied", None, "notify_applied"),
+    ("pending_retry", "failed", None, "notify_failed"),
+    ("manual_required", "failed", None, "notify_failed"),
+    ("manual_required", "unresolved", None, "notify_unresolved"),
+    ("verification_pending", "unresolved", "applied", "notify_applied"),
+    ("verification_pending", "unresolved", "failed", "notify_failed"),
+    ("verification_pending", "unresolved", "unresolved", "notify_unresolved"),
+])
+def test_receipt_subflags_preserve_pending_semantic_result_until_reenabled(
+    tmp_path, monkeypatch, kind, status, category, flag,
+):
+    from src.application.trades import inbox
+    from src.application.trades.deal_identity import broker_deal_key_from_payload
+    from src.application.trades.normalizer import normalize_trade_deal
+
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    payload = _payload("779")
+    path = _source(tmp_path)["inbox_path"]
+    inbox_id = inbox.enqueue_trade_payload(path, payload=payload, source="push", repo=repo,
+        broker_deal_key=broker_deal_key_from_payload(payload, account_mapping={"123": "lx"}))
+    deal = normalize_trade_deal(payload, futu_account_mapping={"123": "lx"}, allow_opend_refresh=False)
+    diagnostics = {"retryable": kind == "pending_retry", "verification_pending": kind == "verification_pending"}
+    if category:
+        diagnostics["notification_category"] = category
+    prepared = inbox.prepare_trade_receipt_result(
+        path, inbox_id=inbox_id, expected_payload_version=1,
+        result={"status": status, "reason": "applied_open" if kind == "recorded" else "sqlite_busy",
+                "receipt_kind": kind, "diagnostics": diagnostics,
+                "_receipt_payload": auto_intake._receipt_deal_snapshot(deal)})
+    sends = []
+    config = {"enabled": True, flag: False}
+    callback = _callback(tmp_path, repo, monkeypatch, lambda **kwargs: sends.append(kwargs) or {
+        "ok": True, "command_ok": True, "delivery_confirmed": True, "message_id": "subflag-enabled"},
+        receipt_config=config)
+    context = {"result": prepared, "deal": deal, "state": {}, "apply_changes": True,
+               "effective_payload": payload, "inbox_path": path, "inbox_id": inbox_id}
+
+    suppressed = callback(context)
+    assert suppressed["status"] == "skipped"
+    assert sends == []
+    frozen = inbox.read_trade_payload(path, inbox_id=inbox_id)["receipt"]
+    assert frozen["receipt_kind"] == kind
+    assert frozen["status"] == "pending" and frozen["attempt_count"] == 0
+    if category:
+        assert frozen["business_result"]["diagnostics"]["notification_category"] == category
+
+    config[flag] = True
+    assert callback(context)["delivery_confirmed"] is True
+    callback(context)
+    assert len(sends) == 1
+    frozen = inbox.read_trade_payload(path, inbox_id=inbox_id)["receipt"]
+    assert frozen["status"] == "sent" and frozen["attempt_count"] == 1
+    assert frozen["result"]["delivery_confirmed"] is True
+    assert repo.list_trade_events() == []
+
+
+@pytest.mark.parametrize("prior_attempts", [0, 19])
+@pytest.mark.parametrize("rollback", [False, True])
+def test_recovery_waits_for_expired_claim_transaction_before_concluding_absence(
+    tmp_path, monkeypatch, prior_attempts, rollback,
+):
+    import sqlite3
+    from src.application.trades import inbox
+    from src.application.trades.deal_identity import broker_deal_key_from_payload
+    from tests.test_trade_receipt_claim_fence import _execution, _process, _receipt_callback, _start_worker
+
+    repo = SQLiteOptionPositionsRepository(tmp_path / "ledger.sqlite3")
+    payload = {**_execution(), "external_execution_id": "888"}
+    source = {**_source(tmp_path), "state_path": tmp_path / "worker" / "state.json"}
+    path = source["inbox_path"]
+    inbox_id = inbox.enqueue_trade_payload(path, payload=payload, source="push", repo=repo,
+        broker_deal_key=broker_deal_key_from_payload(payload, account_mapping={"123": "lx"}))
+    with inbox._connect(path) as conn:
+        conn.execute("UPDATE trade_inbox SET attempt_count=? WHERE inbox_id=?", (prior_attempts, inbox_id))
+    inserted, release, selected, readback = (threading.Event() for _ in range(4))
+    errors, sends = [], []
+    callback = _receipt_callback(tmp_path, repo, monkeypatch, sends)
+    real_insert = repo.upsert_trade_event
+    real_rows = auto_intake.list_trade_receipt_recovery_rows
+    real_readback = auto_intake._readback_trade_receipt_result
+
+    def paused_insert(event, **kwargs):
+        result = real_insert(event, **kwargs)
+        assert kwargs.get("conn") is not None
+        inserted.set()
+        assert release.wait(5)
+        if rollback:
+            raise sqlite3.OperationalError("database is locked")
+        return result
+
+    def recovery_rows(*args, **kwargs):
+        rows = real_rows(*args, **kwargs)
+        selected.set()
+        return rows
+
+    def observe_readback(**kwargs):
+        readback.set()
+        return real_readback(**kwargs)
+
+    monkeypatch.setattr(repo, "upsert_trade_event", paused_insert)
+    monkeypatch.setattr(auto_intake, "list_trade_receipt_recovery_rows", recovery_rows)
+    monkeypatch.setattr(auto_intake, "_readback_trade_receipt_result", observe_readback)
+    started = auto_intake.time.time()
+    writer = _start_worker(lambda: _process(repo, tmp_path, "worker", payload, callback), errors)
+    recovery = None
+    try:
+        assert inserted.wait(5)
+        monkeypatch.setattr(inbox.time, "time", lambda: started + 121)
+        recover = lambda: auto_intake.recover_trade_intake_receipts(
+            repo=repo, source=source, receipt_callback=callback, stop_event=threading.Event())
+        recovery = _start_worker(recover, errors)
+        assert selected.wait(5)
+        assert not readback.wait(0.1), "absence must not be read while an expired writer can still commit"
+        assert sends == []
+    finally:
+        release.set()
+        writer.join(5)
+        if recovery is not None:
+            recovery.join(5)
+    assert not writer.is_alive() and recovery is not None and not recovery.is_alive()
+    assert all(isinstance(error, inbox.TradePayloadClaimLost) for error in errors)
+    recover()
+    row = inbox.read_trade_payload(path, inbox_id=inbox_id)
+    expected = ("manual_required" if prior_attempts == 19 else "pending_retry") if rollback else "recorded"
+    assert row["result"]["receipt_kind"] == expected
+    assert row["receipt"]["status"] == "sent"
+    assert len(sends) == 1
+    assert len(repo.list_trade_events()) == (0 if rollback else 1)
+    assert len(repo.list_position_lots()) == (0 if rollback else 1)
+    if not rollback:
+        assert "✅ 已记录" in sends[0]["message"] and "未记录" not in sends[0]["message"]

--- a/tests/test_trades_auto_intake_backfill.py
+++ b/tests/test_trades_auto_intake_backfill.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1246,6 +1247,8 @@ def test_pm_intent_survives_stock_state_crash_and_is_claimed_once(tmp_path, monk
     with pytest.raises(Crash):
         _process_stock(tmp_path, repo, payload)
     inbox = resolve_execution_inbox_path(repo, tmp_path / "legacy.sqlite3")
+    after_lease = auto_intake.time.time() + 121
+    monkeypatch.setattr(auto_intake.time, "time", lambda: after_lease)
     pending = list_retryable_trade_payloads(inbox, retry_delay_sec=0)[0]
     saved = read_trade_payload(inbox, inbox_id=pending["inbox_id"])
     intent = saved["result"]["portfolio_refresh_intent"]
@@ -1276,6 +1279,8 @@ def test_backfill_disabled_preserves_pending_refresh_for_enabled_replay(tmp_path
         _process_stock(tmp_path, repo, payload)
     monkeypatch.setattr(auto_intake, "update_trade_intake_state_entries", original)
     path = resolve_execution_inbox_path(repo, tmp_path / "unused.sqlite3")
+    after_lease = auto_intake.time.time() + 121
+    monkeypatch.setattr(auto_intake.time, "time", lambda: after_lease)
     pending = list_retryable_trade_payloads(path, retry_delay_sec=0)[0]
     intent = json.loads(read_trade_payload(path, inbox_id=pending["inbox_id"])["portfolio_refresh_intent_json"])
     resume_trade_payload(path, inbox_id=pending["inbox_id"], operator="offline-test", repo=repo)
@@ -1321,15 +1326,24 @@ def test_backfill_counts_one_attempt_per_real_core_attempt(tmp_path, monkeypatch
         monkeypatch.setattr(auto_intake, "save_trade_payload_result",
                             lambda *_, **__: (_ for _ in ()).throw(OSError("result storage unavailable")))
     inbox = resolve_execution_inbox_path(repo, tmp_path / "legacy.sqlite3")
+    key = broker_deal_key_from_payload(payload, account_mapping={"123": "lx"})
+    inbox_id = hashlib.sha256(key.encode()).hexdigest()
+    clock = [auto_intake.time.time()]
+    monkeypatch.setattr(auto_intake.time, "time", lambda: clock[0])
     for expected_attempts in (1, 2):
         result = _run_standard_backfill(tmp_path, repo, payload)
         rows = list_retryable_trade_payloads(inbox, retry_delay_sec=0)
-        assert len(rows) == 1
-        assert rows[0]["attempt_count"] == expected_attempts
         if failure == "unresolved":
+            assert len(rows) == 1
+            assert rows[0]["attempt_count"] == expected_attempts
             assert result["last_result"]["reason"] == "missing_required_fields:multiplier"
         else:
-            assert "result storage unavailable" in rows[0]["last_error"]
+            assert rows == []
+            saved = read_trade_payload(inbox, inbox_id=inbox_id)
+            assert saved["attempt_count"] == 1
+            assert saved["result"]["receipt_kind"] == "verification_pending"
+            assert "result storage unavailable" in saved["last_error"]
+        clock[0] += 61
     assert repo.list_trade_events() == []
 
 

--- a/tests/test_trades_auto_intake_cli.py
+++ b/tests/test_trades_auto_intake_cli.py
@@ -658,7 +658,7 @@ def test_disabled_settlement_observation_retries_seal_without_gateways(
             self.on_deal = on_deal
 
         def start(self, **_kwargs):
-            self.on_deal({"deal_id": "deal-1"})
+            self.on_deal({"deal_id": "deal-1", "futu_account_id": "REAL_LX"})
 
         def check_health(self):
             return None
@@ -997,7 +997,7 @@ def test_deal_json_source_selection_rejects_account_mapping_conflict() -> None:
         )
 
 
-def test_push_source_binding_supplies_account_identity_before_inbox() -> None:
+def test_push_source_binding_preserves_explicit_account_identity_before_inbox() -> None:
     source = {
         "id": "sy",
         "account": "sy",
@@ -1008,6 +1008,7 @@ def test_push_source_binding_supplies_account_identity_before_inbox() -> None:
     }
     push_payload = {
         "deal_id": "deal-expiry-1",
+        "futu_account_id": "REAL_87654321",
         "code": "HK.TCH260730P440000",
         "price": 0.0,
         "qty": 1.0,
@@ -1049,7 +1050,7 @@ def test_push_and_backfill_build_same_inbox_identity_regardless_of_arrival_order
         "futu_account_ids": ["REAL_87654321"],
     }
     push_payload = auto_intake._bind_push_payload_to_source(
-        {"deal_id": "same-deal", "code": "HK.TCH260730P440000"},
+        {"deal_id": "same-deal", "code": "HK.TCH260730P440000", "futu_account_id": "REAL_87654321"},
         source=source,
         received_at_utc="2026-07-30T11:58:17+00:00",
     )
@@ -1103,10 +1104,11 @@ def test_push_source_binding_rejects_payload_from_another_account() -> None:
         )
 
 
-def test_push_source_binding_rejects_ambiguous_source_without_payload_account() -> None:
+@pytest.mark.parametrize("account_ids", [["REAL_12345678"], ["REAL_12345678", "REAL_87654321"]])
+def test_push_source_binding_rejects_source_without_payload_account(account_ids) -> None:
     import pytest
 
-    with pytest.raises(ValueError, match="requires exactly one futu_account_id"):
+    with pytest.raises(ValueError, match="requires verified futu_account_id"):
         auto_intake._bind_push_payload_to_source(
             {"deal_id": "ambiguous"},
             source={
@@ -1117,7 +1119,7 @@ def test_push_source_binding_rejects_ambiguous_source_without_payload_account() 
                     "REAL_12345678": "lx",
                     "REAL_87654321": "sy",
                 },
-                "futu_account_ids": ["REAL_12345678", "REAL_87654321"],
+                "futu_account_ids": account_ids,
             },
             received_at_utc="2026-07-30T11:58:17+00:00",
         )
@@ -1177,10 +1179,11 @@ def test_listener_binds_push_source_before_enqueue(monkeypatch, tmp_path: Path) 
         def __init__(self, *, on_deal, **_kwargs):
             self.on_deal = on_deal
 
-        def start(self, *, cancel_event):
+        def start(self, *, cancel_event, on_wait=None):
             self.on_deal(
                 {
                     "deal_id": "push-deal-1",
+                    "futu_account_id": "REAL_87654321",
                     "code": "HK.TCH260730P440000",
                 }
             )
@@ -1274,7 +1277,7 @@ def test_listener_retry_preserves_source_without_dry_run_refresh_side_effects(
         def __init__(self, **_kwargs):
             pass
 
-        def start(self, *, cancel_event):
+        def start(self, *, cancel_event, on_wait=None):
             pass
 
         def check_health(self):
@@ -1515,6 +1518,8 @@ def test_execution_file_cli_preview_apply_and_saved_inbox_view(tmp_path, monkeyp
             )
         monkeypatch.setattr(auto_intake, "update_trade_intake_state_entries", original_write)
         inbox = resolve_execution_inbox_path(repo, tmp_path / "unused.sqlite3")
+        after_lease = auto_intake.time.time() + 121
+        monkeypatch.setattr(auto_intake.time, "time", lambda: after_lease)
         pending = list_retryable_trade_payloads(inbox, retry_delay_sec=0)[0]
         saved_args = [*common, "--inbox-id", pending["inbox_id"]]
         assert run(saved_args) == 0
@@ -1571,9 +1576,11 @@ def test_om_trade_intake_public_process_accepts_saved_input_flags(tmp_path, entr
 
 @pytest.mark.parametrize("failure", ["unresolved", "exception"])
 def test_listener_core_owns_one_durable_attempt(tmp_path, monkeypatch, failure):
+    import hashlib
     from src.application.ledger.repository import SQLiteOptionPositionsRepository
     from src.application.trades.inbox import (
         list_retryable_trade_payloads,
+        read_trade_payload,
         read_trade_source_evidence,
         trade_payload_evidence_ref,
     )
@@ -1627,7 +1634,15 @@ def test_listener_core_owns_one_durable_attempt(tmp_path, monkeypatch, failure):
     status = json.loads(Path(source["status_path"]).read_text(encoding="utf-8"))
     assert status["inbox_path"] == str(authoritative)
     assert status["inbox"]["path"] == str(authoritative)
+    after_lease = auto_intake.time.time() + 121
+    monkeypatch.setattr(auto_intake.time, "time", lambda: after_lease)
     rows = list_retryable_trade_payloads(authoritative, retry_delay_sec=0)
+    if failure == "exception":
+        from src.application.trades.deal_identity import broker_deal_key_from_payload
+        assert rows == []
+        key = broker_deal_key_from_payload(payload, account_mapping=source["account_mapping"])
+        rows = [read_trade_payload(authoritative, inbox_id=hashlib.sha256(key.encode()).hexdigest())]
+        assert rows[0]["result"]["receipt_kind"] == "verification_pending"
     assert len(rows) == 1
     assert rows[0]["attempt_count"] == 1
     evidence = read_trade_source_evidence(

--- a/tests/test_trades_auto_intake_restart_policy.py
+++ b/tests/test_trades_auto_intake_restart_policy.py
@@ -71,6 +71,8 @@ def test_auth_required_stops_without_retry_and_writes_blocked_status(tmp_path: P
 
 def test_retryable_disconnect_recovers_and_resets_to_floor(tmp_path: Path, monkeypatch) -> None:
     waits: list[float] = []
+    clock = [0.0]
+    monkeypatch.setattr(auto_intake.time, "monotonic", lambda: clock[0])
 
     class _Stop:
         stopped = False
@@ -83,7 +85,8 @@ def test_retryable_disconnect_recovers_and_resets_to_floor(tmp_path: Path, monke
 
         def wait(self, seconds):
             waits.append(seconds)
-            if len(waits) >= 2:
+            clock[0] += seconds
+            if seconds == 0:
                 self.stopped = True
             return self.stopped
 
@@ -107,11 +110,13 @@ def test_retryable_disconnect_recovers_and_resets_to_floor(tmp_path: Path, monke
 
     assert rc == 0
     assert _Listener.starts == 2
-    assert waits == [5, 0]  # Reconnect backoff, then wakeable polling cancellation check.
+    assert waits == [1] * 5 + [0]
 
 
 def test_retry_backoff_is_capped_at_sixty_seconds(tmp_path: Path, monkeypatch) -> None:
     waits: list[float] = []
+    clock = [0.0]
+    monkeypatch.setattr(auto_intake.time, "monotonic", lambda: clock[0])
 
     class _Stop:
         stopped = False
@@ -124,7 +129,8 @@ def test_retry_backoff_is_capped_at_sixty_seconds(tmp_path: Path, monkeypatch) -
 
         def wait(self, seconds):
             waits.append(seconds)
-            if len(waits) >= 2:
+            clock[0] += seconds
+            if clock[0] >= 100:
                 self.stopped = True
             return self.stopped
 
@@ -144,7 +150,9 @@ def test_retry_backoff_is_capped_at_sixty_seconds(tmp_path: Path, monkeypatch) -
     rc = _run(tmp_path, monkeypatch, _Listener, reconnect_sec=40, stop_event=_Stop())
 
     assert rc == 0
-    assert waits == [40, 60]
+    assert waits == [1] * 100
+    status = json.loads((tmp_path / "status.json").read_text())
+    assert status["restart_count"] == 2
 
 
 def test_multi_source_auth_stops_sibling_and_propagates_exit_code() -> None:

--- a/tests/test_trades_inbox.py
+++ b/tests/test_trades_inbox.py
@@ -9,6 +9,7 @@ from src.application.trades.auto_intake import (
 )
 
 from src.application.trades.inbox import (
+    claim_trade_payload,
     claim_trade_payload_refresh_intent,
     enqueue_trade_payload,
     list_retryable_trade_payloads,
@@ -73,10 +74,13 @@ def test_trade_inbox_is_idempotent_and_retries_callback_exception(
     assert first_id == second_id
     assert trade_inbox_summary(path)["pending_count"] == 1
 
+    claim = claim_trade_payload(path, inbox_id=first_id)
     mark_trade_payload_retryable(
         path,
         inbox_id=first_id,
         error="RuntimeError: callback failed",
+        result={"status": "failed", "reason": "sqlite_busy", "diagnostics": {"retryable": True}},
+        claim=claim,
     )
     retry = list_retryable_trade_payloads(path, retry_delay_sec=0)
     assert len(retry) == 1
@@ -104,7 +108,7 @@ def test_trade_inbox_is_idempotent_and_retries_callback_exception(
     summary = trade_inbox_summary(path)
     assert summary["pending_count"] == 0
     assert summary["handled_count"] == 1
-    assert summary["max_attempt_count"] == 2
+    assert summary["max_attempt_count"] == 1
 
 
 def test_trade_inbox_migrates_old_evidence_without_guessing_adapter_version(
@@ -120,7 +124,7 @@ def test_trade_inbox_migrates_old_evidence_without_guessing_adapter_version(
         adapter_version="om.trade-intake.push.v1",
     )
     with sqlite3.connect(path) as conn:
-        conn.create_function("trade_inbox_writer_version", 0, lambda: 1)
+        conn.create_function("trade_inbox_writer_version", 0, lambda: 2)
         conn.execute(
             "UPDATE trade_inbox_evidence SET evidence_id = NULL, evidence_json = NULL"
         )
@@ -272,7 +276,7 @@ def test_trade_inbox_summary_cache_is_revision_gated(
         result={"status": "applied", "reason": "seed"},
     )
     with sqlite3.connect(path) as conn:
-        conn.create_function("trade_inbox_writer_version", 0, lambda: 1)
+        conn.create_function("trade_inbox_writer_version", 0, lambda: 2)
         conn.executemany(
             """
             INSERT INTO trade_inbox (
@@ -353,7 +357,7 @@ def test_trade_inbox_summary_cache_is_revision_gated(
     _cached_trade_inbox_summary(path, cache=cache)
     assert summary_reads == 3
     with sqlite3.connect(path) as conn:
-        conn.create_function("trade_inbox_writer_version", 0, lambda: 1)
+        conn.create_function("trade_inbox_writer_version", 0, lambda: 2)
         conn.execute(
             "DELETE FROM trade_inbox WHERE inbox_id = ?",
             (first_id,),

--- a/tests/test_trades_push_listener.py
+++ b/tests/test_trades_push_listener.py
@@ -35,6 +35,10 @@ def test_trade_push_listener_isolates_callback_exception(monkeypatch) -> None:
         def __init__(self, **_kwargs):
             self.handler = None
 
+        def set_sync_query_connect_timeout(self, timeout):
+            assert timeout == 2
+            self.connect_timeout = timeout
+
         def set_handler(self, handler):
             self.handler = handler
 
@@ -75,6 +79,10 @@ def test_trade_push_listener_health_uses_existing_trade_context(monkeypatch) -> 
         def __init__(self, **_kwargs):
             type(self).instances += 1
 
+        def set_sync_query_connect_timeout(self, timeout):
+            assert timeout == 2
+            self.connect_timeout = timeout
+
         def set_handler(self, _handler):
             return None
 
@@ -110,6 +118,10 @@ def test_trade_push_listener_health_raises_terminal_phone_verification(monkeypat
         def __init__(self, **_kwargs):
             return None
 
+        def set_sync_query_connect_timeout(self, timeout):
+            assert timeout == 2
+            self.connect_timeout = timeout
+
         def set_handler(self, _handler):
             return None
 
@@ -144,6 +156,10 @@ def test_trade_push_listener_health_keeps_disconnect_retryable(monkeypatch) -> N
     class _FakeContext:
         def __init__(self, **_kwargs):
             return None
+
+        def set_sync_query_connect_timeout(self, timeout):
+            assert timeout == 2
+            self.connect_timeout = timeout
 
         def set_handler(self, _handler):
             return None
@@ -282,7 +298,7 @@ def test_listener_raises_typed_unreachable_when_port_closed(monkeypatch) -> None
         listener._build_default_context()
 
 
-def _mock_sdk_rows(monkeypatch, *, rows, accounts, stop=None):
+def _mock_sdk_rows(monkeypatch, *, rows, accounts, stop=None, response=None, handler_base=None):
     class Frame:
         def __init__(self, values):
             self.values = values
@@ -303,11 +319,15 @@ def _mock_sdk_rows(monkeypatch, *, rows, accounts, stop=None):
             self.account_reads += 1
             return (0, Frame(accounts)) if accounts is not None else (-1, "unavailable")
 
+        def set_sync_query_connect_timeout(self, timeout):
+            assert timeout == 2
+            self.connect_timeout = timeout
+
         def set_handler(self, handler):
             self.handler = handler
 
         def start(self):
-            self.handler.on_recv_rsp(None)
+            self.handler.on_recv_rsp(response)
             if stop is not None:
                 stop.set()
 
@@ -315,8 +335,135 @@ def _mock_sdk_rows(monkeypatch, *, rows, accounts, stop=None):
             pass
 
     monkeypatch.setitem(sys.modules, "futu", SimpleNamespace(
-        OpenSecTradeContext=Context, TradeDealHandlerBase=HandlerBase,
+        OpenSecTradeContext=Context, TradeDealHandlerBase=handler_base or HandlerBase,
+        TrdEnv=SimpleNamespace(to_string2=lambda value: {0: "SIMULATE", 1: "REAL"}.get(value, "N/A")),
     ))
+
+
+def _push_response(**fields):
+    return SimpleNamespace(s2c=SimpleNamespace(header=SimpleNamespace(
+        HasField=lambda key: key in fields, **fields,
+    )))
+
+
+@pytest.mark.parametrize("physical,environment", [(123, "REAL"), (456, "SIMULATE")])
+def test_push_header_selects_exact_visible_account_before_conversion(monkeypatch, physical, environment):
+    response = _push_response(accID=physical, trdEnv=1 if environment == "REAL" else 0)
+    row = {"deal_id": "fill-1", "order_id": "order-1", "trd_env": environment}
+    _mock_sdk_rows(monkeypatch, rows=[row], response=response, accounts=[
+        {"acc_id": "123", "trd_env": "REAL"}, {"acc_id": "456", "trd_env": "SIMULATE"},
+    ])
+    seen = []
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=seen.append)
+    listener.start()
+    assert seen == [{**row, "acc_id": str(physical), "environment": environment,
+                     "broker_account_id": f"futu:{environment}:{physical}",
+                     "external_id_namespace": "futu.deal", "external_order_namespace": "futu.order",
+                     "_trade_intake_push_header": {"accID": physical, "trdEnv": 1 if environment == "REAL" else 0}}]
+
+
+@pytest.mark.parametrize("header,row,accounts,error", [
+    ({"accID": 123, "trdEnv": 1}, {"acc_id": "456"}, [{"acc_id": "123", "trd_env": "REAL"}], "conflict:push_physical_account"),
+    ({"accID": 123, "trdEnv": 1}, {"trd_env": "SIMULATE"}, [{"acc_id": "123", "trd_env": "REAL"}], "conflict:push_trd_env"),
+    ({"accID": 123, "trdEnv": 0}, {}, [{"acc_id": "123", "trd_env": "REAL"}], "conflict:push_trd_env"),
+    ({"accID": 123, "trdEnv": 1}, {}, [], "missing:source_account_environment"),
+    ({"accID": 123, "trdEnv": 1}, {}, None, "missing:source_account_environment"),
+    ({"trdEnv": 1}, {"acc_id": "123"}, [{"acc_id": "123", "trd_env": "REAL"}], "missing:push_header_physical_account"),
+    ({"accID": 123}, {}, [{"acc_id": "123", "trd_env": "REAL"}], "missing:push_header_environment"),
+    ({"accID": 0, "trdEnv": 1}, {}, [], "invalid:push_header_physical_account"),
+    ({"accID": "123", "trdEnv": 1}, {}, [], "invalid:push_header_physical_account"),
+    ({"accID": 123, "trdEnv": 7}, {}, [], "invalid:push_header_environment"),
+    ({"accID": 123, "trdEnv": True}, {}, [], "invalid:push_header_environment"),
+    ({"accID": 123, "trdEnv": 1}, {"acc_id": "123.0"}, [], "invalid:push_physical_account"),
+])
+def test_push_header_rejects_missing_invalid_conflicting_identity(monkeypatch, header, row, accounts, error):
+    row = {"deal_id": "fill-1", **row}
+    _mock_sdk_rows(monkeypatch, rows=[row], accounts=accounts, response=_push_response(**header))
+    seen = []
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=seen.append)
+    listener.start()
+    assert len(seen) == 1
+    assert {key: seen[0][key] for key in row} == row
+    assert error in seen[0]["_trade_intake_source_identity_errors"]
+    assert seen[0]["_trade_intake_push_header"] == header
+    assert "broker_account_id" not in seen[0]
+
+
+def test_real_sdk_protobuf_header_survives_dataframe_conversion(monkeypatch, tmp_path):
+    import os.path
+
+    # Importing the SDK opens its logger; keep even that I/O in test storage.
+    join = os.path.join
+    monkeypatch.setattr(os.path, "join", lambda *parts: str(tmp_path / "sdk-log")
+                        if parts[-1:] == (".com.futunn.FutuOpenD/Log",) else join(*parts))
+    futu = pytest.importorskip("futu")
+    from futu.common.pb import Trd_UpdateOrderFill_pb2
+
+    response = Trd_UpdateOrderFill_pb2.Response()
+    response.retType = 0
+    response.s2c.header.accID = 123
+    response.s2c.header.trdEnv = 1
+    response.s2c.header.trdMarket = 2
+    deal = response.s2c.orderFill
+    deal.fillID = 321
+    deal.fillIDEx = "321"
+    deal.orderIDEx = "order-1"
+    deal.trdSide = 1
+    deal.code = "NVDA"
+    deal.name = "NVIDIA"
+    deal.qty = 1
+    deal.price = 100
+    deal.createTime = "2026-09-09 10:00:00"
+    deal.secMarket = 2
+    assert response.IsInitialized()
+    ret, frame = futu.TradeDealHandlerBase().on_recv_rsp(response)
+    assert ret == 0
+    assert "acc_id" not in frame.columns
+    _mock_sdk_rows(monkeypatch, rows=None, accounts=[{"acc_id": "123", "trd_env": "REAL"}],
+                   response=response, handler_base=futu.TradeDealHandlerBase)
+    seen = []
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=seen.append)
+    listener.start()
+    assert len(seen) == 1
+    assert seen[0]["acc_id"] == "123"
+    assert seen[0]["broker_account_id"] == "futu:REAL:123"
+    assert "_trade_intake_source_identity_errors" not in seen[0]
+
+
+def test_start_wait_hook_runs_repeatedly_before_initialization_and_stops(monkeypatch):
+    from src.infrastructure.futu_trade_push import TradeIntakeStartCancelled
+
+    constructed = threading.Event()
+    release_constructor = threading.Event()
+    worker_finished = threading.Event()
+    stop = threading.Event()
+    calls = []
+    listener = OpenDTradePushListener(host="127.0.0.1", port=11111, on_deal=lambda _: None)
+
+    def build():
+        constructed.set()
+        try:
+            assert release_constructor.wait(5)
+            raise RuntimeError("test constructor released")
+        finally:
+            worker_finished.set()
+
+    def on_wait():
+        assert constructed.is_set()
+        assert not release_constructor.is_set()
+        assert not stop.is_set()
+        calls.append(len(calls))
+        if len(calls) == 3:
+            stop.set()
+
+    monkeypatch.setattr(listener, "_build_default_context", build)
+    try:
+        with pytest.raises(TradeIntakeStartCancelled):
+            listener.start(cancel_event=stop, on_wait=on_wait)
+        assert calls == [0, 1, 2]
+    finally:
+        release_constructor.set()
+        assert worker_finished.wait(2)
 
 
 def test_push_binds_only_matching_account_snapshot_and_preserves_order_alias(monkeypatch):

--- a/tests/test_trades_receipt_compensation.py
+++ b/tests/test_trades_receipt_compensation.py
@@ -10,6 +10,7 @@ from src.application.trades.receipt_compensation import (
     LEGACY_FALSE_OUTBOX_REASON,
     SKIPPED_NO_ROUTE_REASON,
     compensate_trade_intake_receipts,
+    receipt_compensation_takeover,
 )
 
 
@@ -444,7 +445,7 @@ def _core_compensation_input(tmp_path, monkeypatch, *, namespace="futu.deal", ou
     }
 
 
-def test_real_core_no_route_receipt_compensation_uses_proven_execution_alias_once(tmp_path, monkeypatch):
+def test_real_core_no_route_receipt_compensation_defers_to_inbox_owner(tmp_path, monkeypatch):
     kwargs = _core_compensation_input(tmp_path, monkeypatch)
     state_before = (tmp_path / "state.json").read_bytes()
     state = json.loads(state_before)
@@ -459,19 +460,17 @@ def test_real_core_no_route_receipt_compensation_uses_proven_execution_alias_onc
         return {"command_ok": True, "delivery_confirmed": True, "message_id": "offline-compensation", "returncode": 0}
 
     preview = compensate_trade_intake_receipts(**kwargs, apply_changes=False)
-    assert preview["status"] == "ready"
-    assert not Path(preview["record_path"]).exists()
+    assert preview["status"] == "inbox_managed"
+    assert preview["inbox_receipts"][0]["current_result_key"] == "recorded"
     assert (tmp_path / "state.json").read_bytes() == state_before
-    with pytest.raises(ValueError, match="payload changed after dry-run"):
-        compensate_trade_intake_receipts(**kwargs, apply_changes=True, expected_payload_hash="stale", send_fn=sender)
     result = compensate_trade_intake_receipts(**kwargs, apply_changes=True,
-                                            expected_payload_hash=preview["payload_hash"], send_fn=sender)
-    assert result["status"] == "confirmed"
-    assert json.loads(Path(result["record_path"]).read_text())["message_id"] == "offline-compensation"
+                                            expected_payload_hash="old-preview", send_fn=sender)
+    assert result["status"] == "inbox_managed"
     replay = compensate_trade_intake_receipts(**kwargs, apply_changes=True,
-                                            expected_payload_hash=preview["payload_hash"], send_fn=sender)
-    assert replay["status"] == "duplicate_suppressed"
-    assert len(calls) == 1
+                                            expected_payload_hash="old-preview", send_fn=sender)
+    assert replay["status"] == "inbox_managed"
+    assert calls == []
+    assert not (tmp_path / "receipt_compensations").exists()
     assert (repo.list_trade_events(), repo.list_position_lots()) == economics_before
     assert (tmp_path / "state.json").read_bytes() == state_before
 
@@ -488,6 +487,106 @@ def test_compensation_does_not_guess_execution_alias_or_override_receipt_evidenc
         state = json.loads(path.read_text())
         state["processed_deal_ids"]["futu:lx:123:777"] = next(iter(state["processed_deal_ids"].values()))
         path.write_text(json.dumps(state))
-    with pytest.raises(ValueError, match="missing deal_id|delivery-confirmed|unsent no-route marker|ambiguous identities"):
-        compensate_trade_intake_receipts(**kwargs, apply_changes=False)
+    if case in {"already_sent", "unknown", "ambiguous_alias"}:
+        assert compensate_trade_intake_receipts(**kwargs, apply_changes=False)["status"] == "inbox_managed"
+    else:
+        with pytest.raises(ValueError, match="missing deal_id"):
+            compensate_trade_intake_receipts(**kwargs, apply_changes=False)
     assert not (tmp_path / "receipt_compensations").exists()
+
+
+@pytest.mark.parametrize("status,blocked", [
+    ("send_started", True), ("unknown", True), ("confirmed", True),
+    ("prepared", True), ("explicit_failed", False),
+])
+def test_takeover_checks_every_member_of_legacy_combined_receipt(tmp_path, status, blocked):
+    preview = _run(tmp_path, apply_changes=False)
+    record = {**preview, "status": status, "explicit_pre_acceptance_failure": status == "explicit_failed"}
+    path = Path(preview["record_path"])
+    path.parent.mkdir()
+    path.write_text(json.dumps(record))
+    source = {"state_path": preview["state_path"], "account": ACCOUNT}
+    for deal_id in DEAL_IDS:
+        with receipt_compensation_takeover(source=source, account=ACCOUNT, canonical_deal_id=deal_id) as evidence:
+            assert evidence["blocked"] is blocked
+            assert evidence["result_key"] == "recorded"
+            assert evidence["records"][0]["deal_ids"] == list(DEAL_IDS)
+            assert evidence["status"] == ("confirmed" if status == "confirmed" else "unknown" if blocked else "clear")
+
+
+@pytest.mark.parametrize("broken", [{}, {"schema_version": "unknown"}, "invalid json"])
+def test_takeover_fails_closed_for_unattributable_legacy_evidence(tmp_path, broken):
+    source = {"state_path": tmp_path / "state.json", "account": ACCOUNT}
+    directory = tmp_path / "receipt_compensations"
+    directory.mkdir()
+    (directory / "unproven.json").write_text(broken if isinstance(broken, str) else json.dumps(broken))
+    with pytest.raises(ValueError, match="unverifiable receipt compensation evidence"):
+        with receipt_compensation_takeover(source=source, account=ACCOUNT, canonical_deal_id=DEAL_IDS[0]):
+            pytest.fail("unproven legacy evidence must not grant takeover")
+
+
+def test_manual_apply_blocks_overlap_with_combined_legacy_send(tmp_path):
+    preview = _run(tmp_path, apply_changes=False)
+    path = Path(preview["record_path"])
+    path.parent.mkdir()
+    path.write_text(json.dumps({**preview, "status": "send_started"}))
+    sources, repo = _fixture(tmp_path)
+    kwargs = dict(base=tmp_path, config={}, sources=sources, repo=repo, account=ACCOUNT,
+                  deal_ids=[DEAL_IDS[0]], route_resolver=_route)
+    single = compensate_trade_intake_receipts(**kwargs, apply_changes=False)
+    result = compensate_trade_intake_receipts(
+        **kwargs, apply_changes=True, expected_payload_hash=single["payload_hash"],
+        send_fn=lambda **_: pytest.fail("overlap must never send"),
+    )
+    assert result["status"] == "duplicate_suppressed"
+    assert result["suppression_reason"] == "overlapping_compensation"
+    assert not Path(single["record_path"]).exists()
+
+
+def test_manual_apply_rechecks_inbox_takeover_after_preview_under_shared_lock(tmp_path):
+    import fcntl
+    import threading
+    from src.application.trades.inbox import enqueue_trade_payload, prepare_trade_receipt_result
+    from src.application.ledger.repository import SQLiteOptionPositionsRepository
+    from src.application.trades.deal_identity import broker_deal_key_from_payload
+    from tests.test_trade_receipt_recovery import _payload
+
+    sources, repo = _fixture(tmp_path)
+    source = sources[0]
+    inbox_path = Path(source["state_path"]).with_name("trade_intake_inbox.sqlite3")
+    kwargs = dict(base=tmp_path, config={}, sources=sources, repo=repo, account=ACCOUNT,
+                  deal_ids=list(DEAL_IDS), route_resolver=_route)
+    preview = compensate_trade_intake_receipts(**kwargs, apply_changes=False)
+    payload = _payload(DEAL_IDS[0].rsplit(":", 1)[1])
+    payload["broker_account_ref"].update(external_account_id=FUTU_ACCOUNT_ID,
+                                          broker_account_id=f"futu:REAL:{FUTU_ACCOUNT_ID}")
+    repo.events[0]["raw_payload"]["execution_input"] = payload
+    key = broker_deal_key_from_payload(payload, account_mapping=None)
+    result = []
+    started = threading.Event()
+
+    def apply():
+        started.set()
+        result.append(compensate_trade_intake_receipts(
+            **kwargs, apply_changes=True, expected_payload_hash=preview["payload_hash"],
+            send_fn=lambda **_: pytest.fail("Inbox owns this multi-deal request")))
+
+    with receipt_compensation_takeover(source=source, account=ACCOUNT, canonical_deal_id=DEAL_IDS[0]) as evidence:
+        assert evidence["blocked"] is False
+        with Path(source["state_path"]).with_name("receipt_compensations.lock").open("a+") as second:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(second.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        worker = threading.Thread(target=apply)
+        worker.start()
+        assert started.wait(2)
+        inbox_id = enqueue_trade_payload(inbox_path, payload=payload, source="push", broker_deal_key=key,
+                                        repo=SQLiteOptionPositionsRepository(tmp_path / "empty-ledger.sqlite3"))
+        prepare_trade_receipt_result(inbox_path, inbox_id=inbox_id,
+                                     result={"status": "applied", "reason": "applied_open"},
+                                     expected_payload_version=1)
+        assert not result
+    worker.join(2)
+    assert not worker.is_alive()
+    assert result[0]["status"] == "inbox_managed"
+    assert result[0]["inbox_receipts"][0]["current_result_key"] == "recorded"
+    assert not Path(preview["record_path"]).exists()


### PR DESCRIPTION
## 修复内容

成交首次录入失败后，旧回执会阻止后续成功回执，用户无法判断是否重试及最终是否入账。本次修复保留 OpenD 推送的账户和环境证据，避免权限处理破坏 SQLite 活跃事务锁，并让录入恢复、账本核验和通知补偿共享一致的回执状态。已入账成交收到迟到的订单关联时立即补充元数据；待重试成交保留原等待时间和预算。

失败回执说明原因及是否会重试；核验恢复成功后生成独立成功回执。重试有次数和时限约束，已入账成交不会重复产生经济效果；发送结果不确定时不盲目重发。补充并发、重启、认领过期、事务提交或回滚、路由隔离及历史回执兼容回归。

## 验证

- 受影响回归：1041 passed；Mac 跳过的 2 项锁测试已在 Linux 使用相同代码通过。
- Agent contract/smoke：129 passed；最终回执文案回归：26 passed。
- 首轮 CI 发现迟到关联恢复回归及 Linux 异常措辞差异，已修复；费用/录入/回执相关回归 173 passed，存储回归 37 passed。
- Ruff、依赖图、guardrails、diff 检查及提交 hooks 通过；完整代码审查无阻塞问题。
- 历史失败的完整 SQL 堆栈不可得，未将复现的锁问题认定为原始事件的唯一原因。

仅合并源代码；VERSION 未改，不发布、不部署、不写生产账本或发送真实回执。
