### PR TITLE
fix(config): decouple market freshness from assistant-only YAML edits

### DIFF
--- a/CONFIGS.md
+++ b/CONFIGS.md
@@ -92,7 +92,164 @@ Symbol 扫描在受支持的 `scan-pipeline` 主线程中串行执行，以保�
   --market us
 ```
 
-`config build` 会写 `_generated` 来源与指纹。`config.yaml` 变化后必须重新生成对应市场快照；`tick` / `tick-cron` 会拒绝过期快照，除非操作者显式使用应急 override。
+`config build` 会写 `_generated` 来源与指纹。新生成的 YAML 市场快照按下面的市场输入指纹判定新鲜度；旧快照仍按完整文件 SHA 检查，需显式重建才能采用新语义。`tick` / `tick-cron` 拒绝过期或无效快照。
+
+### 市场配置新鲜度：按实际依赖判定
+
+#### 目标、边界与验收
+
+目标是让助手独立设置变化不再阻断 US/HK 监控，同时保留真实监控配置变化后的过期保护。
+原始文件 SHA 继续用于来源审计、预览确认和并发修改保护；它与市场配置是否可继续使用是两个判断。
+
+| 验收 | 必须成立的行为 |
+|---|---|
+| S1 助手独立修改 | 只改 `assistant` 的模型、上下文或开关，当前市场输入不变时 US/HK 快照仍 fresh |
+| S2 监控变更保护 | 当前市场 symbols、schedule、选用账户或共享监控参数改变时，相应快照仍 stale |
+| S3 异常与兼容 | 来源缺失、无法读取、YAML 解析或市场转换失败、来源身份错误继续阻断；旧快照按旧规则检查，经显式重建迁移 |
+| S4 只读与一致性 | 所有读取入口使用共同判定；检查不写配置、状态或快照，不自动重建；原始 SHA 并发保护保留 |
+
+范围是 YAML 市场快照的生成元数据和公共新鲜度检查，以及既有生成事务、调用入口的必要回归验证。
+不重构助手 CLI 写入流程、不拆分 YAML 文件、不自动重建、不调整调度、策略、权限或通知行为。
+Assistant runtime JSON 的有效性与激活流程保持现有合同；非 YAML 来源和系统默认配置继续使用现有严格指纹规则。
+本设计不授权 commit、push、merge、release、deploy 或生产写入。
+
+#### 当前事实与 owner
+
+本次修复基于 `4ee3b408edeb020483a8906512d438cb131ad0c1`。
+`config_yaml.py::yaml_to_market_user_config` 已负责选取当前市场、相关账户和共享配置，且不将 `assistant` 放入市场输入。
+原实现的 `_build_yaml_generated_metadata` 只记录完整文件 SHA，导致公共 freshness 检查把助手独立变化也判为 `source_changed`。
+现在 `resolve_yaml_runtime_config` 从一次 YAML 读取构建市场输入并记录原始与 effective 两种指纹；公共 checker 按下述协议比较。
+
+`config_authoring_transaction.py::publish_yaml_config_generation` 已支持多市场生成、来源 SHA 冲突检测、备份与失败恢复。
+聊天模型切换经 `assistant/model_operations.py` 调用该事务；CLI 模型 add/use 经 `write_model_config_update` 只写 YAML。
+补齐 CLI 联动不能覆盖手动编辑 YAML，且仍要求助手操作重建无关市场，因此不作为本次方向。
+
+修复落在现有 config YAML 转换/生成与 freshness owner。tick、tick-cron、runtime readiness/status、升级验证
+继续调用同一个检查函数，不在各入口增加助手特判，也不建立另一份配置字段白名单。
+
+#### 指纹与数据流
+
+生成时对已经得到的 `yaml_to_market_user_config(raw_cfg, market)` 结果计算确定性 SHA-256。
+载荷包含算法版本、规范市场和市场 user config；编码固定为 UTF-8 JSON，key 排序、固定分隔符，
+使用 `allow_nan=False` 拒绝非有限数字，生成和检查复用同一个指纹 helper。
+真实配置数组保持顺序；只有 `_normalize_combo_yield` 派生的 `_explicit_fields` 与 `_explicit_call_fields`
+具有集合语义，须在现有转换 owner 中按字段名稳定排序。这样重排 YAML mapping 键不会改变指纹，
+并通过相同 explicit override 结果证明策略行为未变；不引入通用数组排序。
+不把生成时间、源码路径、`_generated`、`_resolved` 或助手配置混进这一载荷。
+这里的“有效”指现有转换器输出的市场输入，不重新实现默认值合并或配置转换。
+系统 defaults 的变化仍由独立 system 来源指纹阻断；不额外承诺默认值等价化。
+
+在 `_generated.sources` 的 YAML `market_user` 来源项增加可选字段：
+
+```json
+"effective": {
+  "kind": "yaml-market-user-v1",
+  "market": "us",
+  "sha256": "<canonical market input SHA-256>"
+}
+```
+
+保留原 `path`、`sha256` 以及 `_resolved.config_yaml_sha256` 的原始文件含义，不用语义 SHA 替换它们。
+在现有 YAML loader 内只执行一次 `read_bytes`，用该字节缓冲计算原始 SHA，并从同一缓冲按 UTF-8
+解码和现有规则解析；市场输入和 effective SHA 都从这份解析结果产生。保留 tab、根对象、未知键等已有验证。
+元数据构建函数接收这次读取所得 raw SHA，不再打开 YAML 重新计算 `_generated`、`_resolved` 或返回 meta 中的 SHA。
+不能用重新序列化的 YAML 计算人工作者文件的 raw SHA；注释、换行和键顺序属于原始字节证据。
+普通 build 若读取后源文件发生新修改，允许生成内部一致的旧快照，下一次检查必须发现相关市场变化；
+不承诺为整个 build 持有源文件锁。
+
+在现有 `config_yaml.py` 中提供窄的公共转换/指纹 helper，freshness 复用它。
+`GENERATED_KEY`、`GENERATED_SCHEMA_VERSION` 两个共享常量位于现有 `config_primitives.py`；
+`config_yaml` 从该中立 owner 导入，freshness 保留已有导出兼容。freshness 单向依赖 config_yaml，
+不会形成反向边。函数内导入也会被仓库静态依赖图计算，不能把延迟导入当作零循环检查的替代。
+不新建模块或配置子系统；更新生成的依赖图并要求 production module cycles 为 0。
+
+```text
+同一份 YAML 内容 -> 现有市场转换 -> 市场 user config -> runtime config
+       |                         |
+       +-> 原始 SHA              +-> effective SHA
+
+读取快照 -> 校验身份及来源 -> 重算当前市场 effective SHA -> fresh / stale / invalid
+```
+
+新协议的来源校验必须早于任何现有 `loaded`、`inline`、path 缺失等短路分支。
+对带 `effective` 字段的 YAML `market_user`，先确认必需来源 role 唯一且齐全、市场匹配、
+`loaded is True`、非 inline 文件来源、非空合法 path，以及 raw SHA 是 64 位十六进制字符串；
+再检查 effective 对象、已知 kind、相同市场和 64 位十六进制 digest。`effective` 字段存在但为 null、
+空对象、错误类型或未知版本都必须失败，不得当作旧快照缺失字段。重复/丢失来源及不合法 flags 同样非 ok。
+只收紧新 effective 协议的文件来源合同；无 effective 的旧快照保留原规则，不借机重构旧协议。
+
+通过上述检查后：从已记录路径读取并解析 YAML，用相同转换和编码计算当前指纹；
+相同则该来源 fresh，即便原始文件 SHA 不同；不同则保持来源变更阻断，并提示显式重建。
+每次语义检查仍实际读取来源，不通过旧 raw SHA 相等短路元数据和解析验证；无需缓存或后台服务。
+其它来源逐项检查保持不变，不能因为市场输入相同而忽略 system/default 的漂移。
+读取/UTF-8 解码/YAML 解析/转换/编码异常在公共 checker 内转换为结构化非 ok，保留来源 role/path、
+安全的错误分类和重建提示；不把完整 YAML 内容、可能含值的解析片段写入错误结果。
+`ensure_runtime_config_freshness` 继续抛出统一 RuntimeConfigFreshnessError，消费者不增加逐入口捕获或 fallback。
+
+#### 兼容、失败与副作用
+
+| 输入或事件 | 判定/效果 |
+|---|---|
+| effective 存在、版本/市场/digest 合法且重算一致 | 该 YAML 市场来源 fresh |
+| 有效指纹不同 | stale，沿用 `source_changed` 与现有重建提示，补充可区分的指纹比较依据 |
+| effective 缺失的旧快照 | 继续按原始 SHA 严格比较，不在读取时补字段 |
+| effective 已存在但格式错误、空值、未知 kind 或市场不符 | invalid/非 ok，不能退回旧规则放行 |
+| 文件不存在、权限不足、解析/转换/编码失败 | 非 ok，诊断返回结构化错误；执行入口在扫描前阻断 |
+| 非 YAML、非 market_user、system 来源 | 维持原有检查语义 |
+| 生成过程中 YAML 变化 | 不能发布内容与指纹不同代的快照；保留现有事务 stale-preview 保护 |
+
+旧消费者仍读取保留的 raw SHA，遇到源文件变化会保守拒绝；升级后的消费者对旧快照也继续保守拒绝，
+操作者通过已有 build/受控升级流程生成新元数据。此处没有自动迁移或恢复写入。
+
+`_retarget_runtime_metadata` 仅把事务暂存路径改回真实路径并维护原始 SHA；必须原样保留 effective 指纹，
+因为指纹不依赖暂存路径。旧事务备份、提交失败补偿、回滚和 source SHA 预览冲突检查均保持。
+事务的 `expected_source_sha256` 保护修改前版本；`config_doc` 是有意修改后的文档，两者无需也不应要求相同 SHA。
+事务生成中的原始 SHA 与 effective SHA 来自修改后暂存文件的同一份字节，不能另读真实旧 YAML 来计算有效指纹。
+运行时 source 文件每次读取形成一次检查快照；不承诺跨整个 tick 的文件锁或可变配置热加载。
+
+#### 实现切片与验证计划
+
+本任务按一个完整、可独立验证的行为切片交付：**助手配置独立修改时监控继续，真实变更与无效来源仍阻断（S1–S4）**。
+同一切片包含生成与检查、必要的稳定化/常量依赖调整，以及旧快照、普通 build、现有事务和实际入口回归。
+这是一个增量协议，不能单独交付写者或读者；事务与入口测试直接证明该行为，不再单列“仅测试”切片。
+
+源码 owner 为 `src/application/config_yaml.py`、`src/application/runtime_config_freshness.py`、
+`src/application/config_primitives.py`。`src/application/config_authoring_transaction.py` 仅在 retarget 合同确有必要时改动，
+本次只补事务回归，未修改事务源码。
+回归优先扩展 `tests/test_config_yaml.py`、`tests/test_runtime_config_identity.py`、
+`tests/test_config_authoring_transaction.py`、`tests/test_tick_cron.py` 和既有诊断测试。
+使用合成配置和临时目录，不读取生产 secret、不访问 broker、不发送通知。
+
+验证矩阵包括：助手设置的不同改法、注释/键顺序变化、symbols/schedule/选用账户/共享参数变化；
+US/HK 显式身份；来源及元数据缺失/损坏；非 YAML 兼容；默认配置漂移；事务 retarget 与并发改写失败；
+检查前后文件内容和 mtime 不变；普通 build 和至少一个真实执行入口的前置门禁。
+明确反例包括：新来源 loaded=false/缺失、inline=true、缺失 raw SHA、重复必需 role、effective=null/未知版本；
+Combo Yield 顶层及 call 的键顺序互换而 explicit override 不变；readiness 结构化错误和 tick-cron 的
+`[CONFIG_ERROR]`/重建提示而非 traceback；普通 build 在读取后并发修改源文件，以及含注释/CRLF 时 raw SHA
+与读取字节完全一致；事务修改前 SHA 冲突仍拒绝、修改后有效指纹通过 retarget 验证。
+其它市场独立变化按同一个投影规则自然判定，不另建按字段追踪依赖的能力。
+
+针对性命令（在配置好 Python >= 3.12 的工作区运行）：
+
+```bash
+.venv/bin/python -m pytest tests/test_config_yaml.py tests/test_runtime_config_identity.py tests/test_config_authoring_transaction.py tests/test_tick_cron.py
+.venv/bin/python -m ruff check <本次 Python 改动>
+.venv/bin/python scripts/generate_dependency_graph.py --check
+git diff --check
+```
+
+最终运行仓库的 `make test` 和 `make lint`（使用该工作区可用的 Python 环境）；本次会改变 imports，
+因此用既有脚本重新生成依赖图再执行 `--check`，包含零循环检查。
+源码、测试或配置内容变化才重跑相关检查；具体验证结果记录在本次 review artifact。
+
+#### 风险与未决项
+
+- 配置 owner：转换器未来新增市场依赖时，必须继续统一复用同一转换器并补回归，避免指纹遗漏。
+- 配置 owner：effective 格式必须区分旧快照“缺失”与新元数据“损坏”，兼容不得削弱 fail-closed。
+- 运维 owner：新语义只对升级且重建后的快照生效；发布/升级另行授权。
+- 配置诊断 owner：复用转换器可能重复输出已有 legacy 警告；无状态写入，日志静默化及更丰富的指纹展示延后处理。
+- 延后项（助手 CLI owner）：模型 CLI 的事务联动与提示一致性不属于当前批准范围。
+
 
 不确定某个最终值来自哪里时：
 

--- a/docs/DEPENDENCY_GRAPH.md
+++ b/docs/DEPENDENCY_GRAPH.md
@@ -13,7 +13,7 @@ Limitations: this captures Python import edges only. It does not see dynamic imp
 ## Summary
 
 - Python files scanned: 1001 (`src`: 516, `domain`: 82, `scripts`: 11, `tests`: 392)
-- Internal import edges: 6986 total, 2901 production/script edges excluding tests
+- Internal import edges: 6993 total, 2902 production/script edges excluding tests
 - Parse errors: 0
 - Boundary guard status: **PASS**
 - Production module cycles: 0
@@ -46,7 +46,7 @@ flowchart LR
   scripts -->|4| domain
   scripts -->|2| infrastructure
   storage -->|1| domain
-  tests -->|3042| application
+  tests -->|3048| application
   tests -->|468| domain
   tests -->|2| domain_services
   tests -->|245| infrastructure
@@ -79,7 +79,7 @@ flowchart LR
 
 | from | to | imports |
 |---|---|---|
-| tests | application | 3042 |
+| tests | application | 3048 |
 | tests | domain | 468 |
 | tests | infrastructure | 245 |
 | tests | interfaces | 227 |

--- a/src/application/config_primitives.py
+++ b/src/application/config_primitives.py
@@ -11,6 +11,8 @@ from src.application.agent_tool_contracts import AgentToolError
 
 
 MARKETS = ("us", "hk")
+GENERATED_KEY = "_generated"
+GENERATED_SCHEMA_VERSION = "1.0"
 
 
 class IndentedYamlDumper(yaml.SafeDumper):

--- a/src/application/config_yaml.py
+++ b/src/application/config_yaml.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import shlex
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -15,6 +17,8 @@ from src.application.agent_tool_contracts import AgentToolError
 from src.application.account_config import normalize_account_label
 from src.application.assistant.llm_model_profiles import resolve_authoring_assistant_config
 from src.application.config_primitives import (
+    GENERATED_KEY,
+    GENERATED_SCHEMA_VERSION,
     config_key_parts as _key_parts,
     config_path_get as _path_get,
     deep_merge_config as _deep_merge,
@@ -40,7 +44,6 @@ from src.application.layered_config import (
     build_layered_runtime_config_from_user_config,
     default_system_config_path,
 )
-from src.application.runtime_config_freshness import GENERATED_KEY, GENERATED_SCHEMA_VERSION
 from src.application.runtime_config_paths import write_json_atomic
 from src.application.runtime_paths import resolve_runtime_root
 from src.application.portfolio_management import (
@@ -55,6 +58,7 @@ from src.application.wheel.config import (
 
 
 RESOLVED_KEY = "_resolved"
+YAML_MARKET_USER_FINGERPRINT_KIND = "yaml-market-user-v1"
 
 PASSTHROUGH_KEYS = {
     "alert_policy",
@@ -127,6 +131,10 @@ def _system_defaults(system_cfg: dict[str, Any]) -> dict[str, Any]:
 
 
 def load_yaml_config_file(path: str | Path) -> dict[str, Any]:
+    return _load_yaml_config_snapshot(path)[0]
+
+
+def _load_yaml_config_snapshot(path: str | Path) -> tuple[dict[str, Any], str]:
     config_path = Path(path).expanduser().resolve()
     if not config_path.exists():
         raise AgentToolError(
@@ -135,7 +143,8 @@ def load_yaml_config_file(path: str | Path) -> dict[str, Any]:
             hint="Create config.yaml from configs/examples/config.yaml.example, or pass --config-yaml explicitly.",
         )
 
-    text = config_path.read_text(encoding="utf-8")
+    source_bytes = config_path.read_bytes()
+    text = source_bytes.decode("utf-8")
     for line_no, line in enumerate(text.splitlines(), start=1):
         if "\t" in line:
             raise AgentToolError(
@@ -167,7 +176,7 @@ def load_yaml_config_file(path: str | Path) -> dict[str, Any]:
         payload = {}
     if not isinstance(payload, dict):
         raise AgentToolError(code="CONFIG_ERROR", message=f"config.yaml must be a YAML object: {config_path}")
-    return payload
+    return payload, hashlib.sha256(source_bytes).hexdigest()
 
 
 def _reject_unknown_keys(data: dict[str, Any], *, allowed: set[str], path: str) -> None:
@@ -360,7 +369,7 @@ def _normalize_combo_yield(raw: Any, *, path: str) -> dict[str, Any]:
         allow_ranges=False,
         allowed_keys=COMBO_YIELD_AUTHORING_FIELDS,
     )
-    out["_explicit_fields"] = [key for key in out if not str(key).startswith("_")]
+    out["_explicit_fields"] = sorted(key for key in out if not str(key).startswith("_"))
     call_cfg = out.get("call")
     if isinstance(call_cfg, dict):
         _reject_unknown_authoring_keys(
@@ -368,7 +377,7 @@ def _normalize_combo_yield(raw: Any, *, path: str) -> dict[str, Any]:
             allowed=COMBO_YIELD_CALL_ALLOWED_FIELDS,
             path=f"{path}.call",
         )
-        out["_explicit_call_fields"] = [key for key in call_cfg if not str(key).startswith("_")]
+        out["_explicit_call_fields"] = sorted(key for key in call_cfg if not str(key).startswith("_"))
     return out
 
 
@@ -779,6 +788,18 @@ def yaml_to_market_user_config(raw_cfg: dict[str, Any], *, market: str) -> dict[
         raise AgentToolError(code="CONFIG_ERROR", message=str(exc)) from exc
 
 
+def market_user_config_fingerprint(user_config: dict[str, Any], *, market: str) -> dict[str, str]:
+    identity = {"kind": YAML_MARKET_USER_FINGERPRINT_KIND, "market": _normalize_market(market)}
+    body = json.dumps(
+        {**identity, "config": user_config},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return {**identity, "sha256": hashlib.sha256(body).hexdigest()}
+
+
 def _yaml_rebuild_command(*, config_path: Path, market: str, output_path: Path | None = None) -> str:
     command = [
         "./om",
@@ -801,6 +822,8 @@ def _build_yaml_generated_metadata(
     repo_root: Path,
     market: str,
     yaml_path: Path,
+    yaml_sha256: str,
+    effective: dict[str, str],
     system_path: Path | None,
     system_ref: str,
     system_sha256: str,
@@ -848,7 +871,8 @@ def _build_yaml_generated_metadata(
                 "optional": False,
                 "enabled": True,
                 "path": _path_for_metadata(yaml_path, repo_root=repo_root),
-                "sha256": _file_sha256(yaml_path),
+                "sha256": yaml_sha256,
+                "effective": effective,
             },
         ],
         "rebuild_command": _yaml_rebuild_command(
@@ -873,8 +897,9 @@ def resolve_yaml_runtime_config(
     system_cfg = None if system_path is not None else default_config()
     system_ref = str(system_path) if system_path is not None else DEFAULT_CONFIG_REF
     system_sha256 = _file_sha256(system_path) if system_path is not None else default_config_sha256()
-    raw_cfg = load_yaml_config_file(yaml_path)
+    raw_cfg, yaml_sha256 = _load_yaml_config_snapshot(yaml_path)
     user_cfg = yaml_to_market_user_config(raw_cfg, market=normalized_market)
+    effective = market_user_config_fingerprint(user_cfg, market=normalized_market)
     cfg, meta = build_layered_runtime_config_from_user_config(
         repo_root=repo_root,
         market=normalized_market,
@@ -890,6 +915,8 @@ def resolve_yaml_runtime_config(
         repo_root=repo_root,
         market=normalized_market,
         yaml_path=yaml_path,
+        yaml_sha256=yaml_sha256,
+        effective=effective,
         system_path=system_path,
         system_ref=system_ref,
         system_sha256=system_sha256,
@@ -898,7 +925,7 @@ def resolve_yaml_runtime_config(
         "source_format": "yaml",
         "market": normalized_market,
         "config_yaml_path": _path_for_metadata(yaml_path, repo_root=repo_root),
-        "config_yaml_sha256": _file_sha256(yaml_path),
+        "config_yaml_sha256": yaml_sha256,
         "default_source": _path_for_metadata(system_path, repo_root=repo_root) if system_path is not None else system_ref,
         "default_sha256": system_sha256,
         "runtime_schema": "config-json-v1",
@@ -907,7 +934,7 @@ def resolve_yaml_runtime_config(
         {
             "source_format": "yaml",
             "config_yaml_path": str(yaml_path),
-            "config_yaml_sha256": _file_sha256(yaml_path),
+            "config_yaml_sha256": yaml_sha256,
             "system_config_path": str(system_path) if system_path is not None else system_ref,
             "system_config_ref": system_ref,
             "system_config_sha256": system_sha256,
@@ -1188,6 +1215,7 @@ __all__ = [
     "default_yaml_output_config_path",
     "explain_yaml_config_key",
     "load_yaml_config_file",
+    "market_user_config_fingerprint",
     "resolve_yaml_assistant_config",
     "resolve_yaml_runtime_config",
     "runtime_strategy_keys_to_yaml_authoring",

--- a/src/application/runtime_config_freshness.py
+++ b/src/application/runtime_config_freshness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shlex
 from datetime import datetime, timezone
 from pathlib import Path
@@ -10,10 +11,15 @@ from typing import Any
 from src.application.config_defaults import DEFAULT_CONFIG_REF, default_config_sha256
 from src.application.config_primitives import file_sha256 as _file_sha256
 from src.application.config_primitives import path_for_metadata as _path_for_metadata
+from src.application.config_primitives import GENERATED_KEY, GENERATED_SCHEMA_VERSION
+from src.application.config_yaml import (
+    YAML_MARKET_USER_FINGERPRINT_KIND,
+    load_yaml_config_file,
+    market_user_config_fingerprint,
+    yaml_to_market_user_config,
+)
 
 
-GENERATED_KEY = "_generated"
-GENERATED_SCHEMA_VERSION = "1.0"
 RUNTIME_MARKETS = {"us", "hk"}
 RUNTIME_CONFIG_MARKET_BY_NAME = {
     "config.us.json": "us",
@@ -369,6 +375,56 @@ def build_inline_generated_metadata(
     return generated
 
 
+def _check_yaml_effective_source(
+    item: dict[str, Any], *, repo_root: Path, market: str,
+) -> dict[str, Any] | None:
+    effective = item.get("effective")
+    raw_path = item.get("path")
+    error = {"role": "market_user", "path": raw_path if isinstance(raw_path, str) else None}
+    if (
+        item.get("loaded") is not True
+        or item.get("inline", False) is not False
+        or item.get("enabled") is not True
+        or item.get("optional") is not False
+        or not isinstance(raw_path, str)
+        or not raw_path.strip()
+        or "\x00" in raw_path
+        or not isinstance(item.get("sha256"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{64}", item["sha256"])
+        or not isinstance(effective, dict)
+        or effective.get("kind") != YAML_MARKET_USER_FINGERPRINT_KIND
+        or effective.get("market") != market
+        or not isinstance(effective.get("sha256"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{64}", effective["sha256"])
+    ):
+        return {**error, "code": "invalid_source_metadata", "message": "invalid YAML market source fingerprint metadata"}
+
+    try:
+        path = _resolve_metadata_path(raw_path, repo_root=repo_root)
+        raw_cfg = load_yaml_config_file(path)
+        current = market_user_config_fingerprint(
+            yaml_to_market_user_config(raw_cfg, market=market), market=market,
+        )
+    except Exception as exc:
+        # Parser/converter messages may contain source values; expose only the error category.
+        return {
+            **error,
+            "code": "source_check_failed",
+            "message": "cannot read or convert YAML market source; fix the source and rebuild",
+            "error_type": type(exc).__name__,
+        }
+    if current["sha256"] != effective["sha256"].lower():
+        return {
+            **error,
+            "code": "source_changed",
+            "message": "YAML market configuration changed after generation",
+            "fingerprint_kind": current["kind"],
+            "expected_sha256": effective["sha256"],
+            "current_sha256": current["sha256"],
+        }
+    return None
+
+
 def check_runtime_config_freshness(
     config: dict[str, Any],
     *,
@@ -420,6 +476,10 @@ def check_runtime_config_freshness(
         for item in source_items
         if isinstance(item, dict)
     }
+    has_effective = source_format == "yaml" and any(
+        isinstance(item, dict) and item.get("role") == "market_user" and "effective" in item
+        for item in source_items
+    )
     for required_role in ("system", "market_user"):
         if required_role not in roles:
             errors.append(
@@ -429,11 +489,26 @@ def check_runtime_config_freshness(
                     "role": required_role,
                 }
             )
+        elif has_effective and sum(
+            isinstance(item, dict) and str(item.get("role") or "").strip() == required_role
+            for item in source_items
+        ) != 1:
+            errors.append({
+                "code": "duplicate_source_record",
+                "message": "runtime config generation metadata has duplicate required sources",
+                "role": required_role,
+            })
 
-    for item in source_items:
+    sources_to_check = [] if has_effective and errors else source_items
+    for item in sources_to_check:
         if not isinstance(item, dict):
             continue
         role = str(item.get("role") or "").strip()
+        if source_format == "yaml" and role == "market_user" and "effective" in item:
+            error = _check_yaml_effective_source(item, repo_root=repo_root, market=expected_market)
+            if error is not None:
+                errors.append(error)
+            continue
         loaded = bool(item.get("loaded"))
         enabled = bool(item.get("enabled", True))
         inline = bool(item.get("inline"))

--- a/tests/test_config_authoring_transaction.py
+++ b/tests/test_config_authoring_transaction.py
@@ -11,6 +11,8 @@ from src.application.config_authoring_transaction import (
     config_source_sha256,
     publish_yaml_config_generation,
 )
+from src.application.config_yaml import resolve_yaml_runtime_config
+from src.application.runtime_config_freshness import GENERATED_KEY, check_runtime_config_freshness
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -150,3 +152,67 @@ def test_config_authoring_compensates_generation_when_source_commit_fails(
     for path, payload in before_bytes.items():
         assert path.read_bytes() == payload
     assert json.loads(us_path.read_text(encoding="utf-8")) == {"old": "us"}
+
+
+def test_config_authoring_retarget_preserves_effective_fingerprint_for_new_document(tmp_path: Path) -> None:
+    source = tmp_path / "config.yaml"
+    _write_yaml(source, _config_doc())
+    before_sha = config_source_sha256(source)
+    changed = _config_doc()
+    changed["markets"]["us"]["symbols"].append("FUTU")
+    changed["markets"]["hk"]["symbols"].append("9988.HK")
+    comparison_source = tmp_path / "expected.yaml"
+    _write_yaml(comparison_source, changed)
+    expected_effective = {}
+    for market in ("us", "hk"):
+        config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market=market, config_path=comparison_source)
+        expected_effective[market] = next(
+            item["effective"] for item in config[GENERATED_KEY]["sources"] if item["role"] == "market_user"
+        )
+
+    result = publish_yaml_config_generation(
+        repo_root=REPO_ROOT, config_yaml_path=source, config_doc=changed,
+        runtime_root=tmp_path, markets=["us", "hk"], include_assistant=False,
+        apply=True, expected_source_sha256=before_sha,
+    )
+
+    assert result["write_applied"] is True
+    after_sha = config_source_sha256(source)
+    assert before_sha != after_sha
+    assert result["source_revision"] == {"before_sha256": before_sha, "after_sha256": after_sha}
+    for market in ("us", "hk"):
+        runtime = tmp_path / f"config.{market}.json"
+        config = json.loads(runtime.read_text(encoding="utf-8"))
+        record = next(item for item in config[GENERATED_KEY]["sources"] if item["role"] == "market_user")
+        assert record["path"] == str(source)
+        assert record["sha256"] == after_sha
+        assert record["effective"] == expected_effective[market]
+        assert record["effective"]["kind"] == "yaml-market-user-v1"
+        assert record["effective"]["market"] == market
+        assert config["_resolved"]["config_yaml_path"] == str(source)
+        assert config["_resolved"]["config_yaml_sha256"] == after_sha
+        assert check_runtime_config_freshness(
+            config, repo_root=REPO_ROOT, market=market, runtime_config_path=runtime,
+        )["ok"] is True
+
+
+def test_config_authoring_assistant_only_edit_still_invalidates_preview_sha(tmp_path: Path) -> None:
+    source = tmp_path / "config.yaml"
+    original = _config_doc()
+    _write_yaml(source, original)
+    expected_sha = config_source_sha256(source)
+    changed = _config_doc()
+    changed["assistant"] = {"enabled": False}
+    _write_yaml(source, changed)
+    before = source.read_bytes()
+
+    with pytest.raises(AgentToolError) as exc:
+        publish_yaml_config_generation(
+            repo_root=REPO_ROOT, config_yaml_path=source, config_doc=original,
+            runtime_root=tmp_path, markets=["us", "hk"], apply=True,
+            expected_source_sha256=expected_sha,
+        )
+
+    assert exc.value.code == "STALE_PREVIEW"
+    assert source.read_bytes() == before
+    assert list(tmp_path.iterdir()) == [source]

--- a/tests/test_config_yaml.py
+++ b/tests/test_config_yaml.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -16,14 +18,21 @@ from src.application.config_yaml import (
     build_yaml_runtime_config_file,
     build_yaml_assistant_config_file,
     explain_yaml_config_key,
+    market_user_config_fingerprint,
     resolve_yaml_assistant_config,
     resolve_yaml_runtime_config,
     runtime_strategy_keys_to_yaml_authoring,
+    yaml_to_market_user_config,
 )
 from src.application.config_yaml_init import init_yaml_config
 from src.application.config_yaml_symbols import mutate_yaml_symbol_config, set_yaml_symbol_config
 from src.application.pipeline_watchlist import resolve_watchlist_item_runtime_config
-from src.application.runtime_config_freshness import GENERATED_KEY
+from src.application.runtime_config_freshness import (
+    GENERATED_KEY,
+    RuntimeConfigFreshnessError,
+    check_runtime_config_freshness,
+    ensure_runtime_config_freshness,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -564,7 +573,7 @@ markets:
     assert defaulted.config["call"] == {"min_delta": 0.05, "max_delta": 0.20}
 
     overridden = policies["FUTU"]
-    assert overridden.explicit_fields == ("enabled", "min_net_credit_retention", "call")
+    assert overridden.explicit_fields == ("call", "enabled", "min_net_credit_retention")
     assert overridden.config["min_net_credit_retention"] == 0.70
     assert overridden.config["call"] == {"min_delta": 0.12, "max_delta": 0.20}
     assert "output_mode" not in overridden.config
@@ -1866,3 +1875,214 @@ def test_config_validate_cli_supports_yaml_source(tmp_path: Path, capsys) -> Non
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert payload["source_format"] == "yaml"
+
+
+def _market_source(config: dict) -> dict:
+    return next(item for item in config[GENERATED_KEY]['sources'] if item['role'] == 'market_user')
+
+
+@pytest.mark.parametrize('market', ['us', 'hk'])
+@pytest.mark.parametrize('change,stale_markets', [
+    ('assistant_model', set()), ('assistant_context', set()), ('assistant_enabled', set()),
+    ('comments', set()), ('us_symbols', {'us'}), ('hk_symbols', {'hk'}),
+    ('us_schedule', {'us'}), ('us_accounts', {'us'}), ('selected_account', {'us', 'hk'}),
+    ('shared_runtime', {'us', 'hk'}),
+])
+def test_yaml_freshness_tracks_market_inputs(tmp_path: Path, market: str, change: str, stale_markets: set[str]) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market=market, config_path=path)
+    before = deepcopy(config)
+    doc = yaml.safe_load(_minimal_yaml())
+    if change == 'assistant_model':
+        doc['assistant']['llm']['model'] = 'another-model'
+    elif change == 'assistant_context':
+        doc['assistant']['context_window_messages'] = 20
+    elif change == 'assistant_enabled':
+        doc['assistant']['enabled'] = False
+    elif change == 'us_symbols':
+        doc['markets']['us']['symbols'].append('AAPL')
+    elif change == 'hk_symbols':
+        doc['markets']['hk']['symbols'].append('9988.HK')
+    elif change == 'us_schedule':
+        doc['markets']['us']['schedule'] = {'timeout_sec': 333}
+    elif change == 'us_accounts':
+        doc['markets']['us']['accounts'] = ['lx']
+    elif change == 'selected_account':
+        doc['accounts']['lx']['futu_account_id'] = 'REAL_99999'
+    elif change == 'shared_runtime':
+        doc['runtime'] = {'symbol_timeout_sec': 123}
+    path.write_text('# new comment\n' + yaml.safe_dump(doc, sort_keys=True), encoding='utf-8')
+    source_before = (path.read_bytes(), path.stat().st_mtime_ns)
+    result = check_runtime_config_freshness(config, repo_root=REPO_ROOT, market=market)
+    assert result['ok'] is (market not in stale_markets)
+    if market in stale_markets:
+        assert any(error['code'] == 'source_changed' for error in result['errors'])
+    assert (path.read_bytes(), path.stat().st_mtime_ns) == source_before
+    assert config == before
+
+
+@pytest.mark.parametrize('source_format', ['yaml', 'layered'])
+def test_yaml_legacy_and_other_formats_keep_raw_sha_checks(tmp_path: Path, source_format: str) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    if source_format == 'yaml':
+        _market_source(config).pop('effective')
+    config[GENERATED_KEY]['source_format'] = source_format
+    assert check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')['ok']
+    path.write_text(_minimal_yaml() + '\n# assistant-only edit\n', encoding='utf-8')
+    result = check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')
+    assert not result['ok']
+    assert result['errors'][0]['code'] == 'source_changed'
+
+
+@pytest.mark.parametrize('patch', [
+    {'loaded': False}, {'loaded': None}, {'loaded': 1}, {'inline': True},
+    {'inline': 'false'}, {'enabled': False}, {'optional': True},
+    {'path': ''}, {'path': None}, {'path': ['config.yaml']}, {'path': '\x00'},
+    {'sha256': None}, {'sha256': 'bad'}, {'effective': None}, {'effective': {}},
+    {'effective': []},
+    {'effective': {'kind': 'unknown', 'market': 'us', 'sha256': 'a' * 64}},
+    {'effective': {'kind': 'yaml-market-user-v1', 'market': 'hk', 'sha256': 'a' * 64}},
+    {'effective': {'kind': 'yaml-market-user-v1', 'market': 'us', 'sha256': 'not-a-digest'}},
+])
+def test_yaml_freshness_rejects_invalid_new_source_before_shortcuts(tmp_path: Path, patch: dict) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    _market_source(config).update(patch)
+    result = check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')
+    assert not result['ok']
+    assert any(error['code'] == 'invalid_source_metadata' for error in result['errors'])
+
+
+@pytest.mark.parametrize('role', ['system', 'market_user'])
+@pytest.mark.parametrize('damage', ['missing', 'duplicate'])
+def test_yaml_freshness_rejects_missing_or_duplicate_required_roles(tmp_path: Path, role: str, damage: str) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    sources = config[GENERATED_KEY]['sources']
+    item = next(item for item in sources if item['role'] == role)
+    if damage == 'missing':
+        sources.remove(item)
+    else:
+        sources.append(deepcopy(item))
+    result = check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')
+    assert not result['ok']
+    assert any(error['code'] == f'{damage}_source_record' for error in result['errors'])
+
+
+@pytest.mark.parametrize('content', [b'\xff', b'[not: valid', b'- list root', b'markets: {}',
+                                      b'markets:\n\tus: {}', None])
+def test_yaml_freshness_source_failure_is_structured(tmp_path: Path, content: bytes | None) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    if content is None:
+        path.unlink()
+    else:
+        path.write_bytes(content)
+        _market_source(config)['sha256'] = hashlib.sha256(content).hexdigest()
+    result = check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')
+    assert not result['ok']
+    assert result['errors'][0]['code'] == 'source_check_failed'
+    assert result['errors'][0]['role'] == 'market_user'
+    assert 'rebuild_command' in result
+
+
+def test_yaml_freshness_read_error_is_structured(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    original_read = Path.read_bytes
+
+    def unreadable(self: Path) -> bytes:
+        if self == path:
+            raise PermissionError('private diagnostic value')
+        return original_read(self)
+
+    monkeypatch.setattr(Path, 'read_bytes', unreadable)
+    result = check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')
+    assert not result['ok']
+    assert result['errors'][0]['error_type'] == 'PermissionError'
+    assert 'private diagnostic value' not in json.dumps(result)
+
+
+def test_yaml_invalid_source_envelope_stops_before_io(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    config[GENERATED_KEY]['sources'].append({'role': 'system', 'loaded': True, 'path': '\x00'})
+    reads = []
+
+    def unexpected_read(self: Path) -> bytes:
+        reads.append(self)
+        raise OSError('must reject the envelope before reading sources')
+
+    monkeypatch.setattr(Path, 'read_bytes', unexpected_read)
+    result = check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')
+    assert not result['ok']
+    assert [error['code'] for error in result['errors']] == ['duplicate_source_record']
+    with pytest.raises(RuntimeConfigFreshnessError) as exc:
+        ensure_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')
+    assert exc.value.result == result
+    assert reads == []
+
+
+@pytest.mark.parametrize('value', [float('nan'), float('inf'), float('-inf')])
+def test_yaml_market_fingerprint_rejects_nonfinite_values_on_build_and_check(tmp_path: Path, value: float) -> None:
+    path = _write_yaml(tmp_path / 'config.yaml', _minimal_yaml())
+    config, _ = resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    doc = yaml.safe_load(_minimal_yaml())
+    doc['runtime'] = {'symbol_timeout_sec': value}
+    path.write_text(yaml.safe_dump(doc), encoding='utf-8')
+    with pytest.raises(ValueError):
+        resolve_yaml_runtime_config(repo_root=REPO_ROOT, market='us', config_path=path)
+    assert not check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')['ok']
+
+
+def test_yaml_mapping_order_does_not_change_combo_policy_or_fingerprint() -> None:
+    from src.application.combo_yield_config import derive_combo_yield_policy
+
+    doc = yaml.safe_load(_minimal_yaml())
+    combo = {'enabled': True, 'min_net_credit_retention': 0.7, 'call': {'min_delta': 0.12, 'max_delta': 0.18}}
+    doc['markets']['us']['overrides']['FUTU']['combo_yield'] = combo
+    before = yaml_to_market_user_config(doc, market='us')
+    combo['call'] = dict(reversed(list(combo['call'].items())))
+    doc['markets']['us']['overrides']['FUTU']['combo_yield'] = dict(reversed(list(combo.items())))
+    after = yaml_to_market_user_config(doc, market='us')
+    assert market_user_config_fingerprint(before, market='us') == market_user_config_fingerprint(after, market='us')
+    before_policy = derive_combo_yield_policy(before['symbols'][1]['combo_yield'], market='us')
+    after_policy = derive_combo_yield_policy(after['symbols'][1]['combo_yield'], market='us')
+    assert before_policy == after_policy
+    assert before_policy.config['call']['min_delta'] == 0.12
+    assert before_policy.config['min_net_credit_retention'] == 0.7
+    # Symbol lists have real ordering semantics and must not be canonicalized as sets.
+    after['symbols'].reverse()
+    assert market_user_config_fingerprint(before, market='us') != market_user_config_fingerprint(after, market='us')
+
+
+def test_yaml_build_metadata_uses_exact_single_read_even_if_source_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source_bytes = ('# preserve CRLF and comment\r\n' + _minimal_yaml().replace('\n', '\r\n')).encode('utf-8')
+    path = tmp_path / 'config.yaml'
+    path.write_bytes(source_bytes)
+    output = tmp_path / 'config.us.json'
+    original_read = Path.read_bytes
+    reads = []
+
+    def read_then_edit(self: Path) -> bytes:
+        content = original_read(self)
+        if self == path:
+            reads.append(content)
+            self.write_bytes(content.replace(b'- NVDA', b'- AAPL'))
+        return content
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, 'read_bytes', read_then_edit)
+        result = build_yaml_runtime_config_file(repo_root=REPO_ROOT, market='us', config_path=path, output_config_path=output)
+    config = json.loads(output.read_text())
+    assert len(reads) == 1
+    expected_sha = hashlib.sha256(source_bytes).hexdigest()
+    assert _market_source(config)['sha256'] == expected_sha
+    assert config[RESOLVED_KEY]['config_yaml_sha256'] == expected_sha
+    assert result['config_yaml_sha256'] == expected_sha
+    assert config['symbols'][0]['symbol'] == 'NVDA'
+    assert _market_source(config)['effective'] == market_user_config_fingerprint(
+        yaml_to_market_user_config(yaml.safe_load(source_bytes), market='us'), market='us',
+    )
+    assert not check_runtime_config_freshness(config, repo_root=REPO_ROOT, market='us')['ok']

--- a/tests/test_runtime_config_identity.py
+++ b/tests/test_runtime_config_identity.py
@@ -4,11 +4,13 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from src.application.agent_tool_config import load_runtime_config
 from src.application.agent_tool_contracts import AgentToolError
 from src.application.config_yaml import build_yaml_runtime_config_file
 from src.application.runtime_config_freshness import GENERATED_KEY, check_runtime_config_freshness
+from src.application.runtime_config_readiness import evaluate_runtime_config_readiness, require_runtime_config_readiness
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -202,3 +204,72 @@ markets:
     assert result["ok"] is False
     assert any(item["code"] == "inline_source_changed" for item in result["errors"])
     assert "./om config build" in str(result["rebuild_command"])
+
+
+@pytest.mark.parametrize("market,symbol", [("us", "NVDA"), ("hk", "0700.HK")])
+def test_readiness_accepts_assistant_only_edit_without_writes(
+    tmp_path: Path, market: str, symbol: str,
+) -> None:
+    source = tmp_path / "config.yaml"
+    doc = {
+        "accounts": {"lx": {"type": "futu", "futu_account_id": "12345678"}},
+        "markets": {market: {"accounts": ["lx"], "symbols": [symbol]}},
+        "assistant": {"enabled": True, "context_window_messages": 6},
+    }
+    source.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    runtime = tmp_path / f"config.{market}.json"
+    build_yaml_runtime_config_file(
+        repo_root=REPO_ROOT, market=market, config_path=source, output_config_path=runtime,
+    )
+    doc["assistant"] = {"enabled": False, "context_window_messages": 8}
+    source.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    before = {p: (p.read_bytes(), p.stat().st_mtime_ns) for p in tmp_path.rglob("*") if p.is_file()}
+
+    path, config = load_runtime_config(config_key=market, config_path=runtime)
+    result = require_runtime_config_readiness(
+        config, repo_root=REPO_ROOT, runtime_config_path=path, explicit_market=market,
+    )
+
+    assert result["ok"] is True
+    assert result["freshness"]["ok"] is True
+    after = {p: (p.read_bytes(), p.stat().st_mtime_ns) for p in tmp_path.rglob("*") if p.is_file()}
+    assert after == before
+
+
+def test_readiness_reports_invalid_yaml_source_without_leaking_content(tmp_path: Path) -> None:
+    source = tmp_path / "config.yaml"
+    source.write_text(
+        "accounts:\n  lx:\n    type: futu\n    futu_account_id: '12345678'\n"
+        "markets:\n  us:\n    accounts: [lx]\n    symbols: [NVDA]\n",
+        encoding="utf-8",
+    )
+    runtime = tmp_path / "config.us.json"
+    build_yaml_runtime_config_file(
+        repo_root=REPO_ROOT, market="us", config_path=source, output_config_path=runtime,
+    )
+    source.write_text("markets: [PRIVATE_CONFIG_VALUE\n", encoding="utf-8")
+    config = json.loads(runtime.read_text(encoding="utf-8"))
+
+    result = evaluate_runtime_config_readiness(
+        config, repo_root=REPO_ROOT, runtime_config_path=runtime, explicit_market="us",
+    )
+
+    assert result["ok"] is False
+    assert result["validation"]["ok"] is True
+    assert result["identity"]["ok"] is True
+    assert result["schedule"]["ok"] is True
+    assert result["freshness"]["ok"] is False
+    assert result["errors"]
+    assert all(error["component"] == "freshness" for error in result["errors"])
+    error = result["errors"][0]
+    assert error["code"] != "source_changed"
+    assert error["role"] == "market_user"
+    assert error["path"] == str(source)
+    assert "./om config build" in result["freshness"]["rebuild_command"]
+    assert "PRIVATE_CONFIG_VALUE" not in json.dumps(result)
+    with pytest.raises(AgentToolError) as exc:
+        require_runtime_config_readiness(
+            config, repo_root=REPO_ROOT, runtime_config_path=runtime, explicit_market="us",
+        )
+    assert exc.value.code == "CONFIG_ERROR"
+    assert exc.value.details == result

--- a/tests/test_tick_cron.py
+++ b/tests/test_tick_cron.py
@@ -4,6 +4,10 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from src.application.config_yaml import build_yaml_runtime_config_file
+
 
 def _write_json(path: Path, payload: dict) -> Path:
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -277,3 +281,52 @@ def test_scan_scheduler_external_adapter_forwards_force_flag(monkeypatch, tmp_pa
     )
 
     assert '--force' in calls[0][0]
+
+
+@pytest.mark.parametrize("market,symbol", [("us", "NVDA"), ("hk", "0700.HK")])
+@pytest.mark.parametrize("invalid_yaml", [False, True], ids=["assistant-only", "invalid-yaml"])
+def test_tick_cron_real_preflight_after_yaml_edit(
+    tmp_path: Path, capsys, market: str, symbol: str, invalid_yaml: bool,
+) -> None:
+    from src.application.tick_cron import run_tick_cron
+
+    source = tmp_path / "config.yaml"
+    original = (
+        "accounts:\n  lx:\n    type: futu\n    futu_account_id: '12345678'\n"
+        f"markets:\n  {market}:\n    accounts: [lx]\n    symbols: [{symbol}]\n"
+    )
+    source.write_text(original, encoding="utf-8")
+    runtime = tmp_path / f"config.{market}.json"
+    build_yaml_runtime_config_file(
+        repo_root=Path(__file__).resolve().parents[1], market=market,
+        config_path=source, output_config_path=runtime,
+    )
+    source.write_text(
+        "markets: [PRIVATE_CONFIG_VALUE\n" if invalid_yaml
+        else original + "assistant:\n  enabled: false\n  context_window_messages: 8\n",
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_command(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    rc = run_tick_cron(
+        market=market, config_path=str(runtime), lock_path=str(tmp_path / "tick.lock"),
+        run_cmd=run_command, no_send=True, environ={},
+    )
+
+    captured = capsys.readouterr()
+    if invalid_yaml:
+        assert rc == 1
+        assert calls == []
+        assert "[CONFIG_ERROR]" in captured.err
+        assert f"rebuild: ./om config build --source yaml --market {market}" in captured.err
+        assert "Traceback" not in captured.err
+        assert "PRIVATE_CONFIG_VALUE" not in captured.err
+    else:
+        assert rc == 0
+        assert len(calls) == 1
+        assert "--no-send" in calls[0][0]
+        assert captured.err == ""


### PR DESCRIPTION
## Design

- Reference: [CONFIGS.md](CONFIGS.md#市场配置新鲜度按实际依赖判定)
- Problem and scope: assistant-only YAML edits previously made both US/HK runtime snapshots stale because freshness compared the entire source file. New snapshots compare the existing converter’s market input, so independent assistant settings do not interrupt monitoring.
- Constraints and authority: monitoring changes and invalid sources still block; checks remain read-only. Preserve raw SHA for audit and authoring concurrency. No VERSION change, release or deployment.
- Chosen design: record a versioned effective market fingerprint alongside the raw SHA, both derived from the same YAML byte snapshot. Reuse the shared freshness checker and existing conversion owner.

## Decision points

1. Keep old snapshots raw-SHA strict until explicitly rebuilt; malformed new metadata cannot fall back to legacy rules.
2. Sort only derived Combo explicit-field lists, preserving actual configuration array order and override semantics.

- Rejected alternatives: rebuilding both markets on every assistant edit, maintaining a separate field ignore list, or automatically rebuilding at read time.
- Risks and rollback boundary: deployment must explicitly rebuild snapshots to adopt the new semantics. Older consumers remain conservative because raw SHA is retained. Source delivery only.

## Verification

- Full local `make test`: 6532 passed, 2 skipped; `make lint`, dependency graph `--check` and `git diff --check` passed.
- 159 focused tests cover assistant independence, market/shared changes, malformed sources/metadata, legacy compatibility, same-byte generation, transaction SHA conflicts, readiness and tick-cron preflight.
- US/HK public config validation and build dry-runs passed without writes.
- Full current-change Deepreview passed after fixing duplicate-source metadata to return structured errors before source I/O.
