### PR TITLE
feat(bot): adapt Pi 0.85.1 and add controlled session migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Improvements
+- Adapted Bot to Pi 0.85.1 while preserving committed session history, compaction, cancellation, and explicit commit admission; added controlled bidirectional session migration with recovery receipts and runtime readiness checks before service activation.
+
 ## 3.5.1 - 2026-09-09
 
 ### New Features

--- a/agent-runtime/main.ts
+++ b/agent-runtime/main.ts
@@ -2,7 +2,7 @@
 // sequential Host tools over
 // `om-pi-ipc.v1` JSONL stdio.
 //
-// Pinned to @earendil-works/pi-agent-core@0.84.2 and @earendil-works/pi-ai@0.84.2.
+// Pinned to @earendil-works/pi-agent-core@0.85.1 and @earendil-works/pi-ai@0.85.1.
 // The protocol (envelope, start payload, terminal payload) is specified by
 // docs/PI_AGENT_CORE_INTEGRATION.md sections 5, 11, and 12 and mirrored by
 // src/infrastructure/pi_agent_process.py.
@@ -10,19 +10,18 @@
 import process from "node:process";
 import path from "node:path";
 import { createHash } from "node:crypto";
+import { fstatSync, lstatSync } from "node:fs";
 import {
   Agent,
-  SessionError,
-  buildSessionContext,
   compact,
   convertToLlm,
   createCompactionSummaryMessage,
   estimateContextTokens,
   estimateTokens,
   prepareCompaction,
-  uuidv7,
+  TODO_CONTEXT,
+  withAbortSignal,
 } from "@earendil-works/pi-agent-core";
-import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import {
   createAssistantMessageEventStream,
   createModels,
@@ -53,20 +52,19 @@ import type {
   Entry,
   Session,
 } from "@earendil-works/pi-agent-core";
+import type { SqliteSessionRepo } from "@earendil-works/pi-session-backend-sqlite-node";
 import {
-  SqliteSessionRepository,
-  createNodeSqliteFactory,
-} from "@earendil-works/pi-session-backend-sqlite-node";
+  appendCommittedCompaction,
+  appendCommittedTurn,
+  loadCommittedContext,
+  openTargetSession,
+} from "./pi_session_adapter.ts";
 
 const PROTOCOL = "om-pi-ipc.v1";
 const MAX_LINE_BYTES = 1_048_576;
 const MAX_SAFE_MESSAGE_CHARS = 240;
 const MAX_FIXTURE_DELAY_MS = 300_000;
 const SESSION_ID_PATTERN = /^om_[0-9a-f]{64}$/;
-const SESSION_SCHEMA = "om-pi-session.v1";
-const TURN_COMMIT_TYPE = "om.turn.commit.v1";
-const WRITER_LEASE_TTL_MS = 30_000;
-const WRITER_HEARTBEAT_MS = 10_000;
 const OLLAMA_LOCAL_API_KEY = "ollama-local";
 const CONTROL_PREVIEW_TOOL = "request_control_preview";
 const CONTINUATION_PROMPT =
@@ -1309,28 +1307,36 @@ function effectiveSystemPrompt(
   return parts.join("\n\n");
 }
 
-function isCommitMarker(entry: Entry): boolean {
-  return entry.type === "custom" &&
-    entry.customType === TURN_COMMIT_TYPE &&
-    isRecord(entry.data) &&
-    exactKeys(entry.data, ["run_id", "kind"]) &&
-    isNonEmptyString(entry.data.run_id) &&
-    (entry.data.kind === "turn" || entry.data.kind === "compaction");
-}
-
-async function loadCommittedState(session: Session): Promise<SessionState> {
-  const reachable = await session.findEntriesOnBranch({ order: "oldestFirst" });
-  let committedLeaf: string | null = null;
-  for (const entry of reachable) {
-    if (isCommitMarker(entry)) committedLeaf = entry.id;
+function validateInheritedLockFds(databasePath: string, sessionId: string): void {
+  let descriptors: unknown;
+  try {
+    descriptors = JSON.parse(process.env.OM_PI_LOCK_FDS ?? "");
+  } catch {
+    throw new Error("persistent session lock handoff is invalid");
   }
-  await session.moveLane("main", committedLeaf);
-  const entries = await session.findEntriesOnBranch({ order: "oldestFirst" });
-  return { entries, messages: buildSessionContext(entries).messages };
+  if (!Array.isArray(descriptors) || descriptors.length !== 2 ||
+      descriptors.some((fd) => !Number.isInteger(fd) || fd < 0) ||
+      descriptors[0] === descriptors[1]) {
+    throw new Error("persistent session lock handoff is invalid");
+  }
+  const lockPaths = [
+    `${databasePath}.om-pi.lock`,
+    `${databasePath}.${sessionId}.lock`,
+  ];
+  for (let index = 0; index < descriptors.length; index += 1) {
+    const descriptor = fstatSync(descriptors[index] as number);
+    const named = lstatSync(lockPaths[index] as string);
+    if (!descriptor.isFile() || !named.isFile() || descriptor.nlink !== 1 ||
+        descriptor.dev !== named.dev || descriptor.ino !== named.ino ||
+        (named.mode & 0o077) !== 0 ||
+        (typeof process.getuid === "function" && named.uid !== process.getuid())) {
+      throw new Error("persistent session lock handoff is invalid");
+    }
+  }
 }
 
 async function openPiSession(sessionId: string): Promise<{
-  repository: SqliteSessionRepository;
+  repository: SqliteSessionRepo;
   session: Session;
   state: SessionState;
 }> {
@@ -1344,55 +1350,23 @@ async function openPiSession(sessionId: string): Promise<{
       safeError("SESSION_ERROR", "session", "session storage is unavailable", false)
     );
   }
-
-  const repositoryRoot = process.cwd();
-  const repository = new SqliteSessionRepository({
-    env: new NodeExecutionEnv({ cwd: repositoryRoot }),
-    sqlite: createNodeSqliteFactory(),
-    databasePath,
-    writerLease: {
-      ttlMs: WRITER_LEASE_TTL_MS,
-      heartbeatIntervalMs: WRITER_HEARTBEAT_MS,
-    },
-  });
   try {
-    const metadata = (await repository.list()).find((candidate) => candidate.id === sessionId);
-    let session: Session;
-    if (metadata) {
-      if (
-        !isRecord(metadata.metadata) ||
-        !exactKeys(metadata.metadata, ["schema"]) ||
-        metadata.metadata.schema !== SESSION_SCHEMA
-      ) {
-        throw new SafeRunFailure(
-          safeError("SESSION_ERROR", "session", "session storage is unavailable", false)
-        );
-      }
-      session = await repository.open(metadata);
-    } else {
-      session = await repository.create({
-        id: sessionId,
-        cwd: repositoryRoot,
-        metadata: { schema: SESSION_SCHEMA },
-      });
-    }
-    return { repository, session, state: await loadCommittedState(session) };
-  } catch (error) {
-    await repository.close().catch(() => {});
-    throw error;
+    validateInheritedLockFds(databasePath, sessionId);
+    return await openTargetSession(databasePath, sessionId);
+  } catch {
+    throw new SafeRunFailure(
+      safeError("SESSION_ERROR", "session", "session storage is unavailable", false)
+    );
   }
 }
 
 function mapSessionFailure(error: unknown): JsonObject {
   if (error instanceof SafeRunFailure) return error.payload;
-  const retryable = error instanceof SessionError &&
-    error.code === "storage" &&
-    error.message.includes("active writer");
   return safeError(
     "SESSION_ERROR",
     "session",
-    retryable ? "session is temporarily busy" : "session storage is unavailable",
-    retryable
+    "session storage is unavailable",
+    false
   );
 }
 
@@ -1554,9 +1528,10 @@ async function prepareSessionState(
       rejectEmptyCompactionCompletions(models),
       model,
       COMPACTION_INSTRUCTIONS,
-      signal,
       "off",
-      { enabled: false, maxRetries: 0, baseDelayMs: 0 }
+      { enabled: false, maxRetries: 0, baseDelayMs: 0 },
+      undefined,
+      withAbortSignal(signal, TODO_CONTEXT)
     );
   } catch (error) {
     metrics.finishCompaction(metricsStart, {});
@@ -1592,13 +1567,9 @@ async function prepareSessionState(
     );
   }
 
-  await session.appendEntry(
-    { type: "compaction", id: uuidv7(), ...result.value },
-    "main"
-  );
-  await session.appendCustomEntry(TURN_COMMIT_TYPE, { run_id: runId, kind: "compaction" });
+  await appendCommittedCompaction(session, result.value, runId, state.entries.at(-1)?.id ?? null);
   metrics.commitCompaction(compactionMetrics);
-  return loadCommittedState(session);
+  return loadCommittedContext(session);
 }
 
 function validatedTurnSuffix(messages: AgentMessage[], startIndex: number): AgentMessage[] {
@@ -1798,11 +1769,8 @@ async function persistTurn(
   runId: string,
   persistDelayMs: number
 ): Promise<void> {
-  for (const message of messages) {
-    await session.appendMessage(JSON.parse(JSON.stringify(message)) as AgentMessage);
-    if (persistDelayMs > 0) await waitAbortOrDelay(undefined, persistDelayMs);
-  }
-  await session.appendCustomEntry(TURN_COMMIT_TYPE, { run_id: runId, kind: "turn" });
+  if (persistDelayMs > 0) await waitAbortOrDelay(undefined, persistDelayMs);
+  await appendCommittedTurn(session, messages, runId);
 }
 
 function normalizeUsage(usage: Record<string, unknown>): JsonObject {
@@ -1944,7 +1912,7 @@ async function run(): Promise<void> {
   const deadline = receivedAt + (payload.remaining_budget_ms as number);
   const remainingSceneMs = (): number => deadline - performance.now();
   const sessionId = payload.session_id as string | null;
-  let repository: SqliteSessionRepository | null = null;
+  let repository: SqliteSessionRepo | null = null;
   let session: Session | null = null;
   let sessionState: SessionState = { entries: [], messages: [] };
   try {
@@ -1963,7 +1931,7 @@ async function run(): Promise<void> {
   try {
     emitRun("run.accepted", {
       runtime: "pi-agent-core",
-      runtime_version: "0.84.2",
+      runtime_version: "0.85.1",
       session_id: sessionId,
     });
     const catalogEntries = payload.tool_catalog as JsonObject[];
@@ -2286,7 +2254,7 @@ async function run(): Promise<void> {
           ? { isError: true }
           : undefined;
       },
-      prepareNextTurnWithContext: ({ context, message, newMessages, toolResults }) => {
+      prepareNextTurnWithContext: ({ context, toolResults }) => {
         if (bridge.takeSubmissionRepairPending()) {
           if (repairBudgetExhausted()) {
             runtimeFailure = safeError(
@@ -2329,25 +2297,7 @@ async function run(): Promise<void> {
           }
         }
         const remainingMs = remainingSceneMs();
-        const eligibleContinuation =
-          payload.execution_environment !== "memory_consolidation" &&
-          !continuationUsed &&
-          forcedFinalAtTurn === null &&
-          message.stopReason === "length" &&
-          extractText(message).trim().length > 0 &&
-          message.content.every((item) => item.type !== "toolCall") &&
-          newMessages.length >= 2 &&
-          newMessages[0].role === "user" &&
-          newMessages[newMessages.length - 1] === message &&
-          assistantTurns < (limits.max_iterations as number) &&
-          remainingMs > (limits.final_answer_reserve_seconds as number) * 1_000;
-        if (eligibleContinuation) {
-          continuationUsed = true;
-          agent?.followUp({
-            role: "user",
-            content: [{ type: "text", text: CONTINUATION_PROMPT }],
-            timestamp: Date.now(),
-          });
+        if (continuationUsed && toolResults.length === 0) {
           activeTools = bridge.residentTools;
           return { context: { ...context, tools: activeTools } };
         }
@@ -2376,9 +2326,31 @@ async function run(): Promise<void> {
         activeTools = bridge.residentTools.filter((tool) => tool.name === "submit_answer");
         return { context: { ...context, tools: activeTools } };
       },
-      shouldStopAfterTurn: () =>
-        (payload.execution_environment === "memory_consolidation" && assistantTurns >= 1) ||
-        (forcedFinalAtTurn !== null && assistantTurns > forcedFinalAtTurn),
+      shouldStopAfterTurn: ({ message, newMessages }) => {
+        if (bridge.approvedAnswer() !== null || bridge.controlRequest() !== null ||
+            (payload.execution_environment === "memory_consolidation" && assistantTurns >= 1) ||
+            (forcedFinalAtTurn !== null && assistantTurns > forcedFinalAtTurn)) return true;
+        const eligibleContinuation =
+          !continuationUsed &&
+          forcedFinalAtTurn === null &&
+          message.stopReason === "length" &&
+          extractText(message).trim().length > 0 &&
+          message.content.every((item) => item.type !== "toolCall") &&
+          newMessages.length >= 2 &&
+          newMessages[0].role === "user" &&
+          newMessages[newMessages.length - 1] === message &&
+          assistantTurns < (limits.max_iterations as number) &&
+          remainingSceneMs() > (limits.final_answer_reserve_seconds as number) * 1000;
+        if (eligibleContinuation) {
+          continuationUsed = true;
+          agent?.followUp({
+            role: "user",
+            content: [{ type: "text", text: CONTINUATION_PROMPT }],
+            timestamp: Date.now(),
+          });
+        }
+        return false;
+      },
     });
 
     agent.subscribe((event) => {
@@ -2671,7 +2643,7 @@ async function run(): Promise<void> {
     process.exitCode = 0;
     return;
   } finally {
-    if (repository) await repository.close().catch(() => {});
+    if (repository) await repository.close(TODO_CONTEXT).catch(() => {});
   }
 }
 

--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -5,21 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.84.2",
-        "@earendil-works/pi-ai": "0.84.2",
-        "@earendil-works/pi-session-backend-sqlite-node": "0.84.2"
+        "@earendil-works/pi-agent-core": "0.85.1",
+        "@earendil-works/pi-ai": "0.85.1",
+        "@earendil-works/pi-session-backend-sqlite-node": "0.85.1"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -108,17 +109,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
-      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
-        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.31.1",
+        "@smithy/core": "^3.33.3",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -127,15 +128,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
-      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -143,17 +144,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
-      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -161,13 +162,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
-      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
-        "@smithy/types": "^4.17.2",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -175,23 +176,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
-      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/credential-provider-env": "^3.972.69",
-        "@aws-sdk/credential-provider-http": "^3.972.71",
-        "@aws-sdk/credential-provider-login": "^3.972.76",
-        "@aws-sdk/credential-provider-process": "^3.972.69",
-        "@aws-sdk/credential-provider-sso": "^3.973.13",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -199,16 +200,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
-      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -216,21 +217,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.80",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
-      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.69",
-        "@aws-sdk/credential-provider-http": "^3.972.71",
-        "@aws-sdk/credential-provider-ini": "^3.973.14",
-        "@aws-sdk/credential-provider-process": "^3.972.69",
-        "@aws-sdk/credential-provider-sso": "^3.973.13",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -238,15 +239,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
-      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -254,17 +255,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
-      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/token-providers": "3.1111.0",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -272,16 +273,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1111.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
-      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -289,16 +290,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.75",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
-      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/nested-clients": "^3.997.43",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -306,14 +307,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.33.tgz",
-      "integrity": "sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -321,14 +322,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.28.tgz",
-      "integrity": "sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -336,17 +337,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.51.tgz",
-      "integrity": "sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -354,18 +355,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
-      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.8",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
-        "@aws-sdk/types": "^3.974.4",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -373,13 +374,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
-      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
-        "@smithy/types": "^4.17.2",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -387,14 +388,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
-      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/types": "^3.974.5",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -419,12 +420,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
-      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -444,12 +445,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
-      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -474,14 +475,27 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
-      "integrity": "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==",
+    "node_modules/@earendil-works/chord": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
+      "integrity": "sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.2",
-        "@earendil-works/pi-telemetry": "^0.84.2",
+        "esbuild": "0.28.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+      "integrity": "sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -492,16 +506,15 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
-      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -517,25 +530,441 @@
       }
     },
     "node_modules/@earendil-works/pi-session-backend-sqlite-node": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-session-backend-sqlite-node/-/pi-session-backend-sqlite-node-0.84.2.tgz",
-      "integrity": "sha512-0VrMmogNeERG10I8ohpT1wY28XEDQgxeNYUv0UtfhFAp/96Hzjgqi3AlwuPVuPQ1uBg+bwHf7+D8Igq1Sk69vQ==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-session-backend-sqlite-node/-/pi-session-backend-sqlite-node-0.85.1.tgz",
+      "integrity": "sha512-L//vhkibKRWrw0m7bErAcN8Lh7FFumlIoCzWgUMGx2Bl3s9JEQPnwRyBvIDZNRcgdLXRq0IDpB1wLDY6xj4dMg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.2",
-        "@earendil-works/pi-ai": "^0.84.2"
+        "@earendil-works/pi-agent-core": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
-      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google/genai": {
@@ -560,15 +989,6 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -629,9 +1049,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@smithy/core": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
-      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.17.2",
@@ -656,13 +1076,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
-      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
-        "@smithy/types": "^4.17.2",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -696,12 +1116,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
-      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
+        "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
@@ -710,9 +1130,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
-      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -747,13 +1167,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@types/retry": {
@@ -856,11 +1282,58 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -1117,9 +1590,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1168,6 +1641,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -1187,9 +1670,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {

--- a/agent-runtime/package.json
+++ b/agent-runtime/package.json
@@ -5,8 +5,8 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.84.2",
-    "@earendil-works/pi-ai": "0.84.2",
-    "@earendil-works/pi-session-backend-sqlite-node": "0.84.2"
+    "@earendil-works/pi-agent-core": "0.85.1",
+    "@earendil-works/pi-ai": "0.85.1",
+    "@earendil-works/pi-session-backend-sqlite-node": "0.85.1"
   }
 }

--- a/agent-runtime/pi_migration.mjs
+++ b/agent-runtime/pi_migration.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile, realpath, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join, relative, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+import {
+  OM_FORMAT_KEY as FORMAT_KEY,
+  OM_FORMAT_NAMESPACE as FORMAT_NAMESPACE,
+  OM_SESSION_FORMAT as SESSION_FORMAT,
+  OM_TURN_COMMIT_TYPE as TURN_COMMIT_TYPE,
+  exportCommittedMain,
+  importCommittedMain,
+  isCommitMarker,
+  probeTargetStore,
+  validateCommittedEntries,
+} from "./pi_session_core.mjs";
+
+const PACKAGES = [
+  "@earendil-works/pi-agent-core",
+  "@earendil-works/pi-ai",
+  "@earendil-works/pi-session-backend-sqlite-node",
+];
+const SUPPORTED = new Set(["0.84.2", "0.85.1"]);
+const EXPORT_FORMAT = "om-pi-export.v1";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]));
+  }
+  return value;
+}
+
+function encoded(value) {
+  return JSON.stringify(stable(value));
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function parseArgs(argv) {
+  const command = argv[2];
+  const args = {};
+  for (let index = 3; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) fail("invalid arguments");
+    args[key.slice(2)] = value;
+  }
+  if (!command || !args.runtime) fail("command and --runtime are required");
+  return { command, args };
+}
+
+async function runtimeModules(runtime, expectedVersion) {
+  const root = await realpath(resolve(runtime));
+  const manifestPath = join(root, "package.json");
+  const lockPath = join(root, "package-lock.json");
+  const [manifestRaw, lockRaw] = await Promise.all([
+    readFile(manifestPath, "utf8"),
+    readFile(lockPath, "utf8"),
+  ]);
+  const manifest = JSON.parse(manifestRaw);
+  const lock = JSON.parse(lockRaw);
+  const versions = PACKAGES.map((name) => manifest.dependencies?.[name]);
+  if (new Set(versions).size !== 1 || !SUPPORTED.has(versions[0])) fail("runtime pins are unsupported");
+  const version = versions[0];
+  if (expectedVersion && version !== expectedVersion) fail("runtime version does not match request");
+  const locked = lock.packages?.[""]?.dependencies ?? {};
+  const requireFromRuntime = createRequire(pathToFileURL(manifestPath));
+  const packages = {};
+  const modules = {};
+  for (const name of PACKAGES) {
+    if (locked[name] !== version) fail("lockfile root dependency does not match manifest");
+    const packagePath = await realpath(join(root, "node_modules", name, "package.json"));
+    const entryPath = await realpath(new URL(import.meta.resolve(name, pathToFileURL(manifestPath).href)));
+    const packageRelative = relative(join(root, "node_modules"), packagePath);
+    const entryRelative = relative(join(root, "node_modules"), entryPath);
+    if (packageRelative.startsWith("..") || entryRelative.startsWith("..")) fail("package resolved outside selected runtime");
+    const packageRaw = await readFile(packagePath, "utf8");
+    const packageJson = JSON.parse(packageRaw);
+    if (packageJson.version !== version || lock.packages?.[`node_modules/${name}`]?.version !== version) {
+      fail("installed package identity does not match lockfile");
+    }
+    modules[name] = await import(pathToFileURL(entryPath).href);
+    packages[name] = {
+      version,
+      manifestSha256: sha256(packageRaw),
+      entrySha256: sha256(await readFile(entryPath)),
+    };
+  }
+  if (version === "0.84.2") {
+    const nodePath = await realpath(new URL(import.meta.resolve(
+      "@earendil-works/pi-agent-core/node", pathToFileURL(manifestPath).href,
+    )));
+    if (relative(join(root, "node_modules"), nodePath).startsWith("..")) fail("node export resolved outside selected runtime");
+    modules.node = await import(pathToFileURL(nodePath).href);
+  }
+  return {
+    version,
+    identity: { version, lockSha256: sha256(lockRaw), packages },
+    core: modules[PACKAGES[0]],
+    sqlite: modules[PACKAGES[2]],
+    node: modules.node,
+  };
+}
+
+function canonicalEntry(entry, version) {
+  const common = { id: entry.id, parentId: entry.parentId, timestamp: entry.timestamp, type: entry.type };
+  if (entry.type === "message") return { ...common, message: entry.message };
+  if (entry.type === "compaction") {
+    if (version === "0.85.1" && entry.fromHook !== false) fail("hook-origin compaction cannot be converted");
+    return {
+      ...common,
+      summary: entry.summary,
+      retainedTail: entry.retainedTail,
+      tokensBefore: entry.tokensBefore,
+      ...(entry.details === undefined ? {} : { details: entry.details }),
+      ...(entry.usage === undefined ? {} : { usage: entry.usage }),
+      fromHook: false,
+    };
+  }
+  if (isCommitMarker(entry)) return { ...common, customType: entry.customType, data: entry.data };
+  fail("unsupported session entry");
+}
+
+function committedPrefix(pathEntries) {
+  let lastCommit = -1;
+  for (let index = 0; index < pathEntries.length; index += 1) {
+    if (isCommitMarker(pathEntries[index])) lastCommit = index;
+  }
+  if (pathEntries.length > 0 && lastCommit < 0) fail("session has no committed main history");
+  return { entries: pathEntries.slice(0, lastCommit + 1), excludedTailCount: pathEntries.length - lastCommit - 1 };
+}
+
+async function export0842(runtime, db, core, sqlite, node) {
+  const repo = new sqlite.SqliteSessionRepository({
+    env: new node.NodeExecutionEnv({ cwd: runtime }),
+    sqlite: sqlite.createNodeSqliteFactory(),
+    databasePath: db,
+  });
+  try {
+    const sessions = [];
+    for (const metadata of (await repo.list()).sort((a, b) => a.id.localeCompare(b.id))) {
+      if (encoded(metadata.metadata) !== encoded({ schema: SESSION_FORMAT })) fail("unsupported legacy session metadata");
+      const session = await repo.open(metadata);
+      const all = await session.findEntries({ order: "oldestFirst" });
+      const pathEntries = await session.findEntriesOnBranch({ order: "oldestFirst" });
+      const reachableIds = new Set(pathEntries.map((entry) => entry.id));
+      const reachableCanonical = pathEntries.map((entry) => canonicalEntry(entry, "0.84.2"));
+      const selected = committedPrefix(reachableCanonical);
+      const allowedParents = new Set(selected.entries.map((entry) => entry.id));
+      allowedParents.add(null);
+      for (const entry of all) {
+        if (reachableIds.has(entry.id)) continue;
+        const converted = canonicalEntry(entry, "0.84.2");
+        if (converted.type === "custom" || !allowedParents.has(converted.parentId)) {
+          fail("unsupported legacy session branches");
+        }
+        allowedParents.add(converted.id);
+      }
+      const entries = selected.entries;
+      validateCommittedEntries(entries);
+      const selectedRaw = pathEntries.slice(0, entries.length);
+      const messages = core.buildSessionContext(selectedRaw).messages;
+      sessions.push({
+        id: metadata.id,
+        createdAt: metadata.createdAt,
+        entries,
+        excludedTailCount: selected.excludedTailCount + all.length - pathEntries.length,
+        contextSha256: sha256(encoded(messages)),
+        contentSha256: sha256(encoded(entries)),
+      });
+    }
+    return sessions;
+  } finally {
+    await repo.close().catch(() => {});
+  }
+}
+
+async function export0851(runtime, db, core, sqlite) {
+  const context = core.TODO_CONTEXT;
+  const repo = new sqlite.SqliteSessionRepo({
+    directory: dirname(db), databasePath: db, databaseFactory: sqlite.createNodeSqliteFactory(),
+  });
+  try {
+    const sessions = [];
+    for (const metadata of (await repo.list(undefined, context)).sort((a, b) => a.id.localeCompare(b.id))) {
+      const session = await repo.open(metadata, context);
+      const marker = await session.getValue(core.value(FORMAT_NAMESPACE, FORMAT_KEY), context);
+      if (marker?.value !== SESSION_FORMAT) fail("target session format marker is missing");
+      const selected = await exportCommittedMain(session, {
+        context,
+        branchTip: core.branchTip,
+        setValue: core.setValue,
+        createCompactionSummaryMessage: core.createCompactionSummaryMessage,
+      }, { requireAllEntries: true });
+      const entries = selected.entries.map((entry) => canonicalEntry(entry, "0.85.1"));
+      const messages = selected.messages;
+      sessions.push({
+        id: metadata.id,
+        createdAt: metadata.createdAt,
+        entries,
+        excludedTailCount: selected.excludedTailCount,
+        contextSha256: sha256(encoded(messages)),
+        contentSha256: sha256(encoded(entries)),
+      });
+      await session.close(context);
+    }
+    return sessions;
+  } finally {
+    await repo.close(context).catch(() => {});
+  }
+}
+
+async function import0851(runtime, db, payload, core, sqlite) {
+  const context = core.TODO_CONTEXT;
+  let now = Date.now();
+  const repo = new sqlite.SqliteSessionRepo({
+    directory: dirname(db), databasePath: db, databaseFactory: sqlite.createNodeSqliteFactory(), now: () => now,
+  });
+  try {
+    if (payload.sessions.length === 0) {
+      // Public creation initializes the shared schema; deletion keeps it empty.
+      const bootstrap = await repo.create({}, context);
+      await bootstrap.close(context);
+      await repo.delete(bootstrap.metadata, context);
+    }
+    for (const source of payload.sessions) {
+      const readback = await importCommittedMain(repo, source, {
+        context,
+        branchTip: core.branchTip,
+        value: core.value,
+        setValue: core.setValue,
+        insertEntry: core.insertEntry,
+        insertUsage: core.insertUsage,
+        createCompactionSummaryMessage: core.createCompactionSummaryMessage,
+      }, (value) => { now = value; });
+      const canonical = readback.entries.map((entry) => canonicalEntry(entry, "0.85.1"));
+      if (encoded(canonical) !== encoded(source.entries) || sha256(encoded(readback.messages)) !== source.contextSha256) {
+        fail("target import readback differs from canonical session");
+      }
+    }
+  } finally {
+    await repo.close(context).catch(() => {});
+  }
+}
+
+async function import0842(runtime, db, payload, core, sqlite, node) {
+  const originalNow = Date.now;
+  let now = originalNow();
+  Date.now = () => now;
+  const wrapperTimes = payload.sessions.flatMap((session) => [
+    session.createdAt,
+    ...session.entries.map((entry) => entry.timestamp),
+  ]);
+  const leaseTtlMs = wrapperTimes.length === 0 ? 30_000
+    : Math.max(30_000, Math.max(...wrapperTimes) - Math.min(...wrapperTimes) + 60_000);
+  if (!Number.isSafeInteger(leaseTtlMs) || leaseTtlMs <= 10_000) fail("canonical timestamp range is unsupported");
+  const repo = new sqlite.SqliteSessionRepository({
+    env: new node.NodeExecutionEnv({ cwd: runtime }),
+    sqlite: sqlite.createNodeSqliteFactory(),
+    databasePath: db,
+    writerLease: { ttlMs: leaseTtlMs, heartbeatIntervalMs: 10_000 },
+  });
+  try {
+    if (payload.sessions.length === 0) {
+      const bootstrap = await repo.create({ cwd: runtime, metadata: { schema: SESSION_FORMAT } });
+      await repo.delete(await bootstrap.getMetadata());
+    }
+    for (const source of payload.sessions) {
+      validateCommittedEntries(source.entries);
+      now = source.createdAt;
+      const session = await repo.create({
+        id: source.id, cwd: runtime, metadata: { schema: SESSION_FORMAT },
+      });
+      let tip = null;
+      for (const entry of source.entries) {
+        if (entry.parentId !== tip) fail("canonical ancestry is not linear main");
+        now = entry.timestamp;
+        const { parentId: _parentId, timestamp: _timestamp, fromHook: _fromHook, ...mapped } = entry;
+        await session.appendEntry(mapped, "main");
+        tip = entry.id;
+      }
+    }
+  } finally {
+    Date.now = originalNow;
+    await repo.close().catch(() => {});
+  }
+}
+
+async function main() {
+  const { command, args } = parseArgs(process.argv);
+  const loaded = await runtimeModules(args.runtime, args["expected-version"]);
+  if (command === "identity") return loaded.identity;
+  if (command === "probe") {
+    if (!args.database) fail("probe database is required");
+    if (loaded.version !== "0.85.1") fail("store probe requires the exact 0.85.1 controller runtime");
+    let sqlite = loaded.sqlite;
+    if (args.immutable === "true") {
+      sqlite = {
+        createNodeSqliteFactory: () => ({
+          openReadOnly: async (database) => {
+            const url = pathToFileURL(database);
+            url.searchParams.set("immutable", "1");
+            return loaded.sqlite.wrapNodeSqliteDatabase(new DatabaseSync(url, { readOnly: true }));
+          },
+        }),
+      };
+    } else if (args.immutable !== undefined) {
+      fail("probe immutable flag is invalid");
+    }
+    return { version: loaded.version, ...await probeTargetStore(resolve(args.database), sqlite) };
+  }
+  if (command === "export") {
+    if (!args.database || !args.output) fail("export paths are required");
+    const sessions = loaded.version === "0.84.2"
+      ? await export0842(args.runtime, resolve(args.database), loaded.core, loaded.sqlite, loaded.node)
+      : await export0851(args.runtime, resolve(args.database), loaded.core, loaded.sqlite);
+    const payload = { format: EXPORT_FORMAT, sessions };
+    await writeFile(resolve(args.output), encoded(payload), { encoding: "utf8", mode: 0o600 });
+    return {
+      version: loaded.version,
+      sessionCount: sessions.length,
+      entryCount: sessions.reduce((sum, item) => sum + item.entries.length, 0),
+      excludedTailCount: sessions.reduce((sum, item) => sum + item.excludedTailCount, 0),
+      canonicalSha256: sha256(encoded(payload)),
+      contextSha256: sha256(encoded(sessions.map((item) => [item.id, item.contextSha256]))),
+    };
+  }
+  if (command === "import") {
+    if (!args.database || !args.input) fail("import paths are required");
+    const payload = JSON.parse(await readFile(resolve(args.input), "utf8"));
+    if (payload?.format !== EXPORT_FORMAT || !Array.isArray(payload.sessions)) fail("invalid canonical export");
+    if (loaded.version === "0.84.2") {
+      await import0842(args.runtime, resolve(args.database), payload, loaded.core, loaded.sqlite, loaded.node);
+    } else {
+      await import0851(args.runtime, resolve(args.database), payload, loaded.core, loaded.sqlite);
+    }
+    return { version: loaded.version, imported: true, canonicalSha256: sha256(encoded(payload)) };
+  }
+  fail("unsupported migration command");
+}
+
+main().then(
+  (result) => process.stdout.write(`${JSON.stringify({ ok: true, ...result })}\n`),
+  (error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : "migration bridge failed"}\n`);
+    process.exitCode = 1;
+  },
+);

--- a/agent-runtime/pi_session_adapter.ts
+++ b/agent-runtime/pi_session_adapter.ts
@@ -1,0 +1,452 @@
+import path from "node:path";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import {
+  TODO_CONTEXT,
+  branchTip,
+  createCompactionSummaryMessage,
+  insertEntry,
+  setValue,
+  value,
+} from "@earendil-works/pi-agent-core";
+import type {
+  AgentMessage,
+  CompactResult,
+  Entry,
+  JsonValue,
+  NewEntry,
+  Session,
+} from "@earendil-works/pi-agent-core";
+import {
+  SqliteSessionRepo,
+  SqliteStorage,
+  createNodeSqliteFactory,
+} from "@earendil-works/pi-session-backend-sqlite-node";
+import type {
+  SqliteSessionMetadata,
+} from "@earendil-works/pi-session-backend-sqlite-node";
+import {
+  OM_SESSION_FORMAT,
+  OM_TURN_COMMIT_TYPE,
+  exportCommittedMain as exportCommittedMainCore,
+  isCommitMarker,
+  loadCommittedContext as loadCommittedContextCore,
+  probeTargetStore as probeTargetStoreCore,
+  readCommittedMain as readCommittedMainCore,
+  validateToolGroups,
+} from "./pi_session_core.mjs";
+
+export { OM_SESSION_FORMAT, OM_TURN_COMMIT_TYPE };
+export const OM_SESSION_FORMAT_VALUE = value<string>("om.pi", "session-format");
+const MAIN_BRANCH = "main";
+const MIGRATION_RECEIPT_VERSION = "om-pi-migration.v1";
+
+export type PiStoreFormat = "missing" | "target" | "legacy" | "unknown" | "corrupt";
+
+export interface PiStoreProbe {
+  format: PiStoreFormat;
+  sessionIds: string[];
+  writerLeaseCount: number;
+}
+
+export interface CommittedSessionState {
+  entries: Entry[];
+  messages: AgentMessage[];
+}
+
+export interface OpenedPiSession {
+  repository: SqliteSessionRepo;
+  session: Session<SqliteSessionMetadata>;
+  state: CommittedSessionState;
+}
+
+const CORE_API = {
+  context: TODO_CONTEXT,
+  branchTip,
+  createCompactionSummaryMessage,
+  insertEntry,
+  setValue,
+  value,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean {
+  const keys = Object.keys(value);
+  return required.every((key) => keys.includes(key)) &&
+    keys.every((key) => required.includes(key) || optional.includes(key));
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+}
+
+const PI_RUNTIME_PACKAGES = [
+  "@earendil-works/pi-agent-core",
+  "@earendil-works/pi-ai",
+  "@earendil-works/pi-session-backend-sqlite-node",
+];
+
+function isRuntimeIdentity(value: unknown, expectedVersion: "0.84.2" | "0.85.1"): boolean {
+  if (!isRecord(value) || value.version !== expectedVersion || value.ok !== true ||
+      !isSha256(value.lockSha256) || !isRecord(value.packages) ||
+      Object.keys(value.packages).sort().join("\0") !== [...PI_RUNTIME_PACKAGES].sort().join("\0")) {
+    return false;
+  }
+  return PI_RUNTIME_PACKAGES.every((name) => {
+    const installed = value.packages[name];
+    return isRecord(installed) && installed.version === expectedVersion &&
+      isSha256(installed.manifestSha256) && isSha256(installed.entrySha256);
+  });
+}
+
+function isConversionSummary(value: unknown): boolean {
+  return isRecord(value) && exactKeys(value, [
+    "sessionCount", "entryCount", "excludedTailCount",
+    "sourceCanonicalSha256", "targetCanonicalSha256",
+  ]) && [value.sessionCount, value.entryCount, value.excludedTailCount].every((item) =>
+    Number.isSafeInteger(item) && (item as number) >= 0) &&
+    isSha256(value.sourceCanonicalSha256) && isSha256(value.targetCanonicalSha256);
+}
+
+async function assertMigrationReceiptAllowsStartup(databasePath: string): Promise<void> {
+  const receiptPath = `${databasePath}.om-pi-migration.json`;
+  let receiptInfo;
+  try {
+    receiptInfo = await lstat(receiptPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new Error("Pi migration receipt is unavailable");
+  }
+  if (!receiptInfo.isFile() || receiptInfo.isSymbolicLink() ||
+      (receiptInfo.mode & 0o077) !== 0 || receiptInfo.uid !== process.getuid?.()) {
+    throw new Error("Pi migration receipt is invalid");
+  }
+  let receipt: unknown;
+  try {
+    receipt = JSON.parse(await readFile(receiptPath, "utf8"));
+  } catch {
+    throw new Error("Pi migration receipt is invalid");
+  }
+  if (!isRecord(receipt) || !exactKeys(
+    receipt,
+    ["version", "database", "phase", "rollbackRequired", "source", "target", "backup"],
+    ["readback", "published", "prior", "conversion"],
+  ) || receipt.version !== MIGRATION_RECEIPT_VERSION || receipt.rollbackRequired !== true ||
+      !["prepared", "validated", "published"].includes(receipt.phase as string) ||
+      (receipt.conversion !== undefined && !isConversionSummary(receipt.conversion))) {
+    throw new Error("Pi migration receipt is invalid");
+  }
+  let canonicalDatabase: string;
+  try {
+    canonicalDatabase = await realpath(databasePath);
+  } catch {
+    throw new Error("Pi migration receipt does not match the session database");
+  }
+  if (receipt.database !== canonicalDatabase) {
+    throw new Error("Pi migration receipt does not match the session database");
+  }
+  if (receipt.phase !== "published") {
+    throw new Error("Pi migration publication is incomplete");
+  }
+  const source = receipt.source;
+  const target = receipt.target;
+  const backup = receipt.backup;
+  const readback = receipt.readback;
+  const published = receipt.published;
+  const backupPrefix = `${canonicalDatabase}.om-pi-recovery-0.84.2-to-0.85.1-`;
+  const backupSuffix = ".sqlite3";
+  const backupPath = isRecord(backup) && typeof backup.path === "string" ? backup.path : "";
+  const backupGeneration = backupPath.startsWith(backupPrefix) && backupPath.endsWith(backupSuffix)
+    ? backupPath.slice(backupPrefix.length, -backupSuffix.length)
+    : "";
+  if (!isRecord(source) || !exactKeys(source, ["runtimePath", "runtime", "database"]) ||
+      typeof source.runtimePath !== "string" || !path.isAbsolute(source.runtimePath) ||
+      !isRuntimeIdentity(source.runtime, "0.84.2") || !isRecord(source.database) ||
+      !exactKeys(source.database, ["sha256", "format"]) ||
+      !isSha256(source.database.sha256) || source.database.format !== "legacy" ||
+      !isRecord(target) || !exactKeys(target, ["runtimePath", "runtime", "database"]) ||
+      typeof target.runtimePath !== "string" || !path.isAbsolute(target.runtimePath) ||
+      !isRuntimeIdentity(target.runtime, "0.85.1") ||
+      !isRecord(target.database) || !exactKeys(target.database, ["sha256", "format"]) ||
+      !isSha256(target.database.sha256) || target.database.format !== "target" ||
+      !isRecord(backup) || !exactKeys(backup, ["path", "sha256"]) ||
+      !/^[0-9a-f]{32}$/.test(backupGeneration) ||
+      !isSha256(backup.sha256) ||
+      !isRecord(readback) || !exactKeys(readback, ["equivalent", "contextSha256"]) ||
+      readback.equivalent !== true || !isSha256(readback.contextSha256) ||
+      !isRecord(published) || !exactKeys(published, ["databaseSha256"]) ||
+      !isSha256(published.databaseSha256)) {
+    throw new Error("Pi migration receipt is invalid");
+  }
+}
+
+export async function probeTargetStore(databasePath: string): Promise<PiStoreProbe> {
+  return await probeTargetStoreCore(databasePath, {
+    createNodeSqliteFactory,
+  }) as PiStoreProbe;
+}
+
+async function probeAfterConcurrentBootstrap(databasePath: string): Promise<PiStoreProbe> {
+  let probe = await probeTargetStore(databasePath);
+  for (let attempt = 0; attempt < 40 && (probe.format === "unknown" || probe.format === "corrupt"); attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    probe = await probeTargetStore(databasePath);
+  }
+  return probe;
+}
+
+async function inspectTargetSession(databasePath: string, sessionId: string): Promise<{
+  exists: boolean;
+  marker?: unknown;
+  mainTip?: unknown;
+  empty: boolean;
+}> {
+  const db = await createNodeSqliteFactory().openReadOnly(databasePath);
+  const storage = new SqliteStorage(db, { sessionId });
+  try {
+    const exists = db.prepare("SELECT 1 AS found FROM sessions WHERE id = ?").get(sessionId) !== undefined;
+    if (!exists) return { exists: false, empty: true };
+    const [marker, mainTip] = await Promise.all([
+      storage.getValue(OM_SESSION_FORMAT_VALUE, TODO_CONTEXT),
+      storage.getValue(branchTip(MAIN_BRANCH), TODO_CONTEXT),
+    ]);
+    const counts = db.prepare(`
+      SELECT
+        (SELECT COUNT(*) FROM entries WHERE session_id = ?) AS entries,
+        (SELECT COUNT(*) FROM scalar_values WHERE session_id = ?) AS scalars,
+        (SELECT COUNT(*) FROM list_values WHERE session_id = ?) AS lists,
+        (SELECT COUNT(*) FROM usage_ledger WHERE session_id = ?) AS usage,
+        (SELECT COUNT(*) FROM branch_meta WHERE session_id = ?) AS branches
+    `).get<Record<string, number>>(sessionId, sessionId, sessionId, sessionId, sessionId);
+    return {
+      exists: true,
+      marker: marker?.value,
+      mainTip: mainTip?.value,
+      empty: counts !== undefined && Object.values(counts).every((count) => count === 0),
+    };
+  } finally {
+    await storage.close(TODO_CONTEXT);
+    db.close();
+  }
+}
+
+async function readCommittedMain(session: Session): Promise<{ entries: Entry[]; committedTip: string | null }> {
+  return await readCommittedMainCore(session, CORE_API) as {
+    entries: Entry[];
+    committedTip: string | null;
+  };
+}
+
+export async function exportCommittedMain(session: Session): Promise<Entry[]> {
+  return (await exportCommittedMainCore(session, CORE_API)).entries as Entry[];
+}
+
+export async function loadCommittedContext(session: Session): Promise<CommittedSessionState> {
+  return await loadCommittedContextCore(session, CORE_API) as CommittedSessionState;
+}
+
+async function initializeSession(session: Session): Promise<void> {
+  await session.mutate(async (mutator, context) => {
+    const marker = await mutator.getValue(OM_SESSION_FORMAT_VALUE, context);
+    const tip = await mutator.getValue(branchTip(MAIN_BRANCH), context);
+    if (marker !== undefined || tip !== undefined) throw new Error("session initialization is not empty");
+    await mutator.commit([
+      setValue(OM_SESSION_FORMAT_VALUE, OM_SESSION_FORMAT),
+      setValue(branchTip(MAIN_BRANCH), null),
+    ], context);
+  }, TODO_CONTEXT);
+}
+
+function isTransientSqliteBusy(error: unknown): boolean {
+  return error instanceof Error && /database is (?:locked|busy)/i.test(error.message);
+}
+
+function validateInspectedSession(inspected: {
+  exists: boolean;
+  marker?: unknown;
+  mainTip?: unknown;
+  empty: boolean;
+}): void {
+  if (inspected.exists && inspected.marker !== OM_SESSION_FORMAT) {
+    if (inspected.marker !== undefined || !inspected.empty) {
+      throw new Error("Pi session format marker is missing or invalid");
+    }
+  }
+  if (inspected.exists && inspected.marker === OM_SESSION_FORMAT && inspected.mainTip === undefined) {
+    throw new Error("Pi session main branch is missing");
+  }
+}
+
+export async function openTargetSession(databasePath: string, sessionId: string): Promise<OpenedPiSession> {
+  await assertMigrationReceiptAllowsStartup(databasePath);
+  let probe = await probeAfterConcurrentBootstrap(databasePath);
+  let bootstrapAdmitted = probe.format === "missing";
+  let lastBusy: unknown;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    if (attempt > 0) probe = await probeTargetStore(databasePath);
+    if (probe.format === "missing") bootstrapAdmitted = true;
+    if (probe.format !== "missing" && probe.format !== "target" &&
+        !(bootstrapAdmitted && (probe.format === "unknown" || probe.format === "corrupt"))) {
+      throw new Error(`unsupported Pi session store format: ${probe.format}`);
+    }
+    const inspected = probe.format === "target"
+      ? await inspectTargetSession(databasePath, sessionId)
+      : { exists: false, empty: true };
+    validateInspectedSession(inspected);
+    const repository = new SqliteSessionRepo({
+      directory: path.dirname(databasePath),
+      databasePath,
+      databaseFactory: createNodeSqliteFactory(),
+    });
+    try {
+      let session: Session<SqliteSessionMetadata>;
+      if (inspected.exists) {
+        const metadata = (await repository.list(undefined, TODO_CONTEXT)).find((item) => item.id === sessionId);
+        if (!metadata) throw new Error("Pi session metadata is unavailable");
+        session = await repository.open(metadata, TODO_CONTEXT);
+        if (inspected.marker === undefined) await initializeSession(session);
+      } else {
+        session = await repository.create({ id: sessionId }, TODO_CONTEXT);
+        await initializeSession(session);
+      }
+      return { repository, session, state: await loadCommittedContext(session) };
+    } catch (error) {
+      await repository.close(TODO_CONTEXT).catch(() => undefined);
+      if (!isTransientSqliteBusy(error)) throw error;
+      lastBusy = error;
+      const delayMs = 20 * (2 ** attempt) + (process.pid % 23);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastBusy ?? new Error("Pi session database remained busy during initialization");
+}
+
+function entryWrites(
+  session: Session,
+  parentId: string | null,
+  entries: Array<{ type: "message"; message: AgentMessage } | ({ type: "compaction" } & CompactResult)>,
+): { writes: ReturnType<typeof insertEntry>[]; tip: string | null } {
+  const writes: ReturnType<typeof insertEntry>[] = [];
+  let tip = parentId;
+  for (const entry of entries) {
+    const id = session.idGenerator.next();
+    const next: NewEntry = entry.type === "message"
+      ? { id, parentId: tip, type: "message", message: structuredClone(entry.message) }
+      : { id, parentId: tip, type: "compaction", ...structuredClone(entry), fromHook: false };
+    writes.push(insertEntry(next));
+    tip = id;
+  }
+  return { writes, tip };
+}
+
+function comparablePayload(
+  payload: Array<{ type: "message"; message: AgentMessage } | ({ type: "compaction" } & CompactResult)>,
+): unknown[] {
+  return payload.map((item) => item.type === "message"
+    ? { type: "message", message: item.message }
+    : { type: "compaction", ...item, fromHook: false });
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, (_key, item) => {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) return item;
+    return Object.fromEntries(Object.keys(item).sort().map((key) => [key, item[key]]));
+  });
+}
+
+async function committedRunMatches(
+  session: Session,
+  runId: string,
+  kind: "turn" | "compaction",
+  payload: Array<{ type: "message"; message: AgentMessage } | ({ type: "compaction" } & CompactResult)>,
+  expectedParentId?: string | null,
+): Promise<boolean> {
+  const { entries } = await readCommittedMain(session);
+  let groupStart = 0;
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (!entry || !isCommitMarker(entry)) continue;
+    const data = entry.data as { run_id: string; kind: "turn" | "compaction" };
+    if (data.run_id === runId && data.kind === kind &&
+        (kind === "turn" || entries[groupStart]?.parentId === expectedParentId)) {
+      const actual = entries.slice(groupStart, index).map((item) => {
+        if (item.type === "message") return { type: "message", message: item.message };
+        if (item.type === "compaction") {
+          const { id: _id, parentId: _parentId, seq: _seq, timestamp: _timestamp, ...rest } = item;
+          return rest;
+        }
+        throw new Error("invalid committed run payload");
+      });
+      if (stableJson(actual) !== stableJson(comparablePayload(payload))) {
+        throw new Error("committed run identity has different content");
+      }
+      return true;
+    }
+    groupStart = index + 1;
+  }
+  return false;
+}
+
+async function appendCommitted(
+  session: Session,
+  runId: string,
+  kind: "turn" | "compaction",
+  payload: Array<{ type: "message"; message: AgentMessage } | ({ type: "compaction" } & CompactResult)>,
+  expectedParentId?: string | null,
+): Promise<void> {
+  if (await committedRunMatches(session, runId, kind, payload, expectedParentId)) return;
+  try {
+    await session.mutate(async (mutator, context) => {
+      const storedTip = await mutator.getValue(branchTip(MAIN_BRANCH), context);
+      if (!storedTip) throw new Error("missing main branch");
+      if (kind === "compaction" && storedTip.value !== expectedParentId) {
+        throw new Error("compaction parent is no longer current");
+      }
+      const { writes, tip } = entryWrites(session, storedTip.value, payload);
+      const markerId = session.idGenerator.next();
+      writes.push(insertEntry({
+        id: markerId,
+        parentId: tip,
+        type: "custom",
+        customType: OM_TURN_COMMIT_TYPE,
+        data: { run_id: runId, kind } as JsonValue,
+      }));
+      await mutator.commit([...writes, setValue(branchTip(MAIN_BRANCH), markerId)], context);
+    }, TODO_CONTEXT);
+  } catch (error) {
+    if (await committedRunMatches(session, runId, kind, payload, expectedParentId).catch(() => false)) return;
+    throw error;
+  }
+}
+
+export async function appendCommittedTurn(
+  session: Session,
+  messages: AgentMessage[],
+  runId: string,
+): Promise<void> {
+  if (!runId || messages.length === 0 || messages.some((message) =>
+    message.role === "compactionSummary" ||
+    (message.role === "assistant" && ["error", "aborted", "deferred", "pending"].includes(message.stopReason)))) {
+    throw new Error("turn is not eligible for committed session history");
+  }
+  validateToolGroups(messages);
+  await appendCommitted(session, runId, "turn", messages.map((message) => ({ type: "message", message })));
+}
+
+export async function appendCommittedCompaction(
+  session: Session,
+  result: CompactResult,
+  runId: string,
+  expectedParentId: string | null,
+): Promise<void> {
+  if (!runId || !result.summary.trim() || !Number.isSafeInteger(result.tokensBefore) ||
+      result.tokensBefore < 0) {
+    throw new Error("compaction is not eligible for committed session history");
+  }
+  validateToolGroups(result.retainedTail.filter((message) => message.role !== "compactionSummary"));
+  await appendCommitted(
+    session, runId, "compaction", [{ type: "compaction", ...result }], expectedParentId,
+  );
+}

--- a/agent-runtime/pi_session_core.mjs
+++ b/agent-runtime/pi_session_core.mjs
@@ -1,0 +1,396 @@
+import { createHash } from "node:crypto";
+import { stat } from "node:fs/promises";
+
+export const OM_SESSION_FORMAT = "om-pi-session.v1";
+export const OM_TURN_COMMIT_TYPE = "om.turn.commit.v1";
+export const OM_FORMAT_NAMESPACE = "om.pi";
+export const OM_FORMAT_KEY = "session-format";
+export const MAIN_BRANCH = "main";
+export const TARGET_SCHEMA_SHA256 = "0dd7799bef18ac929627e15ef1a55ef3f293ea5d869c0fe48815b812b464a604";
+export const LEGACY_SCHEMA_SHA256 = "6af76c4064917bff53e2f72db67213490ff6e63064f231377ce53d475d48a79d";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, keys) {
+  return isRecord(value) && Object.keys(value).sort().join("\0") === [...keys].sort().join("\0");
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.length === 0) fail(`${label} is invalid`);
+}
+
+function requireTimestamp(value) {
+  if (!Number.isSafeInteger(value) || value < 0) fail("entry timestamp is invalid");
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]));
+  }
+  return value;
+}
+
+function contentSha256(value) {
+  return createHash("sha256").update(JSON.stringify(stable(value))).digest("hex");
+}
+
+export function sqliteSchemaHash(db) {
+  const rows = db.prepare(
+    "SELECT type, name, tbl_name, sql FROM sqlite_schema " +
+    "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name",
+  ).all();
+  return createHash("sha256").update(JSON.stringify(rows)).digest("hex");
+}
+
+export async function probeTargetStore(databasePath, sqlite) {
+  try {
+    const info = await stat(databasePath);
+    if (!info.isFile()) return { format: "unknown", sessionIds: [], writerLeaseCount: 0 };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { format: "missing", sessionIds: [], writerLeaseCount: 0 };
+    }
+    throw error;
+  }
+  let db;
+  try {
+    db = await sqlite.createNodeSqliteFactory().openReadOnly(databasePath);
+    const integrity = db.prepare("PRAGMA integrity_check").get();
+    if (!integrity || Object.values(integrity)[0] !== "ok") {
+      return { format: "corrupt", sessionIds: [], writerLeaseCount: 0 };
+    }
+    const fingerprint = sqliteSchemaHash(db);
+    if (fingerprint === TARGET_SCHEMA_SHA256) {
+      const rows = db.prepare("SELECT id, storage_version FROM sessions ORDER BY id").all();
+      if (rows.some((row) => row.storage_version !== 1)) {
+        return {
+          format: "unknown",
+          sessionIds: rows.map((row) => row.id),
+          writerLeaseCount: 0,
+        };
+      }
+      return {
+        format: "target",
+        sessionIds: rows.map((row) => row.id),
+        writerLeaseCount: 0,
+      };
+    }
+    if (fingerprint === LEGACY_SCHEMA_SHA256) {
+      const rows = db.prepare("SELECT id FROM sessions ORDER BY id").all();
+      const lease = db.prepare("SELECT COUNT(*) AS count FROM writer_leases").get();
+      return {
+        format: "legacy",
+        sessionIds: rows.map((row) => row.id),
+        writerLeaseCount: lease?.count ?? 0,
+      };
+    }
+    return { format: "unknown", sessionIds: [], writerLeaseCount: 0 };
+  } catch {
+    return { format: "corrupt", sessionIds: [], writerLeaseCount: 0 };
+  } finally {
+    db?.close();
+  }
+}
+
+export function isCommitMarker(entry) {
+  return entry?.type === "custom" &&
+    entry.customType === OM_TURN_COMMIT_TYPE &&
+    hasExactKeys(entry.data, ["run_id", "kind"]) &&
+    typeof entry.data.run_id === "string" && entry.data.run_id.length > 0 &&
+    (entry.data.kind === "turn" || entry.data.kind === "compaction");
+}
+
+export function isContextMessage(message) {
+  return message?.role !== "assistant" ||
+    !["error", "aborted", "deferred"].includes(message.stopReason);
+}
+
+export function validateToolGroups(messages) {
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (!isRecord(message) || !["user", "assistant", "toolResult"].includes(message.role)) {
+      fail("unsupported message role in session context");
+    }
+    if (message.role === "toolResult") fail("orphaned tool result in session context");
+    if (message.role !== "assistant") continue;
+    const calls = Array.isArray(message.content)
+      ? message.content.filter((item) => item?.type === "toolCall")
+      : [];
+    const expected = new Map();
+    for (const call of calls) {
+      requireString(call.id, "tool call id");
+      requireString(call.name, "tool call name");
+      if (expected.has(call.id)) fail("duplicate tool call id in session context");
+      expected.set(call.id, call.name);
+    }
+    for (let resultIndex = 0; resultIndex < calls.length; resultIndex += 1) {
+      const result = messages[++index];
+      if (!isRecord(result) || result.role !== "toolResult" ||
+          expected.get(result.toolCallId) !== result.toolName) {
+        fail("incomplete tool group in session context");
+      }
+      expected.delete(result.toolCallId);
+    }
+    if (expected.size > 0) fail("incomplete tool group in session context");
+  }
+}
+
+function validateEntryShape(entry) {
+  if (!isRecord(entry)) fail("session entry is invalid");
+  requireString(entry.id, "entry id");
+  if (entry.parentId !== null) requireString(entry.parentId, "entry parent id");
+  requireTimestamp(entry.timestamp);
+  if ("seq" in entry && (!Number.isSafeInteger(entry.seq) || entry.seq < 1)) {
+    fail("entry sequence is invalid");
+  }
+  if (entry.type === "message") {
+    const keys = Object.keys(entry);
+    const required = ["id", "parentId", "timestamp", "type", "message"];
+    if (required.some((key) => !keys.includes(key)) ||
+        keys.some((key) => !required.includes(key) && key !== "seq")) {
+      fail("message entry shape is invalid");
+    }
+    if (!isRecord(entry.message)) fail("message entry payload is invalid");
+    return;
+  }
+  if (entry.type === "compaction") {
+    const required = ["id", "parentId", "timestamp", "type", "summary", "retainedTail", "tokensBefore", "fromHook"];
+    const optional = ["details", "usage", "seq"];
+    const keys = Object.keys(entry);
+    if (required.some((key) => !keys.includes(key)) ||
+        keys.some((key) => !required.includes(key) && !optional.includes(key))) {
+      fail("compaction entry shape is invalid");
+    }
+    if (typeof entry.summary !== "string" || !entry.summary.trim() ||
+        !Array.isArray(entry.retainedTail) || !Number.isSafeInteger(entry.tokensBefore) ||
+        entry.tokensBefore < 0 || entry.fromHook !== false) {
+      fail("compaction entry payload is invalid");
+    }
+    validateToolGroups(entry.retainedTail.filter(isContextMessage));
+    return;
+  }
+  if (entry.type === "custom") {
+    const keys = Object.keys(entry);
+    const required = ["id", "parentId", "timestamp", "type", "customType", "data"];
+    if (required.some((key) => !keys.includes(key)) ||
+        keys.some((key) => !required.includes(key) && key !== "seq") ||
+        !isCommitMarker(entry)) {
+      fail("unsupported session entry");
+    }
+    return;
+  }
+  fail("unsupported session entry");
+}
+
+export function validateCommittedEntries(entries) {
+  if (!Array.isArray(entries)) fail("committed entries are invalid");
+  let parent = null;
+  let group = [];
+  const ids = new Set();
+  const runs = new Set();
+  for (const entry of entries) {
+    validateEntryShape(entry);
+    if (ids.has(entry.id)) fail("duplicate session entry id");
+    ids.add(entry.id);
+    if (entry.parentId !== parent) fail("broken main ancestry");
+    parent = entry.id;
+    group.push(entry);
+    if (!isCommitMarker(entry)) continue;
+    const payload = group.slice(0, -1);
+    if (entry.data.kind === "compaction") {
+      if (payload.length !== 1 || payload[0]?.type !== "compaction") {
+        fail("invalid compaction commit group");
+      }
+    } else {
+      if (payload.length === 0 || payload.some((item) => item.type !== "message")) {
+        fail("invalid turn commit group");
+      }
+      validateToolGroups(payload.map((item) => item.message).filter(isContextMessage));
+    }
+    const identity = entry.data.kind === "compaction"
+      ? `${entry.data.kind}\0${entry.data.run_id}\0${payload[0].parentId ?? ""}`
+      : `${entry.data.kind}\0${entry.data.run_id}`;
+    if (runs.has(identity)) fail("duplicate committed run identity");
+    runs.add(identity);
+    group = [];
+  }
+  if (group.length > 0) fail("uncommitted session tail");
+}
+
+function validateReachableEntries(entries) {
+  let parent = null;
+  let markerIndex = -1;
+  const ids = new Set();
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    validateEntryShape(entry);
+    if (ids.has(entry.id)) fail("duplicate session entry id");
+    ids.add(entry.id);
+    if (entry.parentId !== parent) fail("broken main ancestry");
+    parent = entry.id;
+    if (isCommitMarker(entry)) markerIndex = index;
+  }
+  if (entries.length > 0 && markerIndex < 0) fail("main branch has no valid commit marker");
+  const committed = markerIndex < 0 ? [] : entries.slice(0, markerIndex + 1);
+  validateCommittedEntries(committed);
+  return {
+    entries: committed,
+    committedTip: committed.at(-1)?.id ?? null,
+    excludedTailCount: entries.length - committed.length,
+  };
+}
+
+export async function readCommittedMain(session, api, options = {}) {
+  const branch = await session.branch(MAIN_BRANCH, api.context);
+  if (!branch) fail("missing main branch");
+  const tip = await branch.getTipId(api.context);
+  const reachable = await branch.findEntries({ order: "oldestFirst" }, api.context);
+  if ((tip === null && reachable.length > 0) ||
+      (tip !== null && reachable.at(-1)?.id !== tip)) {
+    fail("main branch tip is dangling");
+  }
+  const selected = validateReachableEntries(reachable);
+  if (options.requireAllEntries) {
+    const all = await session.findEntries({ order: "asc" }, api.context);
+    const reachableIds = new Set(reachable.map((entry) => entry.id));
+    const allowedParents = new Set(reachableIds);
+    const byId = new Map(reachable.map((entry) => [entry.id, entry]));
+    let detachedCount = 0;
+    for (const entry of all) {
+      if (reachableIds.has(entry.id)) continue;
+      validateEntryShape(entry);
+      const parent = entry.parentId === null ? undefined : byId.get(entry.parentId);
+      if (entry.type === "custom" || entry.parentId === null || !allowedParents.has(entry.parentId) ||
+          (parent !== undefined && reachableIds.has(parent.id) && !isCommitMarker(parent))) {
+        fail("unsupported session branches");
+      }
+      allowedParents.add(entry.id);
+      byId.set(entry.id, entry);
+      detachedCount += 1;
+    }
+    if (reachableIds.size + detachedCount !== all.length) fail("unsupported session branches");
+    selected.excludedTailCount += detachedCount;
+  }
+  return selected;
+}
+
+export function projectCommittedEntries(entries, api) {
+  validateCommittedEntries(entries);
+  let compactionIndex = -1;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (entries[index]?.type === "compaction") {
+      compactionIndex = index;
+      break;
+    }
+  }
+  const messages = [];
+  if (compactionIndex >= 0) {
+    const entry = entries[compactionIndex];
+    messages.push(
+      api.createCompactionSummaryMessage(entry.summary, entry.tokensBefore, entry.timestamp),
+      ...entry.retainedTail.filter(isContextMessage),
+    );
+  }
+  for (const entry of entries.slice(compactionIndex + 1)) {
+    if (entry.type === "message" && isContextMessage(entry.message)) messages.push(entry.message);
+  }
+  validateToolGroups(messages.filter((message) => message.role !== "compactionSummary"));
+  return messages;
+}
+
+export async function exportCommittedMain(session, api, options = {}) {
+  const selected = await readCommittedMain(session, api, options);
+  return {
+    ...selected,
+    messages: projectCommittedEntries(selected.entries, api),
+  };
+}
+
+export async function loadCommittedContext(session, api) {
+  const selected = await exportCommittedMain(session, api);
+  const branch = await session.branch(MAIN_BRANCH, api.context);
+  if (!branch) fail("missing main branch");
+  if (await branch.getTipId(api.context) !== selected.committedTip) {
+    await session.mutate(async (mutator, context) => {
+      await mutator.commit([api.setValue(api.branchTip(MAIN_BRANCH), selected.committedTip)], context);
+    }, api.context);
+  }
+  return { entries: selected.entries, messages: selected.messages };
+}
+
+function migrationUsageId(entryId) {
+  return `om_migration_usage_${createHash("sha256").update(entryId).digest("hex").slice(0, 32)}`;
+}
+
+function entryUsage(entry) {
+  if (entry.type === "message" && entry.message?.role === "assistant") return entry.message.usage;
+  if (entry.type === "compaction") return entry.usage;
+  return undefined;
+}
+
+export async function importCommittedMain(repo, source, api, setNow) {
+  if (!isRecord(source) || !hasExactKeys(source, [
+    "id", "createdAt", "entries", "excludedTailCount", "contextSha256", "contentSha256",
+  ])) {
+    fail("canonical session envelope is invalid");
+  }
+  requireString(source.id, "session id");
+  requireTimestamp(source.createdAt);
+  if (!Number.isSafeInteger(source.excludedTailCount) || source.excludedTailCount < 0 ||
+      !/^[0-9a-f]{64}$/.test(source.contextSha256) || !/^[0-9a-f]{64}$/.test(source.contentSha256)) {
+    fail("canonical session metadata is invalid");
+  }
+  validateCommittedEntries(source.entries);
+  if (source.entries.some((entry) => "seq" in entry)) {
+    fail("canonical session entries must not contain physical sequence numbers");
+  }
+  const projected = projectCommittedEntries(source.entries, api);
+  if (contentSha256(source.entries) !== source.contentSha256 ||
+      contentSha256(projected) !== source.contextSha256) {
+    fail("canonical session fingerprints do not match content");
+  }
+  setNow(source.createdAt);
+  const session = await repo.create({ id: source.id }, api.context);
+  try {
+    await session.mutate(async (mutator, context) => {
+      await mutator.commit([
+        api.setValue(api.value(OM_FORMAT_NAMESPACE, OM_FORMAT_KEY), OM_SESSION_FORMAT),
+        api.setValue(api.branchTip(MAIN_BRANCH), null),
+      ], context);
+    }, api.context);
+    let tip = null;
+    for (const entry of source.entries) {
+      if (entry.parentId !== tip) fail("canonical ancestry is not linear main");
+      setNow(entry.timestamp);
+      const { timestamp: _timestamp, ...mapped } = structuredClone(entry);
+      const writes = [
+        api.insertEntry(mapped),
+        api.setValue(api.branchTip(MAIN_BRANCH), entry.id),
+      ];
+      const usage = entryUsage(entry);
+      if (usage !== undefined) {
+        writes.push(api.insertUsage({
+          id: migrationUsageId(entry.id),
+          entryId: entry.id,
+          adjustment: false,
+          usage: structuredClone(usage),
+          details: { source: "om-pi-export.v1" },
+        }));
+      }
+      await session.mutate(async (mutator, context) => {
+        await mutator.commit(writes, context);
+      }, api.context);
+      tip = entry.id;
+    }
+    return await exportCommittedMain(session, api, { requireAllEntries: true });
+  } finally {
+    await session.close(api.context);
+  }
+}

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -12,8 +12,8 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 
 ## Summary
 
-- Python files scanned: 996 (`src`: 515, `domain`: 82, `scripts`: 11, `tests`: 388)
-- Internal import edges: 6944 total, 2892 production/script edges excluding tests
+- Python files scanned: 1001 (`src`: 516, `domain`: 82, `scripts`: 11, `tests`: 392)
+- Internal import edges: 6984 total, 2900 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -33,23 +33,23 @@ flowchart LR
   storage["domain.storage"]
   application -->|456| domain
   application -->|4| domain_services
-  application -->|145| infrastructure
+  application -->|147| infrastructure
   application -->|44| storage
   domain_services -->|5| domain
   domain_services -->|2| storage
   infrastructure -->|9| application
   infrastructure -->|6| domain
-  interfaces -->|154| application
+  interfaces -->|155| application
   interfaces -->|1| domain
   interfaces -->|4| infrastructure
   scripts -->|42| application
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|3022| application
+  tests -->|3041| application
   tests -->|468| domain
   tests -->|2| domain_services
-  tests -->|237| infrastructure
+  tests -->|245| infrastructure
   tests -->|227| interfaces
   tests -->|21| scripts
   tests -->|20| storage
@@ -60,8 +60,8 @@ flowchart LR
 | from | to | imports |
 |---|---|---|
 | application | domain | 456 |
-| interfaces | application | 154 |
-| application | infrastructure | 145 |
+| interfaces | application | 155 |
+| application | infrastructure | 147 |
 | application | storage | 44 |
 | scripts | application | 42 |
 | infrastructure | application | 9 |
@@ -79,9 +79,9 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 3022 |
+| tests | application | 3041 |
 | tests | domain | 468 |
-| tests | infrastructure | 237 |
+| tests | infrastructure | 245 |
 | tests | interfaces | 227 |
 | tests | scripts | 21 |
 | tests | storage | 20 |
@@ -94,8 +94,8 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 | from | to | imports |
 |---|---|---|
 | src.application | domain.domain | 214 |
-| src.interfaces | src.application | 121 |
-| src.application | src.infrastructure | 100 |
+| src.interfaces | src.application | 122 |
+| src.application | src.infrastructure | 102 |
 | src.application.ledger | domain.domain | 80 |
 | src.application.ledger | domain.domain.ledger | 49 |
 | src.application.trades | domain.domain | 35 |
@@ -111,8 +111,8 @@ The full compressed Mermaid graph is in [`docs/dependency_graph.mmd`](dependency
 | src.application.inbound | src.application | 21 |
 | src.application | domain.domain.ledger | 17 |
 | src.application | src.application.multi_tick | 16 |
+| src.application | src.application.settings | 16 |
 | domain.domain | domain.domain.ledger | 16 |
-| src.application | src.application.settings | 15 |
 | src.application.positions | domain.domain | 14 |
 | domain.domain.ledger | domain.domain | 14 |
 | src.application.trades | src.infrastructure | 13 |
@@ -190,9 +190,9 @@ Package-level cycles are expected to be noisier because many flat `src.applicati
 | src.application.account_config | 43 |
 | domain.domain.decision_state_fingerprint | 37 |
 | domain.domain.ledger | 25 |
+| src.application.settings | 24 |
 | src.infrastructure.futu_gateway | 24 |
 | domain.domain.trade_contract_identity | 24 |
-| src.application.settings | 23 |
 | domain.domain.engine | 22 |
 
 ### Highest Fan-Out Production Modules

--- a/docs/PI_AGENT_CORE_INTEGRATION.md
+++ b/docs/PI_AGENT_CORE_INTEGRATION.md
@@ -2017,3 +2017,468 @@ upstream API details may refine field spelling during implementation, but any
 change to authority, budgets, evidence scope, cursor semantics, compaction
 failure behavior, rollout boundaries, or final-answer admission requires a
 design update before code.
+
+## 14. Pi 0.85.1 Compatibility Upgrade (Target Design)
+
+This section specifies the target upgrade from the installed 0.84.2 baseline;
+it does not claim that 0.85.1 is deployed. Existing behavior in sections 1–13
+remains binding except for the versioned Session storage/API adaptation below.
+The implementation baseline is the Bot code at commit
+`77e740c13d4fff1e1bf0d7596bfe6e28b2c118c1` (OM 3.5.1), not an older checkout
+with the retired `src/application/copilot/` layout. Runtime enablement and production
+migration require their own release and operator actions.
+
+### 14.1 Goal, scope, and success signals
+
+Upgrade `pi-agent-core`, `pi-ai`, and `pi-session-backend-sqlite-node` together to
+exactly 0.85.1 and retain the supported Node.js floor of 22.19.0. The goal is a
+working upgrade of the existing Bot, including its durable conversations, rather
+than a dependency-only change that cannot start.
+
+Acceptance signals:
+
+- **A1 — Execution:** the real Python facade starts 0.85.1, validates the exact
+  runtime version, completes deterministic evaluation, and preserves existing
+  provider profiles, tool activation/admission, one bounded length continuation,
+  budgets, usage accounting, and cancellation.
+- **A2 — Continuity:** every supported source session keeps its opaque identity,
+  committed history, complete tool-call/result groups, compaction summaries and
+  retained tails, and current committed branch. Unknown formats fail closed.
+- **A3 — Durable safety:** concurrent same-session runs cannot overwrite each
+  other; cancelling or killing either process cannot release exclusion while a
+  surviving child can still write; only Host-approved turns become durable.
+  Independent sessions retain their existing ability to run concurrently.
+- **A4 — Migration/recovery:** preview is read-only; explicit apply preserves a
+  verified source backup, detects changed inputs, is restartable without duplicate
+  import, and never publishes an unverified database. Rollback preserves turns
+  committed after upgrading, not merely the pre-upgrade snapshot.
+- **A5 — Delivery readiness:** installed and clean-installed dependencies, runtime
+  smoke, Session/provider/Host regressions, and release packaging checks pass.
+  The offline maintenance order is tested before any real deployment.
+
+Non-goals: changing models or strategy; redesigning Host, memory extraction,
+Scene, registry or tool permissions; adopting AgentHarness or a Pi server;
+changing user/sender/config scope; silently resetting sessions; dual-writing
+old and new stores; adding a general migration framework. Source work does not
+itself commit, push, publish, stop services, migrate production data, or deploy.
+
+### 14.2 Verified compatibility facts
+
+The installed npm artifacts, rather than the release notes alone, establish:
+
+| 0.84.2 integration | 0.85.1 target |
+|---|---|
+| `SessionError`, `SqliteSessionRepository`, top-level `buildSessionContext` | These exports are absent; use `SqliteSessionRepo`, public Session/Branch primitives and explicit OM error adaptation |
+| `env`, `sqlite`, `writerLease` repository options | `directory`, `databasePath`, `databaseFactory`; no equivalent writer-lease option |
+| Session `findEntriesOnBranch`, `moveLane`, append helpers | Public Branch reads; `Session.mutate` plus entry/value writes and `branchTip` for atomic persistence |
+| Repository `metadata.schema` guard | OM format marker stored in an OM-namespaced public scalar value; opaque Session IDs are unchanged |
+| `compact(..., signal, ...)` | Context-taking `compact` / `compactWithRequest`; cancellation is carried through the public Context API |
+| `prepareNextTurnWithContext` runs after completed turns | It runs only when another assistant turn has already been selected |
+| SQLite `sessions.cwd`, lane/record/fact tables and `writer_leases` | Different Session columns plus scalar/list/usage storage; no shipped converter for the installed OM schema |
+
+A direct version bump was observed to fail before the IPC handshake at the
+missing `SessionError` export. The old packages were restored after that probe.
+Both versions retain the public `Agent`, message constructors, and compaction
+primitives. The new internal `harness/session/context` implementation exists but
+is not an exported package subpath; production must not import it by filesystem
+path or patch npm package exports.
+
+The Bot Host lease is a separate admission mechanism. Its TTL and optional
+Host-store use do not prove process-lifetime exclusion for every
+`run_pi_agent` caller. The old Pi writer fence cannot simply be deleted because
+an upstream Session mutation barrier exists inside one Node process.
+
+### 14.3 Runtime and persistence adaptation
+
+Keep `om-pi-ipc.v1`, the existing closed envelopes and tool/answer contracts.
+Change the pinned handshake version in Node, Python and owning fixtures
+atomically. Retain `Agent` as the sole model/tool loop.
+
+Use public 0.85.1 Context cancellation and the existing provider request wrapper
+for ordinary and compaction calls. Preserve per-call budget admission, configured
+retry policy, empty-summary rejection and once-only usage accounting, including
+committed compaction followed by a cancelled main call. Do not reopen earlier
+context-budget policy decisions.
+
+Queue an eligible length continuation only in `shouldStopAfterTurn`, before Pi
+polls its continuation queues. Keep the current eligibility checks and single-use
+budget; the enqueue branch returns `false`, never stop=true. No second callback
+or event subscriber queues the same continuation. Use
+`prepareNextTurnWithContext` only to supply the selected next turn's tools and
+context. Its context replaces the whole prior context, so retain the completed
+turn's messages and systemPrompt when changing tools. A final/admitted answer or
+forced-final budget stop cannot enqueue another turn. Tool arguments cut off by
+a length stop are never executed.
+
+Open the explicit canonical `OM_PI_SESSION_DB`, never the new backend's default
+per-session-file layout. Under the locks in section 14.4, inspect the existing
+file with public `createNodeSqliteFactory().openReadOnly()` and its query API
+before constructing a writable Repository. Check integrity and the exact pinned
+schemas, including table/column definitions and storage version, to distinguish
+legacy 0.84.2, target 0.85.1, and incomplete/corrupt/unknown data. This bounded
+format probe is the only reader coupled to the two SQLite schemas; it imports
+no package internals. A few absent tables or an empty Repository catalog never
+prove a database is missing or safe to initialize.
+
+Database format and requested session existence are separate decisions. A missing
+database may be created; a recognized target database may create a missing
+session ID without disturbing other sessions. Read an existing target session's
+OM scalar marker through public `SqliteStorage.getValue` and `value(namespace,key)`
+on the read-only connection before writable `repo.open()`. A valid marker admits
+normal loading. Legacy, mixed, unknown or nonempty unmarked data returns bounded
+`SESSION_ERROR` remediation; ordinary startup performs no version migration and
+never replaces unreadable data with an empty database.
+
+Public `repo.create({id})` commits the session row before OM initialization.
+Initialize the format marker and `branchTip("main") = null` together in one
+`Session.mutate` commit. If interrupted between creation and initialization,
+retry that mutation only when the target session is proven completely empty:
+no entries, scalar/list values, usage rows or branch state. Any durable content
+without the expected marker fails closed. This recovery is scoped to the requested
+session under its lock; it does not recreate or clear the shared database.
+
+Use a data-only `main` Branch. At load, use its public Branch reads to find and
+validate the last `om.turn.commit.v1` marker on the current ancestry; a session-wide
+entry search is not a substitute. Unknown markers or broken ancestry fail closed.
+Rewind the branch tip to that committed point through public mutation primitives
+before exposing history. Uncommitted tails are not model context.
+
+Because the old context-builder export is gone, the integration owns one narrow
+projection of its allowed persisted entry types: message entries after the most
+recent committed compaction; that compaction's public summary message and retained
+tail; and commit markers, which are ignored as context. Preserve existing
+filtering of failed/aborted assistant turns and complete tool groups. Reject
+unsupported entry/custom-message types rather than invent semantics. Use public
+Pi message constructors and compaction primitives; this adapter does not calculate
+new summaries, prune history independently, or implement general harness branches.
+Keep `estimateProviderInputTokens` as the owner of budget estimation: it disregards
+pre-compaction assistant usage on an estimation-only copy by timestamp. Preserve
+those timestamps and persisted usage; do not duplicate that rule in the projector.
+
+Append a validated canonical turn, its commit marker and new branch tip in one
+`Session.mutate` commit. Persist a successful pre-run compaction and its marker
+in a separate atomic commit, retaining the existing checkpoint rule if the user
+turn is later discarded. Do not call queued public Session writers from inside a
+mutation callback. On an ambiguous return after a durable commit, read the marker
+for that run and canonical content before deciding whether retry is safe; an
+existing matching committed run is not appended twice.
+
+### 14.4 Process-lifetime exclusion
+
+At the common Python `run_pi_agent` boundary, use BSD `fcntl.flock` with
+`LOCK_NB`; `lockf` and traditional POSIX record locks do not satisfy the inherited
+ownership contract. Reuse private path/file validation from
+`src/infrastructure/private_storage.py`, then resolve the validated database path
+consistently before deriving lock identities. Keep existing hostile-symlink
+rejection. Valid aliases such as macOS `/tmp` and `/private/tmp` must identify the
+same database lock and the same opaque-session lock. Database lock identity is
+based on this stable canonical pathname, not the inode replaced by migration.
+
+Each run independently opens its lock descriptors; same-process requests for the
+same session must contend too. Do not reuse the existing helper's reentrant
+ownership or explicit-unlock lifetime for child handoff. No npm locking package
+or new lease table is needed. Lock files are private and remain in place;
+unlinking an active lock file is forbidden.
+
+Acquire a shared database maintenance lock (`LOCK_SH`) before the per-session
+exclusive lock (`LOCK_EX`); the offline converter takes the database lock
+exclusively. Both use nonblocking flock. Lock ordering is always database then
+session. Distinct sessions may hold the shared database lock together.
+A busy session returns the existing retryable session error, before provider or
+Session writes; waiting does not consume a new unbounded execution budget.
+
+Both acquired lock descriptors are passed to the Node child via `pass_fds` and
+are held until the child has exited. Normal cleanup terminates/reaps the child
+before explicitly unlocking. If Python is killed, the inherited descriptors keep
+the lock alive in Node; if Node is killed, Python reaps it before releasing its
+copies. A stopped process retains its lock instead of losing ownership at a TTL.
+If termination cannot be proved, no replacement writer may be admitted. The
+private Node entry must reject a persistent run without both expected descriptor
+identities and a valid handoff. Checking open descriptors and their expected file
+identity is an integrity guard, not proof that flock is held; real contention
+tests prove exclusion. Tests exercise direct-entry rejection as well as the facade.
+Transient evaluation creates no Session database or Session locks.
+
+This exclusion is for supported local SQLite filesystems on macOS/Linux. No
+Windows or network-filesystem lock emulation is introduced. Unsupported locking
+fails explicitly. Host admission leases remain unchanged and retain their own
+run-governance role. A hung or paused writer remains busy until it exits. Diagnose
+the owning processes and drain or terminate them through an authorized operator
+action; never steal the lock or unlink its file to admit another writer. No PID
+registry or automatic lock-stealing timeout is added.
+
+### 14.5 Explicit offline conversion and rollback
+
+Add one bounded operator surface under the existing Bot CLI:
+
+```text
+./om bot migrate-pi --pi-db PATH --source-runtime DIR --target-runtime DIR --dry-run
+./om bot migrate-pi --pi-db PATH --source-runtime DIR --target-runtime DIR --apply --writers-stopped
+```
+
+These are proposed commands, not current commands. Runtime directories contain
+the matching package manifest, lockfile and installed packages. Only the exact
+0.84.2 and 0.85.1 formats are accepted. The existing `./om bot migrate` continues
+to own the Copilot-to-Bot name/config migration; Pi conversion neither invokes
+that migration nor edits its receipt, Host database, outbox, configs or memory
+extraction records. No new global package or old/new runtime fallback is installed.
+
+Use the existing Python SQLite `backup()` pattern to create a self-contained,
+WAL-consistent recovery backup, close/checkpoint it and verify integrity and
+logical parity. Seal that backup and record its identity; Pi never opens it.
+Make a disposable export copy from the sealed backup. The source version's public
+Session APIs open only this working copy, because even old public `open()` writes
+leases and can leave WAL state after a crash. Import into a separate private
+staging database through the target version's public APIs. Recheck the sealed
+backup independently after export; an interrupted working copy can be discarded
+and recreated from it without altering the recovery artifact.
+
+One narrow offline Node bridge runs export and import in separate processes,
+separate from normal IPC. Anchor standard module resolution at each explicitly
+selected runtime manifest, resolve only public package exports, then load the
+resolved module URL and verify the actual package paths/versions against that
+runtime's manifest, lockfile and installed-package identity. Changing cwd alone
+does not select an import's version. Reject wrong-version resolution before any
+Session open. No custom loader/import-map framework or copied old implementation
+is required. Export handles supported OM sessions only.
+
+The conversion report includes versions/package-lock hashes, source logical
+fingerprint including committed WAL contents, opaque session IDs, per-session
+committed entry counts and content hashes, retained compactions/tool groups,
+excluded uncommitted tails, sealed-backup/export-copy/target identities, and
+validation results. Disk checks include all three copies and the active source.
+Do not output conversation text, provider keys or raw authority paths in reports.
+All source rows, including unreachable historical branches and incomplete tails,
+remain preserved in the verified immutable backup; only validated committed main
+history becomes active in the target. Unsupported source branches, metadata or
+custom entry semantics block conversion instead of being silently dropped.
+Physical sequence numbers may be reassigned; message timestamps, entry ancestry,
+IDs referenced by payloads and run commit identities must be preserved or mapped
+explicitly and validated. Readback uses the target runtime's real context loader
+and checks equivalence of the canonical model-visible history, not only row counts.
+Old OM pre-run compaction entries map to target `fromHook:false`; reverse mapping
+removes that field only for supported OM-origin entries. Unsupported hook-origin
+content blocks conversion. Preserve message and compaction timestamps and validate
+one and multiple compactions through both real context loaders, including the
+unchanged budget estimator and complete tool groups.
+
+Apply requires a maintenance window: stop/drain every Agent ingress, shared-db
+writer and manual persistent CLI run; retain the activation-state snapshot.
+`--writers-stopped` records this explicit operator assertion. The converter also
+rejects outstanding source writer leases, obtains the exclusive database lock,
+rechecks the source snapshot immediately before publication, and refuses any
+changed input or unresolved live writer. New runtime locks cannot fence old
+0.84.2 processes; their quiescence is a required precondition, not an inferred
+consequence of an expired lease.
+
+Conversion phases and failure behavior:
+
+1. **Preview:** read-only format/identity/integrity/space checks and conversion
+   feasibility. No lock-file, backup, receipt, Session creation or network/model
+   call. A preview is evidence, not authorization.
+2. **Prepared:** after explicit apply and quiescence, create and seal the verified
+   WAL-consistent backup, durably record its identity plus source/target runtime
+   identities in a private conversion receipt, then make the disposable export
+   copy. Record its separate identity; failure here leaves the source and sealed
+   backup unchanged. Interrupted disposable work is never used as a recovery copy.
+3. **Validated:** import all supported sessions into a private same-filesystem
+   staging database, close/checkpoint it, and verify integrity and context/commit
+   equivalence. Failure leaves the active source unchanged. Receipts never mark
+   a target validated before readback succeeds.
+4. **Published:** after rechecking source identity and closing all database
+   connections, replace the canonical file atomically, fsync the directory, and
+   record readback completion. No live WAL/SHM file is copied onto the new store;
+   their ownership and absence after quiescent checkpoint are checked before
+   publication. A crash between replacement and receipt completion is reconciled
+   by exact source/target identity, never by importing again into the target.
+
+Retries reuse a matching prepared/validated target or report already applied.
+A mismatched receipt, backup, schema, source or target is an error, not an
+invitation to overwrite it. A partial staging file is never a candidate for
+activation. Runtime startup refuses an unresolved publication receipt.
+
+Rollback after new turns requires the same stopped-writer conversion in reverse,
+using the current 0.85.1 committed history and the retained 0.84.2 runtime. Verify
+that the previous runtime can resume that converted history before switching the
+application release. A pre-upgrade backup alone is sufficient only when a checked
+fingerprint proves no new committed data would be lost. Unsupported new content
+blocks automatic rollback; keep the current data and report the incompatibility.
+Neither direction deletes snapshots automatically or restores stale data over
+newly committed conversations.
+
+### 14.6 Owners and rollout boundary
+
+| Owner | Bounded responsibility |
+|---|---|
+| `agent-runtime/main.ts` | Public Pi API adaptation, Context/continuation, canonical Session projection and durable commit |
+| `agent-runtime/package.json`, `package-lock.json` | Three exact pins and reproducible dependency graph |
+| `src/infrastructure/pi_agent_process.py` | Exact handshake, process-lifetime locks and descriptor lifecycle |
+| `src/infrastructure/private_storage.py` | Existing private file/path primitives; preserve existing callers |
+| Proposed `src/application/bot/pi_migration.py` and a narrow offline Node bridge | Preview/apply/reconcile conversion and public old/new backend access |
+| `src/interfaces/cli/bot_ops.py` | Explicit migration CLI and bounded operator result |
+| `src/application/service_upgrade.py` | Format/runtime readiness for upgrade, rollback and failed-transition compensation; retain the verified source runtime; no implicit migration |
+| `src/application/service_cleanup.py` | Exclude source runtime directories still required by the Pi conversion receipt from release cleanup |
+| Existing Bot runtime callers | Preserve canonical database and session identity; no duplicated lock or conversion logic |
+| This document and `docs/RELEASE_PROCESS.md` | Runtime contract and operator maintenance order respectively |
+
+The generic upgrade path must not restart an old runtime against a converted
+store or a new runtime against an unconverted store. Before an authorized real
+rollout, prepare and smoke-test the released target without changing activation;
+quiesce writers; convert/verify Session storage; perform the controlled release
+switch; verify current dependencies, config freshness, and live service health;
+then restore the intended ingress activation state. Automatic version switching
+stops with remediation when this offline step is required. The old deployment's
+upgrade command cannot be assumed to know the new gate; the new release's
+preflight and the operator sequence must be used. Failure after storage
+publication follows the reverse-conversion rule before old services resume.
+Enforce that ordering in `_compensate_service_transition` as well as ordinary
+upgrade/rollback entrypoints: an incompatible old runtime must not restart after
+a failed switch, and a failed reverse conversion leaves ingress stopped with
+explicit remediation rather than restoring stale history.
+
+The release/upgrade owner retains the exact 0.84.2 runtime directory and its
+manifest, lockfile and installed-package identity while Pi rollback depends on it.
+Store that dependency in the existing Pi conversion receipt. Readiness verifies
+the directory before migration and rollback; cleanup refuses to remove a runtime
+referenced by a retained conversion dependency, independently of keep-count rules.
+Use the retained release directory rather than a new runtime cache. Releasing that
+dependency requires an explicit operator decision ending this rollback obligation;
+ordinary cleanup never infers that decision. `docs/RELEASE_PROCESS.md` owns this
+maintenance order and operator handoff.
+
+#### First transition from an unmodified 0.84.2 deployment
+
+The first incompatible transition uses the existing installer in a private
+staging prefix. Old automatic upgraders must be disabled and drained before
+they can consume the incompatible release; retain their activation states.
+Do not invoke the old release's confirmed `update apply` for this transition:
+its dry-run does not prepare a target, and its confirmed call prepares and
+switches in one operation. The new gate cannot retrofit an already running old
+upgrader. This maintenance precondition also covers other operators or jobs that
+could switch the production link during conversion.
+
+Use an explicitly published and verified target tag. In the commands below,
+`PI_OLD_RELEASE` is the resolved active old release, `PI_UPGRADE_STAGE` is a fresh
+private directory outside production release/runtime paths, `PI_TARGET_TAG` is
+that exact `v...` tag, `PI_PRODUCTION_LINK` is the production current symlink,
+`PI_RUNTIME_ROOT` is its runtime root, and `PI_SESSION_DB` is an inventoried
+canonical database. These are operator-supplied paths, not new config keys.
+
+1. Prepare the control runtime with the existing old release's installer:
+
+   ```bash
+   bash "$PI_OLD_RELEASE/scripts/install.sh" --version "$PI_TARGET_TAG" \
+     --prefix "$PI_UPGRADE_STAGE" --no-install-cli
+   PI_TARGET_CONTROL="$PI_UPGRADE_STAGE/releases/$PI_TARGET_TAG"
+   ```
+
+   This changes only the private prefix's `current` link, installs the target's
+   locked dependencies and runs its isolated smoke. It does not change the
+   production current/config/services/SQLite or global CLI wrappers. Verify the
+   published target commit and installed package identities before proceeding;
+   preparation failure leaves production on its old runtime/store.
+
+2. Snapshot and stop/drain every Agent ingress and shared-DB writer as required
+   by section 14.5; the old upgrade jobs remain disabled. Run the target CLI
+   **from the target directory** as well as by absolute path, so Python's current
+   directory cannot select old application modules ahead of the target:
+
+   ```bash
+   (cd "$PI_TARGET_CONTROL" && "$PI_TARGET_CONTROL/om" bot migrate-pi \
+     --pi-db "$PI_SESSION_DB" --source-runtime "$PI_OLD_RELEASE/agent-runtime" \
+     --target-runtime "$PI_TARGET_CONTROL/agent-runtime" --dry-run)
+   ```
+
+   After reviewing the preview within the authorized maintenance window, repeat
+   with `--apply --writers-stopped` instead of `--dry-run`, for each inventoried
+   database. The conversion receipt/readback must validate all stores before
+   any production link switch. `migrate-pi` remains the proposed command in 14.5.
+
+3. From the same target control directory, preview the existing update surface
+   with explicit production paths:
+
+   ```bash
+   (cd "$PI_TARGET_CONTROL" && "$PI_TARGET_CONTROL/om" update apply \
+     --repo-root "$PI_PRODUCTION_LINK" --runtime-root "$PI_RUNTIME_ROOT" \
+     --target-version "$PI_TARGET_TAG" --no-restart-services \
+     --preserve-activation-state)
+   ```
+
+   After a successful readiness preview, repeat with `--confirm --yes`. The
+   target controller owns the storage gate and compensation; production runtime
+   preparation must verify the same release/package identity used for migration.
+   Keep ingress stopped through switch and readback. Only after current runtime,
+   converted stores, configs and live service checks agree may the operator
+   restore the recorded activation states and automatic upgrade jobs, whose
+   entrypoints must now resolve to the new production controller.
+
+Before storage publication, failure keeps the old source and production link.
+After publication, failure at any later step requires verified reverse conversion
+from the current data before old writers can resume, even if the link never
+switched. If reverse conversion fails, keep ingress stopped and preserve the
+data/receipts for remediation. Retain both the old runtime and staged controller
+until the transition and any compensation are verified. The operator commands
+are maintained in `docs/RELEASE_PROCESS.md`; the existing upgrade owner consumes
+the receipt's source/target/backup identities for readiness and compensation.
+No new prepare-only command or generic deployment workflow is introduced.
+
+### 14.7 Three independently verifiable behavior slices
+
+1. **New runtime executes existing requests (A1):** adapt imports, exact version
+   handshake, Context/compaction signatures and continuation scheduling. Prove
+   stateless smoke and existing loopback provider, tool/admission, budget and
+   cancellation behavior, including exactly one admitted continuation and complete
+   context after tool changes. Persistent execution is not enabled until slice 2.
+2. **Conversations remain safe and continuous (A2–A4):** implement canonical
+   Session projection/atomic commits, process-lifetime exclusion and offline
+   forward/reverse conversion. Verify old-format fixtures, distinct-account and
+   same-account processes, kill/stop/cancel scenarios, migration fault injection
+   at every publication boundary, retry/no-op, and rollback after new commits.
+   Explicitly cover: legacy/corrupt source unchanged on startup; interrupted empty
+   session initialization; committed WAL in the sealed backup; exporter death
+   leaving that backup unchanged; runtime-version resolution rejection; single
+   and repeated compactions; same-process lock contention; alias-path contention;
+   parent SIGKILL with child paused while a second same-session run remains busy
+   until child exit; and distinct-session success. Test new transaction atomicity
+   with crashes, and ancestry rewind with a deliberately uncommitted-tail fixture.
+3. **Packaged rollout fails safely or succeeds (A5):** integrate format readiness
+   with release/upgrade checks, CLI help and owner documentation. Prove clean
+   install, source-archive smoke and offline switch/rollback scenarios. This
+   slice prepares delivery; it does not publish or operate production. Include
+   compensation after a failed switch and cleanup refusal for the retained source
+   runtime required by rollback. Begin the first-transition fixture with an
+   unmodified 3.5.1/0.84.2 controller: private-prefix preparation leaves production
+   unchanged, old automatic switchers remain quiescent, the target CLI imports
+   target code, all conversion receipts validate before the production link
+   changes, and every post-publication failure reverses current data before old
+   writers resume. This proves the supported recipe; it does not claim the old
+   binary acquires new safety checks.
+
+Validation uses Node 22.19.0 as well as the available local Node version; model
+requests use loopback fixtures, and all databases, receipts and kill tests use
+private temporary storage. Existing failing assertions about lease-table shape
+may change only when equivalent facade-level exclusion/recovery assertions are
+present. Do not weaken behavioral tests to make the version bump pass.
+
+Run `tests/test_pi_agent_process.py`, relevant `tests/test_bot_*` and Bot eval
+suites, the Pi/service rule from `src/application/release_test_plan.py`, the
+runtime smoke script, dependency-graph check, and documentation/sensitive-artifact
+guardrails. Add narrow migration and lock-lifecycle tests to the owning test plan;
+regenerate the dependency graph if imports change. The final validation scope is
+determined from the complete task diff, including new files.
+
+### 14.8 Residual risks and release prerequisites
+
+- **Runtime adapter owner:** prove public-only context projection parity for all
+  OM-persisted entries. An unsupported type must block, not be erased.
+- **Storage adapter owner:** verify inherited-lock behavior on both supported OSes,
+  real cross-process races, crash recovery, and same-filesystem publication.
+- **Migration owner:** prove both official backend import directions can represent
+  the supported OM history, including compaction/commit identities; inability to
+  preserve them is a blocking design finding, not permission to reset history.
+- **Operator/release owner:** inventory actual database paths, retention/disk
+  capacity and all Agent writers during the separately authorized deployment.
+  Do not collect live conversation content into review artifacts.
+- **Release owner:** a Pi adaptation must be released before the remote consumes
+  it. Publication remains separately authorized; the remote-upgrade request is
+  retained and is not evidence that publication or migration has already run.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -393,6 +393,59 @@ git branch -d <exact-local-branch>
 该参数会在任何写入前读取 profile 并快照已管理 timer；状态未知时 fail closed。未传参数时，
 `service drift` 继续使用严格的 `ensure-active` 默认策略。
 
+### Pi Session 不兼容版本的首次切换
+
+Pi Session 存储格式不兼容时，普通 `update apply` 不会隐式转换数据库。首次从 0.84.2
+切换到 0.85.1 必须由新 release 在维护窗口内控制；不要确认执行旧 release 的
+`update apply`。先记录并停用自动升级任务，停止并 drain 所有 Agent ingress、共享数据库
+writer 和手工持久会话进程，同时保留它们原有的 activation state。
+
+用现有安装器在生产 release/runtime 目录之外准备私有控制目录：
+
+```bash
+bash "$PI_OLD_RELEASE/scripts/install.sh" --version "$PI_TARGET_TAG" \
+  --prefix "$PI_UPGRADE_STAGE" --no-install-cli
+PI_TARGET_CONTROL="$PI_UPGRADE_STAGE/releases/$PI_TARGET_TAG"
+```
+
+这一步只改变私有 prefix 内的 `current`，不改变生产 symlink、配置、服务或 SQLite。验证
+目标 tag、commit 和三项 Pi package identity 后，对每个已清点的 Session 数据库从目标
+目录执行只读 preview，再在已授权的维护窗口内显式 apply：
+
+```bash
+(cd "$PI_TARGET_CONTROL" && "$PI_TARGET_CONTROL/om" bot migrate-pi \
+  --pi-db "$PI_SESSION_DB" \
+  --source-runtime "$PI_OLD_RELEASE/agent-runtime" \
+  --target-runtime "$PI_TARGET_CONTROL/agent-runtime" --dry-run)
+
+(cd "$PI_TARGET_CONTROL" && "$PI_TARGET_CONTROL/om" bot migrate-pi \
+  --pi-db "$PI_SESSION_DB" \
+  --source-runtime "$PI_OLD_RELEASE/agent-runtime" \
+  --target-runtime "$PI_TARGET_CONTROL/agent-runtime" \
+  --apply --writers-stopped)
+```
+
+所有数据库都必须有已发布且读回通过的 conversion receipt，之后才可从同一目标目录预览
+生产切换。维护窗口内保留 ingress 停止状态：
+
+```bash
+(cd "$PI_TARGET_CONTROL" && "$PI_TARGET_CONTROL/om" update apply \
+  --repo-root "$PI_PRODUCTION_LINK" --runtime-root "$PI_RUNTIME_ROOT" \
+  --target-version "$PI_TARGET_TAG" --no-restart-services \
+  --preserve-activation-state)
+```
+
+preview 通过后原样增加 `--confirm --yes`。升级器会在生产 symlink 改变前，用已准备的目标
+runtime 读回当前有效 Session 数据库及已有的 release-local 手工数据库；runtime、store 或
+receipt 任一不匹配都会停止切换。切换后验证当前依赖、runtime config freshness 和 live
+service health，再按记录恢复 ingress 与自动升级任务的 activation state。
+
+数据库发布前失败时保留旧 store 和生产 link。发布后任何失败都必须先在相同维护门禁下，
+用当前数据和保留的旧 runtime 完成并验证反向转换，旧服务才可恢复。反向转换或补偿读回失败
+时保持 ingress 停止，不恢复旧 symlink，也不启动不兼容服务。conversion receipt 引用的旧
+release runtime 是回滚依赖；普通 release cleanup 必须独立于 `--keep-releases` 保留它，直到
+operator 显式结束该回滚义务。
+
 存量主机如果仍使用 `/usr/lib/systemd/system/options-monitor-feishu-agent-credential.service`，首次升级到包含 repository-owned credential 资产的 release 后，必须用新 release 显式执行一次 `service drift` dry-run 和 `--confirm`。原因是升级进程由旧 release 启动，无法在同一次切换中可靠使用尚未加载的新 reconcile 逻辑。收编后 profile 会保留 `feishu_agent_credential` opt-in，后续手动升级、自动升级和回滚都按同一契约 reconcile。在旧 release 回滚窗口结束前保留 `/usr/lib` legacy unit，不由 drift 自动删除。
 
 当 profile 已收编 Feishu Agent credential 时，升级后 Feishu WS 健康检查会在 `sudo` 进程内显式合并 profile 的基础 `env_file` 和 `feishu_agent_credential.runtime_env_file`。命令行只传文件路径，不传或输出明文凭据；这避免 `sudo` 清理父进程环境后出现假性 `missing Feishu app credentials`。
@@ -418,6 +471,7 @@ release 清理默认 dry-run，不删除文件：
 ./om service cleanup \
   --repo-root /opt/options-monitor/current \
   --releases-root /opt/options-monitor/releases \
+  --runtime-root /var/lib/options-monitor \
   --cleanup-downloads \
   --cleanup-pip-cache
 ```
@@ -428,12 +482,13 @@ release 清理默认 dry-run，不删除文件：
 ./om service cleanup \
   --repo-root /opt/options-monitor/current \
   --releases-root /opt/options-monitor/releases \
+  --runtime-root /var/lib/options-monitor \
   --cleanup-downloads \
   --cleanup-pip-cache \
   --confirm
 ```
 
-清理只处理旧 release 和显式允许的缓存，不会触碰 `/var/lib/options-monitor`、SQLite、`output*`、locks、runtime config、用户 overlay config、当前 active release 或最近一个 rollback release。需要额外清理系统缓存时可加 `--include-apt-cache` 或 `--journal-vacuum-size 64M`。
+清理只处理旧 release 和显式允许的缓存，不会触碰 `/var/lib/options-monitor`、SQLite、`output*`、locks、runtime config、用户 overlay config、当前 active release 或最近一个 rollback release。有效 Pi conversion receipt 引用的 release runtime 也会独立于 keep count 保留；receipt 无法验证时 release cleanup 会 fail closed。需要额外清理系统缓存时可加 `--include-apt-cache` 或 `--journal-vacuum-size 64M`。
 
 确认升级成功后也可以追加后置清理：
 

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,7 +1,7 @@
 flowchart LR
   src_application["src.application"] -->|214| domain_domain["domain.domain"]
-  src_interfaces["src.interfaces"] -->|121| src_application["src.application"]
-  src_application["src.application"] -->|100| src_infrastructure["src.infrastructure"]
+  src_interfaces["src.interfaces"] -->|122| src_application["src.application"]
+  src_application["src.application"] -->|102| src_infrastructure["src.infrastructure"]
   src_application_ledger["src.application.ledger"] -->|80| domain_domain["domain.domain"]
   src_application_ledger["src.application.ledger"] -->|49| domain_domain_ledger["domain.domain.ledger"]
   src_application_trades["src.application.trades"] -->|35| domain_domain["domain.domain"]
@@ -18,7 +18,7 @@ flowchart LR
   src_application["src.application"] -->|17| domain_domain_ledger["domain.domain.ledger"]
   domain_domain["domain.domain"] -->|16| domain_domain_ledger["domain.domain.ledger"]
   src_application["src.application"] -->|16| src_application_multi_tick["src.application.multi_tick"]
-  src_application["src.application"] -->|15| src_application_settings["src.application.settings"]
+  src_application["src.application"] -->|16| src_application_settings["src.application.settings"]
   domain_domain_ledger["domain.domain.ledger"] -->|14| domain_domain["domain.domain"]
   src_application_positions["src.application.positions"] -->|14| domain_domain["domain.domain"]
   src_application_trades["src.application.trades"] -->|13| src_infrastructure["src.infrastructure"]

--- a/src/application/bot/pi_migration.py
+++ b/src/application/bot/pi_migration.py
@@ -1,0 +1,694 @@
+"""Bounded offline conversion between OM's Pi 0.84.2 and 0.85.1 stores."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.infrastructure.pi_agent_process import pi_session_locks, run_pi_migration_bridge
+from src.infrastructure.private_storage import atomic_write_private_text, ensure_private_directory, private_path
+
+
+PI_MIGRATION_RECEIPT_VERSION = "om-pi-migration.v1"
+_EXPORT_VERSION = "om-pi-export.v1"
+_SUPPORTED = {"0.84.2": "legacy", "0.85.1": "target"}
+_PHASES = {"prepared", "validated", "published"}
+_PACKAGES = {
+    "@earendil-works/pi-agent-core",
+    "@earendil-works/pi-ai",
+    "@earendil-works/pi-session-backend-sqlite-node",
+}
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def pi_migration_receipt_path(pi_db: str | Path) -> Path:
+    path = _canonical_database(pi_db)
+    return path.with_name(path.name + ".om-pi-migration.json")
+
+
+def _canonical_database(pi_db: str | Path) -> Path:
+    path = private_path(pi_db)
+    if path.is_symlink():
+        raise ValueError("Pi database must not be a symlink")
+    return path.parent.resolve() / path.name
+
+
+def _sha256(path: Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("migration artifact must be an existing regular file")
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> Any:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("migration artifact must be an existing regular file")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_runtime_identity(value: Any) -> dict[str, Any]:
+    if (not isinstance(value, dict) or set(value) != {"ok", "version", "lockSha256", "packages"}
+            or value.get("ok") is not True or value.get("version") not in _SUPPORTED):
+        raise ValueError("Pi runtime identity is invalid")
+    if not _is_sha256(value.get("lockSha256")):
+        raise ValueError("Pi runtime lock identity is invalid")
+    packages = value.get("packages")
+    if not isinstance(packages, dict) or set(packages) != _PACKAGES:
+        raise ValueError("Pi runtime package identity is invalid")
+    for package in packages.values():
+        if (not isinstance(package, dict) or set(package) != {"version", "manifestSha256", "entrySha256"}
+                or package.get("version") != value["version"]):
+            raise ValueError("Pi runtime package version is invalid")
+        if any(not _is_sha256(package.get(key)) for key in ("manifestSha256", "entrySha256")):
+            raise ValueError("Pi runtime package fingerprint is invalid")
+    return value
+
+
+def _validate_receipt(value: Any, database: Path) -> dict[str, Any]:
+    required = {"version", "database", "phase", "rollbackRequired", "source", "target", "backup"}
+    optional = {"readback", "published", "prior", "conversion"}
+    if (not isinstance(value, dict) or not required.issubset(value) or
+            not set(value).issubset(required | optional) or
+            value.get("version") != PI_MIGRATION_RECEIPT_VERSION or value.get("rollbackRequired") is not True):
+        raise ValueError("Pi migration receipt version is invalid")
+    if value.get("database") != str(database):
+        raise ValueError("Pi migration receipt database identity mismatch")
+    if value.get("phase") not in _PHASES:
+        raise ValueError("Pi migration receipt phase is invalid")
+    source = value.get("source")
+    target = value.get("target")
+    if not isinstance(source, dict) or not isinstance(target, dict):
+        raise ValueError("Pi migration receipt direction is invalid")
+    if set(source) != {"runtimePath", "runtime", "database"}:
+        raise ValueError("Pi migration receipt source is invalid")
+    target_keys = {"runtimePath", "runtime"} if value["phase"] == "prepared" else {"runtimePath", "runtime", "database"}
+    if set(target) != target_keys:
+        raise ValueError("Pi migration receipt target is invalid")
+    source_runtime = _validate_runtime_identity(source.get("runtime"))
+    target_runtime = _validate_runtime_identity(target.get("runtime"))
+    if source_runtime["version"] == target_runtime["version"] or {
+        source_runtime["version"], target_runtime["version"],
+    } != set(_SUPPORTED):
+        raise ValueError("Pi migration receipt direction is unsupported")
+    for owner in (source, target):
+        runtime_path = owner.get("runtimePath")
+        if not isinstance(runtime_path, str) or not Path(runtime_path).is_absolute():
+            raise ValueError("Pi migration receipt runtime path is invalid")
+    backup = value.get("backup")
+    if (not isinstance(backup, dict) or set(backup) != {"path", "sha256"} or
+            not isinstance(backup.get("path"), str)):
+        raise ValueError("Pi migration receipt backup identity is invalid")
+    _validate_backup_path(Path(backup["path"]), database, source_runtime["version"], target_runtime["version"])
+    for item in (source.get("database"), backup):
+        if not isinstance(item, dict) or not _is_sha256(item.get("sha256")):
+            raise ValueError("Pi migration receipt database fingerprint is invalid")
+    source_db = source["database"]
+    if set(source_db) != {"sha256", "format"} or source_db["format"] != _SUPPORTED[source_runtime["version"]]:
+        raise ValueError("Pi migration receipt source format is invalid")
+    if value["phase"] in {"validated", "published"}:
+        target_db = target.get("database")
+        readback = value.get("readback")
+        if (not isinstance(target_db, dict) or set(target_db) != {"sha256", "format"}
+                or not _is_sha256(target_db.get("sha256"))
+                or target_db["format"] != _SUPPORTED[target_runtime["version"]]):
+            raise ValueError("Pi migration target identity is missing")
+        if (not isinstance(readback, dict) or set(readback) != {"equivalent", "contextSha256"}
+                or readback.get("equivalent") is not True or not _is_sha256(readback.get("contextSha256"))):
+            raise ValueError("Pi migration readback is missing")
+    if value["phase"] == "published":
+        published = value.get("published")
+        if not isinstance(published, dict) or set(published) != {"databaseSha256"} or not _is_sha256(published.get("databaseSha256")):
+            raise ValueError("Pi migration publication identity is missing")
+    elif "published" in value:
+        raise ValueError("Pi migration publication phase is inconsistent")
+    conversion = value.get("conversion")
+    if conversion is not None and (
+        not isinstance(conversion, dict) or set(conversion) != {
+            "sessionCount", "entryCount", "excludedTailCount", "sourceCanonicalSha256", "targetCanonicalSha256",
+        } or any(not isinstance(conversion[key], int) or isinstance(conversion[key], bool) or conversion[key] < 0
+                 for key in ("sessionCount", "entryCount", "excludedTailCount"))
+        or not _is_sha256(conversion["sourceCanonicalSha256"])
+        or not _is_sha256(conversion["targetCanonicalSha256"])
+    ):
+        raise ValueError("Pi migration conversion summary is invalid")
+    prior = value.get("prior")
+    if prior is not None and _validate_receipt(prior, database)["phase"] != "published":
+        raise ValueError("prior Pi migration receipt is unresolved")
+    return value
+
+
+def read_pi_migration_receipt(pi_db: str | Path) -> dict[str, Any] | None:
+    database = _canonical_database(pi_db)
+    path = pi_migration_receipt_path(database)
+    if not path.exists() and not path.is_symlink():
+        return None
+    return _validate_receipt(_load_json(path), database)
+
+
+def retained_pi_runtime_paths(receipt: Mapping[str, Any]) -> tuple[Path, ...]:
+    database = private_path(str(receipt.get("database", "/invalid")))
+    checked = _validate_receipt(dict(receipt), database)
+    paths = [] if checked.get("rollbackRequired", True) is not True else [Path(checked["source"]["runtimePath"])]
+    prior = checked.get("prior")
+    if isinstance(prior, dict):
+        paths.extend(retained_pi_runtime_paths(prior))
+    return tuple(dict.fromkeys(paths))
+
+
+def _assert_recovery_dependencies(receipt: dict[str, Any]) -> None:
+    try:
+        source_path, source_identity = _runtime_identity(receipt["source"]["runtimePath"])
+    except (OSError, ValueError) as exc:
+        raise ValueError("retained Pi source runtime is unavailable") from exc
+    if source_identity != receipt["source"]["runtime"]:
+        raise ValueError("retained Pi source runtime identity changed")
+    if source_path != Path(receipt["source"]["runtimePath"]):
+        raise ValueError("retained Pi source runtime path changed")
+    backup = Path(receipt["backup"]["path"])
+    try:
+        backup_sha256 = _sha256(backup)
+    except ValueError as exc:
+        raise ValueError("retained Pi recovery backup is unavailable") from exc
+    if backup_sha256 != receipt["backup"]["sha256"]:
+        raise ValueError("retained Pi recovery backup identity changed")
+    if backup.stat().st_mode & 0o222 or any(path.exists() or path.is_symlink() for path in _sidecars(backup)):
+        raise ValueError("retained Pi recovery backup is not sealed")
+    with backup.open("rb") as stream:
+        header = stream.read(20)
+    if len(header) < 20 or header[18:20] != b"\x01\x01":
+        raise ValueError("retained Pi recovery backup is not sealed")
+    prior = receipt.get("prior")
+    if isinstance(prior, dict):
+        _assert_recovery_dependencies(prior)
+
+
+def _bridge(
+    command: str,
+    runtime: Path,
+    *,
+    maintenance_descriptors: tuple[int, ...] = (),
+    **paths: Path | str,
+) -> dict[str, Any]:
+    return run_pi_migration_bridge(
+        command,
+        runtime,
+        {name.replace("_", "-"): value for name, value in paths.items()},
+        maintenance_descriptors=maintenance_descriptors,
+    )
+
+
+def _runtime_identity(runtime: str | Path) -> tuple[Path, dict[str, Any]]:
+    path = private_path(runtime)
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError("Pi runtime must be an existing directory")
+    resolved = path.resolve()
+    identity = _validate_runtime_identity(_bridge("identity", resolved))
+    return resolved, identity
+
+
+def _target_runtime(source: tuple[Path, dict[str, Any]], target: tuple[Path, dict[str, Any]]) -> Path:
+    return source[0] if source[1]["version"] == "0.85.1" else target[0]
+
+
+def _controller_runtime() -> Path:
+    runtime = Path(__file__).resolve().parents[3] / "agent-runtime"
+    resolved, identity = _runtime_identity(runtime)
+    if identity["version"] != "0.85.1":
+        raise ValueError("the current Pi migration controller is not exact 0.85.1")
+    return resolved
+
+
+def _probe_store(
+    database: Path,
+    runtime_0851: Path,
+    *,
+    immutable: bool = False,
+    maintenance_descriptors: tuple[int, ...] = (),
+) -> dict[str, Any]:
+    arguments: dict[str, Path | str] = {"database": database}
+    if immutable:
+        arguments["immutable"] = "true"
+    result = _bridge("probe", runtime_0851, maintenance_descriptors=maintenance_descriptors, **arguments)
+    if result.get("format") not in {"legacy", "target", "unknown", "corrupt", "missing"}:
+        raise ValueError("Pi store probe returned an invalid format")
+    return result
+
+
+def _backup_path(database: Path, source_version: str, target_version: str, generation: str) -> Path:
+    return database.with_name(
+        database.name + f".om-pi-recovery-{source_version}-to-{target_version}-{generation}.sqlite3"
+    )
+
+
+def _validate_backup_path(
+    backup: Path,
+    database: Path,
+    source_version: str,
+    target_version: str,
+) -> Path:
+    prefix = database.name + f".om-pi-recovery-{source_version}-to-{target_version}-"
+    suffix = ".sqlite3"
+    generation = (
+        backup.name[len(prefix):-len(suffix)]
+        if backup.name.startswith(prefix) and backup.name.endswith(suffix)
+        else ""
+    )
+    if (backup.parent != database.parent or len(generation) != 32 or
+            any(character not in "0123456789abcdef" for character in generation)):
+        raise ValueError("Pi migration receipt backup identity is invalid")
+    return backup
+
+
+def _derived_artifacts(backup: Path) -> tuple[Path, Path, Path, Path]:
+    return tuple(Path(str(backup) + suffix) for suffix in (
+        ".export.sqlite3", ".staging.sqlite3", ".source.json", ".readback.json",
+    ))  # type: ignore[return-value]
+
+
+def _new_backup_path(database: Path, source_version: str, target_version: str) -> Path:
+    while True:
+        backup = _backup_path(database, source_version, target_version, secrets.token_hex(16))
+        artifacts = (backup, *_derived_artifacts(backup))
+        if not any(
+            path.exists() or path.is_symlink() or any(
+                sidecar.exists() or sidecar.is_symlink() for sidecar in _sidecars(path)
+            )
+            for path in artifacts
+        ):
+            return backup
+
+
+def _sidecars(database: Path) -> tuple[Path, Path, Path]:
+    return tuple(Path(str(database) + suffix) for suffix in ("-journal", "-wal", "-shm"))  # type: ignore[return-value]
+
+
+def _artifact_inventory(database: Path) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for label, path in (("database", database), ("journal", _sidecars(database)[0]),
+                        ("wal", _sidecars(database)[1]), ("shm", _sidecars(database)[2])):
+        if not path.exists() and not path.is_symlink():
+            continue
+        if path.is_symlink() or not path.is_file():
+            raise ValueError("Pi database artifact is unsafe")
+        state = path.stat()
+        result[label] = {"size": state.st_size, "sha256": _sha256(path)}
+    return result
+
+
+def _assert_previewable(database: Path) -> dict[str, dict[str, Any]]:
+    before = _artifact_inventory(database)
+    if not database.is_file() or database.is_symlink():
+        raise ValueError("Pi database must be an existing regular file")
+    if (("wal" in before and before["wal"]["size"] > 0) or
+            ("journal" in before and before["journal"]["size"] > 0)):
+        raise ValueError("Pi preview needs a quiescent WAL checkpoint before inspection")
+    return before
+
+
+def _logical_sha256(database: Path) -> str:
+    digest = hashlib.sha256()
+    with closing(sqlite3.connect(database.as_uri() + "?mode=ro", uri=True, timeout=2)) as connection:
+        if connection.execute("PRAGMA integrity_check").fetchone()[0] != "ok":
+            raise ValueError("Pi database integrity check failed")
+        for statement in connection.iterdump():
+            digest.update(statement.encode("utf-8"))
+            digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _remove_work(database: Path) -> None:
+    for path in (database, *_sidecars(database)):
+        if path.is_symlink():
+            raise ValueError("Pi migration work artifact is unsafe")
+        if path.exists():
+            path.unlink()
+
+
+def _sqlite_backup(source: Path, destination: Path) -> None:
+    if destination.exists() or destination.is_symlink():
+        raise ValueError("Pi recovery backup already exists without a matching receipt")
+    ensure_private_directory(destination.parent)
+    with closing(sqlite3.connect(str(source), timeout=5)) as origin, closing(sqlite3.connect(str(destination), timeout=5)) as saved:
+        origin.backup(saved)
+        if str(saved.execute("PRAGMA journal_mode=DELETE").fetchone()[0]).lower() != "delete":
+            raise ValueError("Pi recovery backup could not be sealed in DELETE journal mode")
+        if saved.execute("PRAGMA integrity_check").fetchone()[0] != "ok":
+            raise ValueError("Pi recovery backup integrity check failed")
+        saved.commit()
+    with destination.open("rb") as stream:
+        header = stream.read(20)
+    if len(header) < 20 or header[18:20] != b"\x01\x01":
+        raise ValueError("Pi recovery backup is not sealed in rollback journal mode")
+    for sidecar in _sidecars(destination):
+        if sidecar.exists():
+            if sidecar.is_symlink() or (sidecar.name.endswith(("-journal", "-wal")) and sidecar.stat().st_size):
+                raise ValueError("Pi recovery backup is not self-contained")
+            sidecar.unlink()
+    destination.chmod(0o400)
+    _fsync_file(destination)
+
+
+def _checkpoint_source(database: Path) -> None:
+    with closing(sqlite3.connect(str(database), timeout=5)) as connection:
+        row = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if row is not None and row[0] != 0:
+            raise ValueError("Pi source WAL checkpoint is busy")
+        if str(connection.execute("PRAGMA journal_mode=DELETE").fetchone()[0]).lower() != "delete":
+            raise ValueError("Pi source could not enter quiescent rollback journal mode")
+        connection.commit()
+    for sidecar in _sidecars(database):
+        if sidecar.exists():
+            if sidecar.is_symlink() or (sidecar.name.endswith(("-journal", "-wal")) and sidecar.stat().st_size):
+                raise ValueError("Pi source sidecar remains after quiescent checkpoint")
+            sidecar.unlink()
+
+
+def _fsync_file(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_receipt(database: Path, receipt: dict[str, Any]) -> None:
+    _validate_receipt(receipt, database)
+    atomic_write_private_text(
+        pi_migration_receipt_path(database),
+        json.dumps(receipt, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+    )
+    descriptor = os.open(database.parent, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _active_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict) or payload.get("format") != _EXPORT_VERSION or not isinstance(payload.get("sessions"), list):
+        raise ValueError("canonical Pi export is invalid")
+    sessions = []
+    for session in payload["sessions"]:
+        if not isinstance(session, dict):
+            raise ValueError("canonical Pi session is invalid")
+        sessions.append({key: session[key] for key in ("id", "createdAt", "entries", "contextSha256", "contentSha256")})
+    return {"format": _EXPORT_VERSION, "sessions": sessions}
+
+
+def _export(
+    runtime: Path,
+    version: str,
+    database: Path,
+    output: Path,
+    *,
+    maintenance_descriptors: tuple[int, ...] = (),
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    report = _bridge(
+        "export", runtime, maintenance_descriptors=maintenance_descriptors,
+        expected_version=version, database=database, output=output,
+    )
+    return report, _active_payload(_load_json(output))
+
+
+def _same_payload(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    encoded = lambda value: json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return encoded(left) == encoded(right)
+
+
+def _sanitized_report(*, mode: str, source: dict[str, Any], target: dict[str, Any],
+                      store: dict[str, Any], receipt_phase: str | None = None,
+                      write_applied: bool = False, already_applied: bool = False) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "status": "ready" if mode == "preview" else "migrated",
+        "mode": mode,
+        "direction": f"{source['version']}->{target['version']}",
+        "runtime": {
+            "source": {"version": source["version"], "package_lock_sha256": source["lockSha256"]},
+            "target": {"version": target["version"], "package_lock_sha256": target["lockSha256"]},
+        },
+        "database_format": store["format"],
+        "session_ids": list(store.get("sessionIds", [])),
+        "receipt_phase": receipt_phase,
+        "write_applied": write_applied,
+        "already_applied": already_applied,
+    }
+
+
+def assert_pi_storage_ready(
+    pi_db: str | Path,
+    runtime_dir: str | Path,
+    *,
+    maintenance_descriptors: tuple[int, ...] = (),
+) -> dict[str, Any]:
+    database = _canonical_database(pi_db)
+    runtime, identity = _runtime_identity(runtime_dir)
+    receipt = read_pi_migration_receipt(database)
+    if receipt is not None and receipt["phase"] != "published":
+        raise ValueError("Pi migration receipt is unresolved; run migrate-pi apply to reconcile")
+    if not database.exists():
+        if receipt is not None:
+            raise ValueError("published Pi migration database is missing")
+        return {
+            "ok": True, "status": "ready", "runtime": {"version": identity["version"]},
+            "database_format": "missing", "receipt_phase": None,
+        }
+    if receipt is not None:
+        if receipt["target"]["runtime"] != identity:
+            raise ValueError("published Pi migration target runtime identity changed")
+        _assert_recovery_dependencies(receipt)
+    if identity["version"] == "0.85.1":
+        probe_runtime = runtime
+    elif receipt is not None:
+        owner = "source" if receipt["source"]["runtime"]["version"] == "0.85.1" else "target"
+        probe_runtime, probe_identity = _runtime_identity(receipt[owner]["runtimePath"])
+        if probe_identity != receipt[owner]["runtime"]:
+            raise ValueError("retained Pi probe runtime identity changed")
+    else:
+        probe_runtime = _controller_runtime()
+    probe = _probe_store(database, probe_runtime, maintenance_descriptors=maintenance_descriptors)
+    expected = _SUPPORTED[identity["version"]]
+    if probe["format"] != expected:
+        raise ValueError("Pi store format is incompatible with the selected runtime")
+    if receipt is not None:
+        retained_pi_runtime_paths(receipt)
+    return {
+        "ok": True, "status": "ready", "runtime": {"version": identity["version"]},
+        "database_format": probe["format"], "receipt_phase": receipt["phase"] if receipt else None,
+    }
+
+
+def migrate_pi(*, pi_db: str | Path, source_runtime: str | Path, target_runtime: str | Path,
+               apply: bool = False, writers_stopped: bool = False) -> dict[str, Any]:
+    database = _canonical_database(pi_db)
+    source = _runtime_identity(source_runtime)
+    target = _runtime_identity(target_runtime)
+    if source[1]["version"] == target[1]["version"] or {source[1]["version"], target[1]["version"]} != set(_SUPPORTED):
+        raise ValueError("Pi migration supports only exact 0.84.2 and 0.85.1 directions")
+    runtime_0851 = _target_runtime(source, target)
+    receipt = None
+    if not apply:
+        before = _assert_previewable(database)
+        receipt = read_pi_migration_receipt(database)
+        if receipt is not None:
+            _assert_recovery_dependencies(receipt)
+            if receipt["phase"] == "published":
+                if receipt["target"]["runtime"] != source[1]:
+                    raise ValueError("published Pi migration receipt does not match this source")
+            elif (source != (Path(receipt["source"]["runtimePath"]), receipt["source"]["runtime"]) or
+                  target != (Path(receipt["target"]["runtimePath"]), receipt["target"]["runtime"])):
+                raise ValueError("Pi migration receipt runtime identity or path changed")
+        store = _probe_store(database, runtime_0851, immutable=True)
+        if store["format"] != _SUPPORTED[source[1]["version"]]:
+            raise ValueError("Pi store format does not match the selected source runtime")
+        if _artifact_inventory(database) != before:
+            raise ValueError("Pi database changed during read-only preview")
+    else:
+        if database.is_symlink() or not database.is_file():
+            raise ValueError("Pi database must be an existing regular file")
+        store = {"format": "unknown", "sessionIds": []}
+    free = shutil.disk_usage(database.parent).free
+    if free < max(database.stat().st_size * 4, 1024 * 1024):
+        raise ValueError("insufficient disk space for Pi migration copies")
+    report = _sanitized_report(mode="preview", source=source[1], target=target[1], store=store,
+                               receipt_phase=receipt["phase"] if receipt else None)
+    if not apply:
+        return report
+    if not writers_stopped:
+        raise ValueError("--apply requires --writers-stopped")
+
+    with pi_session_locks(database) as (canonical, maintenance_descriptors):
+        database = canonical
+        receipt = read_pi_migration_receipt(database)
+        if receipt is not None:
+            _assert_recovery_dependencies(receipt)
+        current = _probe_store(database, runtime_0851, maintenance_descriptors=maintenance_descriptors)
+        if (receipt and receipt["phase"] == "published" and
+                receipt["source"]["runtime"] == source[1] and receipt["target"]["runtime"] == target[1] and
+                receipt["source"]["runtimePath"] == str(source[0]) and
+                receipt["target"]["runtimePath"] == str(target[0])):
+            ready = assert_pi_storage_ready(
+                database, target[0], maintenance_descriptors=maintenance_descriptors,
+            )
+            return _sanitized_report(mode="apply", source=source[1], target=target[1], store=current,
+                                     receipt_phase=ready["receipt_phase"], already_applied=True)
+        prior_receipt = None
+        if receipt and receipt["phase"] == "published":
+            if (receipt["target"]["runtime"] != source[1] or
+                    current["format"] != _SUPPORTED[source[1]["version"]]):
+                raise ValueError("published Pi migration receipt does not match this source")
+            prior_receipt = receipt
+            receipt = None
+        if receipt:
+            if receipt["source"]["runtime"] != source[1] or receipt["target"]["runtime"] != target[1]:
+                raise ValueError("Pi migration receipt runtime identity changed")
+            if receipt["source"]["runtimePath"] != str(source[0]) or receipt["target"]["runtimePath"] != str(target[0]):
+                raise ValueError("Pi migration receipt runtime path changed")
+
+        backup = (
+            Path(receipt["backup"]["path"])
+            if receipt is not None
+            else _new_backup_path(database, source[1]["version"], target[1]["version"])
+        )
+        work, stage, canonical_source, canonical_readback = _derived_artifacts(backup)
+
+        if receipt and receipt["phase"] == "validated" and current["format"] == _SUPPORTED[target[1]["version"]]:
+            if _sha256(database) != receipt["target"]["database"]["sha256"]:
+                raise ValueError("published target differs from validated staging identity")
+            receipt["phase"] = "published"
+            receipt["published"] = {"databaseSha256": _sha256(database)}
+            _write_receipt(database, receipt)
+            return _sanitized_report(mode="apply", source=source[1], target=target[1], store=current,
+                                     receipt_phase="published", already_applied=True)
+        if receipt and receipt["phase"] == "validated":
+            if current["format"] != _SUPPORTED[source[1]["version"]]:
+                raise ValueError("Pi validated migration cannot identify the active store")
+            _checkpoint_source(database)
+            if _logical_sha256(database) != receipt["source"]["database"]["sha256"]:
+                raise ValueError("Pi source database changed before publication retry")
+            if not stage.is_file() or _sha256(stage) != receipt["target"]["database"]["sha256"]:
+                raise ValueError("Pi validated staging database identity changed")
+            stage_probe = _probe_store(
+                stage, runtime_0851, maintenance_descriptors=maintenance_descriptors,
+            )
+            if stage_probe["format"] != _SUPPORTED[target[1]["version"]]:
+                raise ValueError("Pi validated staging store format changed")
+            if any(path.exists() for path in _sidecars(database)):
+                raise ValueError("Pi source sidecar exists before publication retry")
+            os.replace(stage, database)
+            directory_fd = os.open(database.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+            receipt["phase"] = "published"
+            receipt["published"] = {"databaseSha256": _sha256(database)}
+            _write_receipt(database, receipt)
+            return _sanitized_report(mode="apply", source=source[1], target=target[1],
+                                     store=_probe_store(
+                                         database, runtime_0851,
+                                         maintenance_descriptors=maintenance_descriptors,
+                                     ), receipt_phase="published",
+                                     write_applied=True)
+
+        if receipt is None:
+            if current["format"] != _SUPPORTED[source[1]["version"]]:
+                raise ValueError("Pi active store does not match the selected source runtime")
+            if int(current.get("writerLeaseCount", 0)):
+                raise ValueError("outstanding Pi source writer lease prevents migration")
+            _sqlite_backup(database, backup)
+            _checkpoint_source(database)
+            source_logical = _logical_sha256(backup)
+            if _logical_sha256(database) != source_logical:
+                raise ValueError("Pi recovery backup does not match the active source")
+            receipt = {
+                "version": PI_MIGRATION_RECEIPT_VERSION,
+                "database": str(database),
+                "phase": "prepared",
+                "rollbackRequired": True,
+                "source": {"runtimePath": str(source[0]), "runtime": source[1],
+                           "database": {"sha256": source_logical, "format": current["format"]}},
+                "target": {"runtimePath": str(target[0]), "runtime": target[1]},
+                "backup": {"path": str(backup), "sha256": _sha256(backup)},
+            }
+            if prior_receipt is not None:
+                receipt["prior"] = prior_receipt
+            _write_receipt(database, receipt)
+        else:
+            if current["format"] != _SUPPORTED[source[1]["version"]]:
+                raise ValueError("Pi active store cannot be reconciled safely")
+            _checkpoint_source(database)
+            if _logical_sha256(database) != receipt["source"]["database"]["sha256"]:
+                raise ValueError("Pi source database changed since migration preparation")
+
+        _remove_work(work)
+        shutil.copyfile(backup, work)
+        work.chmod(0o600)
+        _remove_work(stage)
+        for output in (canonical_source, canonical_readback):
+            if output.exists() or output.is_symlink():
+                if output.is_symlink():
+                    raise ValueError("Pi canonical work artifact is unsafe")
+                output.unlink()
+        export_report, source_payload = _export(
+            source[0], source[1]["version"], work, canonical_source,
+            maintenance_descriptors=maintenance_descriptors,
+        )
+        if _sha256(backup) != receipt["backup"]["sha256"]:
+            raise ValueError("Pi recovery backup changed during export")
+        _bridge(
+            "import", target[0], maintenance_descriptors=maintenance_descriptors,
+            expected_version=target[1]["version"], database=stage, input=canonical_source,
+        )
+        _checkpoint_source(stage)
+        stage_probe = _probe_store(stage, runtime_0851, maintenance_descriptors=maintenance_descriptors)
+        if stage_probe["format"] != _SUPPORTED[target[1]["version"]]:
+            raise ValueError("Pi staging store format does not match the selected target runtime")
+        readback_report, target_payload = _export(
+            target[0], target[1]["version"], stage, canonical_readback,
+            maintenance_descriptors=maintenance_descriptors,
+        )
+        if not _same_payload(source_payload, target_payload):
+            raise ValueError("Pi target readback differs from committed source history")
+        _checkpoint_source(stage)
+        _fsync_file(stage)
+        if _logical_sha256(database) != receipt["source"]["database"]["sha256"]:
+            raise ValueError("Pi source database changed before publication")
+        if any(path.exists() for path in _sidecars(database)):
+            raise ValueError("Pi source sidecar exists before publication")
+        receipt["phase"] = "validated"
+        receipt["target"]["database"] = {"sha256": _sha256(stage), "format": _SUPPORTED[target[1]["version"]]}
+        receipt["conversion"] = {
+            "sessionCount": export_report["sessionCount"], "entryCount": export_report["entryCount"],
+            "excludedTailCount": export_report["excludedTailCount"],
+            "sourceCanonicalSha256": export_report["canonicalSha256"],
+            "targetCanonicalSha256": readback_report["canonicalSha256"],
+        }
+        receipt["readback"] = {"equivalent": True, "contextSha256": readback_report["contextSha256"]}
+        _write_receipt(database, receipt)
+        os.replace(stage, database)
+        directory_fd = os.open(database.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        receipt["phase"] = "published"
+        receipt["published"] = {"databaseSha256": _sha256(database)}
+        _write_receipt(database, receipt)
+        final_probe = _probe_store(database, runtime_0851, maintenance_descriptors=maintenance_descriptors)
+        if final_probe["format"] != _SUPPORTED[target[1]["version"]]:
+            raise ValueError("published Pi target format readback failed")
+        return _sanitized_report(mode="apply", source=source[1], target=target[1], store=final_probe,
+                                 receipt_phase="published", write_applied=True)

--- a/src/application/release_test_plan.py
+++ b/src/application/release_test_plan.py
@@ -103,6 +103,7 @@ TEST_RULES: tuple[TestRule, ...] = (
             "src/application/release_version_recommendation.py",
             "src/application/release_target.py",
             "src/application/version_check.py",
+            "src/application/service_cleanup.py",
             "src/application/service_upgrade.py",
             "src/application/service_deploy.py",
             "src/interfaces/cli/service_ops.py",
@@ -114,6 +115,7 @@ TEST_RULES: tuple[TestRule, ...] = (
             "tests/test_install_script.py",
             "tests/test_release_check.py",
             "tests/test_release_delta_coverage.py",
+            "tests/test_service_pi_readiness.py",
         ),
         reason="service, installer, or release-upgrade files changed",
         commands=(
@@ -122,6 +124,7 @@ TEST_RULES: tuple[TestRule, ...] = (
             "tests/test_release_delta_coverage.py "
             "tests/test_release_version_recommendation.py tests/test_version_check.py "
             "tests/test_install_script.py tests/test_release_test_plan.py",
+            "./.venv/bin/python -m pytest tests/test_service_pi_readiness.py",
         ),
     ),
     TestRule(
@@ -143,6 +146,10 @@ TEST_RULES: tuple[TestRule, ...] = (
             "tests/bot_pi_test_support.py",
             "tests/test_architecture_guards.py",
             "tests/test_pi_agent_process.py",
+            "tests/test_pi_runtime_0851.py",
+            "tests/test_bot_pi_migration.py",
+            "tests/test_pi_session_locks.py",
+            "tests/test_service_pi_readiness.py",
             "tests/test_bot_p1_eval.py",
             "tests/test_bot_*.py",
             "tests/test_inbound_control.py",
@@ -158,7 +165,10 @@ TEST_RULES: tuple[TestRule, ...] = (
         reason="Pi Agent runtime, packaging, or public contract files changed",
         commands=(
             "npm ci --omit=dev --ignore-scripts --prefix agent-runtime",
-            "./.venv/bin/python -m pytest tests/test_pi_agent_process.py",
+            "./.venv/bin/python -m pytest tests/test_pi_agent_process.py "
+            "tests/test_pi_runtime_0851.py",
+            "./.venv/bin/python -m pytest tests/test_bot_pi_migration.py "
+            "tests/test_pi_session_locks.py tests/test_service_pi_readiness.py",
             "./.venv/bin/python -m pytest tests/test_bot_phase1.py "
             "tests/test_bot_conversation_memory.py tests/test_bot_p1_eval.py "
             "tests/test_inbound_control.py "

--- a/src/application/service_cleanup.py
+++ b/src/application/service_cleanup.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import os
 import hashlib
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from functools import cmp_to_key
 import shutil
@@ -10,7 +10,42 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
+from src.application.bot.pi_migration import (
+    pi_migration_receipt_path,
+    read_pi_migration_receipt,
+    retained_pi_runtime_paths,
+)
+from src.application.settings import build_effective_env
 from src.application.version_check import compare_versions
+
+
+_PI_SESSION_STATE_RELATIVE_PATH = Path("output_shared/state")
+
+
+def pi_session_database_paths(
+    *,
+    runtime_root: Path,
+    repo_root: Path,
+    release_dirs: tuple[Path, ...] = (),
+) -> tuple[Path, ...]:
+    effective = build_effective_env(repo_root=repo_root)
+    audit_raw = effective.get("OM_INBOUND_AUDIT_DB").strip()
+    audit_db = (
+        Path(audit_raw).expanduser()
+        if audit_raw
+        else runtime_root
+        / _PI_SESSION_STATE_RELATIVE_PATH
+        / "inbound_control.sqlite3"
+    )
+    if not audit_db.is_absolute():
+        audit_db = repo_root / audit_db
+    active_db = audit_db.absolute().with_name("pi_sessions.sqlite3")
+    candidates = [active_db]
+    for release_dir in release_dirs:
+        candidate = (release_dir / _PI_SESSION_STATE_RELATIVE_PATH / "pi_sessions.sqlite3").absolute()
+        if candidate.exists() or pi_migration_receipt_path(candidate).exists():
+            candidates.append(candidate)
+    return tuple(dict.fromkeys(candidates))
 
 
 def _default_releases_root(repo_root: Path) -> Path:
@@ -75,6 +110,35 @@ def _release_dirs(releases_root: Path) -> list[Path]:
         if path.is_dir() and not path.is_symlink() and (path / "VERSION").is_file()
     ]
     return sorted(dirs, key=cmp_to_key(_compare_release_dirs_desc))
+
+
+def _pi_retained_releases(
+    *,
+    runtime_root: Path,
+    repo_root: Path,
+    releases: list[Path],
+) -> tuple[list[Path], list[dict[str, Any]]]:
+    receipts: list[dict[str, Any]] = []
+    retained_runtimes: list[Path] = []
+    for pi_db in pi_session_database_paths(
+        runtime_root=runtime_root,
+        repo_root=repo_root,
+        release_dirs=tuple(releases),
+    ):
+        receipt = read_pi_migration_receipt(pi_db)
+        if receipt is None:
+            continue
+        receipts.append(receipt)
+        retained_runtimes.extend(path.expanduser().resolve() for path in retained_pi_runtime_paths(receipt))
+    retained = [
+        release.resolve()
+        for release in releases
+        if any(
+            runtime_dir == release.resolve() or runtime_dir.is_relative_to(release.resolve())
+            for runtime_dir in retained_runtimes
+        )
+    ]
+    return retained, receipts
 
 
 def _safe_child(path: Path, *, parent: Path) -> bool:
@@ -375,6 +439,7 @@ def service_cleanup(
     repo_link = Path(repo_root).expanduser()
     releases = Path(releases_root).expanduser().resolve() if releases_root else _default_releases_root(repo_link)
     runtime = Path(runtime_root).expanduser().resolve() if runtime_root else None
+    pi_runtime = runtime or Path("/var/lib/options-monitor")
     keep_count = max(2, int(keep_releases or 2))
     base = {
         "schema_version": 1,
@@ -405,6 +470,24 @@ def service_cleanup(
             "changed": False,
         }
 
+    pi_retained: list[Path] = []
+    pi_receipts: list[dict[str, Any]] = []
+    try:
+        pi_retained, pi_receipts = _pi_retained_releases(
+            runtime_root=pi_runtime,
+            repo_root=repo_link,
+            releases=releases_list,
+        )
+    except Exception as exc:
+        return {
+            **base,
+            "ok": False,
+            "status": "pi_retention_unresolved",
+            "reason": f"Pi migration receipt cannot be validated: {type(exc).__name__}: {exc}",
+            "active_release": str(active_release),
+            "changed": False,
+        }
+
     kept: list[Path] = [active_release]
     for release in releases_list:
         if release.resolve() == active_release:
@@ -412,6 +495,7 @@ def service_cleanup(
         if len(kept) >= keep_count:
             break
         kept.append(release.resolve())
+    kept.extend(path for path in pi_retained if path not in kept)
     kept_set = {path.resolve() for path in kept}
     delete_releases = [path for path in releases_list if path.resolve() not in kept_set]
 
@@ -628,6 +712,7 @@ def service_cleanup(
         "user overlay config",
         "active release",
         "rollback release",
+        "Pi migration retained release runtime",
     ]
     failures = [
         item
@@ -650,6 +735,8 @@ def service_cleanup(
         "changed": changed,
         "active_release": str(active_release),
         "kept_releases": [{"path": str(path), "version": path.name} for path in kept],
+        "pi_retained_releases": [{"path": str(path), "version": path.name} for path in pi_retained],
+        "pi_migration_receipt_phases": [receipt.get("phase") for receipt in pi_receipts],
         "delete_releases": release_items,
         "cache_dirs": cache_items,
         "output_runs_cleanup": output_runs_cleanup,

--- a/src/application/service_upgrade.py
+++ b/src/application/service_upgrade.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from src.application.bot.pi_migration import assert_pi_storage_ready
 from src.application.release_target import compare_versions, parse_version, resolve_upgrade_target
 from src.application.runtime_config_freshness import (
     GENERATED_KEY,
@@ -25,6 +26,7 @@ from src.application.service_drift import (
     SERVICE_ACTIVATION_POLICY_PRESERVE_EXISTING,
     service_drift,
 )
+from src.application.service_cleanup import pi_session_database_paths
 
 _CHILD_ENV_PASSTHROUGH_NAMES = {
     "ANTHROPIC_API_KEY",
@@ -35,7 +37,6 @@ _CHILD_ENV_PASSTHROUGH_NAMES = {
     "KIMI_API_KEY",
     "OPENAI_API_KEY",
 }
-
 
 def utc_now_iso(now_fn: Callable[[], datetime] | None = None) -> str:
     now = (now_fn or (lambda: datetime.now(timezone.utc)))()
@@ -2112,13 +2113,28 @@ def service_upgrade_verify(
     }
     upgrade_status = load_upgrade_status(runtime_root=runtime) or {}
     services = _compact_service_health(upgrade_status.get("service_health"), profile=profile)
+    try:
+        pi_storage_readiness = _pi_storage_readiness(
+            runtime_root=runtime,
+            repo_root=repo_link,
+            runtime_dir=repo / "agent-runtime",
+            release_dirs=(repo,),
+        )
+    except ServiceTransitionError as exc:
+        pi_storage_readiness = {
+            "ok": False,
+            "status": exc.status,
+            "error": str(exc),
+            "remediation": exc.remediation,
+        }
     update_ok = True
     if update_check is not None:
         update_ok = bool(update_check.get("ok")) and not bool(update_check.get("upgrade_available"))
     config_ok = all(bool(item.get("ok")) for item in configs.values()) if configs else False
     service_ok = bool(services.get("ok", True))
     upgrade_ok = not _upgrade_status_failed(upgrade_status)
-    ok = bool(current_version) and update_ok and config_ok and service_ok and upgrade_ok
+    pi_storage_ok = pi_storage_readiness.get("ok") is True
+    ok = bool(current_version) and update_ok and config_ok and service_ok and upgrade_ok and pi_storage_ok
     return {
         "ok": ok,
         "status": "ok" if ok else "attention_required",
@@ -2138,6 +2154,7 @@ def service_upgrade_verify(
         },
         "config": configs,
         "services": services,
+        "pi_storage_readiness": pi_storage_readiness,
         "upgrade": _compact_upgrade_status(upgrade_status),
     }
 
@@ -2308,10 +2325,59 @@ def _switch_current_symlink(*, current_link: Path, target_dir: Path) -> None:
     os.replace(tmp_link, current_link)
 
 
+def _pi_storage_readiness(
+    *,
+    runtime_root: Path,
+    repo_root: Path,
+    runtime_dir: Path,
+    release_dirs: tuple[Path, ...],
+) -> dict[str, Any]:
+    stores: list[dict[str, Any]] = []
+    for pi_db in pi_session_database_paths(
+        runtime_root=runtime_root,
+        repo_root=repo_root,
+        release_dirs=release_dirs,
+    ):
+        try:
+            readiness = assert_pi_storage_ready(pi_db, runtime_dir)
+        except Exception as exc:
+            raise ServiceTransitionError(
+                f"Pi Session storage {pi_db} is not ready for runtime "
+                f"{runtime_dir}: {type(exc).__name__}: {exc}",
+                status="pi_storage_not_ready",
+                remediation=[
+                    "keep Agent ingress stopped",
+                    "run the explicit Pi migration preview/apply with the selected source and target runtimes",
+                    "verify every published migration receipt before retrying the release transition",
+                ],
+            ) from exc
+        if not isinstance(readiness, dict) or readiness.get("ok") is not True:
+            raise ServiceTransitionError(
+                f"Pi Session storage {pi_db} readiness rejected runtime "
+                f"{runtime_dir}",
+                status="pi_storage_not_ready",
+                remediation=[
+                    "keep Agent ingress stopped",
+                    "resolve the reported Pi runtime, store, or migration receipt mismatch",
+                ],
+            )
+        stores.append({**readiness, "pi_db": str(pi_db)})
+    return {"ok": True, "stores": stores}
+
+
+def _pi_storage_has_published_receipt(readiness: dict[str, Any]) -> bool:
+    stores = readiness.get("stores")
+    return isinstance(stores, list) and any(
+        isinstance(item, dict) and item.get("receipt_phase") == "published"
+        for item in stores
+    )
+
+
 def _compensate_service_transition(
     *,
     repo_link: Path,
     previous_dir: Path,
+    transition_dir: Path,
     runtime_root: Path,
     previous_profile: dict[str, Any],
     config_commit: dict[str, Any],
@@ -2323,7 +2389,28 @@ def _compensate_service_transition(
 ) -> dict[str, Any]:
     errors: list[str] = []
     symlink_restored = False
+    pi_storage_readiness: dict[str, Any] = {}
     config_restore: dict[str, Any] = {"ok": True, "status": "skipped", "restored": [], "errors": []}
+    try:
+        pi_storage_readiness = _pi_storage_readiness(
+            runtime_root=runtime_root,
+            repo_root=repo_link,
+            runtime_dir=previous_dir / "agent-runtime",
+            release_dirs=(repo_link.resolve(), previous_dir, transition_dir),
+        )
+    except ServiceTransitionError as exc:
+        return {
+            "ok": False,
+            "status": exc.status,
+            "symlink_restored": False,
+            "config_restore": config_restore,
+            "service_reconcile": {},
+            "restarted_services": [],
+            "service_health": {},
+            "pi_storage_readiness": {},
+            "remediation": exc.remediation,
+            "errors": [str(exc)],
+        }
     try:
         _switch_current_symlink(current_link=repo_link, target_dir=previous_dir)
     except Exception as exc:
@@ -2394,6 +2481,7 @@ def _compensate_service_transition(
         "service_reconcile": service_reconcile,
         "restarted_services": restarted,
         "service_health": service_health,
+        "pi_storage_readiness": pi_storage_readiness,
         "errors": errors,
     }
 
@@ -2508,6 +2596,7 @@ def service_upgrade(
         else f"reuse existing release dir {target_dir}",
         f"prepare release runtime at {target_dir / '.venv'}",
         f"validate {target_dir}",
+        "verify every inventoried Pi Session store against the target runtime",
         f"switch {repo_link} -> {target_dir}",
         "reconcile service drift from current release",
         (
@@ -2520,6 +2609,28 @@ def service_upgrade(
     if cleanup_after_upgrade:
         planned.append(f"cleanup old releases after successful upgrade, keep {status_base['cleanup_keep_releases']} releases")
     if not confirm:
+        try:
+            pi_storage_readiness = _pi_storage_readiness(
+                runtime_root=runtime,
+                repo_root=repo_link,
+                runtime_dir=Path(__file__).resolve().parents[2] / "agent-runtime",
+                release_dirs=(repo, target_dir),
+            )
+        except ServiceTransitionError as exc:
+            return {
+                **status_base,
+                "ok": False,
+                "status": exc.status,
+                "changed": False,
+                "target_dir": str(target_dir),
+                "previous_dir": str(previous_dir),
+                "warnings": warnings,
+                "planned_operations": planned,
+                "version_check": check,
+                "remediation": exc.remediation,
+                "error": str(exc),
+                "operations": operations,
+            }
         return {
             **status_base,
             "ok": True,
@@ -2530,6 +2641,7 @@ def service_upgrade(
             "warnings": warnings,
             "planned_operations": planned,
             "version_check": check,
+            "pi_storage_readiness": pi_storage_readiness,
             "operations": operations,
         }
     if not repo_root_is_symlink:
@@ -2556,6 +2668,7 @@ def service_upgrade(
     post_switch_runtime_config_validate: list[dict[str, Any]] = []
     service_reconcile: dict[str, Any] = {}
     service_health: dict[str, Any] = {}
+    pi_storage_readiness: dict[str, Any] = {}
     compensation: dict[str, Any] = {}
     restarted: list[str] = []
     pre_upgrade_profile = _load_service_profile(runtime)
@@ -2639,6 +2752,12 @@ def service_upgrade(
                 run_cmd=run_cmd,
                 operations=operations,
             )
+            pi_storage_readiness = _pi_storage_readiness(
+                runtime_root=runtime,
+                repo_root=repo_link,
+                runtime_dir=target_dir / "agent-runtime",
+                release_dirs=(repo, target_dir),
+            )
             if preserve_activation_state and pre_upgrade_profile:
                 preserved_activation_states = (
                     capture_preserved_timer_activation_states(
@@ -2717,6 +2836,7 @@ def service_upgrade(
             compensation = _compensate_service_transition(
                 repo_link=repo_link,
                 previous_dir=previous_dir,
+                transition_dir=target_dir,
                 runtime_root=runtime,
                 previous_profile=pre_upgrade_profile,
                 config_commit=runtime_config_commit,
@@ -2745,6 +2865,7 @@ def service_upgrade(
             "post_switch_runtime_config_validate": post_switch_runtime_config_validate,
             "service_reconcile": service_reconcile,
             "service_health": service_health,
+            "pi_storage_readiness": pi_storage_readiness,
             "restarted_services": exc.restarted_services,
             "restart_failed_services": exc.failed_services,
             "manual_remediation": exc.remediation,
@@ -2756,10 +2877,14 @@ def service_upgrade(
         write_upgrade_status(runtime_root=runtime, payload=out)
         return out
     except Exception as exc:
-        if symlink_switched:
+        compensation_needed = symlink_switched or _pi_storage_has_published_receipt(
+            pi_storage_readiness
+        )
+        if compensation_needed:
             compensation = _compensate_service_transition(
                 repo_link=repo_link,
                 previous_dir=previous_dir,
+                transition_dir=target_dir,
                 runtime_root=runtime,
                 previous_profile=pre_upgrade_profile,
                 config_commit=runtime_config_commit,
@@ -2769,13 +2894,14 @@ def service_upgrade(
                 run_cmd=run_cmd,
                 operations=operations,
             )
-        compensated = bool(compensation.get("ok")) if symlink_switched else False
+        compensated = bool(compensation.get("ok")) if compensation_needed else False
         failure_status = exc.status if isinstance(exc, ServiceTransitionError) else "failed"
-        remediation = (
+        remediation = list(
             exc.remediation
             if isinstance(exc, (RuntimeConfigPrepareError, ServiceTransitionError))
             else []
         )
+        remediation.extend(str(item) for item in compensation.get("remediation") or [])
         out = {
             **status_base,
             "ok": False,
@@ -2794,6 +2920,7 @@ def service_upgrade(
             "post_switch_runtime_config_validate": post_switch_runtime_config_validate,
             "service_reconcile": service_reconcile,
             "service_health": service_health,
+            "pi_storage_readiness": pi_storage_readiness,
             "compensation": compensation,
             "error": f"{type(exc).__name__}: {exc}",
             **({"remediation": remediation} if remediation else {}),
@@ -2819,6 +2946,7 @@ def service_upgrade(
             cleanup_plan = service_cleanup(
                 repo_root=repo_link,
                 releases_root=releases,
+                runtime_root=runtime,
                 keep_releases=max(2, int(cleanup_keep_releases or 2)),
                 cleanup_downloads=True,
                 cleanup_pip_cache=False,
@@ -2845,6 +2973,7 @@ def service_upgrade(
                 cleanup_result = service_cleanup(
                     repo_root=repo_link,
                     releases_root=releases,
+                    runtime_root=runtime,
                     keep_releases=max(2, int(cleanup_keep_releases or 2)),
                     cleanup_downloads=True,
                     cleanup_pip_cache=False,
@@ -2870,6 +2999,7 @@ def service_upgrade(
         "post_switch_runtime_config_validate": post_switch_runtime_config_validate,
         "service_reconcile": service_reconcile,
         "service_health": service_health,
+        "pi_storage_readiness": pi_storage_readiness,
         "restarted_services": restarted,
         **({"post_upgrade_cleanup": cleanup_result} if cleanup_result is not None else {}),
         "operations": operations,
@@ -2935,6 +3065,25 @@ def service_rollback(
         write_upgrade_status(runtime_root=runtime, payload=out)
         return out
     if not confirm:
+        try:
+            pi_storage_readiness = _pi_storage_readiness(
+                runtime_root=runtime,
+                repo_root=repo_link,
+                runtime_dir=target_dir / "agent-runtime",
+                release_dirs=(repo, target_dir),
+            )
+        except ServiceTransitionError as exc:
+            return {
+                **status_base,
+                "ok": False,
+                "status": exc.status,
+                "changed": False,
+                "target_dir": str(target_dir),
+                "warnings": [] if repo_root_is_symlink else ["confirmed rollback requires repo_root to be a current symlink"],
+                "remediation": exc.remediation,
+                "error": str(exc),
+                "operations": operations,
+            }
         return {
             **status_base,
             "ok": True,
@@ -2944,6 +3093,7 @@ def service_rollback(
             "warnings": [] if repo_root_is_symlink else ["confirmed rollback requires repo_root to be a current symlink"],
             "planned_operations": [
                 f"stage and validate runtime configs with {target_dir}",
+                "verify every inventoried Pi Session store against the rollback runtime",
                 f"switch {repo_link} -> {target_dir}",
                 "commit the staged runtime config bundle",
                 "reconcile service drift for the rollback release",
@@ -2954,6 +3104,7 @@ def service_rollback(
                 ),
                 "restart and health-check long-running services" if restart_services else "skip service restart",
             ],
+            "pi_storage_readiness": pi_storage_readiness,
             "operations": operations,
         }
 
@@ -2963,6 +3114,7 @@ def service_rollback(
     post_switch_runtime_config_validate: list[dict[str, str]] = []
     service_reconcile: dict[str, Any] = {}
     service_health: dict[str, Any] = {}
+    pi_storage_readiness: dict[str, Any] = {}
     compensation: dict[str, Any] = {}
     restarted: list[str] = []
     previous_profile = _load_service_profile(runtime)
@@ -2976,6 +3128,12 @@ def service_rollback(
                 releases_root=releases,
                 run_cmd=run_cmd,
                 operations=operations,
+            )
+            pi_storage_readiness = _pi_storage_readiness(
+                runtime_root=runtime,
+                repo_root=repo_link,
+                runtime_dir=target_dir / "agent-runtime",
+                release_dirs=(repo, target_dir),
             )
             if preserve_activation_state and previous_profile:
                 preserved_activation_states = (
@@ -3055,10 +3213,14 @@ def service_rollback(
                     remediation=[str(item) for item in service_health.get("remediation") or []],
                 )
     except Exception as exc:
-        if symlink_switched:
+        compensation_needed = symlink_switched or _pi_storage_has_published_receipt(
+            pi_storage_readiness
+        )
+        if compensation_needed:
             compensation = _compensate_service_transition(
                 repo_link=repo_link,
                 previous_dir=repo,
+                transition_dir=target_dir,
                 runtime_root=runtime,
                 previous_profile=previous_profile,
                 config_commit=runtime_config_commit,
@@ -3068,7 +3230,7 @@ def service_rollback(
                 run_cmd=run_cmd,
                 operations=operations,
             )
-        compensated = bool(compensation.get("ok")) if symlink_switched else False
+        compensated = bool(compensation.get("ok")) if compensation_needed else False
         failure_status = (
             exc.status
             if isinstance(exc, ServiceTransitionError)
@@ -3076,11 +3238,12 @@ def service_rollback(
             if isinstance(exc, ServiceRestartError)
             else "rollback_failed"
         )
-        remediation = (
+        remediation = list(
             exc.remediation
             if isinstance(exc, (RuntimeConfigPrepareError, ServiceTransitionError, ServiceRestartError))
             else []
         )
+        remediation.extend(str(item) for item in compensation.get("remediation") or [])
         out = {
             **status_base,
             "ok": False,
@@ -3095,6 +3258,7 @@ def service_rollback(
             "post_switch_runtime_config_validate": post_switch_runtime_config_validate,
             "service_reconcile": service_reconcile,
             "service_health": service_health,
+            "pi_storage_readiness": pi_storage_readiness,
             "compensation": compensation,
             "error": f"{type(exc).__name__}: {exc}",
             **({"remediation": remediation} if remediation else {}),
@@ -3113,6 +3277,7 @@ def service_rollback(
         "post_switch_runtime_config_validate": post_switch_runtime_config_validate,
         "service_reconcile": service_reconcile,
         "service_health": service_health,
+        "pi_storage_readiness": pi_storage_readiness,
         "restarted_services": restarted,
         "operations": operations,
     }

--- a/src/infrastructure/pi_agent_process.py
+++ b/src/infrastructure/pi_agent_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import fcntl
 import hashlib
 import json
 import math
@@ -9,12 +10,18 @@ import queue
 import re
 import selectors
 import shutil
+import stat
 import subprocess
 import threading
 import time
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import Any, Callable, Literal, Mapping
+from typing import Any, Callable, Iterator, Literal, Mapping
 from urllib.parse import urlsplit
+
+from src.infrastructure.private_storage import (
+    ensure_private_directory, ensure_private_file, private_path, secure_sqlite_artifacts,
+)
 
 PROTOCOL = "om-pi-ipc.v1"
 MAX_LINE_BYTES = 1_048_576
@@ -120,6 +127,45 @@ def derive_pi_local_session_id(authority_scope: str, session_key: str) -> str:
         raise ValueError("local session identity parts must be non-empty and contain no NUL")
     material = "local\0" + authority_scope + "\0" + session_key
     return "om_" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+@contextmanager
+def pi_session_locks(
+    database: str | Path, session_id: str | None = None,
+) -> Iterator[tuple[Path, tuple[int, ...]]]:
+    """Hold independent inherited flock descriptions; None fences offline conversion."""
+    if session_id is not None and not _SESSION_ID_PATTERN.fullmatch(session_id):
+        raise ValueError("invalid session identity")
+    target = private_path(database)
+    ensure_private_directory(target.parent)
+    if target.is_symlink():
+        raise OSError("session database must not be a symlink")
+    if target.exists():
+        if target.stat().st_nlink != 1:
+            raise OSError("session database must not have hard-link aliases")
+        secure_sqlite_artifacts(target)
+    target = target.resolve()
+    paths = [(Path(str(target) + ".om-pi.lock"), fcntl.LOCK_EX if session_id is None else fcntl.LOCK_SH)]
+    if session_id is not None:
+        paths.append((Path(str(target) + "." + session_id + ".lock"), fcntl.LOCK_EX))
+    descriptors: list[int] = []
+    try:
+        for path, operation in paths:
+            ensure_private_file(path)
+            fd = os.open(path, os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW)
+            descriptors.append(fd)
+            identity = os.fstat(fd)
+            named = path.lstat()
+            if (not stat.S_ISREG(identity.st_mode) or identity.st_nlink != 1
+                    or (identity.st_dev, identity.st_ino) != (named.st_dev, named.st_ino)):
+                raise OSError("session lock identity changed")
+            fcntl.flock(fd, operation | fcntl.LOCK_NB)
+        yield target, tuple(descriptors)
+    finally:
+        # LOCK_UN would also unlock a surviving child's inherited description.
+        # Close only: the kernel releases exclusion when the final holder exits.
+        for fd in reversed(descriptors):
+            os.close(fd)
 
 
 def _is_pos_int(value: Any) -> bool:
@@ -630,6 +676,43 @@ def _runtime_command(
     return [node, "--no-warnings", str(entry)], entry
 
 
+def run_pi_migration_bridge(
+    command: str,
+    runtime: Path,
+    arguments: Mapping[str, str | Path],
+    *,
+    timeout: float = 120,
+    maintenance_descriptors: tuple[int, ...] = (),
+) -> dict[str, Any]:
+    """Run the offline Pi converter with the same Node floor as the Agent."""
+    if command not in {"identity", "probe", "export", "import"}:
+        raise ValueError("unsupported Pi migration bridge command")
+    entry = Path(__file__).resolve().parents[2] / "agent-runtime" / "pi_migration.mjs"
+    environment = {"PATH": os.environ.get("PATH", "")}
+    try:
+        argv, _ = _runtime_command(entry, environment)
+        argv.insert(1, "--experimental-import-meta-resolve")
+        argv.extend((command, "--runtime", str(runtime)))
+        for name, argument in arguments.items():
+            argv.extend(("--" + name.replace("_", "-"), str(argument)))
+        completed = subprocess.run(
+            argv, capture_output=True, text=True, timeout=timeout,
+            check=False, env=environment, pass_fds=maintenance_descriptors,
+        )
+    except (LookupError, OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError("Pi migration Node runtime is unavailable or timed out") from exc
+    if completed.returncode:
+        reason = completed.stderr.strip().splitlines()[-1] if completed.stderr.strip() else "offline bridge failed"
+        raise ValueError(f"Pi migration bridge rejected the store: {reason[:MAX_SAFE_MESSAGE_CHARS]}")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Pi migration bridge returned invalid output") from exc
+    if not isinstance(result, dict) or result.get("ok") is not True:
+        raise ValueError("Pi migration bridge failed")
+    return result
+
+
 def _encode_envelope(
     type_: str, payload: dict[str, Any], identity: dict[str, str], seq: int
 ) -> bytes:
@@ -725,7 +808,7 @@ def _validate_run_accepted(payload: dict[str, Any], expected_session_id: str | N
         raise ValueError("run.accepted payload shape is invalid")
     if payload["runtime"] != "pi-agent-core":
         raise ValueError("run.accepted runtime is not pi-agent-core")
-    if payload["runtime_version"] != "0.84.2":
+    if payload["runtime_version"] != "0.85.1":
         raise ValueError("run.accepted runtime_version is not pinned")
     if payload["session_id"] != expected_session_id:
         raise ValueError("run.accepted session_id does not match run.start")
@@ -968,6 +1051,25 @@ def run_pi_agent(
     child_env = _child_env(environ)
     if deadline - time.monotonic() < 0.001:
         return _safe_failure("PI_PROCESS_TIMEOUT", "deadline", "budget exhausted before spawn", True)
+    locks = ExitStack()
+    pass_fds: tuple[int, ...] = ()
+    if start_payload["session_id"] is not None:
+        database = child_env.get("OM_PI_SESSION_DB")
+        if not database:
+            return _safe_failure("SESSION_ERROR", "session", "session storage is unavailable", False)
+        try:
+            canonical, pass_fds = locks.enter_context(pi_session_locks(database, start_payload["session_id"]))
+            child_env["OM_PI_SESSION_DB"] = str(canonical)
+            child_env["OM_PI_LOCK_FDS"] = json.dumps(pass_fds)
+        except BlockingIOError:
+            locks.close()
+            return _safe_failure("SESSION_ERROR", "session", "session is temporarily busy", True)
+        except (OSError, ValueError):
+            locks.close()
+            return _safe_failure("SESSION_ERROR", "session", "session storage is unavailable", False)
+    if deadline - time.monotonic() < 0.001:
+        locks.close()
+        return _safe_failure("PI_PROCESS_TIMEOUT", "deadline", "budget exhausted before spawn", True)
     try:
         process = subprocess.Popen(
             command,
@@ -976,12 +1078,12 @@ def run_pi_agent(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=child_env,
+            pass_fds=pass_fds,
             bufsize=0,
         )
-    except OSError as exc:
+    except OSError:
+        locks.close()
         return _safe_failure("PI_RUNTIME_UNAVAILABLE", "spawn", "failed to spawn child", False)
-
-    os.set_blocking(process.stdin.fileno(), False)
 
     def write_line(line: bytes) -> None:
         # Node startup or a paused reader must not extend the Host deadline.
@@ -998,12 +1100,18 @@ def run_pi_agent(
                     except BlockingIOError:
                         continue
 
-    os.set_blocking(process.stdout.fileno(), False)
-    os.set_blocking(process.stderr.fileno(), False)
-
     sel = selectors.DefaultSelector()
-    sel.register(process.stdout, selectors.EVENT_READ)
-    sel.register(process.stderr, selectors.EVENT_READ)
+    try:
+        os.set_blocking(process.stdin.fileno(), False)
+        os.set_blocking(process.stdout.fileno(), False)
+        os.set_blocking(process.stderr.fileno(), False)
+        sel.register(process.stdout, selectors.EVENT_READ)
+        sel.register(process.stderr, selectors.EVENT_READ)
+    except OSError:
+        sel.close()
+        _stop_child(process)
+        locks.close()
+        return _safe_failure("PI_PROCESS_EXITED", "process", "failed to initialize child pipes", True)
 
     node_seq = 1
     py_seq = 2
@@ -1428,3 +1536,4 @@ def run_pi_agent(
         except OSError:
             pass
         _stop_child(process)
+        locks.close()

--- a/src/interfaces/cli/bot_ops.py
+++ b/src/interfaces/cli/bot_ops.py
@@ -103,6 +103,14 @@ def add_bot_commands(subparsers: Any) -> argparse.ArgumentParser:
     mode.add_argument("--dry-run", action="store_true")
     mode.add_argument("--apply", action="store_true")
     migrate.add_argument("--writers-stopped", action="store_true")
+    migrate_pi = bot_sub.add_parser("migrate-pi", help="inspect or convert the bounded Pi Session store")
+    migrate_pi.add_argument("--pi-db", required=True)
+    migrate_pi.add_argument("--source-runtime", required=True)
+    migrate_pi.add_argument("--target-runtime", required=True)
+    pi_mode = migrate_pi.add_mutually_exclusive_group(required=True)
+    pi_mode.add_argument("--dry-run", action="store_true")
+    pi_mode.add_argument("--apply", action="store_true")
+    migrate_pi.add_argument("--writers-stopped", action="store_true")
     return bot
 
 
@@ -111,6 +119,15 @@ def handle_bot_command(args: argparse.Namespace) -> dict[str, Any]:
     if args.bot_command == "migrate":
         from src.application.bot.migration import migrate_bot
         return migrate_bot(host_db=args.host_db, config_paths=args.config, pi_paths=args.pi_db, apply=args.apply, writers_stopped=args.writers_stopped)
+    if args.bot_command == "migrate-pi":
+        from src.application.bot.pi_migration import migrate_pi
+        return migrate_pi(
+            pi_db=args.pi_db,
+            source_runtime=args.source_runtime,
+            target_runtime=args.target_runtime,
+            apply=args.apply,
+            writers_stopped=args.writers_stopped,
+        )
     if args.bot_command == "run":
         request = BotRequest(
             request_id=new_id("req"),

--- a/tests/bot_pi_test_support.py
+++ b/tests/bot_pi_test_support.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 from src.application.bot.control_handoff import CONTROL_PREVIEW_TOOL
 from src.application.bot.host import run_contract as _run_contract
 from src.application.bot.model_config import PiModelSettings
+from src.infrastructure.pi_agent_process import derive_pi_local_session_id, run_pi_migration_bridge
+from src.infrastructure.private_storage import atomic_write_private_text, ensure_private_directory
 
 
 _TEST_MODEL = PiModelSettings(
@@ -302,12 +309,106 @@ def run_contract(contract, *, model_runner=None, **kwargs):
         return _run_contract(contract, **kwargs)
 
 
+@dataclass(frozen=True)
+class ActualPiMigrationFixture:
+    database: Path
+    session_id: str
+    source_runtime: Path
+    target_runtime: Path
+
+
+@lru_cache(maxsize=1)
+def actual_pi_runtime_dirs() -> tuple[Path, Path]:
+    target = Path(__file__).resolve().parents[1] / "agent-runtime"
+    configured = os.environ.get("OM_PI_LEGACY_RUNTIME")
+    if configured:
+        source = Path(configured)
+    else:
+        # Keep the real legacy SDK isolated from the shipped runtime dependencies.
+        temporary = tempfile.TemporaryDirectory(prefix="om-pi-legacy-test-")
+        actual_pi_runtime_dirs.temporary = temporary
+        source = Path(temporary.name)
+        packages = (
+            "@earendil-works/pi-agent-core", "@earendil-works/pi-ai",
+            "@earendil-works/pi-session-backend-sqlite-node",
+        )
+        (source / "package.json").write_text(json.dumps({
+            "private": True, "type": "module",
+            "dependencies": {name: "0.84.2" for name in packages},
+        }), encoding="utf-8")
+        subprocess.run(
+            ["npm", "install", "--ignore-scripts", "--no-audit", "--no-fund"],
+            cwd=source, check=True, capture_output=True, text=True, timeout=180,
+        )
+    for runtime, version in ((source, "0.84.2"), (target, "0.85.1")):
+        manifest = json.loads((runtime / "package.json").read_text(encoding="utf-8"))
+        assert set(manifest["dependencies"].values()) == {version}
+        assert (runtime / "package-lock.json").is_file()
+        assert (runtime / "node_modules").is_dir()
+    return source.resolve(), target.resolve()
+
+
+def _migration_usage() -> dict[str, Any]:
+    return {
+        "input": 1, "output": 1, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 2,
+        "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "total": 0},
+    }
+
+
+def seed_actual_legacy_pi_store(database: Path) -> ActualPiMigrationFixture:
+    source_runtime, target_runtime = actual_pi_runtime_dirs()
+    ensure_private_directory(database.parent)
+    session_id = derive_pi_local_session_id("key:us", "pi-migration-fixture")
+    user = {"role": "user", "content": "old question", "timestamp": 1_700_000_000_010}
+    assistant = {
+        "role": "assistant", "content": [{"type": "text", "text": "old answer"}],
+        "api": "openai-responses", "provider": "openai", "model": "fixture",
+        "usage": _migration_usage(), "stopReason": "stop", "timestamp": 1_700_000_000_020,
+    }
+    retained_user = {"role": "user", "content": "retained question", "timestamp": 1_699_999_999_000}
+    retained_assistant = {**assistant, "content": [{"type": "text", "text": "retained answer"}],
+                          "timestamp": 1_699_999_999_010}
+    entries = [
+        {"id": "old_user", "parentId": None, "timestamp": 1_700_000_000_010,
+         "type": "message", "message": user},
+        {"id": "old_assistant", "parentId": "old_user", "timestamp": 1_700_000_000_020,
+         "type": "message", "message": assistant},
+        {"id": "old_commit", "parentId": "old_assistant", "timestamp": 1_700_000_000_030,
+         "type": "custom", "customType": "om.turn.commit.v1",
+         "data": {"run_id": "old_run", "kind": "turn"}},
+        {"id": "old_compaction", "parentId": "old_commit", "timestamp": 1_700_000_000_040,
+         "type": "compaction", "summary": "old summary",
+         "retainedTail": [retained_user, retained_assistant], "tokensBefore": 100,
+         "usage": _migration_usage(), "fromHook": False},
+        {"id": "old_compaction_commit", "parentId": "old_compaction", "timestamp": 1_700_000_000_050,
+         "type": "custom", "customType": "om.turn.commit.v1",
+         "data": {"run_id": "old_compaction_run", "kind": "compaction"}},
+    ]
+    canonical = {
+        "format": "om-pi-export.v1",
+        "sessions": [{
+            "id": session_id, "createdAt": 1_700_000_000_000, "entries": entries,
+            "excludedTailCount": 0, "contextSha256": "0" * 64, "contentSha256": "0" * 64,
+        }],
+    }
+    export_path = database.with_name(database.name + ".seed.json")
+    atomic_write_private_text(export_path, json.dumps(canonical, sort_keys=True))
+    run_pi_migration_bridge(
+        "import", source_runtime,
+        {"expected-version": "0.84.2", "database": database, "input": export_path},
+    )
+    return ActualPiMigrationFixture(database, session_id, source_runtime, target_runtime)
+
+
 __all__ = [
     "_TEST_MODEL",
     "ModelRequest",
     "ModelRunner",
     "ModelTurn",
     "ToolCall",
+    "ActualPiMigrationFixture",
+    "actual_pi_runtime_dirs",
     "fake_pi_agent",
     "run_contract",
+    "seed_actual_legacy_pi_store",
 ]

--- a/tests/integration/test_service_deploy_integration.py
+++ b/tests/integration/test_service_deploy_integration.py
@@ -21,7 +21,15 @@ from tests.service_deploy_test_support import (
     _fake_release_target_query,
     _legacy_credential_migration_fixture,
     _credential_migration_runner,
+    _stub_pi_storage_readiness,
 )
+
+
+@pytest.fixture(autouse=True)
+def _legacy_service_fixtures_have_ready_pi_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_pi_storage_readiness(monkeypatch)
 
 def test_render_systemd_bundle_can_own_feishu_agent_credential_assets(
     tmp_path: Path,

--- a/tests/service_deploy_test_support.py
+++ b/tests/service_deploy_test_support.py
@@ -124,6 +124,16 @@ def _fake_pi_runtime_prepare(command: list[str]) -> subprocess.CompletedProcess 
     return None
 
 
+def _stub_pi_storage_readiness(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import src.application.service_upgrade as service_upgrade_module
+
+    monkeypatch.setattr(
+        service_upgrade_module,
+        "_pi_storage_readiness",
+        lambda **_kwargs: {"ok": True, "stores": []},
+    )
+
+
 def _fake_release_target_query(
     command: list[str],
     *,

--- a/tests/test_bot_pi_migration.py
+++ b/tests/test_bot_pi_migration.py
@@ -1,0 +1,824 @@
+from __future__ import annotations
+
+import errno
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from src.application.bot import pi_migration as migration
+from src.application.bot.pi_migration import (
+    assert_pi_storage_ready,
+    migrate_pi,
+    read_pi_migration_receipt,
+)
+from src.infrastructure.pi_agent_process import run_pi_migration_bridge
+from tests.bot_pi_test_support import seed_actual_legacy_pi_store
+from tests.test_pi_agent_process import _run_session, _start_payload
+
+
+def _file_inventory(root: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _store_format(fixture) -> str:
+    return run_pi_migration_bridge(
+        "probe",
+        fixture.target_runtime,
+        {"expected-version": "0.85.1", "database": fixture.database},
+    )["format"]
+
+
+def _clone_runtime(source: Path, destination: Path) -> Path:
+    def link_or_copy(input_path, output_path):
+        try:
+            return os.link(input_path, output_path)
+        except OSError as exc:
+            if exc.errno != errno.EXDEV:
+                raise
+            return shutil.copy2(input_path, output_path)
+
+    return Path(shutil.copytree(source, destination, copy_function=link_or_copy, symlinks=True))
+
+
+def _add_abandoned_legacy_tail(database: Path, session_id: str, count: int) -> None:
+    with closing(sqlite3.connect(database)) as connection:
+        parent_id = connection.execute(
+            "SELECT leaf_id FROM lanes WHERE session_id = ? AND lane = 'main'",
+            (session_id,),
+        ).fetchone()[0]
+        sequence = connection.execute(
+            "SELECT MAX(seq) + 1 FROM entries WHERE session_id = ?", (session_id,),
+        ).fetchone()[0]
+        payload = connection.execute(
+            "SELECT payload FROM entries WHERE session_id = ? AND type = 'message' ORDER BY seq LIMIT 1",
+            (session_id,),
+        ).fetchone()[0]
+        rows = []
+        for index in range(count):
+            entry_id = f"abandoned-{index}"
+            rows.append((session_id, sequence + index, entry_id, parent_id, 1_700_100_000_000 + index, payload))
+            parent_id = entry_id
+        connection.executemany(
+            "INSERT INTO entries (session_id, seq, id, parent_id, type, timestamp, payload) "
+            "VALUES (?, ?, ?, ?, 'message', ?, ?)",
+            rows,
+        )
+        connection.commit()
+
+
+def _add_unreachable_committed_branch(database: Path, session_id: str) -> None:
+    with closing(sqlite3.connect(database)) as connection:
+        sequence = connection.execute(
+            "SELECT MAX(seq) + 1 FROM entries WHERE session_id = ?", (session_id,),
+        ).fetchone()[0]
+        message_payload = connection.execute(
+            "SELECT payload FROM entries WHERE session_id = ? AND type = 'message' ORDER BY seq LIMIT 1",
+            (session_id,),
+        ).fetchone()[0]
+        marker_payload = connection.execute(
+            "SELECT payload FROM entries WHERE session_id = ? AND type = 'custom' ORDER BY seq LIMIT 1",
+            (session_id,),
+        ).fetchone()[0]
+        connection.execute(
+            "INSERT INTO entries (session_id, seq, id, parent_id, type, timestamp, payload) "
+            "VALUES (?, ?, 'branch-message', 'old_commit', 'message', ?, ?)",
+            (session_id, sequence, 1_700_200_000_000, message_payload),
+        )
+        connection.execute(
+            "INSERT INTO entries (session_id, seq, id, parent_id, type, timestamp, payload) "
+            "VALUES (?, ?, 'branch-commit', 'branch-message', 'custom', ?, ?)",
+            (session_id, sequence + 1, 1_700_200_000_001, marker_payload),
+        )
+        connection.commit()
+
+
+def test_actual_forward_admitted_turn_reverse_preserves_current_history(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    database, old, new = fixture.database, fixture.source_runtime, fixture.target_runtime
+    assert assert_pi_storage_ready(database, old)["ok"] is True
+    with pytest.raises(ValueError, match="incompatible"):
+        assert_pi_storage_ready(database, new)
+
+    forward = migrate_pi(pi_db=database, source_runtime=old, target_runtime=new,
+                         apply=True, writers_stopped=True)
+    assert forward["ok"] is True
+    receipt = read_pi_migration_receipt(database)
+    assert receipt["phase"] == "published"
+    retained_backups = {
+        Path(receipt["backup"]["path"]): Path(receipt["backup"]["path"]).read_bytes(),
+    }
+    with pytest.raises(ValueError):
+        assert_pi_storage_ready(database, old)
+    result = _run_session(
+        database, fixture.session_id,
+        _start_payload(session_id=fixture.session_id, user_message="post-migration question",
+                       debug={"fixture_response": "post-migration answer", "delay_ms": 0,
+                              "expected_history": ["old summary", "retained question", "retained answer"]}),
+        run_id="post_migration_turn",
+    )
+    assert result["ok"] is True, result
+    assert result["result"]["committed"] is True
+    assert assert_pi_storage_ready(database, new)["ok"] is True
+    assert migrate_pi(pi_db=database, source_runtime=old, target_runtime=new,
+                      apply=True, writers_stopped=True)["already_applied"] is True
+
+    before_path = tmp_path / "current-target.json"
+    run_pi_migration_bridge("export", new, {
+        "expected-version": "0.85.1", "database": database, "output": before_path,
+    })
+    current = json.loads(before_path.read_text())
+    reverse = migrate_pi(pi_db=database, source_runtime=new, target_runtime=old,
+                         apply=True, writers_stopped=True)
+    assert reverse["ok"] is True
+    assert assert_pi_storage_ready(database, old)["ok"] is True
+    receipt = read_pi_migration_receipt(database)
+    assert receipt["prior"]["target"]["runtime"]["version"] == "0.85.1"
+    reverse_backup = Path(receipt["backup"]["path"])
+    retained_backups[reverse_backup] = reverse_backup.read_bytes()
+    after_path = tmp_path / "current-legacy.json"
+    run_pi_migration_bridge("export", old, {
+        "expected-version": "0.84.2", "database": database, "output": after_path,
+    })
+    restored = json.loads(after_path.read_text())
+    assert restored == current
+    entries = restored["sessions"][0]["entries"]
+    assert any(entry.get("data", {}).get("run_id") == "post_migration_turn" for entry in entries)
+    assert any(entry.get("type") == "compaction" for entry in entries)
+
+    assert migrate_pi(pi_db=database, source_runtime=old, target_runtime=new,
+                      apply=True, writers_stopped=True)["write_applied"] is True
+    receipt = read_pi_migration_receipt(database)
+    second_forward_backup = Path(receipt["backup"]["path"])
+    retained_backups[second_forward_backup] = second_forward_backup.read_bytes()
+    second_turn = _run_session(
+        database, fixture.session_id,
+        _start_payload(session_id=fixture.session_id, user_message="second upgrade question",
+                       debug={"fixture_response": "second upgrade answer", "delay_ms": 0}),
+        run_id="second_post_migration_turn",
+    )
+    assert second_turn["ok"] is True, second_turn
+    second_current_path = tmp_path / "second-current-target.json"
+    run_pi_migration_bridge("export", new, {
+        "expected-version": "0.85.1", "database": database, "output": second_current_path,
+    })
+    second_current = json.loads(second_current_path.read_text())
+
+    assert migrate_pi(pi_db=database, source_runtime=new, target_runtime=old,
+                      apply=True, writers_stopped=True)["write_applied"] is True
+    receipt = read_pi_migration_receipt(database)
+    second_reverse_backup = Path(receipt["backup"]["path"])
+    retained_backups[second_reverse_backup] = second_reverse_backup.read_bytes()
+    final_path = tmp_path / "second-current-legacy.json"
+    run_pi_migration_bridge("export", old, {
+        "expected-version": "0.84.2", "database": database, "output": final_path,
+    })
+    assert json.loads(final_path.read_text()) == second_current
+
+    chain = []
+    current_receipt = receipt
+    while current_receipt is not None:
+        chain.append(current_receipt)
+        current_receipt = current_receipt.get("prior")
+    assert len(chain) == 4
+    assert {Path(item["backup"]["path"]) for item in chain} == set(retained_backups)
+    assert all(path.read_bytes() == contents for path, contents in retained_backups.items())
+
+
+def test_preview_preserves_exact_file_inventory_including_sidecars(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    Path(str(fixture.database) + "-wal").touch(mode=0o600)
+    Path(str(fixture.database) + "-shm").write_bytes(b"preview-sidecar-sentinel")
+    before = _file_inventory(tmp_path)
+
+    result = migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+    )
+
+    assert result["mode"] == "preview"
+    assert result["write_applied"] is False
+    assert _file_inventory(tmp_path) == before
+
+
+def test_empty_stores_convert_in_both_directions(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "runtime-seed.sqlite3")
+    empty_payload = tmp_path / "empty.json"
+    empty_payload.write_text(json.dumps({"format": "om-pi-export.v1", "sessions": []}))
+    directions = (
+        (fixture.source_runtime, "0.84.2", "legacy", fixture.target_runtime, "target"),
+        (fixture.target_runtime, "0.85.1", "target", fixture.source_runtime, "legacy"),
+    )
+
+    for index, (source, source_version, source_format, target, target_format) in enumerate(directions):
+        database = tmp_path / f"empty-{index}.sqlite3"
+        run_pi_migration_bridge("import", source, {
+            "expected-version": source_version, "database": database, "input": empty_payload,
+        })
+        assert run_pi_migration_bridge("probe", fixture.target_runtime, {
+            "expected-version": "0.85.1", "database": database,
+        })["format"] == source_format
+
+        preview = migrate_pi(pi_db=database, source_runtime=source, target_runtime=target)
+        assert preview["session_ids"] == []
+        applied = migrate_pi(
+            pi_db=database, source_runtime=source, target_runtime=target,
+            apply=True, writers_stopped=True,
+        )
+        assert applied["write_applied"] is True
+        assert assert_pi_storage_ready(database, target)["database_format"] == target_format
+        exported = tmp_path / f"empty-{index}.json"
+        report = run_pi_migration_bridge("export", target, {
+            "expected-version": "0.85.1" if target_format == "target" else "0.84.2",
+            "database": database,
+            "output": exported,
+        })
+        assert report["sessionCount"] == 0
+        assert json.loads(exported.read_text())["sessions"] == []
+
+
+def test_prepared_receipt_failure_preserves_orphan_and_retries_with_new_generation(tmp_path, monkeypatch):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    original_write_receipt = migration._write_receipt
+
+    def fail_first_prepared_receipt(database, receipt):
+        if receipt["phase"] == "prepared":
+            raise RuntimeError("prepared receipt fault")
+        original_write_receipt(database, receipt)
+
+    monkeypatch.setattr(migration, "_write_receipt", fail_first_prepared_receipt)
+    with pytest.raises(RuntimeError, match="prepared receipt fault"):
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+    assert read_pi_migration_receipt(fixture.database) is None
+    orphaned = list(tmp_path.glob("pi_sessions.sqlite3.om-pi-recovery-0.84.2-to-0.85.1-*.sqlite3"))
+    assert len(orphaned) == 1
+    orphan_bytes = orphaned[0].read_bytes()
+
+    monkeypatch.setattr(migration, "_write_receipt", original_write_receipt)
+    retried = migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+
+    receipt = read_pi_migration_receipt(fixture.database)
+    assert retried["write_applied"] is True
+    assert Path(receipt["backup"]["path"]) != orphaned[0]
+    assert orphaned[0].read_bytes() == orphan_bytes
+    assert assert_pi_storage_ready(fixture.database, fixture.target_runtime)["ok"] is True
+
+
+def test_exporter_death_leaves_prepared_backup_and_retry_recovers(tmp_path, monkeypatch):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    abandoned_count = 15_000
+    _add_abandoned_legacy_tail(fixture.database, fixture.session_id, abandoned_count)
+    original_bridge = migration._bridge
+    node = shutil.which("node")
+    assert node is not None
+    bridge_entry = Path(__file__).resolve().parents[1] / "agent-runtime" / "pi_migration.mjs"
+    exporter_opened_store = False
+
+    def kill_real_legacy_export(command, runtime, **arguments):
+        nonlocal exporter_opened_store
+        if command != "export" or Path(runtime) != fixture.source_runtime:
+            return original_bridge(command, runtime, **arguments)
+        maintenance_descriptors = arguments.pop("maintenance_descriptors", ())
+        argv = [node, "--experimental-import-meta-resolve", "--no-warnings", str(bridge_entry),
+                command, "--runtime", str(runtime)]
+        for name, value in arguments.items():
+            argv.extend(("--" + name.replace("_", "-"), str(value)))
+        process = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={"PATH": os.environ.get("PATH", "")},
+            pass_fds=maintenance_descriptors,
+        )
+        deadline = time.monotonic() + 10
+        work = Path(arguments["database"])
+        while process.poll() is None and time.monotonic() < deadline:
+            try:
+                with closing(sqlite3.connect(f"file:{work}?mode=ro", uri=True, timeout=0.01)) as connection:
+                    exporter_opened_store = connection.execute(
+                        "SELECT COUNT(*) FROM writer_leases",
+                    ).fetchone()[0] > 0
+            except sqlite3.Error:
+                pass
+            if exporter_opened_store:
+                break
+            time.sleep(0.001)
+        process.kill()
+        process.communicate(timeout=5)
+        if not exporter_opened_store:
+            raise AssertionError("real legacy exporter exited before its public repository opened")
+        raise RuntimeError("exporter killed")
+
+    monkeypatch.setattr(migration, "_bridge", kill_real_legacy_export)
+    with pytest.raises(RuntimeError, match="exporter killed"):
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+    receipt = read_pi_migration_receipt(fixture.database)
+    assert receipt["phase"] == "prepared"
+    backup = Path(receipt["backup"]["path"])
+    backup_bytes = backup.read_bytes()
+    assert exporter_opened_store is True
+    assert not any(path.exists() for path in migration._sidecars(backup))
+    assert _store_format(fixture) == "legacy"
+    with pytest.raises(ValueError, match="unresolved"):
+        assert_pi_storage_ready(fixture.database, fixture.source_runtime)
+
+    monkeypatch.setattr(migration, "_bridge", original_bridge)
+    retried = migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+
+    assert retried["write_applied"] is True
+    assert backup.read_bytes() == backup_bytes
+    assert not any(path.exists() for path in migration._sidecars(backup))
+    published = read_pi_migration_receipt(fixture.database)
+    assert published["phase"] == "published"
+    assert published["conversion"]["excludedTailCount"] == abandoned_count
+    with closing(sqlite3.connect(f"file:{backup}?mode=ro", uri=True)) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM entries WHERE id LIKE 'abandoned-%'",
+        ).fetchone()[0] == abandoned_count
+
+
+def test_validated_migration_retries_without_reimport(tmp_path, monkeypatch):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    original_write_receipt = migration._write_receipt
+
+    def fail_after_validated(database, receipt):
+        original_write_receipt(database, receipt)
+        if receipt["phase"] == "validated":
+            raise RuntimeError("validated fault")
+
+    monkeypatch.setattr(migration, "_write_receipt", fail_after_validated)
+    with pytest.raises(RuntimeError, match="validated fault"):
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+    receipt = read_pi_migration_receipt(fixture.database)
+    stage = Path(receipt["backup"]["path"] + ".staging.sqlite3")
+    assert receipt["phase"] == "validated"
+    assert stage.is_file()
+    stage_bytes = stage.read_bytes()
+    assert _store_format(fixture) == "legacy"
+    with pytest.raises(ValueError, match="unresolved"):
+        assert_pi_storage_ready(fixture.database, fixture.source_runtime)
+
+    monkeypatch.setattr(migration, "_write_receipt", original_write_receipt)
+    original_bridge = migration._bridge
+
+    def forbid_reimport(command, *args, **kwargs):
+        if command == "import":
+            raise AssertionError("validated retry must reuse staging")
+        return original_bridge(command, *args, **kwargs)
+
+    monkeypatch.setattr(migration, "_bridge", forbid_reimport)
+    retried = migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+
+    assert retried["write_applied"] is True
+    assert not stage.exists()
+    assert fixture.database.read_bytes() == stage_bytes
+    assert assert_pi_storage_ready(fixture.database, fixture.target_runtime)["ok"] is True
+
+
+def test_retry_reconciles_target_renamed_before_published_receipt(tmp_path, monkeypatch):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    original_write_receipt = migration._write_receipt
+
+    def fail_before_published_receipt(database, receipt):
+        if receipt["phase"] == "published":
+            raise RuntimeError("published receipt fault")
+        original_write_receipt(database, receipt)
+
+    monkeypatch.setattr(migration, "_write_receipt", fail_before_published_receipt)
+    with pytest.raises(RuntimeError, match="published receipt fault"):
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+    assert read_pi_migration_receipt(fixture.database)["phase"] == "validated"
+    assert _store_format(fixture) == "target"
+    with pytest.raises(ValueError, match="unresolved"):
+        assert_pi_storage_ready(fixture.database, fixture.target_runtime)
+
+    monkeypatch.setattr(migration, "_write_receipt", original_write_receipt)
+    original_bridge = migration._bridge
+
+    def forbid_reimport(command, *args, **kwargs):
+        if command == "import":
+            raise AssertionError("publication reconciliation must not import")
+        return original_bridge(command, *args, **kwargs)
+
+    monkeypatch.setattr(migration, "_bridge", forbid_reimport)
+    reconciled = migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+
+    assert reconciled["already_applied"] is True
+    assert reconciled["write_applied"] is False
+    assert read_pi_migration_receipt(fixture.database)["phase"] == "published"
+
+
+def test_apply_captures_committed_wal_in_sealed_backup(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    wal_cwd = "/tmp/committed-in-wal"
+    subprocess.run(
+        [sys.executable, "-c", """
+import os, sqlite3, sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("PRAGMA journal_mode=WAL")
+connection.execute("PRAGMA wal_autocheckpoint=0")
+connection.execute("UPDATE sessions SET cwd = ? WHERE id = ?", (sys.argv[2], sys.argv[3]))
+connection.commit()
+os._exit(0)
+""", str(fixture.database), wal_cwd, fixture.session_id],
+        check=True,
+    )
+    assert Path(str(fixture.database) + "-wal").stat().st_size > 0
+
+    result = migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+
+    receipt = read_pi_migration_receipt(fixture.database)
+    with closing(sqlite3.connect(f"file:{receipt['backup']['path']}?mode=ro", uri=True)) as backup:
+        assert backup.execute("SELECT cwd FROM sessions WHERE id = ?", (fixture.session_id,)).fetchone() == (wal_cwd,)
+    assert result["write_applied"] is True
+    assert assert_pi_storage_ready(fixture.database, fixture.target_runtime)["ok"] is True
+
+
+def test_invalid_store_and_runtime_inputs_fail_closed(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "valid.sqlite3")
+    valid_before = fixture.database.read_bytes()
+    with pytest.raises(ValueError, match="only exact"):
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.source_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+    assert fixture.database.read_bytes() == valid_before
+
+    invalid = tmp_path / "invalid.sqlite3"
+    invalid.write_bytes(b"not a sqlite database")
+    invalid_before = invalid.read_bytes()
+    with pytest.raises(ValueError, match="does not match"):
+        migrate_pi(
+            pi_db=invalid,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+        )
+    with pytest.raises(ValueError, match="does not match"):
+        migrate_pi(
+            pi_db=invalid,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+    assert invalid.read_bytes() == invalid_before
+    assert read_pi_migration_receipt(invalid) is None
+    assert not list(tmp_path.glob("invalid.sqlite3.om-pi-*"))
+
+
+def test_invalid_staging_format_is_rejected_before_validation_or_publication(tmp_path, monkeypatch):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    original_checkpoint = migration._checkpoint_source
+
+    def checkpoint_then_corrupt_target(database):
+        original_checkpoint(database)
+        if str(database).endswith(".staging.sqlite3"):
+            with sqlite3.connect(database) as connection:
+                connection.execute("DROP TRIGGER trg_entries_validate")
+
+    monkeypatch.setattr(migration, "_checkpoint_source", checkpoint_then_corrupt_target)
+    with pytest.raises(ValueError, match="staging store format"):
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+
+    receipt = read_pi_migration_receipt(fixture.database)
+    assert receipt["phase"] == "prepared"
+    assert _store_format(fixture) == "legacy"
+    backup = Path(receipt["backup"]["path"])
+    backup_bytes = backup.read_bytes()
+
+    monkeypatch.setattr(migration, "_checkpoint_source", original_checkpoint)
+    assert migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )["write_applied"] is True
+    assert backup.read_bytes() == backup_bytes
+
+
+def test_unreachable_committed_legacy_branch_is_not_silently_dropped(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    _add_unreachable_committed_branch(fixture.database, fixture.session_id)
+
+    with pytest.raises(ValueError, match="unsupported legacy session branches"):
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+
+    assert _store_format(fixture) == "legacy"
+    receipt = read_pi_migration_receipt(fixture.database)
+    assert receipt["phase"] == "prepared"
+    with closing(sqlite3.connect(f"file:{receipt['backup']['path']}?mode=ro", uri=True)) as backup:
+        assert backup.execute(
+            "SELECT id FROM entries WHERE id IN ('branch-message', 'branch-commit') ORDER BY seq",
+        ).fetchall() == [("branch-message",), ("branch-commit",)]
+
+
+def test_corrupt_legacy_payload_does_not_leak_content_through_facade(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    sentinel = "PRIVATE_CONVERSATION_SENTINEL"
+    with closing(sqlite3.connect(fixture.database)) as connection:
+        connection.execute(
+            "UPDATE entries SET payload = ? WHERE session_id = ? AND id = 'old_user'",
+            (f'{{"message":"{sentinel}"', fixture.session_id),
+        )
+        connection.commit()
+
+    with pytest.raises(ValueError) as rejected:
+        migrate_pi(
+            pi_db=fixture.database,
+            source_runtime=fixture.source_runtime,
+            target_runtime=fixture.target_runtime,
+            apply=True,
+            writers_stopped=True,
+        )
+
+    assert sentinel not in str(rejected.value)
+    assert _store_format(fixture) == "legacy"
+
+
+def test_repeated_same_run_compactions_roundtrip(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "initial.sqlite3")
+    exported = tmp_path / "initial.json"
+    run_pi_migration_bridge(
+        "export",
+        fixture.source_runtime,
+        {"expected-version": "0.84.2", "database": fixture.database, "output": exported},
+    )
+    payload = json.loads(exported.read_text(encoding="utf-8"))
+    entries = payload["sessions"][0]["entries"]
+    first_compaction = next(entry for entry in entries if entry["type"] == "compaction")
+    first_marker = entries[-1]
+    second_compaction = {
+        **first_compaction,
+        "id": "second-compaction",
+        "parentId": first_marker["id"],
+        "timestamp": first_marker["timestamp"] + 10,
+        "summary": "second summary",
+    }
+    second_marker = {
+        **first_marker,
+        "id": "second-compaction-commit",
+        "parentId": second_compaction["id"],
+        "timestamp": second_compaction["timestamp"] + 10,
+    }
+    entries.extend((second_compaction, second_marker))
+    source_seed = tmp_path / "repeated-seed.json"
+    source_seed.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    repeated = tmp_path / "repeated.sqlite3"
+    run_pi_migration_bridge(
+        "import",
+        fixture.source_runtime,
+        {"expected-version": "0.84.2", "database": repeated, "input": source_seed},
+    )
+
+    forward = migrate_pi(
+        pi_db=repeated,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+    assert forward["write_applied"] is True
+    target_export = tmp_path / "target.json"
+    run_pi_migration_bridge(
+        "export",
+        fixture.target_runtime,
+        {"expected-version": "0.85.1", "database": repeated, "output": target_export},
+    )
+    current = json.loads(target_export.read_text(encoding="utf-8"))
+    compaction_markers = [
+        entry for entry in current["sessions"][0]["entries"]
+        if entry.get("data", {}).get("kind") == "compaction"
+    ]
+    assert [entry["data"]["run_id"] for entry in compaction_markers] == [
+        first_marker["data"]["run_id"], first_marker["data"]["run_id"],
+    ]
+
+    reverse = migrate_pi(
+        pi_db=repeated,
+        source_runtime=fixture.target_runtime,
+        target_runtime=fixture.source_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+    assert reverse["write_applied"] is True
+    restored_export = tmp_path / "restored.json"
+    run_pi_migration_bridge(
+        "export",
+        fixture.source_runtime,
+        {"expected-version": "0.84.2", "database": repeated, "output": restored_export},
+    )
+    assert json.loads(restored_export.read_text(encoding="utf-8")) == current
+
+
+def test_readiness_accepts_relocated_target_but_rejects_same_version_drift(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+    relocated = _clone_runtime(fixture.target_runtime, tmp_path / "relocated-target")
+    assert assert_pi_storage_ready(fixture.database, relocated)["ok"] is True
+
+    preview = migrate_pi(pi_db=fixture.database, source_runtime=relocated,
+                         target_runtime=fixture.source_runtime)
+    assert preview["receipt_phase"] == "published"
+
+    lock_path = relocated / "package-lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["omTestDrift"] = True
+    replacement = relocated / "package-lock.changed.json"
+    replacement.write_text(json.dumps(lock, sort_keys=True), encoding="utf-8")
+    replacement.replace(lock_path)
+
+    with pytest.raises(ValueError, match="target runtime identity changed"):
+        assert_pi_storage_ready(fixture.database, relocated)
+    before = {path.name: path.read_bytes() for path in tmp_path.glob("pi_sessions.sqlite3*")}
+    for apply in (False, True):
+        with pytest.raises(ValueError, match="published Pi migration receipt does not match this source"):
+            migrate_pi(pi_db=fixture.database, source_runtime=relocated,
+                       target_runtime=fixture.source_runtime, apply=apply, writers_stopped=apply)
+        assert {path.name: path.read_bytes() for path in tmp_path.glob("pi_sessions.sqlite3*")} == before
+
+
+def test_readiness_rejects_missing_recovery_backup(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.source_runtime,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+    receipt = read_pi_migration_receipt(fixture.database)
+    backup = Path(receipt["backup"]["path"])
+    backup.rename(backup.with_name(backup.name + ".missing"))
+
+    with pytest.raises(ValueError, match="recovery backup is unavailable"):
+        assert_pi_storage_ready(fixture.database, fixture.target_runtime)
+
+
+def test_readiness_recursively_requires_prior_source_runtime(tmp_path):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    retained_old = _clone_runtime(fixture.source_runtime, tmp_path / "retained-old")
+    migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=retained_old,
+        target_runtime=fixture.target_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+    migrate_pi(
+        pi_db=fixture.database,
+        source_runtime=fixture.target_runtime,
+        target_runtime=fixture.source_runtime,
+        apply=True,
+        writers_stopped=True,
+    )
+    retained_old.rename(tmp_path / "retained-old.missing")
+
+    with pytest.raises(ValueError, match="source runtime is unavailable"):
+        assert_pi_storage_ready(fixture.database, fixture.source_runtime)
+
+
+@pytest.mark.parametrize(("phase", "damage"), [
+    ("prepared", "missing"),
+    ("prepared", "writable"),
+    ("prepared", "sidecar"),
+    ("validated-source", "missing"),
+    ("validated-target", "missing"),
+    ("published", "missing"),
+    ("prior", "missing"),
+])
+def test_migration_preflight_rejects_broken_recovery_without_writes(tmp_path, monkeypatch, phase, damage):
+    fixture = seed_actual_legacy_pi_store(tmp_path / "pi_sessions.sqlite3")
+    source, target = fixture.source_runtime, fixture.target_runtime
+    original_write = migration._write_receipt
+
+    def interrupt_phase(database, receipt):
+        if phase == "validated-target" and receipt["phase"] == "published":
+            raise RuntimeError("phase fault")
+        original_write(database, receipt)
+        if receipt["phase"] == phase or (phase == "validated-source" and receipt["phase"] == "validated"):
+            raise RuntimeError("phase fault")
+
+    if phase in {"published", "prior"}:
+        migrate_pi(pi_db=fixture.database, source_runtime=source, target_runtime=target,
+                   apply=True, writers_stopped=True)
+        source, target = target, source
+        if phase == "prior":
+            migrate_pi(pi_db=fixture.database, source_runtime=source, target_runtime=target,
+                       apply=True, writers_stopped=True)
+            source, target = target, source
+    else:
+        with monkeypatch.context() as patch:
+            patch.setattr(migration, "_write_receipt", interrupt_phase)
+            with pytest.raises(RuntimeError, match="phase fault"):
+                migrate_pi(pi_db=fixture.database, source_runtime=source, target_runtime=target,
+                           apply=True, writers_stopped=True)
+    receipt = read_pi_migration_receipt(fixture.database)
+    backup_receipt = receipt["prior"] if phase == "prior" else receipt
+    backup = Path(backup_receipt["backup"]["path"])
+    if damage == "missing":
+        backup.unlink()
+    elif damage == "writable":
+        backup.chmod(0o600)
+    else:
+        Path(str(backup) + "-wal").write_bytes(b"unexpected sidecar")
+    before = _file_inventory(tmp_path)
+    before_modes = {str(path): path.stat().st_mode for path in tmp_path.rglob("*")}
+    for apply in (False, True):
+        with pytest.raises(ValueError, match="retained Pi recovery backup"):
+            migrate_pi(pi_db=fixture.database, source_runtime=source, target_runtime=target,
+                       apply=apply, writers_stopped=apply)
+        assert _file_inventory(tmp_path) == before
+        expected_modes = dict(before_modes)
+        if apply:
+            # The existing maintenance lock tightens active-file permissions.
+            expected_modes[str(fixture.database)] = (before_modes[str(fixture.database)] & ~0o777) | 0o600
+        assert {str(path): path.stat().st_mode for path in tmp_path.rglob("*")} == expected_modes

--- a/tests/test_bot_pi_migration.py
+++ b/tests/test_bot_pi_migration.py
@@ -296,6 +296,22 @@ def test_exporter_death_leaves_prepared_backup_and_retry_recovers(tmp_path, monk
     node = shutil.which("node")
     assert node is not None
     bridge_entry = Path(__file__).resolve().parents[1] / "agent-runtime" / "pi_migration.mjs"
+    ready = tmp_path / "exporter-opened"
+    preload = tmp_path / "pause-exporter.mjs"
+    preload.write_text(f'''
+import {{ writeFileSync }} from "node:fs";
+import {{ pathToFileURL }} from "node:url";
+const runtime = process.argv[process.argv.indexOf("--runtime") + 1];
+const sdk = await import(import.meta.resolve("@earendil-works/pi-session-backend-sqlite-node", pathToFileURL(runtime + "/package.json").href));
+const prototype = sdk.SqliteSessionRepository.prototype;
+const original = prototype.open;
+prototype.open = async function (...args) {{
+  const session = await original.apply(this, args);
+  writeFileSync({json.dumps(str(ready))}, String(process.pid));
+  process.kill(process.pid, "SIGSTOP");
+  return session;
+}};
+''')
     exporter_opened_store = False
 
     def kill_real_legacy_export(command, runtime, **arguments):
@@ -303,7 +319,7 @@ def test_exporter_death_leaves_prepared_backup_and_retry_recovers(tmp_path, monk
         if command != "export" or Path(runtime) != fixture.source_runtime:
             return original_bridge(command, runtime, **arguments)
         maintenance_descriptors = arguments.pop("maintenance_descriptors", ())
-        argv = [node, "--experimental-import-meta-resolve", "--no-warnings", str(bridge_entry),
+        argv = [node, "--experimental-import-meta-resolve", "--no-warnings", "--import", str(preload), str(bridge_entry),
                 command, "--runtime", str(runtime)]
         for name, value in arguments.items():
             argv.extend(("--" + name.replace("_", "-"), str(value)))
@@ -316,22 +332,15 @@ def test_exporter_death_leaves_prepared_backup_and_retry_recovers(tmp_path, monk
             pass_fds=maintenance_descriptors,
         )
         deadline = time.monotonic() + 10
-        work = Path(arguments["database"])
-        while process.poll() is None and time.monotonic() < deadline:
-            try:
-                with closing(sqlite3.connect(f"file:{work}?mode=ro", uri=True, timeout=0.01)) as connection:
-                    exporter_opened_store = connection.execute(
-                        "SELECT COUNT(*) FROM writer_leases",
-                    ).fetchone()[0] > 0
-            except sqlite3.Error:
-                pass
-            if exporter_opened_store:
-                break
-            time.sleep(0.001)
-        process.kill()
-        process.communicate(timeout=5)
-        if not exporter_opened_store:
-            raise AssertionError("real legacy exporter exited before its public repository opened")
+        try:
+            while not ready.exists() and process.poll() is None and time.monotonic() < deadline:
+                time.sleep(0.01)
+            exporter_opened_store = ready.exists()
+        finally:
+            if process.poll() is None:
+                process.kill()
+            stdout, stderr = process.communicate(timeout=5)
+        assert exporter_opened_store, f"legacy exporter did not reach repository open: {stdout}\n{stderr}"
         raise RuntimeError("exporter killed")
 
     monkeypatch.setattr(migration, "_bridge", kill_real_legacy_export)

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -67,11 +68,12 @@ chmod +x "$dest/om" "$dest/om-agent"
 if [[ "${FAKE_MISSING_OM_AGENT:-0}" == "1" ]]; then
   rm -f "$dest/om-agent"
 fi
-cat > "$dest/agent-runtime/package.json" <<'JSON'
-{"dependencies":{"@earendil-works/pi-agent-core":"0.84.2","@earendil-works/pi-ai":"0.84.2","@earendil-works/pi-session-backend-sqlite-node":"0.84.2"}}
+pi_version="${FAKE_PI_PACKAGE_VERSION:-0.84.2}"
+cat > "$dest/agent-runtime/package.json" <<JSON
+{"dependencies":{"@earendil-works/pi-agent-core":"$pi_version","@earendil-works/pi-ai":"$pi_version","@earendil-works/pi-session-backend-sqlite-node":"$pi_version"}}
 JSON
-cat > "$dest/agent-runtime/package-lock.json" <<'JSON'
-{"lockfileVersion":3,"packages":{"":{"dependencies":{"@earendil-works/pi-agent-core":"0.84.2","@earendil-works/pi-ai":"0.84.2","@earendil-works/pi-session-backend-sqlite-node":"0.84.2"}}}}
+cat > "$dest/agent-runtime/package-lock.json" <<JSON
+{"lockfileVersion":3,"packages":{"":{"dependencies":{"@earendil-works/pi-agent-core":"$pi_version","@earendil-works/pi-ai":"$pi_version","@earendil-works/pi-session-backend-sqlite-node":"$pi_version"}}}}
 JSON
 cat > "$dest/scripts/pi_runtime_smoke.sh" <<'SH'
 #!/usr/bin/env bash
@@ -551,6 +553,65 @@ def test_install_script_no_install_cli_skips_wrappers(tmp_path: Path) -> None:
     assert not (tmp_path / "home" / ".local" / "bin" / "om").exists()
     assert "cd " in result.stdout
     assert "./om setup check" in result.stdout
+
+
+def test_first_pi_transition_stages_private_target_without_changing_production(
+    tmp_path: Path,
+) -> None:
+    production = tmp_path / "production"
+    old_release = production / "releases" / "3.5.1"
+    old_runtime = old_release / "agent-runtime"
+    old_runtime.mkdir(parents=True)
+    (old_release / "VERSION").write_text("3.5.1\n", encoding="utf-8")
+    (old_runtime / "package.json").write_text(
+        '{"dependencies":{"@earendil-works/pi-agent-core":"0.84.2"}}\n',
+        encoding="utf-8",
+    )
+    production_link = production / "current"
+    production_link.symlink_to(old_release, target_is_directory=True)
+    production_runtime = tmp_path / "production-runtime"
+    production_runtime.mkdir()
+    runtime_marker = production_runtime / "service.profile.json"
+    runtime_marker.write_text('{"activation":"stopped"}\n', encoding="utf-8")
+    before_link = production_link.resolve()
+    before_runtime = runtime_marker.read_bytes()
+
+    stage = tmp_path / "private-upgrade-control"
+    env = _installer_env(tmp_path)
+    env["FAKE_PI_PACKAGE_VERSION"] = "0.85.1"
+    result = subprocess.run(
+        [
+            "bash",
+            str(ROOT / "scripts" / "install.sh"),
+            "--version",
+            "v9.9.9",
+            "--prefix",
+            str(stage),
+            "--repo-url",
+            "https://example.invalid/options-monitor.git",
+            "--no-install-cli",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert production_link.resolve() == before_link
+    assert runtime_marker.read_bytes() == before_runtime
+    assert json.loads((old_runtime / "package.json").read_text(encoding="utf-8"))[
+        "dependencies"
+    ]["@earendil-works/pi-agent-core"] == "0.84.2"
+    target_control = stage / "releases" / "v9.9.9"
+    assert (stage / "current").resolve() == target_control.resolve()
+    assert json.loads(
+        (target_control / "agent-runtime" / "package.json").read_text(
+            encoding="utf-8"
+        )
+    )["dependencies"]["@earendil-works/pi-agent-core"] == "0.85.1"
+    assert not (tmp_path / "home" / ".local" / "bin" / "om").exists()
+    assert not (tmp_path / "home" / ".local" / "bin" / "om-agent").exists()
 
 
 def test_install_script_refuses_existing_non_om_wrapper_before_installing(tmp_path: Path) -> None:

--- a/tests/test_pi_agent_process.py
+++ b/tests/test_pi_agent_process.py
@@ -37,9 +37,9 @@ CONTINUATION_PROMPT_FOR_TEST = (
 
 def test_pi_runtime_dependencies_are_exactly_pinned():
     expected = {
-        "@earendil-works/pi-agent-core": "0.84.2",
-        "@earendil-works/pi-ai": "0.84.2",
-        "@earendil-works/pi-session-backend-sqlite-node": "0.84.2",
+        "@earendil-works/pi-agent-core": "0.85.1",
+        "@earendil-works/pi-ai": "0.85.1",
+        "@earendil-works/pi-session-backend-sqlite-node": "0.85.1",
     }
     package = json.loads((REPO / "agent-runtime/package.json").read_text(encoding="utf-8"))
     lock = json.loads((REPO / "agent-runtime/package-lock.json").read_text(encoding="utf-8"))
@@ -1772,7 +1772,7 @@ def _run_session(
 def _session_entries(database: Path, session_id: str) -> list[dict]:
     with sqlite3.connect(database) as connection:
         rows = connection.execute(
-            "SELECT seq, id, parent_id, type, payload FROM entries "
+            "SELECT seq, id, parent_id, type, custom_type, payload FROM entries "
             "WHERE session_id = ? ORDER BY seq",
             (session_id,),
         ).fetchall()
@@ -1782,9 +1782,10 @@ def _session_entries(database: Path, session_id: str) -> list[dict]:
             "id": entry_id,
             "parent_id": parent_id,
             "type": type_,
+            "custom_type": custom_type,
             "payload": json.loads(payload),
         }
-        for seq, entry_id, parent_id, type_, payload in rows
+        for seq, entry_id, parent_id, type_, custom_type, payload in rows
     ]
 
 
@@ -1855,15 +1856,21 @@ def _write_child_record(process, identity, seq, type_, payload):
 def _start_node_until_proposed(database, payload, run_id):
     command, entry = _runtime_command(None, None)
     identity = {"request_id": f"req_{run_id}", "run_id": run_id}
-    process = subprocess.Popen(
-        command,
-        cwd=entry.parent.parent,
-        env=_session_env(database),
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        bufsize=0,
-    )
+    session_id = payload["session_id"]
+    assert session_id is not None
+    with pi_process.pi_session_locks(database, session_id) as (canonical, lock_fds):
+        environ = _session_env(canonical)
+        environ["OM_PI_LOCK_FDS"] = json.dumps(lock_fds)
+        process = subprocess.Popen(
+            command,
+            cwd=entry.parent.parent,
+            env=environ,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            pass_fds=lock_fds,
+            bufsize=0,
+        )
     _write_child_record(process, identity, 1, "run.start", payload)
     buffer = bytearray()
     next_seq = 2
@@ -1894,25 +1901,6 @@ def _start_node_until_proposed(database, payload, run_id):
         process.kill()
         process.wait(timeout=2)
         raise
-
-
-def _expire_writer_lease(database: Path, session_id: str) -> None:
-    now_ms = int(time.time() * 1000)
-    with sqlite3.connect(database) as connection:
-        row = connection.execute(
-            "SELECT expires_at_ms FROM writer_leases WHERE session_id = ?",
-            (session_id,),
-        ).fetchone()
-        assert row is not None
-        assert row[0] > now_ms
-        updated = connection.execute(
-            "UPDATE writer_leases SET expires_at_ms = ? WHERE session_id = ?",
-            (now_ms - 1, session_id),
-        ).rowcount
-        connection.commit()
-    assert updated == 1
-
-
 def _wait_for_tool_slot(expected: bool, timeout: float = 2.0) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -2044,7 +2032,7 @@ const rec = (type, seq, payload) =>
     seq, payload,
   }) + "\\n");
 rl.once("line", () => {
-  rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+  rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.85.1", session_id: null });
 """
         + records
         + "\n});\n"
@@ -2069,7 +2057,7 @@ let n = 0;
 rl.on("line", (line) => {{
   n += 1;
   if (n === 1) {{
-    rec("run.accepted", 1, {{ runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null }});
+    rec("run.accepted", 1, {{ runtime: "pi-agent-core", runtime_version: "0.85.1", session_id: null }});
     scripted.forEach((record, index) => rec(record.type, index + 2, record.payload));
   }} else if (n === 2 && finalPayload !== null) {{
     const committed = JSON.parse(line).type === "run.commit";
@@ -2092,7 +2080,7 @@ let n = 0;
 rl.on("line", (line) => {
   n += 1;
   if (n === 1) {
-    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.85.1", session_id: null });
     rec("agent.event", 2, { event_type: "agent_start", data: {} });
     rec("agent.event", 3, { event_type: "turn_start", data: {} });
     rec("agent.event", 4, { event_type: "model_turn_completed", data: { stop_reason: "stop", attempt_count: 0, model_retry_count: 0, usage: { input: 1, output: 1, totalTokens: 2 }, usage_total: { input: 1, output: 1, totalTokens: 2 } } });
@@ -2187,7 +2175,7 @@ def test_malformed_child_fails_protocol(tmp_path):
 def test_mismatched_run_id_fails_closed(tmp_path):
     entry = _write_fake(
         tmp_path,
-        'process.stdout.write(JSON.stringify({protocol:"om-pi-ipc.v1",type:"run.accepted",request_id:"req_1",run_id:"OTHER",seq:1,payload:{runtime:"pi-agent-core",runtime_version:"0.84.2",session_id:null}})+"\\n");\n',
+        'process.stdout.write(JSON.stringify({protocol:"om-pi-ipc.v1",type:"run.accepted",request_id:"req_1",run_id:"OTHER",seq:1,payload:{runtime:"pi-agent-core",runtime_version:"0.85.1",session_id:null}})+"\\n");\n',
     )
     result = run_pi_agent(
         _start_payload(),
@@ -2237,7 +2225,7 @@ def test_accepted_then_nonzero_exit(tmp_path):
     child = (
         'process.stdout.write(JSON.stringify({protocol:"om-pi-ipc.v1",type:"run.accepted",'
         'request_id:"req_1",run_id:"run_1",seq:1,payload:{runtime:"pi-agent-core",'
-        'runtime_version:"0.84.2",session_id:null}})+"\\n", () => process.exit(2));\n'
+        'runtime_version:"0.85.1",session_id:null}})+"\\n", () => process.exit(2));\n'
     )
     entry = _write_fake(tmp_path, child)
     result = run_pi_agent(
@@ -2619,7 +2607,7 @@ let n = 0;
 rl.on("line", (line) => {
   n += 1;
   if (n === 1) {
-    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.85.1", session_id: null });
     rec("agent.event", 2, { event_type: "agent_start", data: {} });
     rec("agent.event", 3, { event_type: "turn_start", data: {} });
     rec("agent.event", 4, { event_type: "model_turn_completed", data: { stop_reason: "stop", attempt_count: 0, model_retry_count: 0, usage: {}, usage_total: {} } });
@@ -2667,7 +2655,7 @@ const rec = (type, seq, payload) =>
     seq, payload,
   }) + "\\n");
 rl.once("line", () => {
-  rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+  rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.85.1", session_id: null });
   const proposal = { status: "answered", text: "hello", control_request: null, termination_reason: "stop", usage: {} };
   rec("run.proposed", 2, proposal);
   rec("run.proposed", 3, proposal);
@@ -2996,7 +2984,7 @@ let n = 0;
 rl.on("line", (line) => {
   n += 1;
   if (n === 1) {
-    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.84.2", session_id: null });
+    rec("run.accepted", 1, { runtime: "pi-agent-core", runtime_version: "0.85.1", session_id: null });
     rec("agent.event", 2, { event_type: "agent_start", data: {} });
     rec("agent.event", 3, { event_type: "turn_start", data: {} });
     rec("agent.event", 4, { event_type: "model_turn_completed", data: { stop_reason: "stop", attempt_count: 0, model_retry_count: 0, usage: {}, usage_total: {} } });
@@ -3784,6 +3772,7 @@ def test_transient_eval_run_does_not_create_session_database(tmp_path):
 
     assert result["ok"] is True
     assert database.exists() is False
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_only_admitted_turn_messages_are_persisted(tmp_path):
@@ -3893,60 +3882,103 @@ def _seed_compactable_history(
     }
 
 
-def test_killed_partial_turns_rewind_and_writer_lease_expires(tmp_path):
-    cases = []
-    for appended_messages in range(1, 5):
-        database = tmp_path / f"partial_{appended_messages}.sqlite3"
-        session_id = derive_pi_session_id(
-            "feishu", f"sender-{appended_messages}", "group-1", "key:us"
-        )
-        baseline_question = f"baseline-question-{appended_messages}"
-        baseline_answer = f"baseline-answer-{appended_messages}"
-        assert _run_session(
-            database,
-            session_id,
-            _start_payload(
-                session_id=session_id,
-                user_message=baseline_question,
-                debug={"fixture_response": baseline_answer, "delay_ms": 0},
-            ),
-            run_id=f"baseline_{appended_messages}",
-        )["ok"]
-        baseline = _session_entries(database, session_id)
-        baseline_marker = baseline[-1]["id"]
-        partial_question = f"partial-question-{appended_messages}"
-        partial_answer = f"partial-answer-{appended_messages}"
-        payload = _tool_payload(
-            [_tool_turn(arguments={"index": appended_messages}), {"text": partial_answer}],
-            session_id=session_id,
-            user_message=partial_question,
-        )
-        payload["debug"]["persist_delay_ms"] = 750
-        process, identity, seq = _start_node_until_proposed(
-            database, payload, f"partial_{appended_messages}"
-        )
-        _write_child_record(process, identity, seq, "run.commit", {})
+def test_failed_marker_insert_rolls_back_whole_admitted_turn(tmp_path):
+    database = tmp_path / "atomic_failure.sqlite3"
+    session_id = derive_pi_session_id("feishu", "atomic-failure", "group", "key:us")
+    assert _run_session(database, session_id, _start_payload(session_id=session_id),
+                        run_id="baseline")["ok"]
+    before = _session_entries(database, session_id)
 
-        target = len(baseline) + appended_messages
-        deadline = time.monotonic() + 10
-        while len(_session_entries(database, session_id)) < target:
-            if time.monotonic() >= deadline:
-                process.kill()
-                raise AssertionError(f"append point {appended_messages} was not reached")
-            time.sleep(0.02)
-        process.kill()
-        process.wait(timeout=2)
-        cases.append(
-            (
-                database,
-                session_id,
-                baseline_marker,
-                baseline_question,
-                baseline_answer,
-                partial_question,
-                partial_answer,
-            )
-        )
+    def fail_commit_after_messages(_proposal):
+        with sqlite3.connect(database) as connection:
+            connection.execute("""
+                CREATE TRIGGER fail_turn_marker BEFORE INSERT ON entries
+                WHEN NEW.custom_type = 'om.turn.commit.v1'
+                BEGIN SELECT RAISE(ABORT, 'injected marker failure'); END
+            """)
+        return "commit"
+
+    payload = _start_payload(session_id=session_id, user_message="failed-atomic-turn")
+    failed = run_pi_agent(
+        payload, request_id="atomic", run_id="failed_commit", timeout_seconds=60,
+        on_proposed=fail_commit_after_messages, environ=_session_env(database),
+    )
+    assert failed["ok"] is False
+    assert failed["error"]["code"] == "SESSION_ERROR"
+    assert _session_entries(database, session_id) == before
+    with sqlite3.connect(database) as connection:
+        connection.execute("DROP TRIGGER fail_turn_marker")
+    recovered = _run_session(database, session_id, payload, run_id="failed_commit")
+    assert recovered["ok"] is True, recovered
+    after = _session_entries(database, session_id)
+    assert after[:len(before)] == before
+    assert after[len(before)]["parent_id"] == before[-1]["id"]
+    assert sum(entry["type"] == "custom" and entry["payload"]["data"]["run_id"] == "failed_commit"
+               for entry in after) == 1
+
+
+def test_killed_turn_commit_is_atomic_and_compaction_checkpoint_survives(tmp_path):
+    database = tmp_path / "atomic_turn.sqlite3"
+    session_id = derive_pi_session_id(
+        "feishu", "atomic-turn", "group-1", "key:us"
+    )
+    baseline_question = "baseline-question"
+    baseline_answer = "baseline-answer"
+    assert _run_session(
+        database,
+        session_id,
+        _start_payload(
+            session_id=session_id,
+            user_message=baseline_question,
+            debug={"fixture_response": baseline_answer, "delay_ms": 0},
+        ),
+        run_id="atomic_baseline",
+    )["ok"]
+    baseline = _session_entries(database, session_id)
+    baseline_marker = baseline[-1]["id"]
+    crash_question = "atomic-crash-question"
+    crash_answer = "atomic-crash-answer"
+    payload = _tool_payload(
+        [_tool_turn(arguments={"index": 1}), {"text": crash_answer}],
+        session_id=session_id,
+        user_message=crash_question,
+    )
+    payload["debug"]["persist_delay_ms"] = 1_500
+    process, identity, seq = _start_node_until_proposed(
+        database, payload, "atomic_crash"
+    )
+    _write_child_record(process, identity, seq, "run.commit", {})
+    time.sleep(0.2)
+
+    assert process.poll() is None
+    assert _session_entries(database, session_id) == baseline
+    process.kill()
+    process.wait(timeout=2)
+    assert _session_entries(database, session_id) == baseline
+
+    recovered_question = "recovery-after-atomic-crash"
+    recovered = _run_session(
+        database,
+        session_id,
+        _start_payload(
+            session_id=session_id,
+            user_message=recovered_question,
+            debug={
+                "fixture_response": "recovered-answer",
+                "delay_ms": 0,
+                "expected_history": [baseline_question, baseline_answer],
+                "forbidden_history": [crash_question, crash_answer],
+            },
+        ),
+        run_id="atomic_recovered",
+    )
+    assert recovered["ok"] is True, recovered
+    recovered_entry = next(
+        entry
+        for entry in _session_entries(database, session_id)
+        if recovered_question in json.dumps(entry["payload"], ensure_ascii=False)
+    )
+    assert recovered_entry["parent_id"] == baseline_marker
 
     compact_database = tmp_path / "compaction_crash.sqlite3"
     compact_session = derive_pi_session_id(
@@ -3956,10 +3988,10 @@ def test_killed_partial_turns_rewind_and_writer_lease_expires(tmp_path):
         compact_database, compact_session, label="compact_crash"
     )
     compact_before = _session_entries(compact_database, compact_session)
-    crash_question = "crashed-after-compaction"
+    compact_crash_question = "crashed-after-compaction"
     crash_payload = _start_payload(
         session_id=compact_session,
-        user_message=crash_question,
+        user_message=compact_crash_question,
         model={
             **_start_payload()["model"],
             "context_window_tokens": 8_000,
@@ -3981,62 +4013,7 @@ def test_killed_partial_turns_rewind_and_writer_lease_expires(tmp_path):
         "compaction",
         "custom",
     ]
-    assert crash_question not in json.dumps(compact_after, ensure_ascii=False)
-    busy = _run_session(
-        compact_database,
-        compact_session,
-        _start_payload(
-            session_id=compact_session,
-            debug={"fixture_response": "busy", "delay_ms": 0},
-        ),
-        run_id="busy_before_ttl",
-    )
-    assert busy == {
-        "ok": False,
-        "error": {
-            "code": "SESSION_ERROR",
-            "stage": "session",
-            "message": "session is temporarily busy",
-            "retryable": True,
-        },
-    }
-
-    for database, session_id, *_ in cases:
-        _expire_writer_lease(database, session_id)
-    _expire_writer_lease(compact_database, compact_session)
-
-    for (
-        database,
-        session_id,
-        baseline_marker,
-        baseline_question,
-        baseline_answer,
-        partial_question,
-        partial_answer,
-    ) in cases:
-        recovered_question = f"recovery-question-{session_id[-4:]}"
-        recovered = _run_session(
-            database,
-            session_id,
-            _start_payload(
-                session_id=session_id,
-                user_message=recovered_question,
-                debug={
-                    "fixture_response": "recovered-answer",
-                    "delay_ms": 0,
-                    "expected_history": [baseline_question, baseline_answer],
-                    "forbidden_history": [partial_question, partial_answer],
-                },
-            ),
-            run_id=f"recovered_{session_id[-4:]}",
-        )
-        assert recovered["ok"] is True, recovered
-        recovered_entry = next(
-            entry
-            for entry in _session_entries(database, session_id)
-            if recovered_question in json.dumps(entry["payload"], ensure_ascii=False)
-        )
-        assert recovered_entry["parent_id"] == baseline_marker
+    assert compact_crash_question not in json.dumps(compact_after, ensure_ascii=False)
 
     compact_recovered = _run_session(
         compact_database,
@@ -4059,7 +4036,7 @@ def test_killed_partial_turns_rewind_and_writer_lease_expires(tmp_path):
                 "forbidden_history": [
                     compact_history["summarized_question"],
                     compact_history["summarized_answer"],
-                    crash_question,
+                    compact_crash_question,
                 ],
             },
         ),
@@ -4210,7 +4187,7 @@ def test_compaction_persists_pi_payload_and_complete_tool_turn(tmp_path):
         "custom",
     }
     assert all(
-        entry["payload"]["customType"] == "om.turn.commit.v1"
+        entry["custom_type"] == "om.turn.commit.v1"
         for entry in _session_entries(database, session_id)
         if entry["type"] == "custom"
     )
@@ -4654,8 +4631,9 @@ def test_session_storage_errors_are_safe(tmp_path):
     )["ok"]
     with sqlite3.connect(metadata_database) as connection:
         connection.execute(
-            "UPDATE sessions SET metadata = ? WHERE id = ?",
-            (json.dumps({"schema": "unknown"}), session_id),
+            "UPDATE scalar_values SET value = ? WHERE session_id = ? "
+            "AND namespace = 'om.pi' AND key = 'session-format'",
+            (json.dumps("unknown"), session_id),
         )
     metadata = _run_session(
         metadata_database,

--- a/tests/test_pi_runtime_0851.py
+++ b/tests/test_pi_runtime_0851.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
 from pathlib import Path
 
 from src.infrastructure.pi_agent_process import _runtime_command, derive_pi_session_id
@@ -198,12 +199,14 @@ def test_dangling_main_tip_fails_closed_without_rewind(tmp_path):
         run_id="dangling_seed",
     )
     assert seeded["ok"] is True
-    with sqlite3.connect(database) as connection:
+    with closing(sqlite3.connect(database)) as connection:
         connection.execute(
             "UPDATE scalar_values SET value = ? "
             "WHERE session_id = ? AND namespace = 'pi.branch.tip' AND key = 'main'",
             (json.dumps("missing-entry-id"), session_id),
         )
+        connection.commit()
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     before = database.read_bytes()
 
     rejected = _run_session(

--- a/tests/test_pi_runtime_0851.py
+++ b/tests/test_pi_runtime_0851.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from src.infrastructure.pi_agent_process import _runtime_command, derive_pi_session_id
+from test_pi_agent_process import (
+    _run_session,
+    _seed_compactable_history,
+    _session_entries,
+    _start_payload,
+    _tool_payload,
+    _tool_turn,
+)
+
+
+REPO = Path(__file__).resolve().parents[1]
+RUNTIME = REPO / "agent-runtime"
+
+
+def _node_eval(source: str, *arguments: str) -> dict:
+    command, _ = _runtime_command(None, None)
+    completed = subprocess.run(
+        [command[0], "--no-warnings", "--input-type=module", "--eval", source, *arguments],
+        cwd=RUNTIME,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+def _create_empty_target_session(database: Path, session_id: str) -> None:
+    result = _node_eval(
+        """
+        import path from "node:path";
+        import { TODO_CONTEXT } from "@earendil-works/pi-agent-core";
+        import {
+          SqliteSessionRepo, createNodeSqliteFactory,
+        } from "@earendil-works/pi-session-backend-sqlite-node";
+        const [database, sessionId] = process.argv.slice(1);
+        const repo = new SqliteSessionRepo({
+          directory: path.dirname(database), databasePath: database,
+          databaseFactory: createNodeSqliteFactory(),
+        });
+        await repo.create({ id: sessionId }, TODO_CONTEXT);
+        await repo.close(TODO_CONTEXT);
+        process.stdout.write(JSON.stringify({ ok: true }));
+        """,
+        str(database),
+        session_id,
+    )
+    assert result == {"ok": True}
+
+
+def _receipt(database: Path, phase: str = "published", target_version: str = "0.85.1") -> dict:
+    def runtime_identity(version: str, fill: str) -> dict:
+        return {
+            "ok": True,
+            "version": version,
+            "lockSha256": fill * 64,
+            "packages": {
+                name: {
+                    "version": version,
+                    "manifestSha256": fill * 64,
+                    "entrySha256": fill * 64,
+                }
+                for name in (
+                    "@earendil-works/pi-agent-core",
+                    "@earendil-works/pi-ai",
+                    "@earendil-works/pi-session-backend-sqlite-node",
+                )
+            },
+        }
+
+    digest = hashlib.sha256(database.read_bytes()).hexdigest()
+    receipt = {
+        "version": "om-pi-migration.v1",
+        "database": str(database.resolve()),
+        "phase": phase,
+        "rollbackRequired": True,
+        "source": {
+            "runtimePath": str(RUNTIME.resolve()),
+            "runtime": runtime_identity("0.84.2", "4"),
+            "database": {"sha256": "1" * 64, "format": "legacy"},
+        },
+        "target": {
+            "runtimePath": str(RUNTIME.resolve()),
+            "runtime": runtime_identity(target_version, "5"),
+            "database": {"sha256": digest, "format": "target"},
+        },
+        "backup": {
+            "path": str(database.resolve()) + ".om-pi-recovery-0.84.2-to-0.85.1-" + "a" * 32 + ".sqlite3",
+            "sha256": "2" * 64,
+        },
+    }
+    if phase == "published":
+        receipt["readback"] = {"equivalent": True, "contextSha256": "3" * 64}
+        receipt["published"] = {"databaseSha256": digest}
+    return receipt
+
+
+def _write_receipt(database: Path, receipt: dict) -> Path:
+    target = Path(str(database) + ".om-pi-migration.json")
+    target.write_text(json.dumps(receipt), encoding="utf-8")
+    target.chmod(0o600)
+    return target
+
+
+def test_empty_public_session_initialization_recovers_without_disturbing_peer(tmp_path):
+    database = tmp_path / "sessions.sqlite3"
+    peer = derive_pi_session_id("feishu", "peer", "group", "key:us")
+    recovering = derive_pi_session_id("feishu", "recover", "group", "key:us")
+    peer_result = _run_session(
+        database,
+        peer,
+        _start_payload(
+            session_id=peer,
+            user_message="peer-history",
+            debug={"fixture_response": "peer-answer", "delay_ms": 0},
+        ),
+        run_id="peer_seed",
+    )
+    assert peer_result["ok"] is True
+    peer_entries = _session_entries(database, peer)
+    _create_empty_target_session(database, recovering)
+
+    recovered = _run_session(
+        database,
+        recovering,
+        _start_payload(
+            session_id=recovering,
+            user_message="recovered-history",
+            debug={"fixture_response": "recovered-answer", "delay_ms": 0},
+        ),
+        run_id="empty_recovery",
+    )
+
+    assert recovered["ok"] is True, recovered
+    assert _session_entries(database, peer) == peer_entries
+    with sqlite3.connect(database) as connection:
+        values = dict(
+            connection.execute(
+                "SELECT namespace || ':' || key, value FROM scalar_values "
+                "WHERE session_id = ?",
+                (recovering,),
+            )
+        )
+    assert json.loads(values["om.pi:session-format"]) == "om-pi-session.v1"
+    assert json.loads(values["pi.branch.tip:main"]) == _session_entries(database, recovering)[-1]["id"]
+
+
+def test_exact_schema_probe_rejects_altered_constraint_without_writing_database(tmp_path):
+    database = tmp_path / "hostile.sqlite3"
+    session_id = derive_pi_session_id("feishu", "schema", "group", "key:us")
+    seeded = _run_session(
+        database,
+        session_id,
+        _start_payload(session_id=session_id, debug={"fixture_response": "seed", "delay_ms": 0}),
+        run_id="schema_seed",
+    )
+    assert seeded["ok"] is True
+    with sqlite3.connect(database) as connection:
+        connection.execute("DROP TRIGGER trg_entries_validate")
+        connection.execute(
+            "CREATE TRIGGER trg_entries_validate BEFORE INSERT ON entries BEGIN SELECT 1; END"
+        )
+    before = database.read_bytes()
+    entries = _session_entries(database, session_id)
+
+    rejected = _run_session(
+        database,
+        session_id,
+        _start_payload(session_id=session_id, debug={"fixture_response": "must-not-run", "delay_ms": 0}),
+        run_id="schema_rejected",
+    )
+
+    assert rejected["ok"] is False
+    assert rejected["error"]["code"] == "SESSION_ERROR"
+    assert database.read_bytes() == before
+    assert _session_entries(database, session_id) == entries
+
+
+def test_dangling_main_tip_fails_closed_without_rewind(tmp_path):
+    database = tmp_path / "dangling.sqlite3"
+    session_id = derive_pi_session_id("feishu", "dangling", "group", "key:us")
+    seeded = _run_session(
+        database,
+        session_id,
+        _start_payload(session_id=session_id, debug={"fixture_response": "seed", "delay_ms": 0}),
+        run_id="dangling_seed",
+    )
+    assert seeded["ok"] is True
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE scalar_values SET value = ? "
+            "WHERE session_id = ? AND namespace = 'pi.branch.tip' AND key = 'main'",
+            (json.dumps("missing-entry-id"), session_id),
+        )
+    before = database.read_bytes()
+
+    rejected = _run_session(
+        database,
+        session_id,
+        _start_payload(session_id=session_id, debug={"fixture_response": "must-not-run", "delay_ms": 0}),
+        run_id="dangling_rejected",
+    )
+
+    assert rejected["ok"] is False
+    assert rejected["error"]["code"] == "SESSION_ERROR"
+    assert database.read_bytes() == before
+    with sqlite3.connect(database) as connection:
+        stored = connection.execute(
+            "SELECT value FROM scalar_values WHERE session_id = ? "
+            "AND namespace = 'pi.branch.tip' AND key = 'main'",
+            (session_id,),
+        ).fetchone()
+    assert stored is not None and json.loads(stored[0]) == "missing-entry-id"
+
+
+def test_uncommitted_public_tail_rewinds_before_next_admitted_turn(tmp_path):
+    database = tmp_path / "tail.sqlite3"
+    session_id = derive_pi_session_id("feishu", "tail", "group", "key:us")
+    assert _run_session(
+        database, session_id,
+        _start_payload(session_id=session_id, user_message="committed question",
+                       debug={"fixture_response": "committed answer", "delay_ms": 0}),
+        run_id="tail_baseline",
+    )["ok"] is True
+    baseline = _session_entries(database, session_id)
+    _node_eval(
+        """
+        import { TODO_CONTEXT, branchTip, insertEntry, setValue } from "@earendil-works/pi-agent-core";
+        import { openTargetSession } from "./pi_session_adapter.ts";
+        const [database, sessionId] = process.argv.slice(1);
+        const opened = await openTargetSession(database, sessionId);
+        await opened.session.mutate(async (mutator, context) => {
+          const parent = await mutator.getValue(branchTip("main"), context);
+          await mutator.commit([
+            insertEntry({id: "orphan_tail", parentId: parent.value, type: "message",
+              message: {role: "user", content: "uncommitted question", timestamp: 1000}}),
+            setValue(branchTip("main"), "orphan_tail"),
+          ], context);
+        }, TODO_CONTEXT);
+        await opened.repository.close(TODO_CONTEXT);
+        process.stdout.write(JSON.stringify({ok: true}));
+        """,
+        str(database), session_id,
+    )
+    recovered = _run_session(
+        database, session_id,
+        _start_payload(session_id=session_id, user_message="next question", debug={
+            "fixture_response": "next answer", "delay_ms": 0,
+            "expected_history": ["committed question", "committed answer"],
+            "forbidden_history": ["uncommitted question"],
+        }), run_id="tail_recovery",
+    )
+    assert recovered["ok"] is True, recovered
+    entries = _session_entries(database, session_id)
+    assert entries[:len(baseline)] == baseline
+    assert entries[len(baseline)]["id"] == "orphan_tail"
+    assert entries[len(baseline) + 1]["parent_id"] == baseline[-1]["id"]
+    assert entries[-1]["payload"]["data"]["run_id"] == "tail_recovery"
+
+
+def test_unresolved_and_invalid_migration_receipts_block_before_session_write(tmp_path):
+    database = tmp_path / "receipted.sqlite3"
+    session_id = derive_pi_session_id("feishu", "receipt", "group", "key:us")
+    seeded = _run_session(
+        database,
+        session_id,
+        _start_payload(session_id=session_id, debug={"fixture_response": "seed", "delay_ms": 0}),
+        run_id="receipt_seed",
+    )
+    assert seeded["ok"] is True
+    before = database.read_bytes()
+    entries = _session_entries(database, session_id)
+    receipt_path = _write_receipt(database, _receipt(database, phase="validated"))
+
+    unresolved = _run_session(
+        database,
+        session_id,
+        _start_payload(session_id=session_id, debug={"fixture_response": "blocked", "delay_ms": 0}),
+        run_id="receipt_unresolved",
+    )
+    assert unresolved["ok"] is False
+    assert unresolved["error"]["code"] == "SESSION_ERROR"
+    assert database.read_bytes() == before
+    assert _session_entries(database, session_id) == entries
+
+    invalid_receipts = [
+        _receipt(database, target_version="0.84.2"),
+        _receipt(database),
+        _receipt(database),
+        _receipt(database),
+    ]
+    del invalid_receipts[1]["target"]["runtime"]["lockSha256"]
+    invalid_receipts[2]["source"]["runtime"]["version"] = "0.85.1"
+    invalid_receipts[3]["backup"]["path"] = str(database.resolve()) + ".om-pi-recovery.sqlite3"
+    for index, invalid_receipt in enumerate(invalid_receipts):
+        _write_receipt(database, invalid_receipt)
+        invalid = _run_session(
+            database,
+            session_id,
+            _start_payload(session_id=session_id, debug={"fixture_response": "blocked", "delay_ms": 0}),
+            run_id=f"receipt_invalid_{index}",
+        )
+        assert invalid["ok"] is False
+        assert invalid["error"]["code"] == "SESSION_ERROR"
+        assert database.read_bytes() == before
+        assert _session_entries(database, session_id) == entries
+    assert receipt_path.exists()
+
+
+def test_valid_published_receipt_allows_target_history_to_advance(tmp_path):
+    database = tmp_path / "published.sqlite3"
+    session_id = derive_pi_session_id("feishu", "published", "group", "key:us")
+    seeded = _run_session(
+        database,
+        session_id,
+        _start_payload(session_id=session_id, debug={"fixture_response": "seed", "delay_ms": 0}),
+        run_id="published_seed",
+    )
+    assert seeded["ok"] is True
+    _write_receipt(database, _receipt(database))
+
+    for index in range(2):
+        advanced = _run_session(
+            database,
+            session_id,
+            _start_payload(
+                session_id=session_id,
+                user_message=f"published-question-{index}",
+                debug={"fixture_response": f"published-answer-{index}", "delay_ms": 0},
+            ),
+            run_id=f"published_advance_{index}",
+        )
+        assert advanced["ok"] is True, advanced
+    persisted = json.dumps(_session_entries(database, session_id), ensure_ascii=False)
+    assert "published-question-0" in persisted
+    assert "published-question-1" in persisted
+
+
+def test_distinct_sessions_concurrently_bootstrap_shared_database(tmp_path):
+    database = tmp_path / "concurrent.sqlite3"
+    session_ids = [
+        derive_pi_session_id("feishu", f"concurrent-{index}", "group", "key:us")
+        for index in range(2)
+    ]
+
+    def run(index: int) -> dict:
+        return _run_session(
+            database,
+            session_ids[index],
+            _start_payload(
+                session_id=session_ids[index],
+                user_message=f"concurrent-question-{index}",
+                debug={"fixture_response": f"concurrent-answer-{index}", "delay_ms": 100},
+            ),
+            run_id=f"concurrent_{index}",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(run, range(2)))
+
+    assert all(result["ok"] is True for result in results), results
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sessions").fetchone() == (2,)
+    for index, session_id in enumerate(session_ids):
+        persisted = json.dumps(_session_entries(database, session_id), ensure_ascii=False)
+        assert f"concurrent-question-{index}" in persisted
+        assert f"concurrent-answer-{index}" in persisted
+
+
+def test_one_run_can_commit_initial_and_mid_turn_compactions(tmp_path):
+    database = tmp_path / "same_run_compactions.sqlite3"
+    session_id = derive_pi_session_id("feishu", "same-run", "group", "key:us")
+    _seed_compactable_history(database, session_id, label="same_run")
+    payload = _tool_payload(
+        [_tool_turn(arguments={"index": 1}), {"text": "finished"}],
+        session_id=session_id,
+        user_message="current question",
+        model={**_start_payload()["model"], "context_window_tokens": 8_000},
+    )
+    payload["debug"]["compaction_response"] = "same-run-summary"
+
+    result = _run_session(
+        database,
+        session_id,
+        payload,
+        run_id="same_run_compactions",
+        on_tool_call=lambda _call: {"ok": True, "value": "x" * 4_500},
+    )
+
+    assert result["ok"] is True, result
+    markers = [
+        entry["payload"]["data"]
+        for entry in _session_entries(database, session_id)
+        if entry["type"] == "custom"
+        and entry["payload"]["data"]["run_id"] == "same_run_compactions"
+    ]
+    assert [marker["kind"] for marker in markers] == ["compaction", "compaction", "turn"]
+
+
+def test_ambiguous_atomic_commit_readback_deduplicates_matching_run(tmp_path):
+    database = tmp_path / "ambiguous.sqlite3"
+    session_id = derive_pi_session_id("feishu", "ambiguous", "group", "key:us")
+    result = _node_eval(
+        """
+        import {
+          appendCommittedCompaction, appendCommittedTurn, exportCommittedMain, openTargetSession,
+        } from "./pi_session_adapter.ts";
+        const [database, sessionId] = process.argv.slice(1);
+        const opened = await openTargetSession(database, sessionId);
+        const originalMutate = opened.session.mutate.bind(opened.session);
+        let injectAmbiguousReturn = true;
+        opened.session.mutate = async (...args) => {
+          const result = await originalMutate(...args);
+          if (injectAmbiguousReturn) {
+            injectAmbiguousReturn = false;
+            throw new Error("injected ambiguous return after durable commit");
+          }
+          return result;
+        };
+        const messages = [
+          { role: "user", content: [{ type: "text", text: "ambiguous-question" }], timestamp: 1000 },
+          {
+            role: "assistant", content: [{ type: "text", text: "ambiguous-answer" }],
+            api: "openai-completions", provider: "fixture", model: "fixture",
+            usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+            stopReason: "stop", timestamp: 1001,
+          },
+        ];
+        await appendCommittedTurn(opened.session, messages, "ambiguous-run");
+        await appendCommittedTurn(opened.session, messages, "ambiguous-run");
+        const compactionParent = (await exportCommittedMain(opened.session)).at(-1)?.id ?? null;
+        const compaction = {
+          summary: "ambiguous-summary", retainedTail: messages, tokensBefore: 17,
+          details: { z: 2, a: 1 }, usage: messages[1].usage,
+        };
+        injectAmbiguousReturn = true;
+        await appendCommittedCompaction(
+          opened.session, compaction, "ambiguous-compaction", compactionParent,
+        );
+        await appendCommittedCompaction(opened.session, {
+          usage: messages[1].usage, details: { a: 1, z: 2 }, tokensBefore: 17,
+          retainedTail: messages, summary: "ambiguous-summary",
+        }, "ambiguous-compaction", compactionParent);
+        let mismatchRejected = false;
+        try {
+          await appendCommittedCompaction(opened.session, {
+            ...compaction, summary: "different-summary",
+          }, "ambiguous-compaction", compactionParent);
+        } catch {
+          mismatchRejected = true;
+        }
+        const entries = await exportCommittedMain(opened.session);
+        await opened.repository.close((await import("@earendil-works/pi-agent-core")).TODO_CONTEXT);
+        process.stdout.write(JSON.stringify({
+          entryTypes: entries.map((entry) => entry.type),
+          runs: entries.filter((entry) => entry.type === "custom").map((entry) => entry.data.run_id),
+          mismatchRejected,
+        }));
+        """,
+        str(database),
+        session_id,
+    )
+
+    assert result == {
+        "entryTypes": ["message", "message", "custom", "compaction", "custom"],
+        "runs": ["ambiguous-run", "ambiguous-compaction"],
+        "mismatchRejected": True,
+    }
+    assert len(_session_entries(database, session_id)) == 5

--- a/tests/test_pi_session_locks.py
+++ b/tests/test_pi_session_locks.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from src.infrastructure.pi_agent_process import derive_pi_local_session_id, pi_session_locks, run_pi_agent
+from test_pi_agent_process import _start_payload
+
+REPO = Path(__file__).resolve().parents[1]
+SESSION = derive_pi_local_session_id('key:us', 'lock-test')
+
+
+def test_offline_bridge_uses_public_resolver_and_excludes_provider_credentials(monkeypatch, tmp_path):
+    import src.infrastructure.pi_agent_process as module
+
+    monkeypatch.setenv("OM_PI_MODEL_API_KEY", "must-not-reach-offline-converter")
+    monkeypatch.setenv("NODE_OPTIONS", "--import=unapproved-loader")
+    calls = []
+
+    def run(argv, **kwargs):
+        if argv[1:] == ["--version"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="v22.19.0\n")
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0, stdout='{"ok":true,"version":"0.85.1"}')
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+    result = module.run_pi_migration_bridge("identity", tmp_path / "selected runtime", {})
+    assert result["version"] == "0.85.1"
+    argv, options = calls[0]
+    assert "--experimental-import-meta-resolve" in argv
+    assert argv[-3:] == ["identity", "--runtime", str(tmp_path / "selected runtime")]
+    assert options["env"] == {"PATH": os.environ["PATH"]}
+    monkeypatch.setattr(module.subprocess, "run", lambda argv, **kwargs: subprocess.CompletedProcess(
+        argv, 0, stdout="v22.19.0\n" if argv[1:] == ["--version"] else '{"ok":false}'
+    ))
+    with pytest.raises(ValueError, match="bridge failed"):
+        module.run_pi_migration_bridge("probe", tmp_path, {"database": tmp_path / "sessions.sqlite3"})
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_independent_runs_contend_but_distinct_sessions_can_run(tmp_path):
+    database = tmp_path / 'sessions.sqlite3'
+    with pi_session_locks(database, SESSION):
+        with pytest.raises(BlockingIOError):
+            with pi_session_locks(database, SESSION):
+                pytest.fail('same-process lock became reentrant')
+        with pytest.raises(BlockingIOError):
+            with pi_session_locks(database):
+                pytest.fail('converter entered an active database')
+        with pi_session_locks(database, derive_pi_local_session_id('key:hk', 'lock-test')):
+            pass
+    with pi_session_locks(database):
+        with pytest.raises(BlockingIOError):
+            with pi_session_locks(database, SESSION):
+                pytest.fail('writer entered a conversion')
+    assert not database.exists()
+
+
+def test_aliases_share_lock_identity_and_final_symlinks_are_rejected(tmp_path):
+    actual = tmp_path / 'actual'
+    actual.mkdir()
+    alias = tmp_path / 'alias'
+    alias.symlink_to(actual, target_is_directory=True)
+    database = actual / 'private' / 'sessions.sqlite3'
+    with pi_session_locks(database, SESSION):
+        with pytest.raises(BlockingIOError):
+            with pi_session_locks(alias / 'private' / database.name, SESSION):
+                pytest.fail('alias bypassed lock')
+    target = actual / 'private' / 'target.sqlite3'
+    target.touch()
+    database.symlink_to(target)
+    with pytest.raises(OSError):
+        with pi_session_locks(database, SESSION):
+            pytest.fail('database symlink was accepted')
+    database.unlink()
+    os.link(target, database)
+    with pytest.raises(OSError, match='hard-link'):
+        with pi_session_locks(database, SESSION):
+            pytest.fail('hard-link alias could bypass database lock identity')
+
+
+def test_closing_parent_copy_keeps_inherited_child_lock(tmp_path):
+    database = tmp_path / 'sessions.sqlite3'
+    with pi_session_locks(database, SESSION) as (_, descriptors):
+        child = subprocess.Popen([sys.executable, '-c', 'import sys; sys.stdin.buffer.read()'],
+                                 stdin=subprocess.PIPE, pass_fds=descriptors)
+    try:
+        with pytest.raises(BlockingIOError):
+            with pi_session_locks(database, SESSION):
+                pytest.fail('parent close released the surviving child lock')
+    finally:
+        child.communicate(timeout=5)
+    with pi_session_locks(database, SESSION):
+        pass
+
+
+@pytest.mark.parametrize("paused_command", ["export", "import"])
+def test_conversion_parent_death_retains_actual_sdk_child_lock(tmp_path, paused_command):
+    from src.application.bot.pi_migration import migrate_pi, read_pi_migration_receipt
+    from tests.bot_pi_test_support import seed_actual_legacy_pi_store
+
+    database = tmp_path / "sessions.sqlite3"
+    fixture = seed_actual_legacy_pi_store(database)
+    ready = tmp_path / "converter.pid"
+    preload = tmp_path / "pause-sdk.mjs"
+    preload.write_text(f'''
+import {{ writeFileSync }} from "node:fs";
+import {{ pathToFileURL }} from "node:url";
+if (process.argv[2] === {json.dumps(paused_command)}) {{
+  const runtime = process.argv[process.argv.indexOf("--runtime") + 1];
+  const sdk = await import(import.meta.resolve("@earendil-works/pi-session-backend-sqlite-node", pathToFileURL(runtime + "/package.json").href));
+  const prototype = (sdk.SqliteSessionRepository ?? sdk.SqliteSessionRepo).prototype;
+  const method = process.argv[2] === "export" ? "open" : "create";
+  const original = prototype[method];
+  prototype[method] = async function (...args) {{
+    const session = await original.apply(this, args);
+    writeFileSync({json.dumps(str(ready))}, String(process.pid));
+    process.kill(process.pid, "SIGSTOP");
+    return session;
+  }};
+}}
+''')
+    script = f'''
+from pathlib import Path
+from src.infrastructure import pi_agent_process as process
+from src.application.bot.pi_migration import migrate_pi
+original = process._runtime_command
+def instrument(*args, **kwargs):
+    argv, entry = original(*args, **kwargs)
+    argv[1:1] = ["--import", {str(preload)!r}]
+    return argv, entry
+process._runtime_command = instrument
+migrate_pi(pi_db={str(database)!r}, source_runtime={str(fixture.source_runtime)!r},
+           target_runtime={str(fixture.target_runtime)!r}, apply=True, writers_stopped=True)
+'''
+    child_pid = None
+    log = tmp_path / "converter.log"
+    with log.open("w") as output:
+        parent = subprocess.Popen([sys.executable, "-c", script], cwd=REPO, stdout=output, stderr=output)
+    try:
+        deadline = time.monotonic() + 30
+        while not ready.exists():
+            assert parent.poll() is None, log.read_text()
+            assert time.monotonic() < deadline, "actual SDK converter did not reach store open"
+            time.sleep(0.02)
+        child_pid = int(ready.read_text())
+        receipt = read_pi_migration_receipt(database)
+        assert receipt["phase"] == "prepared"
+        backup = Path(receipt["backup"]["path"])
+        preserved = {path: path.read_bytes() for path in (database, backup)}
+        parent.kill()
+        parent.wait(timeout=5)
+        with pytest.raises(BlockingIOError):
+            migrate_pi(pi_db=database, source_runtime=fixture.source_runtime,
+                       target_runtime=fixture.target_runtime, apply=True, writers_stopped=True)
+        os.kill(child_pid, signal.SIGKILL)
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                with pi_session_locks(database):
+                    break
+            except BlockingIOError:
+                assert time.monotonic() < deadline, "dead converter retained maintenance lock"
+                time.sleep(0.02)
+        assert all(path.read_bytes() == contents for path, contents in preserved.items())
+        recovered = migrate_pi(pi_db=database, source_runtime=fixture.source_runtime,
+                               target_runtime=fixture.target_runtime, apply=True, writers_stopped=True)
+        assert recovered["receipt_phase"] == "published"
+        assert backup.read_bytes() == preserved[backup]
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=5)
+        if child_pid is not None:
+            try:
+                os.kill(child_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+@pytest.mark.parametrize("death_order", ["parent_first", "child_first"])
+def test_facade_kill_order_keeps_surviving_holder_excluded(tmp_path, death_order):
+    database = tmp_path / 'sessions.sqlite3'
+    ready = tmp_path / 'child.pid'
+    runtime = tmp_path / 'paused.ts'
+    runtime.write_text('import fs from "node:fs";\n'
+                       f'fs.writeFileSync({json.dumps(str(ready))}, String(process.pid));\n'
+                       'process.kill(process.pid, "SIGSTOP");\nsetInterval(() => {}, 1000);\n')
+    script = (
+        'import sys, os\n'
+        f'sys.path.insert(0, {str(REPO / "tests")!r})\n'
+        'from pathlib import Path\nfrom test_pi_agent_process import _start_payload\n'
+        'from src.infrastructure.pi_agent_process import run_pi_agent\n'
+        f'run_pi_agent(_start_payload(session_id={SESSION!r}), request_id="lock", run_id="lock", '
+        f'timeout_seconds=60, runtime_entry=Path({str(runtime)!r}), '
+        f'environ={{**os.environ, "OM_PI_SESSION_DB": {str(database)!r}}})\n'
+    )
+    parent = subprocess.Popen([sys.executable, '-c', script], cwd=REPO)
+    child_pid = None
+    try:
+        import time
+        deadline = time.monotonic() + 10
+        while not ready.exists():
+            assert parent.poll() is None, 'facade exited before Node startup'
+            assert time.monotonic() < deadline, 'Node startup timed out'
+            time.sleep(0.02)
+        child_pid = int(ready.read_text())
+        if death_order == 'parent_first':
+            parent.kill()
+            parent.wait(timeout=3)
+        else:
+            os.kill(parent.pid, signal.SIGSTOP)
+            os.kill(child_pid, signal.SIGKILL)
+        result = run_pi_agent(_start_payload(session_id=SESSION), request_id='second', run_id='second',
+                              timeout_seconds=60, runtime_entry=runtime,
+                              environ={**os.environ, 'OM_PI_SESSION_DB': str(database)})
+        assert result['error']['code'] == 'SESSION_ERROR'
+        assert result['error']['retryable'] is True
+        if death_order == 'parent_first':
+            os.kill(child_pid, signal.SIGKILL)
+        else:
+            os.kill(parent.pid, signal.SIGCONT)
+            parent.wait(timeout=5)
+        # Orphan exit/reap is asynchronous; lock release is the observable fact.
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                with pi_session_locks(database, SESSION):
+                    break
+            except BlockingIOError:
+                assert time.monotonic() < deadline, 'dead child retained the lock'
+                time.sleep(0.02)
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=3)
+        if child_pid is not None:
+            try:
+                os.kill(child_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    assert not database.exists()
+
+
+@pytest.mark.parametrize('failure', ['spawn', 'pipe_setup'])
+def test_failed_spawn_or_pipe_setup_releases_session_lock(tmp_path, monkeypatch, failure):
+    from src.infrastructure import pi_agent_process as process_module
+    import shutil
+
+    database = tmp_path / 'sessions.sqlite3'
+    runtime = tmp_path / 'wait.ts'
+    runtime.write_text('setInterval(() => {}, 1000);\n')
+    monkeypatch.setattr(process_module, '_runtime_command',
+                        lambda *args, **kwargs: ([shutil.which('node'), str(runtime)], runtime))
+
+    def fail(*args, **kwargs):
+        raise OSError('injected process setup failure')
+
+    if failure == 'spawn':
+        monkeypatch.setattr(subprocess, 'Popen', fail)
+    else:
+        monkeypatch.setattr(os, 'set_blocking', fail)
+    result = run_pi_agent(_start_payload(session_id=SESSION), request_id='setup', run_id='setup',
+                          timeout_seconds=60, runtime_entry=runtime,
+                          environ={**os.environ, 'OM_PI_SESSION_DB': str(database)})
+    assert result['ok'] is False
+    assert result['error']['code'] == ('PI_RUNTIME_UNAVAILABLE' if failure == 'spawn' else 'PI_PROCESS_EXITED')
+    with pi_session_locks(database, SESSION):
+        pass

--- a/tests/test_service_pi_readiness.py
+++ b/tests/test_service_pi_readiness.py
@@ -1,0 +1,838 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _release(path: Path, version: str) -> Path:
+    path.mkdir(parents=True)
+    (path / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+    (path / "agent-runtime").mkdir()
+    return path
+
+
+def _upgrade_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    releases = tmp_path / "releases"
+    previous = _release(releases / "3.5.1", "3.5.1")
+    target = _release(releases / "3.5.2", "3.5.2")
+    current = tmp_path / "current"
+    current.symlink_to(previous, target_is_directory=True)
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    return current, previous, target, runtime
+
+
+def _stub_upgrade_preparation(monkeypatch: pytest.MonkeyPatch, module, target: Path) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        module,
+        "service_upgrade_check",
+        lambda **_kwargs: {"ok": True, "latest_version": "3.5.2", "release_tag": "v3.5.2"},
+    )
+    monkeypatch.setattr(
+        module,
+        "_materialize_release_from_git_cache",
+        lambda **_kwargs: {"status": "reused", "target_dir": str(target)},
+    )
+    monkeypatch.setattr(module, "_ensure_release_runtime", lambda **_kwargs: {"status": "ready"})
+    monkeypatch.setattr(module, "_run_required", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        module,
+        "_prepare_runtime_configs_for_release",
+        lambda **_kwargs: {"status": "prepared", "items": []},
+    )
+    monkeypatch.setattr(module, "_commit_prepared_runtime_configs", lambda **_kwargs: {"status": "committed"})
+    monkeypatch.setattr(module, "_validate_committed_runtime_configs", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_load_service_profile", lambda _runtime: {})
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _stage_actual_target_with_old_installer(
+    *,
+    tmp_path: Path,
+    old_release: Path,
+) -> Path:
+    from test_install_script import _installer_env
+
+    source = Path(__file__).resolve().parents[1]
+    installer_root = tmp_path / "installer"
+    env = _installer_env(installer_root)
+    fake_bin = Path(env["PATH"].split(os.pathsep)[0])
+    _write_executable(
+        fake_bin / "git",
+        f"""#!{sys.executable}
+import os
+import shutil
+import sys
+from pathlib import Path
+
+source = Path(os.environ["PI_TEST_CLONE_SOURCE"])
+destination = Path(sys.argv[-1])
+destination.mkdir(parents=True)
+for name in ("src", "domain", "scripts", "requirements", "constraints", "agent-runtime"):
+    shutil.copytree(source / name, destination / name, symlinks=True)
+for name in ("om", "om-agent", "requirements.txt", "constraints.txt", "pyproject.toml"):
+    os.link(source / name, destination / name)
+version = destination / "VERSION"
+version.write_text("3.5.2\\n", encoding="utf-8")
+smoke = destination / "scripts" / "pi_runtime_smoke.sh"
+smoke.unlink()
+smoke.write_text("#!/usr/bin/env bash\\nset -euo pipefail\\n[[ -x \\\"$4\\\" ]]\\n", encoding="utf-8")
+smoke.chmod(0o755)
+""",
+    )
+    env["PI_TEST_CLONE_SOURCE"] = str(source)
+    prefix = tmp_path / "private-upgrade-control"
+    before_link = (tmp_path / "production" / "current").resolve()
+    completed = subprocess.run(
+        [
+            "bash",
+            str(old_release / "scripts" / "install.sh"),
+            "--version",
+            "v3.5.2",
+            "--prefix",
+            str(prefix),
+            "--repo-url",
+            "https://example.invalid/options-monitor.git",
+            "--no-install-cli",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr + completed.stdout
+    assert (tmp_path / "production" / "current").resolve() == before_link
+    target = prefix / "releases" / "v3.5.2"
+    shutil.rmtree(target / ".venv")
+    (target / ".venv").symlink_to(source / ".venv", target_is_directory=True)
+    return target
+
+
+def _target_cli_env(target: Path, *, extra_python_path: Path | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    env["OM_PYTHON"] = str(target / ".venv" / "bin" / "python")
+    if extra_python_path is None:
+        env.pop("PYTHONPATH", None)
+    else:
+        env["PYTHONPATH"] = str(extra_python_path)
+    return env
+
+
+def _run_json(command: list[str], *, cwd: Path, env: dict[str, str]) -> tuple[subprocess.CompletedProcess[str], dict]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(completed.stderr + completed.stdout) from exc
+    return completed, payload
+
+
+def _isolated_update_python(tmp_path: Path) -> Path:
+    """Keep target wrapper/argparse/application real; substitute external effects only."""
+    bootstrap = tmp_path / "isolated-update-python"
+    _write_executable(bootstrap, f'''#!{sys.executable}
+import atexit
+import hashlib
+import json
+import os
+import runpy
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+if sys.argv[1:2] == ["-c"]:
+    os.execv(sys.executable, [sys.executable, *sys.argv[1:]])
+assert sys.argv[1:3] == ["-m", "src.interfaces.cli.main"]
+import src.application.service_upgrade as module
+
+target = Path.cwd()
+assert Path(module.__file__).resolve() == target / "src/application/service_upgrade.py"
+calls = []
+def run_service(command, **kwargs):
+    command = list(command)
+    calls.append(command)
+    output = "enabled\\n" if "is-enabled" in command else "active\\n" if "is-active" in command else "ok\\n"
+    return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+def materialize(**kwargs):
+    destination = kwargs["target_dir"]
+    if not destination.exists():
+        shutil.copytree(target, destination, symlinks=True, copy_function=os.link)
+    return {{"status": "materialized", "target_dir": str(destination)}}
+
+module.service_upgrade_check = lambda **kwargs: {{"ok": True, "latest_version": "3.5.2", "release_tag": "v3.5.2"}}
+module._materialize_release_from_git_cache = materialize
+module._ensure_release_runtime = lambda **kwargs: {{"status": "ready"}}
+module._run_required = lambda *args, **kwargs: {{}}
+module._prepare_runtime_configs_for_release = lambda **kwargs: {{"status": "prepared", "items": []}}
+module._commit_prepared_runtime_configs = lambda **kwargs: {{"status": "committed"}}
+module._validate_committed_runtime_configs = lambda **kwargs: []
+module._load_service_profile = lambda runtime: {{"service_provider": "systemd", "restart": {{"requires_sudo": False, "services": ["options-monitor-feishu-ws.service"]}}}}
+module.service_drift = lambda **kwargs: {{"summary": {{"status": "ok"}}}}
+module._post_upgrade_service_health = lambda **kwargs: {{"ok": True, "status": "ok"}}
+module.service_upgrade.__kwdefaults__["run_cmd"] = run_service
+if os.environ.get("PI_TEST_FAIL_ACTIVATION") == "1":
+    def fail_activation(**kwargs):
+        raise module.ServiceTransitionError("activation snapshot failed", status="service_activation_snapshot_failed")
+    module.capture_preserved_timer_activation_states = fail_activation
+
+argv = sys.argv[3:]
+def record():
+    Path(os.environ["PI_TEST_UPDATE_AUDIT"]).write_text(json.dumps({{
+        "argv": argv, "cwd": str(target), "module": module.__file__,
+        "sha256": hashlib.sha256(Path(module.__file__).read_bytes()).hexdigest(),
+        "calls": calls,
+    }}))
+atexit.register(record)
+sys.argv = ["src.interfaces.cli.main", *argv]
+runpy.run_module("src.interfaces.cli.main", run_name="__main__")
+''')
+    return bootstrap
+
+
+def test_pi_readiness_checks_custom_and_release_local_session_stores(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import src.application.service_upgrade as module
+
+    runtime = tmp_path / "runtime"
+    old = _release(tmp_path / "releases" / "3.5.1", "3.5.1")
+    target = _release(tmp_path / "releases" / "3.5.2", "3.5.2")
+    custom_db = tmp_path / "custom" / "pi_sessions.sqlite3"
+    old_db = old / "output_shared" / "state" / "pi_sessions.sqlite3"
+    target_db = target / "output_shared" / "state" / "pi_sessions.sqlite3"
+    for path in (custom_db, old_db, target_db):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    monkeypatch.setenv("OM_INBOUND_AUDIT_DB", str(custom_db.with_name("inbound.sqlite3")))
+    observed: list[tuple[Path, Path]] = []
+
+    def _assert_ready(pi_db: Path, runtime_dir: Path) -> dict[str, object]:
+        observed.append((Path(pi_db), Path(runtime_dir)))
+        return {"ok": True, "status": "ready", "database": str(pi_db)}
+
+    monkeypatch.setattr(module, "assert_pi_storage_ready", _assert_ready)
+
+    out = module._pi_storage_readiness(  # noqa: SLF001 - transition safety contract
+        runtime_root=runtime,
+        repo_root=old,
+        runtime_dir=target / "agent-runtime",
+        release_dirs=(old, target),
+    )
+
+    assert out["ok"] is True
+    assert {item[0] for item in observed} == {custom_db, old_db, target_db}
+    assert {item[1] for item in observed} == {target / "agent-runtime"}
+
+
+def test_pi_readiness_requires_explicit_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import src.application.service_upgrade as module
+
+    monkeypatch.delenv("OM_INBOUND_AUDIT_DB", raising=False)
+    monkeypatch.setattr(module, "assert_pi_storage_ready", lambda *_args: {"status": "ready"})
+
+    with pytest.raises(module.ServiceTransitionError, match="readiness rejected"):
+        module._pi_storage_readiness(  # noqa: SLF001 - malformed helper result proof
+            runtime_root=tmp_path / "runtime",
+            repo_root=tmp_path / "repo",
+            runtime_dir=tmp_path / "target" / "agent-runtime",
+            release_dirs=(),
+        )
+
+
+def test_upgrade_verify_reports_pi_storage_gate_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.service_upgrade as module
+
+    current, previous, _target, runtime = _upgrade_fixture(tmp_path)
+    (runtime / "config.us.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(module, "_load_service_profile", lambda _runtime: {})
+    monkeypatch.setattr(
+        module,
+        "_runtime_config_verify_summary",
+        lambda **_kwargs: {"ok": True},
+    )
+    monkeypatch.setattr(
+        module,
+        "_pi_storage_readiness",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            module.ServiceTransitionError(
+                "reverse conversion required",
+                status="pi_storage_not_ready",
+                remediation=["keep Agent ingress stopped"],
+            )
+        ),
+    )
+
+    out = module.service_upgrade_verify(
+        repo_root=current,
+        runtime_root=runtime,
+        check_latest=False,
+    )
+
+    assert out["ok"] is False
+    assert out["status"] == "attention_required"
+    assert out["repo_root_resolved"] == str(previous)
+    assert out["pi_storage_readiness"] == {
+        "ok": False,
+        "status": "pi_storage_not_ready",
+        "error": "reverse conversion required",
+        "remediation": ["keep Agent ingress stopped"],
+    }
+
+
+def test_upgrade_preview_is_read_only_and_keeps_services_stopped(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import src.application.service_upgrade as module
+
+    current, previous, target, runtime = _upgrade_fixture(tmp_path)
+    _stub_upgrade_preparation(monkeypatch, module, target)
+    monkeypatch.setattr(module, "_pi_storage_readiness", lambda **_kwargs: {"ok": True, "stores": []})
+    monkeypatch.setattr(module, "_materialize_release_from_git_cache", lambda **_kwargs: pytest.fail("preview materialized release"))
+    monkeypatch.setattr(module, "_switch_current_symlink", lambda **_kwargs: pytest.fail("preview switched current"))
+    monkeypatch.setattr(module, "_restart_services_from_loaded_profile", lambda **_kwargs: pytest.fail("preview restarted service"))
+
+    out = module.service_upgrade(
+        repo_root=current,
+        runtime_root=runtime,
+        releases_root=target.parent,
+        target_version="3.5.2",
+        confirm=False,
+        restart_services=False,
+        preserve_activation_state=True,
+    )
+
+    assert out["status"] == "dry_run"
+    assert current.resolve() == previous
+
+
+def test_upgrade_reads_target_store_before_switch_and_does_not_restart_in_maintenance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.service_upgrade as module
+
+    current, previous, target, runtime = _upgrade_fixture(tmp_path)
+    _stub_upgrade_preparation(monkeypatch, module, target)
+    events: list[str] = []
+    original_switch = module._switch_current_symlink  # noqa: SLF001
+
+    def _readiness(**kwargs):  # type: ignore[no-untyped-def]
+        assert kwargs["runtime_dir"] == target / "agent-runtime"
+        events.append("readiness")
+        return {"ok": True, "stores": []}
+
+    def _switch(**kwargs):  # type: ignore[no-untyped-def]
+        events.append("switch")
+        original_switch(**kwargs)
+
+    monkeypatch.setattr(module, "_pi_storage_readiness", _readiness)
+    monkeypatch.setattr(module, "_switch_current_symlink", _switch)
+    monkeypatch.setattr(module, "_restart_services_from_loaded_profile", lambda **_kwargs: pytest.fail("maintenance restarted service"))
+
+    out = module.service_upgrade(
+        repo_root=current,
+        runtime_root=runtime,
+        releases_root=target.parent,
+        target_version="3.5.2",
+        confirm=True,
+        restart_services=False,
+        preserve_activation_state=True,
+    )
+
+    assert out["status"] == "upgraded"
+    assert events == ["readiness", "switch"]
+    assert current.resolve() == target
+
+
+def test_rollback_rejects_incompatible_store_before_switch_or_restart(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import src.application.service_upgrade as module
+
+    current, old, new, runtime = _upgrade_fixture(tmp_path)
+    current.unlink()
+    current.symlink_to(new, target_is_directory=True)
+    monkeypatch.setattr(
+        module,
+        "_prepare_runtime_configs_for_release",
+        lambda **_kwargs: {"status": "prepared", "items": []},
+    )
+    monkeypatch.setattr(
+        module,
+        "_pi_storage_readiness",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            module.ServiceTransitionError("reverse conversion required", status="pi_storage_not_ready")
+        ),
+    )
+    monkeypatch.setattr(module, "_switch_current_symlink", lambda **_kwargs: pytest.fail("rollback switched current"))
+    monkeypatch.setattr(module, "_restart_services_from_loaded_profile", lambda **_kwargs: pytest.fail("rollback restarted service"))
+
+    out = module.service_rollback(
+        repo_root=current,
+        runtime_root=runtime,
+        releases_root=old.parent,
+        to_version="3.5.1",
+        confirm=True,
+    )
+
+    assert out["status"] == "pi_storage_not_ready"
+    assert out["changed"] is False
+    assert current.resolve() == new
+
+
+def test_failed_compensation_never_restores_or_starts_incompatible_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.service_upgrade as module
+
+    current, previous, target, runtime = _upgrade_fixture(tmp_path)
+    current.unlink()
+    current.symlink_to(target, target_is_directory=True)
+
+    readiness_call: dict[str, object] = {}
+
+    def _reject_readiness(**kwargs):  # type: ignore[no-untyped-def]
+        readiness_call.update(kwargs)
+        raise module.ServiceTransitionError(
+            "reverse conversion required",
+            status="pi_storage_not_ready",
+            remediation=["keep Agent ingress stopped"],
+        )
+
+    monkeypatch.setattr(
+        module,
+        "_pi_storage_readiness",
+        _reject_readiness,
+    )
+    monkeypatch.setattr(module, "_switch_current_symlink", lambda **_kwargs: pytest.fail("compensation restored old runtime"))
+    monkeypatch.setattr(module, "service_drift", lambda **_kwargs: pytest.fail("compensation reconciled old services"))
+    monkeypatch.setattr(module, "_restart_services_from_loaded_profile", lambda **_kwargs: pytest.fail("compensation started old service"))
+
+    out = module._compensate_service_transition(  # noqa: SLF001 - exact failure boundary
+        repo_link=current,
+        previous_dir=previous,
+        transition_dir=target,
+        runtime_root=runtime,
+        previous_profile={"service_provider": "systemd"},
+        config_commit={},
+        restart_services=True,
+        activation_policy="preserve-existing",
+        preserved_activation_states={},
+        run_cmd=lambda *_args, **_kwargs: pytest.fail("unexpected service command"),
+        operations=[],
+    )
+
+    assert out["status"] == "pi_storage_not_ready"
+    assert out["symlink_restored"] is False
+    assert out["restarted_services"] == []
+    assert set(readiness_call["release_dirs"]) == {previous, target}
+    assert current.resolve() == target
+
+
+def test_post_publication_failure_before_switch_does_not_resume_old_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.service_upgrade as module
+
+    current, previous, target, runtime = _upgrade_fixture(tmp_path)
+    _stub_upgrade_preparation(monkeypatch, module, target)
+    monkeypatch.setattr(
+        module,
+        "_load_service_profile",
+        lambda _runtime: {"service_provider": "systemd"},
+    )
+
+    def _readiness(**kwargs):  # type: ignore[no-untyped-def]
+        if kwargs["runtime_dir"] == target / "agent-runtime":
+            return {"ok": True, "stores": [{"receipt_phase": "published"}]}
+        raise module.ServiceTransitionError(
+            "reverse conversion required",
+            status="pi_storage_not_ready",
+            remediation=["keep Agent ingress stopped"],
+        )
+
+    monkeypatch.setattr(module, "_pi_storage_readiness", _readiness)
+    monkeypatch.setattr(
+        module,
+        "capture_preserved_timer_activation_states",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            module.ServiceTransitionError(
+                "activation snapshot failed",
+                status="service_activation_snapshot_failed",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_switch_current_symlink",
+        lambda **_kwargs: pytest.fail("failure path switched current"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_restart_services_from_loaded_profile",
+        lambda **_kwargs: pytest.fail("failure path started old service"),
+    )
+
+    out = module.service_upgrade(
+        repo_root=current,
+        runtime_root=runtime,
+        releases_root=target.parent,
+        target_version="3.5.2",
+        confirm=True,
+        restart_services=True,
+        preserve_activation_state=True,
+    )
+
+    assert out["status"] == "service_activation_snapshot_failed"
+    assert out["compensation"]["status"] == "pi_storage_not_ready"
+    assert "keep Agent ingress stopped" in out["remediation"]
+    assert current.resolve() == previous
+
+
+@pytest.mark.parametrize(
+    "fail_after_publish",
+    [False, True],
+    ids=["switch", "compensate"],
+)
+def test_first_pi_transition_composes_private_stage_migration_and_safe_switch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fail_after_publish: bool,
+) -> None:
+    import src.application.service_upgrade as module
+    from src.application.bot.pi_migration import assert_pi_storage_ready
+    from tests.bot_pi_test_support import seed_actual_legacy_pi_store
+    from tests.service_deploy_test_support import _credential_migration_runner
+
+    source = Path(__file__).resolve().parents[1]
+    production = tmp_path / "production"
+    old_release = production / "releases" / "3.5.1"
+    old_release.mkdir(parents=True)
+    (old_release / "VERSION").write_text("3.5.1\n", encoding="utf-8")
+    runtime = tmp_path / "runtime"
+    database = runtime / "output_shared" / "state" / "pi_sessions.sqlite3"
+    fixture = seed_actual_legacy_pi_store(database)
+    old_runtime = old_release / "agent-runtime"
+    shutil.copytree(
+        fixture.source_runtime,
+        old_runtime,
+        symlinks=True,
+    )
+    (old_release / "scripts").mkdir()
+    shutil.copy2(source / "scripts" / "install.sh", old_release / "scripts" / "install.sh")
+    assert (old_release / "scripts" / "install.sh").read_bytes() == (
+        source / "scripts" / "install.sh"
+    ).read_bytes()
+    current = production / "current"
+    current.symlink_to(old_release, target_is_directory=True)
+    monkeypatch.setenv(
+        "OM_INBOUND_AUDIT_DB",
+        str(database.with_name("inbound_control.sqlite3")),
+    )
+
+    store_before_stage = database.read_bytes()
+    target_control = _stage_actual_target_with_old_installer(
+        tmp_path=tmp_path,
+        old_release=old_release,
+    )
+    assert current.resolve() == old_release
+    assert database.read_bytes() == store_before_stage
+    assert_pi_storage_ready(database, old_runtime)
+    assert (
+        target_control / "src" / "application" / "bot" / "pi_migration.py"
+    ).read_bytes() == (
+        source / "src" / "application" / "bot" / "pi_migration.py"
+    ).read_bytes()
+
+    old_controller_path = tmp_path / "old-controller-python"
+    (old_controller_path / "src" / "interfaces" / "cli").mkdir(parents=True)
+    for package in (
+        old_controller_path / "src",
+        old_controller_path / "src" / "interfaces",
+        old_controller_path / "src" / "interfaces" / "cli",
+    ):
+        (package / "__init__.py").write_text("", encoding="utf-8")
+    (old_controller_path / "src" / "interfaces" / "cli" / "main.py").write_text(
+        'raise RuntimeError("old controller imported")\n',
+        encoding="utf-8",
+    )
+    cli_env = _target_cli_env(
+        target_control,
+        extra_python_path=old_controller_path,
+    )
+    migration = [
+        str(target_control / "om"),
+        "bot",
+        "migrate-pi",
+        "--pi-db",
+        str(database),
+    ]
+    preview_process, preview = _run_json(
+        [
+            *migration,
+            "--source-runtime",
+            str(old_runtime),
+            "--target-runtime",
+            str(target_control / "agent-runtime"),
+            "--dry-run",
+        ],
+        cwd=target_control,
+        env=cli_env,
+    )
+    assert preview_process.returncode == 0, preview_process.stderr
+    assert preview["direction"] == "0.84.2->0.85.1"
+    assert preview["write_applied"] is False
+    assert current.resolve() == old_release
+    assert database.read_bytes() == store_before_stage
+
+    forward_process, forward = _run_json(
+        [
+            *migration,
+            "--source-runtime",
+            str(old_runtime),
+            "--target-runtime",
+            str(target_control / "agent-runtime"),
+            "--apply",
+            "--writers-stopped",
+        ],
+        cwd=target_control,
+        env=cli_env,
+    )
+    assert forward_process.returncode == 0, forward_process.stderr
+    assert forward["receipt_phase"] == "published"
+    assert assert_pi_storage_ready(database, target_control / "agent-runtime")["ok"] is True
+    assert current.resolve() == old_release
+
+    target_release = production / "releases" / "3.5.2"
+    profile = {
+        "service_provider": "systemd",
+        "restart": {
+            "requires_sudo": False,
+            "services": ["options-monitor-feishu-ws.service"],
+        },
+    }
+    service_calls: list[list[str]] = []
+    run_service = _credential_migration_runner(service_calls)
+    update_env = dict(cli_env)
+    update_env["OM_PYTHON"] = str(_isolated_update_python(tmp_path))
+    audit_path = tmp_path / "update-audit.json"
+    update_env["PI_TEST_UPDATE_AUDIT"] = str(audit_path)
+    update = [
+        str(target_control / "om"), "update", "apply",
+        "--repo-root", str(current), "--runtime-root", str(runtime),
+        "--releases-root", str(target_release.parent), "--target-version", "3.5.2",
+        "--no-restart-services", "--preserve-activation-state",
+    ]
+
+    def run_update(*, confirm: bool, fail_activation: bool = False) -> dict:
+        env = {**update_env, "PI_TEST_FAIL_ACTIVATION": "1" if fail_activation else "0"}
+        command = [*update, *(["--confirm"] if confirm else [])]
+        process, response = _run_json(command, cwd=target_control, env=env)
+        assert process.returncode == (2 if fail_activation else 0), process.stderr + process.stdout
+        audit = json.loads(audit_path.read_text())
+        assert audit["argv"] == command[1:]
+        assert Path(audit["cwd"]).resolve() == target_control.resolve()
+        assert Path(audit["module"]).resolve() == target_control / "src/application/service_upgrade.py"
+        assert audit["sha256"] == hashlib.sha256((source / "src/application/service_upgrade.py").read_bytes()).hexdigest()
+        service_calls.extend(audit["calls"])
+        return response["data"]
+
+    preview_upgrade = run_update(confirm=False)
+    assert preview_upgrade["status"] == "dry_run"
+    assert current.resolve() == old_release
+    assert not [call for call in service_calls if "restart" in call]
+
+    if not fail_after_publish:
+        successful_upgrade = run_update(confirm=True)
+        assert successful_upgrade["status"] == "upgraded"
+        assert successful_upgrade["restarted_services"] == []
+        assert successful_upgrade["pi_storage_readiness"]["stores"] == [
+            {
+                "ok": True,
+                "status": "ready",
+                "runtime": {"version": "0.85.1"},
+                "database_format": "target",
+                "receipt_phase": "published",
+                "pi_db": str(database),
+            }
+        ]
+        assert current.resolve() == target_release
+        assert not [call for call in service_calls if "restart" in call]
+        return
+
+    failed_upgrade = run_update(confirm=True, fail_activation=True)
+    assert failed_upgrade["status"] == "service_activation_snapshot_failed"
+    assert failed_upgrade["compensation"]["status"] == "pi_storage_not_ready"
+    assert current.resolve() == old_release
+    assert not [call for call in service_calls if "restart" in call]
+
+    reverse_process, reverse = _run_json(
+        [
+            *migration,
+            "--source-runtime",
+            str(target_control / "agent-runtime"),
+            "--target-runtime",
+            str(old_runtime),
+            "--apply",
+            "--writers-stopped",
+        ],
+        cwd=target_control,
+        env=cli_env,
+    )
+    assert reverse_process.returncode == 0, reverse_process.stderr
+    assert reverse["direction"] == "0.85.1->0.84.2"
+    assert assert_pi_storage_ready(database, old_runtime)["ok"] is True
+
+    monkeypatch.setattr(module, "service_drift", lambda **_kwargs: {"summary": {"status": "ok"}})
+    monkeypatch.setattr(module, "_post_upgrade_service_health", lambda **_kwargs: {"ok": True, "status": "ok"})
+    compensation = module._compensate_service_transition(  # noqa: SLF001 - exact offline recovery order
+        repo_link=current,
+        previous_dir=old_release,
+        transition_dir=target_release,
+        runtime_root=runtime,
+        previous_profile=profile,
+        config_commit={},
+        restart_services=True,
+        activation_policy=module.SERVICE_ACTIVATION_POLICY_PRESERVE_EXISTING,
+        preserved_activation_states={},
+        run_cmd=run_service,
+        operations=[],
+    )
+    assert compensation["ok"] is True
+    assert compensation["restarted_services"] == [
+        "options-monitor-feishu-ws.service"
+    ]
+    restart_calls = [call for call in service_calls if "restart" in call]
+    assert restart_calls == [
+        ["systemctl", "restart", "options-monitor-feishu-ws.service"]
+    ]
+
+
+def test_cleanup_keeps_receipt_runtime_outside_keep_count(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import src.application.service_cleanup as module
+
+    releases = tmp_path / "releases"
+    current_release = _release(releases / "3.5.3", "3.5.3")
+    _release(releases / "3.5.2", "3.5.2")
+    retained_release = _release(releases / "3.5.1", "3.5.1")
+    stale_release = _release(releases / "3.5.0", "3.5.0")
+    current = tmp_path / "current"
+    current.symlink_to(current_release, target_is_directory=True)
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    pi_db = runtime / "pi_sessions.sqlite3"
+    monkeypatch.setattr(module, "pi_session_database_paths", lambda **_kwargs: (pi_db,))
+    monkeypatch.setattr(module, "read_pi_migration_receipt", lambda _path: {"phase": "published"})
+    monkeypatch.setattr(
+        module,
+        "retained_pi_runtime_paths",
+        lambda _receipt: (retained_release / "agent-runtime",),
+    )
+
+    out = module.service_cleanup(
+        repo_root=current,
+        releases_root=releases,
+        runtime_root=runtime,
+        keep_releases=2,
+        confirm=True,
+    )
+
+    assert out["status"] == "cleaned"
+    assert {item["version"] for item in out["kept_releases"]} == {"3.5.3", "3.5.2", "3.5.1"}
+    assert out["pi_retained_releases"] == [{"path": str(retained_release), "version": "3.5.1"}]
+    assert retained_release.exists()
+    assert not stale_release.exists()
+
+
+def test_cleanup_without_runtime_root_still_keeps_release_local_receipt_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import src.application.service_cleanup as module
+    from src.application.bot.pi_migration import pi_migration_receipt_path
+
+    releases = tmp_path / "releases"
+    current_release = _release(releases / "3.5.3", "3.5.3")
+    _release(releases / "3.5.2", "3.5.2")
+    retained_release = _release(releases / "3.5.1", "3.5.1")
+    stale_release = _release(releases / "3.5.0", "3.5.0")
+    current = tmp_path / "current"
+    current.symlink_to(current_release, target_is_directory=True)
+    retained_db = retained_release / "output_shared" / "state" / "pi_sessions.sqlite3"
+    retained_db.parent.mkdir(parents=True)
+    pi_migration_receipt_path(retained_db).write_text("{}\n", encoding="utf-8")
+    observed: list[Path] = []
+
+    def _read_receipt(pi_db: Path):  # type: ignore[no-untyped-def]
+        observed.append(pi_db)
+        return {"phase": "published"} if pi_db == retained_db else None
+
+    monkeypatch.setattr(module, "read_pi_migration_receipt", _read_receipt)
+    monkeypatch.setattr(
+        module,
+        "retained_pi_runtime_paths",
+        lambda _receipt: (retained_release / "agent-runtime",),
+    )
+
+    out = module.service_cleanup(
+        repo_root=current,
+        releases_root=releases,
+        keep_releases=2,
+        confirm=True,
+    )
+
+    assert out["status"] == "cleaned"
+    assert retained_db in observed
+    assert {item["version"] for item in out["kept_releases"]} == {"3.5.3", "3.5.2", "3.5.1"}
+    assert retained_release.exists()
+    assert not stale_release.exists()
+
+
+def test_cleanup_fails_closed_when_receipt_cannot_be_validated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import src.application.service_cleanup as module
+
+    releases = tmp_path / "releases"
+    current_release = _release(releases / "3.5.2", "3.5.2")
+    old_release = _release(releases / "3.5.1", "3.5.1")
+    current = tmp_path / "current"
+    current.symlink_to(current_release, target_is_directory=True)
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    monkeypatch.setattr(module, "pi_session_database_paths", lambda **_kwargs: (runtime / "pi_sessions.sqlite3",))
+    monkeypatch.setattr(
+        module,
+        "read_pi_migration_receipt",
+        lambda _path: (_ for _ in ()).throw(ValueError("receipt identity mismatch")),
+    )
+
+    out = module.service_cleanup(
+        repo_root=current,
+        releases_root=releases,
+        runtime_root=runtime,
+        keep_releases=2,
+        confirm=True,
+    )
+
+    assert out["status"] == "pi_retention_unresolved"
+    assert out["changed"] is False
+    assert old_release.exists()


### PR DESCRIPTION
Bot now uses the public Pi 0.85.1 APIs while preserving committed session history, compaction, length continuation, cancellation, account isolation, and explicit Host commit admission. Persistent writes use atomic Session mutations and inherited maintenance/session locks that remain held while a child process is alive.

Adds explicit bidirectional 0.84.2 ↔ 0.85.1 session migration with sealed recovery backups, validated readback, resumable receipts, and retained runtime dependencies. Service activation and compensation check storage compatibility; conversion remains an explicit operator action. The first-transition test runs the staged target CLI through migration, update, failure, reverse conversion, and compensation.

Validation:
- Exact Node 22 runtime/process/lock suite: 216 passed.
- Current migration suite: 23 passed, independently repeated during review.
- Fresh source archive: pinned npm install, public startup smoke, and 33 migration/lock tests passed.
- Current staged-controller readiness tests: 13 passed; service/release-plan/architecture coverage also passed.
- Node 25 runtime tests and smoke passed; four isolated Linux lock-lifetime checks passed.
- Ruff, dependency graph, staged guardrails, commit hook, and whitespace checks passed.

VERSION is unchanged. Includes an Unreleased changelog entry and the operator migration procedure.
