### PR TITLE
fix(bot): load configured account list for memory

### DIFF
--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 996 (`src`: 515, `domain`: 82, `scripts`: 11, `tests`: 388)
-- Internal import edges: 6944 total, 2892 production/script edges excluding tests
+- Internal import edges: 6946 total, 2893 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,7 +46,7 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|3022| application
+  tests -->|3023| application
   tests -->|468| domain
   tests -->|2| domain_services
   tests -->|237| infrastructure
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 3022 |
+| tests | application | 3023 |
 | tests | domain | 468 |
 | tests | infrastructure | 237 |
 | tests | interfaces | 227 |
@@ -186,8 +186,8 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | domain.domain.ledger.position_fields | 48 |
 | src.application.payload_helpers | 48 |
 | src.infrastructure.io_utils | 44 |
+| src.application.account_config | 44 |
 | domain.domain.option_position_identity | 44 |
-| src.application.account_config | 43 |
 | domain.domain.decision_state_fingerprint | 37 |
 | domain.domain.ledger | 25 |
 | src.infrastructure.futu_gateway | 24 |

--- a/src/application/bot/memory_worker.py
+++ b/src/application/bot/memory_worker.py
@@ -249,13 +249,18 @@ _WORKERS_LOCK = threading.Lock()
 
 def configured_memory_scope(contract: Any) -> Any:
     """Reuse the canonical config identity gate and its authoritative account names."""
+    from src.application.account_config import accounts_from_config
     from src.application.agent_tool_config import load_runtime_config
 
     scope_from_contract(contract)  # Reject untrusted/local callers before loading configuration.
     _, config = load_runtime_config(config_key=contract.input.get("config_key"),
                                     config_path=contract.input.get("config_path"))
-    accounts = config.get("accounts")
-    if not isinstance(accounts, dict):
+    try:
+        raw_accounts = config.get("accounts")
+        # Older generated snapshots used an account->settings mapping; the
+        # current canonical shape is a validated list of labels.
+        accounts = list(raw_accounts) if isinstance(raw_accounts, dict) else accounts_from_config(config, fallback=())
+    except (TypeError, ValueError):
         raise ValueError("MEMORY_ACCOUNT_CONFIG_INVALID")
     return scope_from_contract(contract, accounts)
 

--- a/tests/test_bot_memory_host.py
+++ b/tests/test_bot_memory_host.py
@@ -6,6 +6,7 @@ from src.application.bot.contracts import AppResult
 from src.application.bot.host import run_contract
 from src.application.bot.host_store import BotHostStore
 from src.application.bot.memory_worker import MemoryWorker
+from src.application.bot.memory_worker import configured_memory_scope
 from src.application.bot.service import prepare_contract
 from src.infrastructure.pi_agent_process import derive_pi_session_id
 from tests.bot_pi_test_support import _TEST_MODEL
@@ -20,6 +21,48 @@ def channel(tmp_path, monkeypatch, text="记住：我喜欢简短回答", *, env
     host = BotHostStore(tmp_path / "host.sqlite3")
     session = derive_pi_session_id("test", "test-user", "test-conversation", "key:us") if environment == "channel" else None
     return contract, host, session
+
+
+def test_configured_memory_scope_accepts_runtime_account_list(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "src.application.agent_tool_config.load_runtime_config",
+        lambda **_: (tmp_path, {"accounts": ["lx", "sy"]}),
+    )
+    contract = prepare_contract(
+        _request("查看记忆", environment="channel"),
+        reference_year=2026,
+        report_now_ms=1788319188212,
+    )
+
+    scope = configured_memory_scope(contract)
+
+    assert scope.allowed_accounts == frozenset({"lx", "sy"})
+
+
+def test_channel_memory_runtime_config_list_is_enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "src.application.agent_tool_config.load_runtime_config",
+        lambda **_: (tmp_path, {"accounts": ["lx", "sy"]}),
+    )
+    monkeypatch.setattr(MemoryWorker, "wake", lambda _: None)
+    contract = prepare_contract(
+        _request("介绍一下自己", environment="channel"),
+        reference_year=2026,
+        report_now_ms=1788319188212,
+    )
+    host = BotHostStore(tmp_path / "host.sqlite3")
+    session = derive_pi_session_id("test", "test-user", "test-conversation", "key:us")
+
+    def ordinary(start, call, _):
+        assert "bot_memory" in {item["name"] for item in start["tools"]}
+        assert "memory and historical progress are unavailable" not in "\n".join(
+            item["content"] for item in start["runtime_context"]
+        )
+        return submit(call, "结论：我是 Bot。")
+
+    result = execute(monkeypatch, contract, host, session, ordinary)
+
+    assert result.status == "answered"
 
 
 def execute(monkeypatch, contract, host, session, flow):


### PR DESCRIPTION
修复运行配置使用 accounts 列表时记忆作用域加载失败的问题，复用现有 accounts_from_config；补充渠道记忆回归测试。验证：55 passed，Ruff 通过，git diff --check 通过。仅源码修复，不包含发布或远端升级。